### PR TITLE
Element jumping fix

### DIFF
--- a/src/joint.dia.js
+++ b/src/joint.dia.js
@@ -391,6 +391,7 @@ Element.prototype = {
 	dia._currentDrag.removeToolbox();
 	// small hack to get the connections to front
 	dia._currentDrag.translate(1,1);
+	dia._currentDrag.translate(-1,-1);
 
 	dia._currentDrag.dx = e.clientX;
 	dia._currentDrag.dy = e.clientY;
@@ -890,6 +891,7 @@ Element.mouseUp = function(e){
 	dia._currentDrag.toFront();
 	// small hack: change slightely the position to get the connections to front
 	dia._currentDrag.translate(1,1);
+	dia._currentDrag.translate(-1,-1);
     }
 
     // add toolbar again when zooming is stopped


### PR DESCRIPTION
Found this thread today: http://groups.google.com/group/jointjs/browse_thread/thread/4e635cd4b198f879?pli=1

It mentions a possible fix for the elements jumping around whenever they are clicked, but it was shot down because links can get hidden, which I assume was the original problem someone was trying to fix when they introduced this jumping around problem.

By moving them right back to where it was when it started, elements no longer jump around when clicked, and the links are still visible.
