### PR TITLE
Fix transform=translate removal.

### DIFF
--- a/src/joint.dia.element.js
+++ b/src/joint.dia.element.js
@@ -276,7 +276,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
         // relative to the root bounding box following the `ref-x` and `ref-y` attributes.
         if (vel.attr('transform')) {
 
-            vel.attr('transform', vel.attr('transform').replace(/translate\([^)]*\)/g, '') || '');
+            vel.attr('transform', vel.attr('transform').replace(/translate\([^)]*\)/g, '').trim() || '');
         }
 
         function isDefined(x) {


### PR DESCRIPTION
This replacement could produce the `" "` string, producing an invalid entry for the transform attribute, instead of removing it.

I've only added a `trim()` call to avoid this issue.
