### PR TITLE
Add "main" section to bower.json to support build processes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,9 @@
     "requirejs": "2.1.17",
     "resemblejs": "~1.2.1",
     "sinonjs": "~1.14.1"
-  }
+  },
+  "main": [
+    "dist/joint.js",
+    "dist/joint.css"
+  ]
 }


### PR DESCRIPTION
I added a "main" section so that things like wiredep can automatically wire-up the script/css tags in HTML to include the resources.