### PR TITLE
Fixed bug where link z order is corrupt when previous state was 0 on head move

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -1150,7 +1150,7 @@ joint.dia.LinkView = joint.dia.CellView.extend({
 
     _afterArrowheadMove: function() {
 
-        if (this._z) {
+        if (!_.isUndefined(this._z)) {
             this.model.set('z', this._z, { ui: true });
             delete this._z;
         }


### PR DESCRIPTION
If a link has a Z order of 0, then after an arrowhead move the original z order will
be corrupted (set to Number.MAX_VALUE instead of back to 0). This was due to incorrect
logic [if(0), 0 evaluates to false in this case]. Replacing this with an undefined check
is the correct behavior to handle a 0 z order value.