### PR TITLE
Complete typescript definitions for geometry and vectorizer utilities.

### DIFF
--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -11,7 +11,17 @@ export namespace g {
     function toRad(deg: number, over360?: boolean): number;
 
     namespace bezier {
-        // TODO
+	function curveThroughPoints(points: dia.Point[] | Point[]): string[];
+	export function getCurveControlPoints(points: dia.Point[] | Point[]): [Point[], Point[]];
+	interface ICurveDivider {
+	    p0: Point;
+	    p1: Point;
+	    p2: Point;
+	    p3: Point;
+	}
+	export function getCurveDivider(p0: string | dia.Point | Point, p1: string | dia.Point | Point, p2: string | dia.Point | Point, p3: string | dia.Point | Point): (t: number) => [ICurveDivider, ICurveDivider];
+	export function getFirectControlPoints(rhs: number[]): number[];
+	export function getInversionSolver(p0: dia.Point | Point, p1: dia.Point | Point, p2: dia.Point | Point, p3: dia.Point | Point): (p: dia.Point | Point) => number;
     }
 
     class Ellipse {
@@ -28,19 +38,19 @@ export namespace g {
 
         clone(): Ellipse;
 
-        normalizedDistance(point: Point): number;
+        normalizedDistance(point: dia.Point | Point): number;
 
-        inflate(dx: number, dy: number): Ellipse
+        inflate(dx: number, dy: number): this;
 
-        containsPoint(p: Point): boolean;
+        containsPoint(p: dia.Point | Point): boolean;
 
         center(): Point;
 
-        tangentTheta(p: Point): number;
+        tangentTheta(p: dia.Point | Point): number;
 
         equals(ellipse: Ellipse): boolean;
 
-        intersectionWithLineFromCenterToPoint(p: Point, angle: number): Point;
+        intersectionWithLineFromCenterToPoint(p: dia.Point | Point, angle: number): Point;
 
         toString(): string;
     }
@@ -49,7 +59,7 @@ export namespace g {
         start: Point;
         end: Point;
 
-        constructor(p1: Point, p2: Point);
+        constructor(p1: string | dia.Point | Point, p2: string | dia.Point | Point);
 
         bearing(): CardinalDirection;
 
@@ -57,8 +67,8 @@ export namespace g {
 
         equals(line: Line): boolean;
 
-        intersect(line: Line): Point;
-        intersect(rect: Rect): Point[];
+        intersect(line: Line): Point | undefined;
+        intersect(rect: Rect): Point[] | undefined;
 
         length(): number;
 
@@ -66,69 +76,76 @@ export namespace g {
 
         pointAt(t: number): Point;
 
-        pointOffset(p: Point): number;
+        pointOffset(p: dia.Point | Point): number;
 
         squaredLength(): number;
+
+	toString(): string;
     }
 
     class Point {
-        static fromPolar(distance: number, angle: number, origin: Point): Point;
+        static fromPolar(distance: number, angle: number, origin?: string | dia.Point | Point): Point;
 
-        static random(distance, angle, origin): Point;
+        static random(x1: number, x2: number, y1: number, y2: number): Point;
 
         x: number;
         y: number;
 
         constructor(x: number | string | Point, y?: number);
 
-        adhereToRect(r: Rect): Point;
+        adhereToRect(r: Rect): this;
 
         bearing(p: Point): CardinalDirection;
 
-        changeInAngle(dx, dy, ref) //FIXME
+        changeInAngle(dx: number, dy: number, ref: string | dia.Point | Point): number;
         clone(): Point;
 
-        difference(dx: number, dy: number): Point;
+        difference(dx: dia.Point | Point | number, dy?: number): Point;
 
-        distance(p: Point): number;
+        distance(p: string | dia.Point | Point): number;
 
         equals(p: Point): boolean;
 
         magnitude(): number;
 
-        manhattanDistance(): number;
+        manhattanDistance(p: dia.Point | Point): number;
 
-        move(ref, distance): Point;
+        move(ref: string | dia.Point | Point, distance: number): this;
 
-        normalize(length: number): Point;
+        normalize(length: number): this;
 
-        offset(dx: number, dy?: number): Point;
+        offset(dx: number | dia.Point | Point, dy?: number): this;
 
-        reflection(ref: Point): Point;
+        reflection(ref: string | dia.Point | Point): Point;
 
-        rotate(origin: Point, angle: number): Point;
+        rotate(origin: string | dia.Point | Point, angle: number): this;
 
-        round(precision: number): Point;
+        round(precision: number): this;
 
-        scale(sx: number, sy: number, origin: Point): Point;
+        scale(sx: number, sy: number, origin: string | dia.Point | Point): this;
 
-        snapToGrid(gx: number, gy?: number): Point;
+        snapToGrid(gx: number, gy?: number): this;
 
-        theta(p: Point): number;
+        theta(p: string | dia.Point | Point): number;
 
-        toJSON(): any;
+        toJSON(): dia.Point;
 
-        toPolar(origin: Point): Point;
+        toPolar(origin: string | dia.Point | Point): this;
 
         toString(): string;
 
-        update(x: number, y: number): Point;
+        update(x: number, y: number): this;
     }
 
     class Rect {
         static fromEllipse(e: Ellipse): Rect;
 
-        constructor(x, y, w, h);
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+
+        constructor(x?: number | dia.BBox, y?: number, w?: number, h?: number);
 
         bbox(angle: number): Rect;
 
@@ -142,43 +159,43 @@ export namespace g {
 
         clone(): Rect;
 
-        containsPoint(p: Point): boolean;
+        containsPoint(p: string | dia.Point | Point): boolean;
 
-        containsRect(r: Rect): boolean;
+        containsRect(r: dia.BBox | Rect): boolean;
 
         corner(): Point;
 
-        equals(r: Rect): Rect;
+        equals(r: dia.BBox | Rect): boolean;
 
-        intersect(r: Rect): Rect;
+        intersect(r: Rect): Rect | undefined;
 
-        intersectionWithLineFromCenterToPoint(p: Point, angle: number): Point;
+        intersectionWithLineFromCenterToPoint(p: string | dia.Point | Point, angle: number): Point;
 
         leftLine(): Line;
 
         leftMiddle(): Point;
 
-        moveAndExpand(r: Rect): Rect;
+        moveAndExpand(r: dia.BBox | Rect): this;
 
-        inflate(dx: number, dy: number): Rect;
+        inflate(dx?: number, dy?: number): this;
 
-        normalize(): Rect;
+        normalize(): this;
 
         origin(): Point;
 
-        pointNearestToPoint(point: Point): Point;
+        pointNearestToPoint(point: string | dia.Point | Point): Point;
 
         rightLine(): Line;
 
         rightMiddle(): Point;
 
-        round(precision: number): Rect;
+        round(precision: number): this;
 
-        scale(sx: number, sy: number, origin: Point): Rect;
+        scale(sx: number, sy: number, origin?: string | dia.Point | Point): this;
 
-        sideNearestToPoint(point: Point): 'left' | 'right' | 'top' | 'bottom';
+        sideNearestToPoint(point: string | dia.Point | Point): 'left' | 'right' | 'top' | 'bottom';
 
-        snapToGrid(gx: number, gy: number): Rect;
+        snapToGrid(gx: number, gy?: number): this;
 
         topLine(): Line;
 
@@ -186,7 +203,9 @@ export namespace g {
 
         topRight(): Point;
 
-        toJSON(): any;
+        toJSON(): dia.BBox;
+
+	toString(): string;
 
         union(rect: Rect): Rect;
     }
@@ -195,24 +214,14 @@ export namespace g {
         function linear(domain: number[], range: number[], value: number): number;
     }
 
-    interface IPoint {
-        x:number;
-        y:number;
-    }
-
-    interface IBBox extends IPoint{
-        width:number;
-        height:number;
-    }
-
     function ellipse(c: number, a: number, b: number): Ellipse;
 
-    function line(start: IPoint | Point, end: IPoint | Point): Line
+    function line(start: dia.Point | Point, end: dia.Point | Point): Line
 
     function point(x: number, y: number): Point;
     function point(xy: string): Point;
-    function point(point: IPoint): Point;
+    function point(point: dia.Point): Point;
 
-    function rect(x,y,w,h): Rect;
-    function rect(rect:IBBox): Rect;
+    function rect(x: number, y: number, w: number, h: number): Rect;
+    function rect(rect: dia.BBox): Rect;
 }

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1169,7 +1169,7 @@ export namespace layout {
         setLinkVertices?: (link: dia.Link, vertices: Position[]) => void;
     }
 
-    class DirectedGraph {
-        static layout(graph: dia.Graph | dia.Cell[], options?: LayoutOptions): dia.BBox;
+    export namespace DirectedGraph {
+        export function layout(graph: dia.Graph | dia.Cell[], options?: LayoutOptions): dia.BBox;
     }
 }

--- a/types/vectorizer.d.ts
+++ b/types/vectorizer.d.ts
@@ -1,31 +1,249 @@
-export function V(svg: SVGElement | string): Vectorizer;
+export function V(svg: SVGElement | string, attrs?: Object, children?: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]): Vectorizer;
+
+export namespace Vectorizer {
+
+    interface RotateOptions {
+	absolute: boolean;
+    }
+
+    interface Sample {
+	x: number;
+	y: number;
+	distance: number;
+    }
+    interface TextAnnotation {
+	start: number;
+	end: number;
+	attrs: object;
+    }
+    interface TextOptions {
+	lineHeight: number | string;
+	textPath: string | object;
+	annotations: TextAnnotation[];
+	includeAnnotationIndices: boolean;
+    }
+    interface TransformOptions {
+	absolute: boolean;
+    }
+    // modifiable Matrix. SVGMatrix doesn't allow set on properties or a constructor.
+    interface Matrix {
+	a: number;
+	b: number;
+	c: number;
+	d: number;
+	e: number;
+	f: number;
+    }
+    interface DecomposedTransformation {
+	translateX: number;
+	translateY: number;
+	scaleX: number;
+	scaleY: number;
+	skewX: number;
+	skewY: number;
+	rotation: number;
+    }
+    interface Rect extends dia.BBox {
+	'top-rx'?: number;
+	'top-ry'?: number;
+	'bottom-rx'?: number;
+	'bottom-ry'?: number;
+    }
+    interface Rotation {
+	angle: number;
+	cx?: number;
+	cy?: number;
+    }
+    interface Translation {
+	tx: number;
+	ty: number;
+    }
+    interface Scale {
+	sx: number;
+	sy: number;
+    }
+    interface Transform {
+	value: string;
+	translate: Translation;
+	rotate: Rotation;
+	scale: Scale;
+    }
+    interface ParseXMLOptions {
+	async: boolean;
+    }
+    interface QualifiedAttribute {
+	ns?: string;
+	local: string;
+    }
+}
 
 export class Vectorizer {
-    constructor(svg: SVGElement);
+    constructor(svg: string | SVGElement, attrs?: Object, children?: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]);
 
     node: SVGElement;
 
-    append(node: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]): Vectorizer;
+    animateAlongPath(attrs: Object, path: Vectorizer | SVGElement): void;
+
+    append(node: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]): this;
 
     attr(): object;
-    attr(name: string, value: string | number): Vectorizer;
-    attr(attrs: object): Vectorizer;
+    attr(name: string): string | number | object;
+    attr(name: string, value: string | number): this;
+    attr(attrs: object): this;
 
     addClass(className: string): Vectorizer;
 
+    bbox(withoutTransformations?: boolean, target?: SVGElement): dia.BBox;
+
+    before(els: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]): this;
+
     clone(): Vectorizer;
+
+    contains(el: SVGElement): boolean;
+
+    convertToPath(): Vectorizer;
+
+    convertToPathData(): string;
+
+    defs(): Vectorizer | undefined;
+
+    empty(): this;
+
+    find(selector: string): Vectorizer[];
+
+    findIntersection(ref: dia.Point, target: SVGElement | Vectorizer): dia.Point | undefined;
+
+    findOne(selector: string): Vectorizer | undefined;
+
+    findParentByClass(className: string, ternimator: SVGElement): Vectorizer | undefined;
+
+    getTransformToElement(elem: SVGGElement): SVGMatrix;
+
+    hasClass(className: string): boolean;
 
     index(): number;
 
-    removeClass(className: string): Vectorizer;
+    prepend(els: Vectorizer | Vectorizer[] | SVGElement | SVGElement[]): this;
 
-    scale(): { sx: number, sy: number };
-    scale(sx: number, sy?: number): void;
+    remove(): this;
 
+    removeAttr(name: string): this;
+
+    removeClass(className: string): this;
+
+    rotate(): Vectorizer.Rotation;
+
+    rotate(angle: number, cx?: number, cy?: number, opt?: Vectorizer.RotateOptions): this;
+
+    sample(interval: number): Vectorizer.Sample[];
+
+    scale(): Vectorizer.Scale;
+
+    scale(sx: number, sy: number): this;
+
+    setAttribute(name: string, value: string): this;
+
+    setAttributes(attrs: object): this;
+
+    // returns either this or Vectorizer, no point in specifying this.
     svg(): Vectorizer;
 
-    transform(matrix: SVGMatrix, opt: any): Vectorizer
+    text(content: string, opt: Vectorizer.TextOptions): this;
+
+    toggleClass(className: string, switchArg?: boolean): this;
+
+    toLocalPoint(x: number, y: number): dia.Point;
+
     transform(): SVGMatrix;
 
-    translate(tx: number, ty?: number): Vectorizer;
+    transform(matrix: SVGMatrix, opt?: Vectorizer.TransformOptions): this;
+
+    translate(): Vectorizer.Translation;
+
+    translate(tx: number, ty?: number, opt?: Vectorizer.TransformOptions): this;
+
+    translateAndAutoOrient(position: dia.Point, reference: dia.Point, target?: SVGElement): this;
+
+    translateCenterToPoint(p: dia.Point): void;
+
+    static convertCircleToPathData(circle: string | SVGElement): string;
+
+    static convertEllipseToPathData(ellipse: string | SVGElement): string;
+
+    static convertLineToPathData(line: string | SVGElement): string;
+
+    static convertPolylineToPathData(line: string | SVGElement): string;
+
+    static convertPolygonToPathData(line: string | SVGElement): string;
+
+    static convertRectToPathData(rect: string | SVGElement): string;
+
+    static createSlicePathData(innerRadius: number, outRadius: number, startAngle: number, endAngle: number): string;
+
+    static createSVGDocument(content: string): Document;
+
+    static createSVGMatrix(extension: Vectorizer.Matrix): SVGMatrix;
+
+    static createSVGPoint(x: number, y: number): SVGPoint;
+
+    static createSVGTransform(matrix?: Vectorizer.Matrix | SVGMatrix): SVGTransform;
+
+    static decomposeMatrix(matrix: SVGMatrix): Vectorizer.DecomposedTransformation;
+
+    static deltaTransformPoint(matrix: SVGMatrix | Vectorizer.Matrix, point: SVGPoint | dia.Point): dia.Point;
+
+    static ensureId(node: SVGElement): string;
+
+    static findAnnotationsAtIndex(annotations: Vectorizer.TextAnnotation[], start: number, end: number): Vectorizer.TextAnnotation;
+
+    static findAnnotationsBetweenIndexes(annotations: Vectorizer.TextAnnotation[], start: number, end: number): Vectorizer.TextAnnotation;
+
+    static getPointsFromSvgNode(node: SVGElement): SVGPoint[];
+
+    static isArray(value: any): boolean;
+
+    static isObject(value: any): boolean;
+
+    static isString(value: any): boolean;
+
+    static isUndefined(value: any): boolean;
+
+    static isV(value: any): boolean;
+
+    static isVElement(object: any): boolean;
+
+    static matrixToRotate(matrix: SVGMatrix | Vectorizer.Matrix): Vectorizer.Rotation;
+
+    static matrixToScale(matrix: SVGMatrix | Vectorizer.Matrix): Vectorizer.Scale;
+
+    static matrixToTransformString(matrix: SVGMatrix | Vectorizer.Matrix): string;
+
+    static matrixToTranslate(matrix: SVGMatrix | Vectorizer.Matrix): Vectorizer.Translation;
+
+    static mergeAttrs(a: Object, b: Object): Object;
+
+    static parseTransformString(transform: string): Vectorizer.Transform;
+
+    static parseXML(data: string, opt?: Vectorizer.ParseXMLOptions): XMLDocument;
+    static qualifyAttr(name: string): Vectorizer.QualifiedAttribute;
+
+    static rectToPath(r: Vectorizer.Rect): string;
+
+    static sanitizeText(text: string): string;
+
+    static shiftAnnotations(annotations: Vectorizer.TextAnnotation[], index: number, offset: number): Vectorizer.TextAnnotation[];
+
+    static styleToObject(styleString: string): object;
+
+    static svgPointsToPath(points: dia.Point[] | SVGPoint[]): string;
+
+    static toNode(el: Vectorizer | SVGElement | SVGElement[]): SVGElement;
+
+    static transformPoint(p: dia.Point | g.Point, matrix: SVGMatrix): g.Point;
+
+    static transformRect(r: Vectorizer.Rect, matrix: SVGMatrix): g.Rect;
+
+    static transformStringToMatrix(transform: string): SVGMatrix;
+
+    static uniqueId(): string;
 }


### PR DESCRIPTION
I had previously opened this with the DefinitelyTyped library (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15552). Just wanted to finish the type definitions for the geometry and vectorizer library here, since that version is deprecated.

Tested by building with grunt and compiling the build/joint.d.ts file with tsc -v == 2.2.1.