### PR TITLE
Added style field  to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "url": "https://github.com/clientIO/joint/issues"
   },
   "license": "MPL-2.0",
+  "style": "dist/joint.min.css",
   "dependencies": {
     "backbone": "1.3.3",
     "dagre": "0.7.4",


### PR DESCRIPTION
To support requiring css like with [npm-css](https://www.npmjs.com/package/npm-css) to make it easier for people to consume the package when they are using npm for all the things instead of gulp/bower/grunt. I chose the minified css because i figured that's what most people would use in production.