### PR TITLE
Added the possibility of multiple extensions on the Ports interfaces

### DIFF
--- a/plugins/joint.shapes.basic.js
+++ b/plugins/joint.shapes.basic.js
@@ -151,8 +151,8 @@ joint.shapes.basic.PortsModelInterface = {
         this.updatePortsAttrs();
         this.on('change:inPorts change:outPorts', this.updatePortsAttrs, this);
 
-        // Call the `initialize()` of the parent.
-        var thisInterface = this.constructor.__super__;
+        //Call parent's existent initialize function
+        var thisInterface = this;
         while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
             thisInterface = thisInterface.constructor.__super__;
         }
@@ -225,7 +225,8 @@ joint.shapes.basic.PortsViewInterface = {
         // `Model` emits the `process:ports` whenever it's done configuring the `attrs` object for ports.
         this.listenTo(this.model, 'process:ports', this.update);
         
-        var thisInterface = this.constructor.__super__;
+        //Call parent's existent initialize function
+        var thisInterface = this;
         while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
             thisInterface = thisInterface.constructor.__super__;
         }
@@ -241,7 +242,9 @@ joint.shapes.basic.PortsViewInterface = {
         // First render ports so that `attrs` can be applied to those newly created DOM elements
         // in `ElementView.prototype.update()`.
         this.renderPorts();
-        var thisInterface = this.constructor.__super__;
+        
+        //Call parent's existent update function
+        var thisInterface = this;
         while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
             thisInterface = thisInterface.constructor.__super__;
         }

--- a/plugins/joint.shapes.basic.js
+++ b/plugins/joint.shapes.basic.js
@@ -143,6 +143,8 @@ joint.shapes.basic.Rhombus = joint.shapes.basic.Path.extend({
 //     }
 //}));
 joint.shapes.basic.PortsModelInterface = {
+    
+    interface: "Ports",
 
     initialize: function() {
 
@@ -150,7 +152,15 @@ joint.shapes.basic.PortsModelInterface = {
         this.on('change:inPorts change:outPorts', this.updatePortsAttrs, this);
 
         // Call the `initialize()` of the parent.
-        this.constructor.__super__.constructor.__super__.initialize.apply(this, arguments);
+        var thisInterface = this.constructor.__super__;
+        while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
+            thisInterface = thisInterface.constructor.__super__;
+        }
+        var parentWithInitialize = thisInterface.constructor.__super__;
+        while(!parentWithInitialize.hasOwnProperty("initialize")){
+            parentWithInitialize = parentWithInitialize.constructor.__super__;
+        }
+        parentWithInitialize.initialize.apply(this, arguments);
     },
     
     updatePortsAttrs: function(eventName) {

--- a/plugins/joint.shapes.basic.js
+++ b/plugins/joint.shapes.basic.js
@@ -218,12 +218,22 @@ joint.shapes.basic.PortsModelInterface = {
 
 joint.shapes.basic.PortsViewInterface = {
     
+    interface: "Ports",
+    
     initialize: function() {
 
         // `Model` emits the `process:ports` whenever it's done configuring the `attrs` object for ports.
         this.listenTo(this.model, 'process:ports', this.update);
         
-        joint.dia.ElementView.prototype.initialize.apply(this, arguments);
+        var thisInterface = this.constructor.__super__;
+        while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
+            thisInterface = thisInterface.constructor.__super__;
+        }
+        var parentWithInitialize = thisInterface.constructor.__super__;
+        while(!parentWithInitialize.hasOwnProperty("initialize")){
+            parentWithInitialize = parentWithInitialize.constructor.__super__;
+        }
+        parentWithInitialize.initialize.apply(this, arguments);
     },
 
     update: function() {
@@ -231,7 +241,15 @@ joint.shapes.basic.PortsViewInterface = {
         // First render ports so that `attrs` can be applied to those newly created DOM elements
         // in `ElementView.prototype.update()`.
         this.renderPorts();
-        joint.dia.ElementView.prototype.update.apply(this, arguments);
+        var thisInterface = this.constructor.__super__;
+        while(!thisInterface.hasOwnProperty("interface") || !(thisInterface.interface == "Ports")){
+            thisInterface = thisInterface.constructor.__super__;
+        }
+        var parentWithUpdate = thisInterface.constructor.__super__;
+        while(!parentWithUpdate.hasOwnProperty("update")){
+            parentWithUpdate = parentWithUpdate.constructor.__super__;
+        }
+        parentWithUpdate.update.apply(this, arguments);
     },
 
     renderPorts: function() {


### PR DESCRIPTION
I was extending the functionality of the Elements, but when using Ports, their's interfaces were made to call their inmediate parent function's, forbidding the option of having several interfaces implemented unless the port's interface were the last used to extend the functionality.
Just changed that code for having better options when implementing interfaces