### PR TITLE
Fix for entry/exit attributes appearing in IE when they are not wanted.

### DIFF
--- a/src/joint.dia.uml.js
+++ b/src/joint.dia.uml.js
@@ -144,7 +144,7 @@ uml.State = Element.extend({
     getActionsElement: function(){
 	// collect all actions
 	var p = this.properties;
-	var str = (p.actions. != "") ? "entry/ " + p.actions.entry + "\n" : "";
+	var str = (p.actions.entry != "") ? "entry/ " + p.actions.entry + "\n" : "";
 	str += (p.actions.exit != "") ? "exit/ " + p.actions.exit + "\n" : "";
 	var l = p.actions.inner.length;
 	for (var i = 0; i < l; i += 2){


### PR DESCRIPTION
I have set the entry and exit properties to empty strings by default and used an empty string check when collecting all the actions together.

See http://groups.google.com/group/jointjs/browse_thread/thread/6098947cee706951# for the original issue

Hope this is OK.  I have tested this in Internet Explorer 7 and Firefox 5 with no problems.
