### PR TITLE
set SVG attribute into correct namespace

### DIFF
--- a/src/vectorizer.js
+++ b/src/vectorizer.js
@@ -932,7 +932,7 @@ V = Vectorizer = (function() {
             // Attribute names can be namespaced. E.g. `image` elements
             // have a `xlink:href` attribute to set the source of the image.
             var combinedKey = name.split(':');
-            el.setAttributeNS(ns[combinedKey[0]], combinedKey[1], value);
+            el.setAttributeNS(ns[combinedKey[0]], name, value);
 
         } else if (name === 'id') {
             el.id = value;


### PR DESCRIPTION
@kumilingus ready for review 

set SVG attribute into correct namespace, otherwise some browsers might serialize svg document incorrecltly.

In Svg markup there will be attributtes with namespace defined e.g ```<a xlink:href="http://jointjs.com">...</a>```
