### PR TITLE
Can now run e2e tests in Chrome; broken by some recent version of chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 lib/*/*
 coverage.info
 npm-debug.log
+phantomjsdriver.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -809,10 +809,6 @@ module.exports = function(grunt) {
     grunt.registerTask('install', ['bowerInstall', 'build:all']);
     grunt.registerTask('default', ['install', 'build', 'watch']);
 
-    /*
-        List of Available Platforms on Sauce Labs:
-        https://saucelabs.com/platforms
-    */
     var e2eBrowsers = {
         'chrome': {
             'browserName': 'chrome',
@@ -849,15 +845,11 @@ module.exports = function(grunt) {
         },
         'phantomjs': {
             'browserName': 'phantomjs',
-            'name': 'PhantomJS'
-        },
-        'phantomjs-2.x': {
-            'browserName': 'phantomjs',
-            // Set the path to the PhantomJS 2.x binary.
+            // Set the path to the PhantomJS binary.
             // Can be in different places depending upon the current environment.
             // For example, if phantomjs is on the current user's PATH (with the correct version).
             'phantomjs.binary.path': phantomjs.path,
-            'name': 'PhantomJS 2.x'
+            'name': 'PhantomJS'
         }
     };
 
@@ -922,16 +914,23 @@ module.exports = function(grunt) {
     });
 
     var seleniumInstalled = (function() {
-
         return grunt.file.exists(__dirname + '/node_modules/selenium-standalone/.selenium/selenium-server');
-
     }());
 
     var seleniumChildProcess;
 
+    var seleniumConfig = {
+        drivers: {
+            chrome: {
+                version: 2.29,
+                baseURL: 'https://chromedriver.storage.googleapis.com'
+            }
+        }
+    };
+
     function startSelenium(cb) {
         grunt.log.writeln('Starting selenium..');
-        selenium.start(function(error, child) {
+        selenium.start(seleniumConfig, function(error, child) {
             if (error) return cb(error);
             seleniumChildProcess = child;
             cb();
@@ -947,8 +946,9 @@ module.exports = function(grunt) {
         if (seleniumInstalled) return cb();
         grunt.log.writeln('Installing selenium..');
         seleniumInstalled = true;
-        selenium.install(cb);
+        selenium.install(seleniumConfig, cb);
     }
+
     process.on('exit', function() {
         // Kill selenium server process if it is running.
         if (seleniumChildProcess) seleniumChildProcess.kill();

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "grunt-contrib-qunit": "1.2.0",
     "grunt-contrib-uglify": "2.0.0",
     "grunt-contrib-watch": "1.0.0",
+    "grunt-env": "0.4.4",
     "grunt-eslint": "19.0.0",
     "grunt-mocha-test": "0.12.7",
     "grunt-newer": "1.2.0",


### PR DESCRIPTION
Also fix for specifying browser for e2e tests like `grunt test:e2e:chrome`; was missing grunt-env module.

-------------------------

Run `rm -r node_modules/selenium-standalone && npm install` to re-install selenium-standalone. Then run:
```bash
grunt selenium
```
When selenium is finished installing you can run tests:
```bash
grunt test:e2e:chrome
```