### PR TITLE
dia.Paper: add convenient methods to convert coordinates

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/clientOffset.html
+++ b/docs/src/joint/api/dia/Paper/prototype/clientOffset.html
@@ -1,0 +1,3 @@
+<pre class="docs-method-signature"><code>paper.clientOffset()</code></pre>
+<p>Returns coordinates of the paper viewport, relative to the application's client area.
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/clientToLocalPoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/clientToLocalPoint.html
@@ -1,5 +1,8 @@
-<pre class="docs-method-signature"><code>paper.clientToLocalPoint(p)</code></pre><p>Transform client coordinates represented by point <code>p</code> to the paper local coordinates.
-                  This is especially useful when you have a mouse event object and want coordinates
-                  inside the paper that correspond to event <code>clientX</code> and <code>clientY</code> point.
-                  Example: <code>var paperPoint = paper.clientToLocalPoint({ x: evt.clientX, y: evt.clientY })</code>.
-                </p>
+<pre class="docs-method-signature"><code>paper.clientToLocalPoint(p)</code></pre>
+<p>Transform client coordinates represented by point <code>p</code> to the paper local coordinates.
+    This is especially useful when you have a mouse event object and want coordinates
+    inside the paper that correspond to event <code>clientX</code> and <code>clientY</code> point.
+    <pre><code>var localPoint1 = paper.clientToLocalPoint({ x: evt.clientX, y: evt.clientY });
+// alternative method signature
+var localPoint2 = paper.clientToLocalPoint(evt.clientX, evt.clientY);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/clientToLocalRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/clientToLocalRect.html
@@ -1,0 +1,11 @@
+<pre class="docs-method-signature"><code>paper.clientToLocalRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in the client coordinate system to the local coordinate system.
+<pre><code>var bcr = paper.svg.getBoundingClientRect();
+var localRect1 = paper.clientToLocalRect({ x: bcr.left, y: bcr.top, width: bcr.width, height: bcr.height });
+// alternative method signature
+var localRect2 = paper.clientToLocalRect(bcr.left, bcr.top, bcr.width, bcr.height);
+// Move the element to the center of the paper viewport.
+var localCenter = localRect1.center();
+var elSize = element.size();
+element.position(localCenter.x - elSize.width, localCenter.y - elSize.height);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToClientPoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToClientPoint.html
@@ -1,0 +1,18 @@
+<pre class="docs-method-signature"><code>paper.localToClientPoint(p)</code></pre>
+<p>Transform the point <code>p</code> defined in the local coordinate system to the client coordinate system.
+    <pre><code>var rightMidPoint = element.getBBox().rightMiddle();
+var clientPoint1 = paper.localToClientPoint(rightMidPoint);
+ // alternative method signature
+var clientPoint2 = paper.localToClientPoint(rightMidPoint.x, rightMidPoint.y);
+// Draw an HTML rectangle next to the element.
+var div = document.createElement('div');
+div.style.position = 'fixed';
+div.style.background = 'red';
+div.style.left = clientPoint1.x + 'px';
+div.style.top = clientPoint1.y + 'px';
+div.style.width = '40px';
+div.style.height = '40px';
+div.style.marginLeft = '10px';
+div.style.marginTop = '-20px';
+document.body.appendChild(div);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToClientRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToClientRect.html
@@ -1,0 +1,16 @@
+<pre class="docs-method-signature"><code>paper.localToClientRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in local coordinate system to the client coordinate system.
+    <pre><code>var bbox = element.getBBox();
+var clientRect1 = paper.localToClientRect(bbox);
+ // alternative method signature
+var clientRect2 = paper.localToClientRect(bbox.x, bbox.y, bbox.width, bbox.height);
+// Draw an HTML rectangle above the element.
+var div = document.createElement('div');
+div.style.position = 'fixed';
+div.style.background = 'red';
+div.style.left = clientRect1.x + 'px';
+div.style.top = clientRect1.y + 'px';
+div.style.width = clientRect1.width + 'px';
+div.style.height = clientRect1.height + 'px';
+paper.el.appendChild(div);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToPagePoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToPagePoint.html
@@ -1,0 +1,18 @@
+<pre class="docs-method-signature"><code>paper.localToPagePoint(p)</code></pre>
+<p>Transform the point <code>p</code> defined in the local coordinate system to the page coordinate system.
+    <pre><code>var rightMidPoint = element.getBBox().rightMiddle();
+var pagePoint1 = paper.localToPagePoint(rightMidPoint);
+ // alternative method signature
+var pagePoint2 = paper.localToPagePoint(rightMidPoint.x, rightMidPoint.y);
+// Draw an HTML rectangle next to the element.
+var div = document.createElement('div');
+div.style.position = 'absolute';
+div.style.background = 'red';
+div.style.left = pagePoint1.x + 'px';
+div.style.top = pagePoint1.y + 'px';
+div.style.width = '40px';
+div.style.height = '40px';
+div.style.marginLeft = '10px';
+div.style.marginTop = '-20px';
+document.body.appendChild(div);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToPageRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToPageRect.html
@@ -1,0 +1,16 @@
+<pre class="docs-method-signature"><code>paper.localToPageRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in local coordinate system to the page coordinate system.
+    <pre><code>var bbox = element.getBBox();
+var pageRect1 = paper.localToPageRect(bbox);
+ // alternative method signature
+var pageRect2 = paper.localToPageRect(bbox.x, bbox.y, bbox.width, bbox.height);
+// Draw an HTML rectangle above the element.
+var div = document.createElement('div');
+div.style.position = 'absolute';
+div.style.background = 'red';
+div.style.left = pageRect1.x + 'px';
+div.style.top = pageRect1.y + 'px';
+div.style.width = pageRect1.width + 'px';
+div.style.height = pageRect1.height + 'px';
+document.body.appendChild(div);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToPaperPoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToPaperPoint.html
@@ -1,0 +1,18 @@
+<pre class="docs-method-signature"><code>paper.localToPaperPoint(p)</code></pre>
+<p>Transform the point <code>p</code> defined in the local coordinate system to the paper coordinate system.
+    <pre><code>var rightMidPoint = element.getBBox().rightMiddle();
+var paperPoint1 = paper.localToPaperPoint(rightMidPoint);
+ // alternative method signature
+var paperPoint2 = paper.localToPaperPoint(rightMidPoint.x, rightMidPoint.y);
+// Draw an HTML rectangle next to the element.
+var div = document.createElement('div');
+div.style.position = 'absolute';
+div.style.background = 'red';
+div.style.left = paperPoint1.x + 'px';
+div.style.top = paperPoint1.y + 'px';
+div.style.width = '40px';
+div.style.height = '40px';
+div.style.marginLeft = '10px';
+div.style.marginTop = '-20px';
+paper.el.appendChild(div); </code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/localToPaperRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/localToPaperRect.html
@@ -1,0 +1,16 @@
+<pre class="docs-method-signature"><code>paper.localToPaperRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in the local coordinate system to the paper coordinate system.
+<pre><code>var bbox = element.getBBox();
+var paperRect1 = paper.localToPaperRect(bbox);
+ // alternative method signature
+var paperRect2 = paper.localToPaperRect(bbox.x, bbox.y, bbox.width, bbox.height);
+// Draw an HTML rectangle above the element.
+var div = document.createElement('div');
+div.style.position = 'absolute';
+div.style.background = 'red';
+div.style.left = paperRect1.x + 'px';
+div.style.top = paperRect1.y + 'px';
+div.style.width = paperRect1.width + 'px';
+div.style.height = paperRect1.height + 'px';
+paper.el.appendChild(div);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/pageOffset.html
+++ b/docs/src/joint/api/dia/Paper/prototype/pageOffset.html
@@ -1,0 +1,3 @@
+<pre class="docs-method-signature"><code>paper.pageOffset()</code></pre>
+<p>Returns coordinates of the paper viewport, relative to the document.
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/pageToLocalPoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/pageToLocalPoint.html
@@ -1,0 +1,11 @@
+<pre class="docs-method-signature"><code>paper.pageToLocalPoint(p)</code></pre>
+<p>Transform the point <code>p</code> defined in the page coordinate system to the local coordinate system.
+    <pre><code>paper.on('blank:pointerup', function(evt) {
+  var pagePoint = g.Point(evt.pageX, evt.pageY);
+  var localPoint1 = this.pageToLocalPoint(pagePoint);
+  // alternative method signature
+  var localPoint2 = this.pageToLocalPoint(evt.pageX, evt.pageY);
+  // Move the element to the point, where the user just clicks.
+  element.position(localPoint1.x, localPoint1.y);
+});</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/pageToLocalRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/pageToLocalRect.html
@@ -1,0 +1,17 @@
+<pre class="docs-method-signature"><code>paper.pageToLocalRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in the page coordinate system to the local coordinate system.
+    <pre><code>var x, y;
+paper.on('blank:pointerdown', function(evt) {
+  x = evt.pageX;
+  y = evt.pageY;
+});
+paper.on('blank:pointerup', function(evt) {
+  var pageRect = g.Rect(x, y, evt.pageX - x, evt.pageY - y).normalize();
+  var localRect1 = this.pageToLocalRect(pageRect);
+  // alternative method signature
+  var localRect2 = this.pageToLocalRect(x, y, evt.pageX - x, evt.pageY - y).normalize();
+  // Move and resize the element to cover the area, that the user just selected.
+  element.position(localRect1.x, localRect1.y);
+  element.resize(localRect1.width, localRect1.height);
+});</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/paperToLocalPoint.html
+++ b/docs/src/joint/api/dia/Paper/prototype/paperToLocalPoint.html
@@ -1,0 +1,10 @@
+<pre class="docs-method-signature"><code>paper.paperToLocalPoint(p)</code></pre>
+<p>Transform the point <code>p</code> defined in the paper coordinate system to the local coordinate system.
+    <pre><code>var paperCenter = g.Point(paper.options.width / 2, paper.options.height / 2);
+var localPoint1 = paper.paperToLocalPoint(paperCenter);
+ // alternative method signature
+var localPoint2 = paper.paperToLocalPoint(paper.options.width / 2, paper.options.height / 2);
+// Move the element to the center of the paper viewport.
+var elSize = element.size();
+element.position(localPoint1.x - elSize.width, localPoint1.y - elSize.height);</code></pre>
+</p>

--- a/docs/src/joint/api/dia/Paper/prototype/paperToLocalRect.html
+++ b/docs/src/joint/api/dia/Paper/prototype/paperToLocalRect.html
@@ -1,0 +1,11 @@
+<pre class="docs-method-signature"><code>paper.paperToLocalRect(rect)</code></pre>
+<p>Transform the rectangle <code>rect</code> defined in the paper coordinate system to the local coordinate system.
+    <pre><code>var paperRect = g.Rect(0, 0, paper.options.width, paper.options.height);
+var localRect1 = paper.paperToLocalRect(paperRect);
+ // alternative method signature
+var localRect2 = paper.paperToLocalRect(0, 0, paper.options.width, paper.options.height);
+// Move and resize the element to cover the entire paper viewport.
+element.position(localRect1.x , localRect1.y);
+element.size(localRect1.width, localRect1.height);
+</code></pre>
+</p>

--- a/src/joint.dia.element.js
+++ b/src/joint.dia.element.js
@@ -954,9 +954,8 @@ joint.dia.ElementView = joint.dia.CellView.extend({
     getBBox: function(opt) {
 
         if (opt && opt.useModelGeometry) {
-            var noTransformationBBox = this.model.getBBox().bbox(this.model.get('angle'));
-            var transformationMatrix = this.paper.matrix();
-            return g.rect(V.transformRect(noTransformationBBox, transformationMatrix));
+            var bbox = this.model.getBBox().bbox(this.model.get('angle'));
+            return this.paper.localToPaperRect(bbox);
         }
 
         return joint.dia.CellView.prototype.getBBox.apply(this, arguments);

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -886,27 +886,39 @@ joint.dia.Paper = joint.mvc.View.extend({
     // Useful when you have a mouse event object and you'd like to get coordinates
     // inside the paper that correspond to `evt.clientX` and `evt.clientY` point.
     // Exmaple: var paperPoint = paper.clientToLocalPoint({ x: evt.clientX, y: evt.clientY });
-    clientToLocalPoint: function(p) {
+    clientToLocalPoint: function(x, y) {
+        // allow `x` to be a point and `y` undefined
+        var clientPoint = g.Point(x, y);
+        var localPoint = V(this.viewport).toLocalPoint(clientPoint.x, clientPoint.y);
+        return g.Point(localPoint);
+    },
 
-        p = g.point(p);
+    localToPaperPoint: function(x, y) {
+        // allow `x` to be a point and `y` undefined
+        var localPoint = g.Point(x, y);
+        var paperPoint = V.transformPoint(localPoint, this.matrix());
+        return g.Point(paperPoint);
+    },
 
-        // This is a hack for Firefox! If there wasn't a fake (non-visible) rectangle covering the
-        // whole SVG area, `$(paper.svg).offset()` used below won't work.
-        var fakeRect = V('rect', { width: this.options.width, height: this.options.height, x: 0, y: 0, opacity: 0 });
-        V(this.svg).prepend(fakeRect);
+    paperToLocalPoint: function(x, y) {
+        // allow `x` to be a point and `y` undefined
+        var paperPoint = g.Point(x, y);
+        var localPoint = V.transformPoint(paperPoint, this.matrix().inverse());
+        return g.Point(localPoint);
+    },
 
-        var paperOffset = $(this.svg).offset();
+    localToScreenPoint: function(x, y) {
+        // allow `x` to be a point and `y` undefined
+        var localPoint = g.Point(x, y);
+        var screenPoint = V.transformPoint(localPoint, this.viewport.getScreenCTM().inverse());
+        return g.Point(screenPoint);
+    },
 
-        // Clean up the fake rectangle once we have the offset of the SVG document.
-        fakeRect.remove();
-
-        var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft || document.documentElement.scrollLeft;
-
-        p.offset(scrollLeft - paperOffset.left, scrollTop - paperOffset.top);
-
-        // Transform point into the viewport coordinate system.
-        return V.transformPoint(p, this.matrix().inverse());
+    screenToLocalPoint: function(x, y) {
+        // allow `x` to be a point and `y` undefined
+        var screenPoint = g.Point(x, y);
+        var localPoint = V.transformPoint(screenPoint, this.viewport.getScreenCTM());
+        return g.Point(localPoint);
     },
 
     linkAllowed: function(linkViewOrModel) {

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -951,6 +951,37 @@ joint.dia.Paper = joint.mvc.View.extend({
         return g.Rect(localRect);
     },
 
+    localToPagePoint: function(x, y) {
+        return this.localToPaperPoint(x, y).offset(this.pageOffset());
+    },
+
+    localToPageRect: function(x, y, width, height) {
+        return this.localToPaperRect(x, y, width, height).moveAndExpand(this.pageOffset());
+    },
+
+    pageToLocalPoint: function(x, y) {
+        var pagePoint = g.Point(x, y);
+        var paperPoint = pagePoint.difference(this.pageOffset());
+        return this.paperToLocalPoint(paperPoint);
+    },
+
+    pageToLocalRect: function(x, y, width, height) {
+        var pageOffset = this.pageOffset();
+        var paperRect = g.Rect(x, y, width, height);
+        paperRect.x -= pageOffset.x;
+        paperRect.y -= pageOffset.y;
+        return this.paperToLocalRect(paperRect);
+    },
+
+    clientOffset: function() {
+        var clientRect = this.svg.getBoundingClientRect();
+        return g.Point(clientRect.left, clientRect.top);
+    },
+
+    pageOffset: function() {
+        return this.clientOffset().offset(window.scrollX, window.scrollY);
+    },
+
     linkAllowed: function(linkViewOrModel) {
 
         var link;

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -884,17 +884,6 @@ joint.dia.Paper = joint.mvc.View.extend({
         return this.clientToLocalPoint(x, y).snapToGrid(this.options.gridSize);
     },
 
-    // Transform client coordinates to the paper local coordinates.
-    // Useful when you have a mouse event object and you'd like to get coordinates
-    // inside the paper that correspond to `evt.clientX` and `evt.clientY` point.
-    // Exmaple: var paperPoint = paper.clientToLocalPoint({ x: evt.clientX, y: evt.clientY });
-    // clientToLocalPoint: function(x, y) {
-    //     // allow `x` to be a point and `y` undefined
-    //     var clientPoint = g.Point(x, y);
-    //     var localPoint = V(this.viewport).toLocalPoint(clientPoint.x, clientPoint.y);
-    //     return g.Point(localPoint);
-    // },
-
     localToPaperPoint: function(x, y) {
         // allow `x` to be a point and `y` undefined
         var localPoint = g.Point(x, y);
@@ -937,6 +926,10 @@ joint.dia.Paper = joint.mvc.View.extend({
         return g.Rect(clientRect);
     },
 
+    // Transform client coordinates to the paper local coordinates.
+    // Useful when you have a mouse event object and you'd like to get coordinates
+    // inside the paper that correspond to `evt.clientX` and `evt.clientY` point.
+    // Example: var localPoint = paper.clientToLocalPoint({ x: evt.clientX, y: evt.clientY });
     clientToLocalPoint: function(x, y) {
         // allow `x` to be a point and `y` undefined
         var clientPoint = g.Point(x, y);


### PR DESCRIPTION
# CHANGELOG
- **dia.Paper** add `paperToLocalPoint()`,  `clientToLocalPoint()`, `pageToLocalPoint()`, `localToPaperPoint()`, `localToPagePoint()` and `localToClientPoint()`.
- **dia.Paper** add `paperToLocalRect()`, `clientToLocalRect()`, `pageToLocalRect()`, `localToPaperRect()`, `localToClientRect()` and `localToPageRect()`
- **dia.Paper** add `clientOffset()` and `pageOffset()`
