### PR TITLE
Fix jumpover on cells reset

### DIFF
--- a/plugins/connectors/joint.connectors.jumpover.js
+++ b/plugins/connectors/joint.connectors.jumpover.js
@@ -40,7 +40,7 @@ joint.connectors.jumpover = (function(_, g) {
             updateList = jumpOverLinkView.paper._jumpOverUpdateList = [];
             jumpOverLinkView.paper.on('cell:pointerup', updateJumpOver);
             jumpOverLinkView.paper.model.on('reset', function() {
-                updateList = [];
+            	updateList = jumpOverLinkView.paper._jumpOverUpdateList = [];
             });
         }
 

--- a/plugins/connectors/joint.connectors.jumpover.js
+++ b/plugins/connectors/joint.connectors.jumpover.js
@@ -40,7 +40,7 @@ joint.connectors.jumpover = (function(_, g) {
             updateList = jumpOverLinkView.paper._jumpOverUpdateList = [];
             jumpOverLinkView.paper.on('cell:pointerup', updateJumpOver);
             jumpOverLinkView.paper.model.on('reset', function() {
-            	updateList = jumpOverLinkView.paper._jumpOverUpdateList = [];
+                updateList = jumpOverLinkView.paper._jumpOverUpdateList = [];
             });
         }
 


### PR DESCRIPTION
When cells are reset, only the local variable got replaced and the old list of views was used in `updateJumpOver()`.

The symptoms were errors thrown on every `stop:batch` event resulting from missing `ownerSVGElement`s.