### PR TITLE
Avoid to call sort too much

### DIFF
--- a/src/joint.dia.graph.js
+++ b/src/joint.dia.graph.js
@@ -17,7 +17,6 @@ joint.dia.GraphCells = Backbone.Collection.extend({
                 --activeBatches;
             }
         }, this);
-    
         // Backbone automatically doesn't trigger re-sort if models attributes are changed later when
         // they're already in the collection. Therefore, we're triggering sort manually here.
         this.on('change:z', function() { return activeBatches === 0 && this.sort(); }, this);

--- a/src/joint.dia.graph.js
+++ b/src/joint.dia.graph.js
@@ -10,8 +10,8 @@ joint.dia.GraphCells = Backbone.Collection.extend({
         //In order to avoid multiple sort during toFront and toBack deep operations
         //The change:z event is disabled during batch:start and reactivated when all the batches have stopped
         var activeBatches = 0;
-        this.on('batch:start', function (e) { if ((e.batchName === 'to-front') || (e.batchName === 'to-back')) { ++activeBatches; }});
-        this.on('batch:stop', function (e) {
+        this.on('batch:start', function(e) { if ((e.batchName === 'to-front') || (e.batchName === 'to-back')) { ++activeBatches; }});
+        this.on('batch:stop', function(e) {
             if (activeBatches > 0 && ((e.batchName === 'to-front') || (e.batchName === 'to-back'))) {
                 this.sort();
                 --activeBatches;
@@ -20,7 +20,7 @@ joint.dia.GraphCells = Backbone.Collection.extend({
     
         // Backbone automatically doesn't trigger re-sort if models attributes are changed later when
         // they're already in the collection. Therefore, we're triggering sort manually here.
-        this.on('change:z', function () { return activeBatches === 0 && this.sort(); }, this);
+        this.on('change:z', function() { return activeBatches === 0 && this.sort(); }, this);
 
         // Set the optional namespace where all model classes are defined.
         if (opt.cellNamespace) {


### PR DESCRIPTION
Call sort just one time during toFront or toBack deep operations see issue #249