### PR TITLE
Added license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,6 @@
   "main": [
     "dist/joint.js",
     "dist/joint.css"
-  ]
+  ],
+  "license": "MPL-2.0"
 }


### PR DESCRIPTION
Hopefully this will fix (as MPL 2.0 is a valid license for bintray) webjars bower generation:

> Failed! No valid licenses found. No licenses were found. The acceptable licenses on BinTray are at:  https://bintray.com/docs/api/#_footnote_1
> License detection first uses the package metadata (e.g. package.json or bower.json) and falls back to looking for a LICENSE, LICENSE.txt, or LICENSE.md file in the master branch of the GitHub repo. Since these methods failed to detect a valid license you will need to work with the upstream project to add discoverable license metadata to a release or to the GitHub repo.  If you feel you have reached this failure in error, please file an issue: https://github.com/webjars/webjars/issues
>  Created Bower WebJar
> Fetched Bower zip
> Generated POM
> Converted dependencies to Maven
> Got Bower info
> Starting Deploy