### PR TITLE
dia.Element.port: add:ports, remove:ports events proposal 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+??-??-???? (v1.1.0)
+ * ports events `ports:add` and `ports:remove` triggered when port is added to element/removed from element
+
 18-11-2016 (v1.0.3)
   * make compatibility changes towards jQuery 3.1
   * shapes.TextBlock - fix `SVGForeignObject` detection

--- a/src/ports.js
+++ b/src/ports.js
@@ -397,7 +397,25 @@
                 throw new Error(err.join(' '));
             }
 
+            var prevPortData;
+
+            if (this._portSettingsData) {
+
+                prevPortData = this._portSettingsData.getPorts();
+            }
+
             this._portSettingsData = new PortData(this.get('ports'));
+
+            var curPortData = this._portSettingsData.getPorts();
+            if (prevPortData && prevPortData.length < curPortData.length) {
+
+                this.trigger('add:ports', this, _.difference(curPortData, prevPortData));
+            }
+
+            if (prevPortData && prevPortData.length > curPortData.length) {
+
+                this.trigger('remove:ports', this, _.difference(prevPortData, curPortData));
+            }
         }
     });
 

--- a/src/ports.js
+++ b/src/ports.js
@@ -409,12 +409,22 @@
             var curPortData = this._portSettingsData.getPorts();
             if (prevPortData && prevPortData.length < curPortData.length) {
 
-                this.trigger('add:ports', this, _.difference(curPortData, prevPortData));
+                // _.filter can be replaced with _.differenceBy in lodash 4
+                this.trigger('ports:add', this, _.filter(curPortData, function(item) {
+                    if (!_.find(prevPortData, 'id', item.id)) {
+                        return item;
+                    }
+                }));
             }
 
             if (prevPortData && prevPortData.length > curPortData.length) {
 
-                this.trigger('remove:ports', this, _.difference(prevPortData, curPortData));
+                // _.filter can be replaced with _.differenceBy in lodash 4
+                this.trigger('ports:remove', this, _.filter(prevPortData, function (item) {
+                    if (!_.find(curPortData, 'id', item.id)) {
+                        return item;
+                    }
+                }));
             }
         }
     });

--- a/src/ports.js
+++ b/src/ports.js
@@ -407,24 +407,29 @@
             this._portSettingsData = new PortData(this.get('ports'));
 
             var curPortData = this._portSettingsData.getPorts();
-            if (prevPortData && prevPortData.length < curPortData.length) {
+
+            if (prevPortData) {
 
                 // _.filter can be replaced with _.differenceBy in lodash 4
-                this.trigger('ports:add', this, _.filter(curPortData, function(item) {
+                var added = _.filter(curPortData, function(item) {
                     if (!_.find(prevPortData, 'id', item.id)) {
                         return item;
                     }
-                }));
-            }
+                });
 
-            if (prevPortData && prevPortData.length > curPortData.length) {
-
-                // _.filter can be replaced with _.differenceBy in lodash 4
-                this.trigger('ports:remove', this, _.filter(prevPortData, function (item) {
+                var removed = _.filter(prevPortData, function(item) {
                     if (!_.find(curPortData, 'id', item.id)) {
                         return item;
                     }
-                }));
+                });
+
+                if (removed.length > 0) {
+                    this.trigger('ports:remove', this, removed);
+                }
+
+                if (added.length > 0) {
+                    this.trigger('ports:add', this, added);
+                }
             }
         }
     });

--- a/test/jointjs/elementPorts.js
+++ b/test/jointjs/elementPorts.js
@@ -448,7 +448,7 @@ QUnit.module('element ports', function() {
             var shape = create(data);
             new joint.dia.ElementView({ model: shape }).render();
 
-            var getPort = function (id) {
+            var getPort = function(id) {
                 return _.find(shape._portSettingsData.ports, function(p) {
                     return p.id === id;
                 });
@@ -486,7 +486,7 @@ QUnit.module('element ports', function() {
             var shape = create(data);
             new joint.dia.ElementView({ model: shape }).render();
 
-            var getPort = function (id) {
+            var getPort = function(id) {
                 return _.find(shape._portSettingsData.ports, function(p) {
                     return p.id === id;
                 });
@@ -640,14 +640,9 @@ QUnit.module('element ports', function() {
 
     QUnit.module('event ports:add and ports:remove', function(hooks) {
 
-        var x = QUnit.config.testTimeout;
-        QUnit.config.testTimeout = 500;
+        QUnit.config.testTimeout = 5000;
 
-        hooks.afterEach(function() {
-            QUnit.config.testTimeout = x;
-        });
-
-        QUnit.test('jbsakfd', function(assert) {
+        QUnit.test('simple add', function(assert) {
 
             var shape = create({ items: [{}] });
 
@@ -663,6 +658,56 @@ QUnit.module('element ports', function() {
             });
 
             shape.addPort({ id: 'a' })
+        });
+
+        QUnit.test('rewrite', function(assert) {
+
+            var shape = create({ items: [{ id: 'a' }] });
+
+            assert.expect(5);
+            assert.equal(shape.getPorts().length, 1);
+
+            var eventAddDone = assert.async();
+            var eventRemoveDone = assert.async();
+
+            shape.on('ports:add', function(cell, ports) {
+                assert.equal(ports.length, 1);
+                assert.equal(ports[0].id, 'b');
+                eventAddDone();
+            });
+
+            shape.on('ports:remove', function(cell, ports) {
+                assert.equal(ports.length, 1);
+                assert.equal(ports[0].id, 'a');
+                eventRemoveDone();
+            });
+
+            shape.prop('ports/items', [{ id: 'b' }], { rewrite: true });
+        });
+
+        QUnit.test('change id', function(assert) {
+
+            var shape = create({ items: [{ id: 'a' }] });
+
+            assert.expect(5);
+            assert.equal(shape.getPorts().length, 1);
+
+            var eventAddDone = assert.async();
+            var eventRemoveDone = assert.async();
+
+            shape.on('ports:add', function(cell, ports) {
+                assert.equal(ports.length, 1);
+                assert.equal(ports[0].id, 'b');
+                eventAddDone();
+            });
+
+            shape.on('ports:remove', function(cell, ports) {
+                assert.equal(ports.length, 1);
+                assert.equal(ports[0].id, 'a');
+                eventRemoveDone();
+            });
+
+            shape.prop('ports/items/0/id', 'b');
         });
 
         QUnit.test('failed to add', function(assert) {


### PR DESCRIPTION
with only `change:ports` event it's hard to detect when ports are added or removed to the element.  

`add:port/remove:port` events provide the `cell` and array of added/removed elements
```
element.on('add:ports', function(cell, addedPorts) {
    console.log("add port(s)", arguments);
});

element.on('remove:ports', function(cell, removecPorts) {
    console.log("remove port(s)", arguments);
});
```