### PR TITLE
Backwards compatibility fixes for paper.drawGrid()

### DIFF
--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -16,7 +16,7 @@ joint.dia.Paper = joint.mvc.View.extend({
         /*
             Whether or not to draw the grid lines on the paper's DOM element.
         */
-        drawGrid: true,
+        drawGrid: false,
 
         /*
             Default options used for the drawGrid() method.
@@ -1014,6 +1014,12 @@ joint.dia.Paper = joint.mvc.View.extend({
         opt = _.defaults(opt || {}, this.options.drawGridOptions);
 
         var gridSize = this.options.gridSize;
+
+        if (gridSize <= 1) {
+            this.el.style['background-image'] = 'none';
+            return;
+        }
+
         var currentScale = V(this.viewport).scale();
         var scaleX = currentScale.sx;
         var scaleY = currentScale.sy;

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -545,6 +545,8 @@ test('drawGrid(opt)', function(assert) {
         }
     ];
 
+    paper.options.drawGrid = true;
+
     _.each(callerMethods, function(callerMethod) {
         called = false;
         paper[callerMethod.name].apply(paper, callerMethod.args || []);


### PR DESCRIPTION
Default paper.options.drawGrid to FALSE.

Don't draw grid lines if paper.options.gridSize is less than or equal to 1.