### PR TITLE
Changin the URL of the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/DavidDurman/joint.git"
+    "url": "https://github.com/clientIO/joint.git"
   },
   "bugs": {
-    "url": "https://github.com/DavidDurman/joint/issues"
+    "url": "https://github.com/clientIO/joint/issues"
   },
   "license": "MPL 2.0",
   "dependencies": {


### PR DESCRIPTION
Bower has a problem to find the version : 
bower ENORESTARGET  No tag found that was able to satisfy ~0.9.3

Additional error details:
No versions found in git://github.com/DavidDurman/joint.git