### PR TITLE
RAP-845: Fix for white-space issue when using V.sanitizeText

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -412,6 +412,9 @@ module.exports = function(grunt) {
             }
         },
         uglify: {
+            options: {
+                ASCIIOnly: true
+            },
             geometry: {
                 src: js.geometry,
                 dest: 'build/min/geometry.min.js'


### PR DESCRIPTION
The issue only affected the minified version of Vectorizer.