### PR TITLE
Override Backbone's _ensureElement and _setElement for an svg element view

### DIFF
--- a/plugins/highlighters/joint.highlighters.stroke.js
+++ b/plugins/highlighters/joint.highlighters.stroke.js
@@ -70,7 +70,6 @@ joint.highlighters.stroke = {
         var highlightView = this._views[magnetEl.id] = new joint.mvc.View({
             svgElement: true,
             className: 'highlight-stroke',
-            // This is necessary because we're passing in a vectorizer element (not jQuery).
             el: highlightVel.node,
         });
 

--- a/plugins/highlighters/joint.highlighters.stroke.js
+++ b/plugins/highlighters/joint.highlighters.stroke.js
@@ -68,10 +68,10 @@ joint.highlighters.stroke = {
 
         // joint.mvc.View will handle the theme class name and joint class name prefix.
         var highlightView = this._views[magnetEl.id] = new joint.mvc.View({
+            svgElement: true,
             className: 'highlight-stroke',
             // This is necessary because we're passing in a vectorizer element (not jQuery).
             el: highlightVel.node,
-            $el: highlightVel
         });
 
         // Remove the highlight view when the cell is removed from the graph.

--- a/src/joint.dia.cell.js
+++ b/src/joint.dia.cell.js
@@ -640,6 +640,8 @@ joint.dia.CellView = joint.mvc.View.extend({
 
     tagName: 'g',
 
+    svgElement: true,
+
     className: function() {
 
         var classNames = ['cell'];
@@ -706,34 +708,6 @@ joint.dia.CellView = joint.mvc.View.extend({
 
         return (_.isObject(interactive) && interactive[feature] !== false) ||
                 (_.isBoolean(interactive) && interactive !== false);
-    },
-
-    // Override the Backbone `_ensureElement()` method in order to create a `<g>` node that wraps
-    // all the nodes of the Cell view.
-    _ensureElement: function() {
-
-        var el;
-
-        if (!this.el) {
-
-            var attrs = _.extend({ id: this.id }, _.result(this, 'attributes'));
-            if (this.className) attrs['class'] = _.result(this, 'className');
-            el = V(_.result(this, 'tagName'), attrs).node;
-
-        } else {
-
-            el = _.result(this, 'el');
-        }
-
-        this.setElement(el, false);
-    },
-
-    // Utilize an alternative DOM manipulation API by
-    // adding an element reference wrapped in Vectorizer.
-    _setElement: function(el) {
-        this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
-        this.el = this.$el[0];
-        this.vel = V(this.el);
     },
 
     findBySelector: function(selector) {

--- a/src/joint.mvc.view.js
+++ b/src/joint.mvc.view.js
@@ -27,6 +27,52 @@ joint.mvc.View = Backbone.View.extend({
         this.init();
     },
 
+    // Override the Backbone `_ensureElement()` method in order to create an
+    // svg element (e.g., `<g>`) node that wraps all the nodes of the Cell view.
+    _ensureElement: function() {
+        var el;
+
+        if (this.svgElement) {
+
+            if (!this.el) {
+
+                var attrs = _.extend({ id: this.id }, _.result(this, 'attributes'));
+                if (this.className) attrs['class'] = _.result(this, 'className');
+                el = V(_.result(this, 'tagName'), attrs).node;
+
+            } else {
+
+                el = _.result(this, 'el');
+            }
+
+            this.setElement(el, false);
+
+        } else {
+
+            Backbone.View.prototype._ensureElement.call(this);
+
+        }
+
+    },
+
+    // Utilize an alternative DOM manipulation API by
+    // adding an element reference wrapped in Vectorizer.
+    _setElement: function(el) {
+
+        if (this.svgElement) {
+
+            this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
+            this.el = this.$el[0];
+            this.vel = V(this.el);
+
+        } else {
+
+            Backbone.View.prototype._setElement.call(this, el);
+
+        }
+
+    },
+
     _ensureElClassName: function() {
 
         var className = _.result(this, 'className');

--- a/test/jointjs/mvc.view.js
+++ b/test/jointjs/mvc.view.js
@@ -64,6 +64,19 @@ test('options', function(assert) {
     assert.deepEqual(view.options, expectedOptions, 'options should be inherited correctly');
 });
 
+test('options for an svg element', function(assert) {
+
+    var svgElementView = joint.mvc.View.extend({
+        tagName: 'g',
+        svgElement: true
+    });
+    var svgEl = new svgElementView();
+
+    assert.ok(svgEl.el, "element is created");
+    assert.equal(svgEl.el.tagName.toLowerCase(), "g", "creates the correct element");
+    assert.ok(svgEl.el instanceof SVGElement, "element is of the type SVGElement");
+});
+
 test('init()', function(assert) {
 
     var called = false;


### PR DESCRIPTION
@kumilingus Please review. I went with the methods on the view itself since they are called just once during initialization.