### PR TITLE
Unignoring webpack in node v5

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,9 +10,6 @@ module.exports = function(grunt) {
     var pkg = grunt.file.readJSON('package.json');
     var banner = grunt.template.process('/*! <%= pkg.title %> v<%= pkg.version %> - <%= pkg.description %>  <%= grunt.template.today("yyyy-mm-dd") %> \n\n\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.\n */\n', { data: { pkg: pkg }, delimiter: 'default' });
 
-    // Ignore webpack in node v5, until webpack is fixed for that version.
-    var ignoreWebpack = process.version.substr(0, 'v5'.length) === 'v5';
-
     var js = {
 
         core: [
@@ -355,11 +352,6 @@ module.exports = function(grunt) {
         }
     };
 
-    if (ignoreWebpack) {
-        config.qunit.all.push('!test/**/webpack.html');
-        config.qunit.joint.push('!test/jointjs/webpack.html');
-    }
-
     function enableCodeCoverage() {
 
         // Replace all qunit configurations with the 'urls' method.
@@ -498,9 +490,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('build', ['build:joint']);
 
-    grunt.registerTask('build:bundles', ignoreWebpack ? [
-        'newer:browserify'
-    ] : [
+    grunt.registerTask('build:bundles', [
         'newer:browserify',
         'newer:webpack'
     ]);

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "serve-static": "1.10.2",
     "should": "8.1.1",
     "sinon": "1.17.2",
-    "time-grunt": "1.3.0"
+    "time-grunt": "1.3.0",
+    "webpack": "1.12.13",
+    "webpack-dev-server": "1.14.1"
   }
 }


### PR DESCRIPTION
Fix for installing + using grunt-webpack in build process when using npm v3.

See #219 