### PR TITLE
Flesh out joint.dia types. Clarify options on methods where I could understand them

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -35,14 +35,18 @@ export namespace dia {
         deep?: boolean;
     }
 
+    interface EdgeMap {
+	[key: string]: boolean;
+    }
+
     class Graph extends Backbone.Model {
-        constructor(attributes?: any, options?: { cellNamespace: any });
+        constructor(attributes?: any, options?: { cellNamespace: any, cellModel: typeof Cell });
 
-        addCell(cell: Cell | Cell[]): this;
+        addCell(cell: Cell | Cell[], opt?: object): this;
 
-        addCells(cells: Cell[]): this;
+        addCells(cells: Cell[], opt: object): this;
 
-        resetCells(cells: Cell[], options?: any): this;
+        resetCells(cells: Cell[], options?: object): this;
 
         getCell(id: string): Cell;
 
@@ -58,9 +62,9 @@ export namespace dia {
 
         getConnectedLinks(element: Cell, options?: { inbound?: boolean, outbound?: boolean, deep?: boolean }): Link[];
 
-        disconnectLinks(cell: Cell, options?: any): void;
+        disconnectLinks(cell: Cell, options?: object): void;
 
-        removeLinks(cell: Cell, options?: any): void;
+        removeLinks(cell: Cell, options?: object): void;
 
         translate(tx: number, ty?: number, options?: TranslateOptions): void;
 
@@ -98,45 +102,42 @@ export namespace dia {
 
         getCommonAncestor(...cells: Cell[]): Element;
 
-        toJSON(): any;
+        toJSON(): object;
 
-        fromJSON(json: any, options?: any): this;
+        fromJSON(json: {cells: Cell[]}, options?: object): this;
 
-        clear(options?: any): this;
+        clear(options?: object): this;
 
-        findModelsFromPoint(rect: BBox): Element[];
+        findModelsFromPoint(p: Point): Element[];
 
         findModelsUnderElement(element: Element, options?: {
-                                   searchBy?: 'bbox'
-                                       | 'center'
-                                       | 'origin'
-                                       | 'corner'
-                                       | 'topRight'
-                                       | 'bottomLeft'
+                                   searchBy?: 'bottomLeft' | 'bottomMiddle' | 'center' |
+                                              'corner' | 'leftMiddle' | 'origin' | 'rightMiddle' |
+                                              'topMiddle' | 'topRight'
                                }): Element[];
 
-        getBBox(elements: Element[], options?: any): BBox;
+        getBBox(elements: Element[], options?: {deep?: boolean}): g.Rect;
 
-        toGraphLib(): any; // graphlib graph object
-        findModelsInArea(rect: BBox, options?: any): BBox | boolean;
+        toGraphLib(): object; // graphlib graph object
+        findModelsInArea(rect: g.Rect | BBox, options?: {strict?: boolean}): BBox | boolean;
 
-        getCellsBBox(cells: Cell[], options?: any): BBox;
+        getCellsBBox(cells: Cell[], options?: {deep?: boolean}): g.Rect;
 
-        getInboundEdges(node: string): Object;
+        getInboundEdges(node: string): EdgeMap;
 
-        getOutboundEdges(node: string): Object;
+        getOutboundEdges(node: string): EdgeMap;
 
         hasActiveBatch(name?: string): number | boolean;
 
         maxZIndex(): number;
 
-        removeCells(cells: Cell[], options?: any): this;
+        removeCells(cells: Cell[], options?: object): this;
 
-        resize(width: number, height: number, options?: number): this;
+        resize(width: number, height: number, options?: object): this;
 
-        resizeCells(width: number, height: number, cells: Cell[], options?: number): this;
+        resizeCells(width: number, height: number, cells: Cell[], options?: object): this;
 
-        set(key: Object | string, value: any, options?: any): this;
+        set(key: object | string, value: any, options?: object): this;
 
         startBatch(name: string, data?: Object): any;
 
@@ -144,9 +145,11 @@ export namespace dia {
     }
 
     class Cell extends Backbone.Model {
+	constructor(attributes?: object, options?: object);
+
         id: string;
 
-        toJSON(): any;
+        toJSON(): object;
 
         remove(options?: { disconnectLinks?: boolean }): this;
 
@@ -158,11 +161,11 @@ export namespace dia {
 
         isEmbeddedIn(element: Element, options?: { deep: boolean }): boolean;
 
-        prop(key: string): any;
-        prop(object: any): this;
-        prop(key: string, value: any, options?: any): this;
+        prop(key: string | string[]): any;
+        prop(object: object): this;
+        prop(key: string | string[], value: any, options?: object): this;
 
-        removeProp(path: string, options?: any): this;
+        removeProp(path: string | string[], options?: object): this;
 
         attr(key: string): any;
         attr(object: SVGAttributes): this;
@@ -171,7 +174,7 @@ export namespace dia {
         clone(): Cell;
         clone(opt: { deep?: boolean }): Cell | Cell[];
 
-        removeAttr(path: string | string[], options?: any): this;
+        removeAttr(path: string | string[], options?: object): this;
 
         transition(path: string, value?: any, options?: TransitionOptions, delim?: string): number;
 
@@ -179,17 +182,17 @@ export namespace dia {
 
         stopTransitions(path?: string, delim?: string): this;
 
-        addTo(graph: Graph, options?: any): this;
+        addTo(graph: Graph, options?: object): this;
 
         isLink(): boolean;
 
-        embed(cell: Cell, options?: any): this;
+        embed(cell: Cell, options?: object): this;
 
         findView(paper: Paper): CellView;
 
-        getEmbeddedCells(options?: any): Cell[];
+        getEmbeddedCells(options?: {deep?: boolean, breadthFirst?: boolean}): Cell[];
 
-        initialize(options?: any): void;
+        initialize(options?: {id?: string}): void;
 
         isElement(): boolean;
 
@@ -197,11 +200,11 @@ export namespace dia {
 
         processPorts(): void;
 
-        startBatch(name: string, options?: any): this;
+        startBatch(name: string, options?: object): this;
 
-        stopBatch(name: string, options?: any): this;
+        stopBatch(name: string, options?: object): this;
 
-        unembed(cell: Cell, options?: any): this;
+        unembed(cell: Cell, options?: object): this;
     }
 
     type Padding = number | {
@@ -211,24 +214,53 @@ export namespace dia {
         left?: number
     };
 
+    type Direction = 'left'
+                    | 'right'
+                    | 'top'
+                    | 'bottom'
+                    | 'top-right'
+                    | 'top-left'
+                    | 'bottom-left'
+                    | 'bottom-right';
+
+    interface Port {
+	id?: string;
+	markup?: string;
+	group?: string;
+	attrs?: object;
+	args?: object;
+	size?: Size;
+	label: {
+            size?: Size;
+	    markup?: string;
+	    position?: any;
+	    args?: any;
+	}
+	z?: number | 'auto';
+    }
+
+    interface PortPosition extends Point {
+	angle: number;
+    }
+
     class Element extends Cell {
+	defaults: {
+	    position: Point;
+	    size: Size;
+	    angle: number;
+	};
+
         translate(tx: number, ty?: number, options?: TranslateOptions): this;
 
-        position(options?: { parentRelative: boolean }): Point;
+        position(options?: { parentRelative: boolean }): g.Point;
         position(x: number, y: number, options?: { parentRelative?: boolean }): this;
 
-        resize(width: number, height: number, options?: {
-                   direction?: 'left'
-                       | 'right'
-                       | 'top'
-                       | 'bottom'
-                       | 'top-right'
-                       | 'top-left'
-                       | 'bottom-left'
-                       | 'bottom-right'
-               }): this;
+	size(): Size;
+	size(width: number, height?: number, options?: { direction?: Direction}): this;
 
-        rotate(deg: number, absolute?: boolean, origin?: Point): this;
+        resize(width: number, height: number, options?: { direction?: Direction }): this;
+
+        rotate(deg: number, absolute?: boolean, origin?: Point, opt: { parentRelative?: boolean }): this;
 
         embed(cell: Cell): this;
 
@@ -238,29 +270,31 @@ export namespace dia {
 
         fitEmbeds(options?: { deep?: boolean, padding?: Padding }): this;
 
-        getBBox(options?: any): BBox;
+        getBBox(options?: { deep?: boolean }): g.Rect;
 
         findView(paper: Paper): ElementView;
 
         isElement(): boolean;
 
-        scale(scaleX: number, scaleY: number, origin?: Point, options?: any): this;
+        scale(scaleX: number, scaleY: number, origin?: Point, options?: { direction?: Direction, parentRelative?: boolean}): this;
 
-        addPort(port: any, opt?: any): this;
+        addPort(port: Port, opt?: object): this;
 
-        addPorts(ports: any[], opt?: any): this;
+        addPorts(ports: Port[], opt?: object): this;
 
-        removePort(port: any, opt?: any): this;
+        removePort(port: string | Port, opt?: object): this;
 
         hasPorts(): boolean;
 
         hasPort(id: string): boolean;
 
-        getPorts(): any[];
+        getPorts(): Port[];
 
-        getPort(id: string): any;
+        getPort(id: string): Port;
 
-        getPortIndex(port: any): number;
+	getPortsPositions(groupName: string): {[id: string]: PortPosition};
+
+        getPortIndex(port: string | Port): number;
 
         portProp(portId: string, path: any, value?: any, opt?: any): joint.dia.Element;
     }
@@ -307,32 +341,34 @@ export namespace dia {
 
         constructor(attributes?: LinkAttributes, options?: Object);
 
+	applyToPoints(fn: (p: Point) => Point, opt?: object): this;
+
         disconnect(): this;
 
         label(index?: number): any;
-        label(index: number, value: Label): this;
+        label(index: number, value: Label, opt?: object): this;
 
-        reparent(options?: any): Element;
+        reparent(options?: object): Element;
 
         findView(paper: Paper): LinkView;
 
-        getSourceElement(): Element;
+        getSourceElement(): undefined | Element | Graph;
 
-        getTargetElement(): Element;
+        getTargetElement(): undefined | Element | Graph;
 
         hasLoop(options?: { deep?: boolean }): boolean;
 
         applyToPoints(fn: Function, options?: any): this;
 
-        getRelationshipAncestor(): Element;
+        getRelationshipAncestor(): undefined | Element;
 
         isLink(): boolean;
 
         isRelationshipEmbeddedIn(element: Element): boolean;
 
-        scale(sx: number, sy: number, origin: Point, optionts?: any): this;
+        scale(sx: number, sy: number, origin: Point | g.Point | string, opt?: object): this;
 
-        translate(tx: number, ty: number, options?: any): this;
+        translate(tx: number, ty: number, options?: object): this;
     }
 
     interface ManhattanRouterArgs {
@@ -342,15 +378,23 @@ export namespace dia {
         endDirections?: ['left' | 'right' | 'top' | 'bottom'];
     }
 
+    interface GridOptions {
+	color?: string;
+	thickness?: number;
+	name?: 'dot' | 'fixedDot' | 'mesh' | 'doubleMesh';
+	args?: object[] | object;
+    }
+
     interface PaperOptions extends Backbone.ViewOptions<Graph> {
         el?: string | JQuery | HTMLElement;
         width?: number | string;
         height?: number | string;
         origin?: Point;
         gridSize?: number;
+	drawGrid?: boolean | GridOptions;
         perpendicularLinks?: boolean;
-        elementView?: (element: Element) => ElementView | ElementView;
-        linkView?: (link: Link) => LinkView | LinkView;
+        elementView?: (element: Element) => typeof ElementView | typeof ElementView;
+        linkView?: (link: Link) => typeof LinkView | typeof LinkView;
         defaultLink?: ((cellView: CellView, magnet: SVGElement) => Link) | Link;
         defaultRouter?: ((vertices: Point[], args: Object, linkView: LinkView) => Point[])
             | { name: string, args?: ManhattanRouterArgs };
@@ -370,14 +414,17 @@ export namespace dia {
         markAvailable?: boolean;
         async?: boolean | { batchZise: number };
         embeddingMode?: boolean;
+	findParentBy?: 'bbox' | 'center' | 'origin' | 'corner' | 'topRight' | 'bottomLeft';
         validateEmbedding?: (childView: ElementView, parentView: ElementView) => boolean;
-        restrictTranslate?: ((elementView: ElementView) => BBox) | boolean;
+        restrictTranslate?: (elementView: ElementView) => BBox | boolean;
         guard?: (evt: Event, view: CellView) => boolean;
         multiLinks?: boolean;
-        cellViewNamespace?: Object;
+        cellViewNamespace?: object;
+	highlighterNamespace?: object;
         /** useful undocumented option */
         clickThreshold?: number;
         highlighting?: any;
+	preventContextMenu?: boolean;
     }
 
     interface ScaleContentOptions {
@@ -404,6 +451,11 @@ export namespace dia {
         maxHeight?: number;
     }
 
+    interface Highlighter {
+	name: string;
+	options?: object;
+    }
+
     class Paper extends Backbone.View<Graph> {
         constructor(options?: PaperOptions);
 
@@ -411,36 +463,19 @@ export namespace dia {
         svg: SVGElement;
         viewport: SVGGElement;
         defs: SVGDefsElement;
-
-        setDimensions(width: number, height: number): void;
-
-        setOrigin(x: number, y: number): void;
-
-        scale(sx: number, sy?: number, ox?: number, oy?: number): this;
-
-        findView(element: any): CellView;
-
-        findViewByModel(model: Cell | string): CellView;
-
-        findViewsFromPoint(point: Point): ElementView[];
-
-        findViewsInArea(rect: BBox, options?: { strict?: boolean }): CellView[];
-
-        fitToContent(options?: FitToContentOptions): void;
-
-        scaleContentToFit(options?: ScaleContentOptions): void;
-
-        getContentBBox(): BBox;
-
-        clientToLocalPoint(p: Point): Point;
-
-        rotate(deg: number, ox?: number, oy?: number): Paper;      // @todo not released yet though it's in the source code already
+	events: {[key: string]: string};
 
         afterRenderViews(): void;
 
-        asyncRenderViews(cells: Cell[], options?: any): void;
+        asyncRenderViews(cells: Cell[], options?: object): void;
 
         beforeRenderViews(cells: Cell[]): Cell[];
+
+        bindDocumentEvents(): void;
+
+	cellMouseEnter(evt: Event): void;
+
+	cellMouseleave(evt: Event): void;
 
         cellMouseout(evt: Event): void;
 
@@ -448,25 +483,78 @@ export namespace dia {
 
         clearGrid(): this;
 
+        clientMatrix(): SVGMatrix;
+
+	clientToLocalPoint(x: number | g.Point, y?: number): g.Point;
+
+	clientToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+
+	clientOffset(): g.Point;
+
+        cloneOptions(): PaperOptions;
+
         contextmenu(evt: Event): void;
 
         createViewForModel(cell: Cell): CellView;
 
-        drawGrid(options?: any): this;
+	defineFilter(filter: object): string;
+
+	defineGradient(gradient: object): string;
+
+	defineMarker(marker: object): string;
+
+	drawBackground(opt?: {color?: string, img?: string}): this;
+
+	drawBackgroundImage(img: HTMLImageElement, opt: object): void;
+
+        drawGrid(options?: {width?: number, height?: number, scaleFactor?: number,
+			    update: any, ox?: number, oy?: number}): this;
+
+        findView(element: string | JQuery | SVGElement): CellView;
+
+        findViewByModel(model: Cell | string): CellView;
+
+        findViewsFromPoint(point: string | Point | g.Point): ElementView[];
+
+        findViewsInArea(rect: g.Rect | BBox, options?: { strict?: boolean }): CellView[];
 
         fitToContent(gridWidth?: number, gridHeight?: number, padding?: number, options?: any): void;
 
-        getArea(): BBox;
+        fitToContent(options?: FitToContentOptions): void;
+
+        getArea(): g.Rect;
+
+        getContentBBox(): g.Rect;
 
         getDefaultLink(cellView: CellView, magnet: HTMLElement): Link;
 
         getModelById(id: string): Cell;
 
-        getRestrictedArea(): BBox;
+        getRestrictedArea(): g.Rect | undefined;
 
         guard(evt: Event, view: CellView): boolean;
 
+        init(): void;
+
+	isDefined(defId: string): boolean;
+
         linkAllowed(linkViewOrModel: LinkView | Link): boolean;
+
+	localToClientPoint(x: number | g.Point, y?: number): g.Point;
+
+	localToClientRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+
+	localToPagePoint(x: number | g.Point, y?: number): g.Point;
+
+	localToPageRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+
+	localToPaperPoint(x: number | g.Point, y?: number): g.Point;
+
+	localToPaperRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+
+        matrix(): SVGMatrix;
+
+        matrix(ctm: SVGMatrix | Vectorizer.Matrix): this;
 
         mouseclick(evt: Event): void;
 
@@ -474,13 +562,23 @@ export namespace dia {
 
         mousewheel(evt: Event): void;
 
-        onCellAdded(cell: Cell, graph: Graph, options: Object): void;
+        onCellAdded(cell: Cell, graph: Graph, options: {async?: boolean, position?: number}): void;
 
-        onCellHighlight(cellView: CellView, magnetEl: HTMLElement, options?: any): void;
+        onCellHighlight(cellView: CellView, magnetEl: HTMLElement, options?: {highlighter?: Highlighter}): void;
 
-        onCellUnhighlight(cellView: CellView, magnetEl: HTMLElement, options?: any): void;
+        onCellUnhighlight(cellView: CellView, magnetEl: HTMLElement, options?: {highlighter?: Highlighter}): void;
 
         onRemove(): void;
+
+	pageOffset(): g.Point;
+
+	pageToLocalPoint(x: number | g.Point, y?: number): g.Point;
+
+	pageToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+
+	paperToLocalPoint(x: number | g.Point, y?: number): g.Point;
+
+	paperToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
         pointerdown(evt: Event): void;
 
@@ -494,19 +592,46 @@ export namespace dia {
 
         removeViews(): void;
 
+        render(): this;
+
         renderView(cell: Cell): CellView;
 
-        resetViews(cellsCollection: Cell[], options: any): void;
+        resetViews(cellsCollection: Cell[], options: object): void;
 
-        resolveHighlighter(options?: any): boolean | Object;
+        resolveHighlighter(opt: {highlighter?: Highlighter}): boolean | {highlighter: Highlighter, options: object, name: string};
+
+	rotate(): Vectorizer.Rotation;
+        rotate(deg: number, ox?: number, oy?: number): this;      // @todo not released yet though it's in the source code already
+
+	scale(): Vectorizer.Scale;
+        scale(sx: number, sy?: number, ox?: number, oy?: number): this;
+
+        scaleContentToFit(options?: ScaleContentOptions): void;
+
+        setDimensions(width: number, height: number): void;
+
+	setGrid(drawGrid: GridOptions | GridOptions[]): this;
 
         setGridSize(gridSize: number): this;
 
         setInteractivity(value: any): void;
 
-        snapToGrid(p: Point): Point;
+        setOrigin(x: number, y: number): this;
+
+        snapToGrid(x: g.Point | number, y?: number): g.Point;
 
         sortViews(): void;
+
+	translate(): Vectorizer.Translation;
+	translate(tx: number, ty?: number): this;
+
+        unbindDocumentEvents(): void;
+
+        update(): void;
+
+	updateBackgroundColor(color: string): void;
+
+	updateBackgroundImage(opt: {position?: any, size?: any}): void;
     }
 
 
@@ -519,36 +644,59 @@ export namespace dia {
         }>;
     }
     class CellViewGeneric<T extends Backbone.Model> extends Backbone.View<T> {
-        getBBox(options?: { useModelGeometry?: boolean }): BBox;
+	constructor(options?: {id: string});
 
-        highlight(el?: any, options?: any): this;
+	initialize(options?: object): void;
 
-        unhighlight(el?: any, options?: any): this;
+	init(): void;
 
-        applyFilter(selector: string | HTMLElement, filter: Object): void;
+        getBBox(options?: { useModelGeometry?: boolean }): g.Rect;
+
+        highlight(el?: any, options?: object): this;
+
+        unhighlight(el?: any, options?: object): this;
+
+	addThemeClassName(theme?: string): this;
+
+        applyFilter(selector: string | HTMLElement, filter: object): void;
 
         applyGradient(selector: string | HTMLElement, attr: 'fill' | 'stroke', gradient: GradientOptions): void;
 
         can(feature: string): boolean;
 
+	className(): string;
+
+	contextmenu(evt: Event, x: number, y: number): void;
+
         findBySelector(selector: string): JQuery;
 
-        findMagnet(el: any): HTMLElement;
+        findMagnet(el: SVGElement | JQuery): undefined | JQuery;
+
+	getEventNamespace(): string;
 
         getSelector(el: HTMLElement, prevSelector: string): string;
 
-        getStrokeBBox(el: any): BBox; // string|HTMLElement|Vectorizer
+        getStrokeBBox(el?: Vectorizer | string | SVGElement): g.Rect;
+
+	mouseenter(evt: Event): void;
+
+	mouseleave(evt: Event): void;
+
         mouseout(evt: Event): void;
 
         mouseover(evt: Event): void;
 
         mousewheel(evt: Event, x: number, y: number, delta: number): void
 
-        notify(eventName: string): void;
+        notify(eventName: string, ...notifyArgs: any[]): void;
 
-        onChangeAttrs(cell: Cell, attrs: Backbone.ViewOptions<T>, options?: any): this;
+        onChangeAttrs(cell: Cell, attrs: Backbone.ViewOptions<T>, options?: {dirty?: boolean}): this;
 
         onSetTheme(oldTheme: string, newTheme: string): void;
+
+	onRemove(): void;
+
+	onRender(): void;
 
         pointerclick(evt: Event, x: number, y: number): void;
 
@@ -562,9 +710,11 @@ export namespace dia {
 
         remove(): this;
 
+	removeThemeClassName(theme?: string): this;
+
         setInteractivity(value: any): void;
 
-        setTheme(theme: string, options?: any): this;
+        setTheme(theme: string, options?: {override?: boolean}): this;
     }
 
     class CellView extends CellViewGeneric<Cell> {
@@ -587,9 +737,13 @@ export namespace dia {
     }
     class ElementView extends CellViewGeneric<Element> {
         scale(sx: number, sy: number): void; // @todo Documented in source but not released
-        finalizeEmbedding(options?: any): void;
+        finalizeEmbedding(options?: {model?: Backbone.Model, paper?: Paper}): void;
 
-        getBBox(options?: any): BBox;
+        getBBox(options?: {useModelGeometry?: boolean}): g.Rect;
+
+	mouseenter(evt: Event): void;
+
+	mouseleave(evt: Event): void;
 
         pointerdown(evt: Event, x: number, y: number): void;
 
@@ -598,21 +752,30 @@ export namespace dia {
         pointerup(evt: Event, x: number, y: number): void;
 
         positionRelative(vel: any, bbox: BBox, attributes: ElementViewAttributes, nodesBySelector?: Object): void; // Vectorizer
-        prepareEmbedding(options?: any): void;
 
-        processEmbedding(options?: any): void;
+        prepareEmbedding(options?: {model?: Backbone.Model, paper?: Paper}): void;
+
+        processEmbedding(options?: {model?: Backbone.Model, paper?: Paper}): void;
 
         render(): this;
 
         renderMarkup(): void;
 
-        resize(): void;
+	resize(): void;
+	// cell and changed are not used in the method, but opt is.
+        resize(cell: any, changed: any, opt: object): void;
 
         rotate(): void;
 
+	translate(): void;
+	// none of these args are used in the function body.
         translate(model: Backbone.Model, changes?: any, options?: any): void;
 
-        update(cell: Cell, renderingOnlyAttrs?: Object): void;
+        update(cell: Cell, renderingOnlyAttrs?: object): void;
+
+	applyPortTransform(element: Vectorizer,
+			   transformData: {dx: number, dy: number, angle: number,
+					   attrs: object, x: number, y: number}, initialAngle: number): void;
     }
 
     class LinkView extends CellViewGeneric<Link> {
@@ -631,27 +794,33 @@ export namespace dia {
 
         addVertex(vertex: Point): number;
 
-        getPointAtLength(length: number): Point; // Marked as public api in source but not in the documents
-        createWatcher(endType: { id: string }): Function;
+        getPointAtLength(length: number): g.Point; // Marked as public api in source but not in the documents
+        createWatcher(endType: { id: string }): (link: Link, end?: {id: string}) => this;
 
         findRoute(oldVertices: Point[]): Point[];
 
         getConnectionPoint(end: 'source' | 'target', selectorOrPoint: Element | Point, referenceSelectorOrPoint: Element
-                               | Point): Point;
+                               | Point): g.Point;
 
-        getPathData(vertices: Point[]): any;
+        getPathData(vertices: Point[]): string;
 
-        onEndModelChange(endType: 'source' | 'target', endModel?: Element, opt?: any): void;
+	mouseenter(evt: Event): void;
+
+	mouseleave(evt: Event): void;
+
+        onEndModelChange(endType: 'source' | 'target', endModel?: Element,
+			 opt?: {cacheOnly?: boolean, handleBy?: string, translateBy?: boolean, tx?: number, ty?: number}): void;
 
         onLabelsChange(): void;
 
-        onSourceChange(cell: Cell, sourceEnd: { id: string }, options: any): void;
+        onSourceChange(cell: Cell, sourceEnd: { id: string }, options: object): void;
 
-        onTargetChange(cell: Cell, targetEnd: { id: string }, options: any): void;
+        onTargetChange(cell: Cell, targetEnd: { id: string }, options: object): void;
 
         onToolsChange(): void;
 
-        onVerticesChange(cell: Cell, changed: any, options: any): void;
+	// changed is not used in function body.
+        onVerticesChange(cell: Cell, changed: any, options: object): void;
 
         pointerdown(evt: Event, x: number, y: number): void;
 
@@ -671,17 +840,17 @@ export namespace dia {
 
         renderVertexMarkers(): this;
 
-        startArrowheadMove(end: 'source' | 'target', options?: any): void;
+        startArrowheadMove(end: 'source' | 'target', options?: { whenNotAllowed: 'remove' | 'revert' }): void;
 
         startListening(): void;
 
-        update(model: any, attributes: any, options?: any): this;
+        update(model: Cell, attributes: object, options?: object): this;
 
         updateArrowheadMarkers(): this;
 
         updateAttributes(): void;
 
-        updateConnection(options?: any): void;
+        updateConnection(options?: {translateBy?: any, tx?: number, ty?: number}): void;
 
         updateLabelPositions(): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -244,11 +244,7 @@ export namespace dia {
     }
 
     class Element extends Cell {
-	defaults: {
-	    position: Point;
-	    size: Size;
-	    angle: number;
-	};
+	constructor(attributes?: object, options?: object);
 
         translate(tx: number, ty?: number, options?: TranslateOptions): this;
 
@@ -260,7 +256,7 @@ export namespace dia {
 
         resize(width: number, height: number, options?: { direction?: Direction }): this;
 
-        rotate(deg: number, absolute?: boolean, origin?: Point, opt: { parentRelative?: boolean }): this;
+        rotate(deg: number, absolute?: boolean, origin?: Point, opt?: { parentRelative?: boolean }): this;
 
         embed(cell: Cell): this;
 
@@ -271,8 +267,6 @@ export namespace dia {
         fitEmbeds(options?: { deep?: boolean, padding?: Padding }): this;
 
         getBBox(options?: { deep?: boolean }): g.Rect;
-
-        findView(paper: Paper): ElementView;
 
         isElement(): boolean;
 
@@ -349,8 +343,6 @@ export namespace dia {
         label(index: number, value: Label, opt?: object): this;
 
         reparent(options?: object): Element;
-
-        findView(paper: Paper): LinkView;
 
         getSourceElement(): undefined | Element | Graph;
 
@@ -463,7 +455,6 @@ export namespace dia {
         svg: SVGElement;
         viewport: SVGGElement;
         defs: SVGDefsElement;
-	events: {[key: string]: string};
 
         afterRenderViews(): void;
 
@@ -664,8 +655,6 @@ export namespace dia {
 
         can(feature: string): boolean;
 
-	className(): string;
-
 	contextmenu(evt: Event, x: number, y: number): void;
 
         findBySelector(selector: string): JQuery;
@@ -757,8 +746,6 @@ export namespace dia {
 
         processEmbedding(options?: {model?: Backbone.Model, paper?: Paper}): void;
 
-        render(): this;
-
         renderMarkup(): void;
 
 	resize(): void;
@@ -829,8 +816,6 @@ export namespace dia {
         pointerup(evt: Event, x: number, y: number): void;
 
         removeVertex(idx: number): this;
-
-        render(): this;
 
         renderArrowheadMarkers(): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -36,7 +36,7 @@ export namespace dia {
     }
 
     interface EdgeMap {
-	[key: string]: boolean;
+        [key: string]: boolean;
     }
 
     class Graph extends Backbone.Model {
@@ -145,7 +145,7 @@ export namespace dia {
     }
 
     class Cell extends Backbone.Model {
-	constructor(attributes?: object, options?: object);
+        constructor(attributes?: object, options?: object);
 
         id: string;
 
@@ -224,35 +224,35 @@ export namespace dia {
                     | 'bottom-right';
 
     interface Port {
-	id?: string;
-	markup?: string;
-	group?: string;
-	attrs?: object;
-	args?: object;
-	size?: Size;
-	label: {
+        id?: string;
+        markup?: string;
+        group?: string;
+        attrs?: object;
+        args?: object;
+        size?: Size;
+        label: {
             size?: Size;
-	    markup?: string;
-	    position?: any;
-	    args?: any;
-	}
-	z?: number | 'auto';
+            markup?: string;
+            position?: any;
+            args?: any;
+        }
+        z?: number | 'auto';
     }
 
     interface PortPosition extends Point {
-	angle: number;
+        angle: number;
     }
 
     class Element extends Cell {
-	constructor(attributes?: object, options?: object);
+        constructor(attributes?: object, options?: object);
 
         translate(tx: number, ty?: number, options?: TranslateOptions): this;
 
         position(options?: { parentRelative: boolean }): g.Point;
         position(x: number, y: number, options?: { parentRelative?: boolean }): this;
 
-	size(): Size;
-	size(width: number, height?: number, options?: { direction?: Direction}): this;
+        size(): Size;
+        size(width: number, height?: number, options?: { direction?: Direction}): this;
 
         resize(width: number, height: number, options?: { direction?: Direction }): this;
 
@@ -286,7 +286,7 @@ export namespace dia {
 
         getPort(id: string): Port;
 
-	getPortsPositions(groupName: string): {[id: string]: PortPosition};
+        getPortsPositions(groupName: string): {[id: string]: PortPosition};
 
         getPortIndex(port: string | Port): number;
 
@@ -335,7 +335,7 @@ export namespace dia {
 
         constructor(attributes?: LinkAttributes, options?: Object);
 
-	applyToPoints(fn: (p: Point) => Point, opt?: object): this;
+        applyToPoints(fn: (p: Point) => Point, opt?: object): this;
 
         disconnect(): this;
 
@@ -371,10 +371,10 @@ export namespace dia {
     }
 
     interface GridOptions {
-	color?: string;
-	thickness?: number;
-	name?: 'dot' | 'fixedDot' | 'mesh' | 'doubleMesh';
-	args?: object[] | object;
+        color?: string;
+        thickness?: number;
+        name?: 'dot' | 'fixedDot' | 'mesh' | 'doubleMesh';
+        args?: object[] | object;
     }
 
     interface PaperOptions extends Backbone.ViewOptions<Graph> {
@@ -383,7 +383,7 @@ export namespace dia {
         height?: number | string;
         origin?: Point;
         gridSize?: number;
-	drawGrid?: boolean | GridOptions;
+        drawGrid?: boolean | GridOptions;
         perpendicularLinks?: boolean;
         elementView?: (element: Element) => typeof ElementView | typeof ElementView;
         linkView?: (link: Link) => typeof LinkView | typeof LinkView;
@@ -406,17 +406,17 @@ export namespace dia {
         markAvailable?: boolean;
         async?: boolean | { batchZise: number };
         embeddingMode?: boolean;
-	findParentBy?: 'bbox' | 'center' | 'origin' | 'corner' | 'topRight' | 'bottomLeft';
+        findParentBy?: 'bbox' | 'center' | 'origin' | 'corner' | 'topRight' | 'bottomLeft';
         validateEmbedding?: (childView: ElementView, parentView: ElementView) => boolean;
         restrictTranslate?: (elementView: ElementView) => BBox | boolean;
         guard?: (evt: Event, view: CellView) => boolean;
         multiLinks?: boolean;
         cellViewNamespace?: object;
-	highlighterNamespace?: object;
+        highlighterNamespace?: object;
         /** useful undocumented option */
         clickThreshold?: number;
         highlighting?: any;
-	preventContextMenu?: boolean;
+        preventContextMenu?: boolean;
     }
 
     interface ScaleContentOptions {
@@ -444,8 +444,8 @@ export namespace dia {
     }
 
     interface Highlighter {
-	name: string;
-	options?: object;
+        name: string;
+        options?: object;
     }
 
     class Paper extends Backbone.View<Graph> {
@@ -464,9 +464,9 @@ export namespace dia {
 
         bindDocumentEvents(): void;
 
-	cellMouseEnter(evt: Event): void;
+        cellMouseEnter(evt: Event): void;
 
-	cellMouseleave(evt: Event): void;
+        cellMouseleave(evt: Event): void;
 
         cellMouseout(evt: Event): void;
 
@@ -476,11 +476,11 @@ export namespace dia {
 
         clientMatrix(): SVGMatrix;
 
-	clientToLocalPoint(x: number | g.Point, y?: number): g.Point;
+        clientToLocalPoint(x: number | g.Point, y?: number): g.Point;
 
-	clientToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        clientToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
-	clientOffset(): g.Point;
+        clientOffset(): g.Point;
 
         cloneOptions(): PaperOptions;
 
@@ -488,18 +488,18 @@ export namespace dia {
 
         createViewForModel(cell: Cell): CellView;
 
-	defineFilter(filter: object): string;
+        defineFilter(filter: object): string;
 
-	defineGradient(gradient: object): string;
+        defineGradient(gradient: object): string;
 
-	defineMarker(marker: object): string;
+        defineMarker(marker: object): string;
 
-	drawBackground(opt?: {color?: string, img?: string}): this;
+        drawBackground(opt?: {color?: string, img?: string}): this;
 
-	drawBackgroundImage(img: HTMLImageElement, opt: object): void;
+        drawBackgroundImage(img: HTMLImageElement, opt: object): void;
 
         drawGrid(options?: {width?: number, height?: number, scaleFactor?: number,
-			    update: any, ox?: number, oy?: number}): this;
+                            update: any, ox?: number, oy?: number}): this;
 
         findView(element: string | JQuery | SVGElement): CellView;
 
@@ -527,21 +527,21 @@ export namespace dia {
 
         init(): void;
 
-	isDefined(defId: string): boolean;
+        isDefined(defId: string): boolean;
 
         linkAllowed(linkViewOrModel: LinkView | Link): boolean;
 
-	localToClientPoint(x: number | g.Point, y?: number): g.Point;
+        localToClientPoint(x: number | g.Point, y?: number): g.Point;
 
-	localToClientRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        localToClientRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
-	localToPagePoint(x: number | g.Point, y?: number): g.Point;
+        localToPagePoint(x: number | g.Point, y?: number): g.Point;
 
-	localToPageRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        localToPageRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
-	localToPaperPoint(x: number | g.Point, y?: number): g.Point;
+        localToPaperPoint(x: number | g.Point, y?: number): g.Point;
 
-	localToPaperRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        localToPaperRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
         matrix(): SVGMatrix;
 
@@ -561,15 +561,15 @@ export namespace dia {
 
         onRemove(): void;
 
-	pageOffset(): g.Point;
+        pageOffset(): g.Point;
 
-	pageToLocalPoint(x: number | g.Point, y?: number): g.Point;
+        pageToLocalPoint(x: number | g.Point, y?: number): g.Point;
 
-	pageToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        pageToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
-	paperToLocalPoint(x: number | g.Point, y?: number): g.Point;
+        paperToLocalPoint(x: number | g.Point, y?: number): g.Point;
 
-	paperToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
+        paperToLocalRect(x: number | g.Rect, y?: number, width?: number, height?: number): g.Rect;
 
         pointerdown(evt: Event): void;
 
@@ -591,17 +591,17 @@ export namespace dia {
 
         resolveHighlighter(opt: {highlighter?: Highlighter}): boolean | {highlighter: Highlighter, options: object, name: string};
 
-	rotate(): Vectorizer.Rotation;
+        rotate(): Vectorizer.Rotation;
         rotate(deg: number, ox?: number, oy?: number): this;      // @todo not released yet though it's in the source code already
 
-	scale(): Vectorizer.Scale;
+        scale(): Vectorizer.Scale;
         scale(sx: number, sy?: number, ox?: number, oy?: number): this;
 
         scaleContentToFit(options?: ScaleContentOptions): void;
 
         setDimensions(width: number, height: number): void;
 
-	setGrid(drawGrid: GridOptions | GridOptions[]): this;
+        setGrid(drawGrid: GridOptions | GridOptions[]): this;
 
         setGridSize(gridSize: number): this;
 
@@ -613,16 +613,16 @@ export namespace dia {
 
         sortViews(): void;
 
-	translate(): Vectorizer.Translation;
-	translate(tx: number, ty?: number): this;
+        translate(): Vectorizer.Translation;
+        translate(tx: number, ty?: number): this;
 
         unbindDocumentEvents(): void;
 
         update(): void;
 
-	updateBackgroundColor(color: string): void;
+        updateBackgroundColor(color: string): void;
 
-	updateBackgroundImage(opt: {position?: any, size?: any}): void;
+        updateBackgroundImage(opt: {position?: any, size?: any}): void;
     }
 
 
@@ -635,11 +635,11 @@ export namespace dia {
         }>;
     }
     class CellViewGeneric<T extends Backbone.Model> extends Backbone.View<T> {
-	constructor(options?: {id: string});
+        constructor(options?: {id: string});
 
-	initialize(options?: object): void;
+        initialize(options?: object): void;
 
-	init(): void;
+        init(): void;
 
         getBBox(options?: { useModelGeometry?: boolean }): g.Rect;
 
@@ -647,7 +647,7 @@ export namespace dia {
 
         unhighlight(el?: any, options?: object): this;
 
-	addThemeClassName(theme?: string): this;
+        addThemeClassName(theme?: string): this;
 
         applyFilter(selector: string | HTMLElement, filter: object): void;
 
@@ -655,21 +655,21 @@ export namespace dia {
 
         can(feature: string): boolean;
 
-	contextmenu(evt: Event, x: number, y: number): void;
+        contextmenu(evt: Event, x: number, y: number): void;
 
         findBySelector(selector: string): JQuery;
 
         findMagnet(el: SVGElement | JQuery): undefined | JQuery;
 
-	getEventNamespace(): string;
+        getEventNamespace(): string;
 
         getSelector(el: HTMLElement, prevSelector: string): string;
 
         getStrokeBBox(el?: Vectorizer | string | SVGElement): g.Rect;
 
-	mouseenter(evt: Event): void;
+        mouseenter(evt: Event): void;
 
-	mouseleave(evt: Event): void;
+        mouseleave(evt: Event): void;
 
         mouseout(evt: Event): void;
 
@@ -683,9 +683,9 @@ export namespace dia {
 
         onSetTheme(oldTheme: string, newTheme: string): void;
 
-	onRemove(): void;
+        onRemove(): void;
 
-	onRender(): void;
+        onRender(): void;
 
         pointerclick(evt: Event, x: number, y: number): void;
 
@@ -699,7 +699,7 @@ export namespace dia {
 
         remove(): this;
 
-	removeThemeClassName(theme?: string): this;
+        removeThemeClassName(theme?: string): this;
 
         setInteractivity(value: any): void;
 
@@ -730,9 +730,9 @@ export namespace dia {
 
         getBBox(options?: {useModelGeometry?: boolean}): g.Rect;
 
-	mouseenter(evt: Event): void;
+        mouseenter(evt: Event): void;
 
-	mouseleave(evt: Event): void;
+        mouseleave(evt: Event): void;
 
         pointerdown(evt: Event, x: number, y: number): void;
 
@@ -748,21 +748,21 @@ export namespace dia {
 
         renderMarkup(): void;
 
-	resize(): void;
-	// cell and changed are not used in the method, but opt is.
+        resize(): void;
+        // cell and changed are not used in the method, but opt is.
         resize(cell: any, changed: any, opt: object): void;
 
         rotate(): void;
 
-	translate(): void;
-	// none of these args are used in the function body.
+        translate(): void;
+        // none of these args are used in the function body.
         translate(model: Backbone.Model, changes?: any, options?: any): void;
 
         update(cell: Cell, renderingOnlyAttrs?: object): void;
 
-	applyPortTransform(element: Vectorizer,
-			   transformData: {dx: number, dy: number, angle: number,
-					   attrs: object, x: number, y: number}, initialAngle: number): void;
+        applyPortTransform(element: Vectorizer,
+                           transformData: {dx: number, dy: number, angle: number,
+                                           attrs: object, x: number, y: number}, initialAngle: number): void;
     }
 
     class LinkView extends CellViewGeneric<Link> {
@@ -791,12 +791,12 @@ export namespace dia {
 
         getPathData(vertices: Point[]): string;
 
-	mouseenter(evt: Event): void;
+        mouseenter(evt: Event): void;
 
-	mouseleave(evt: Event): void;
+        mouseleave(evt: Event): void;
 
         onEndModelChange(endType: 'source' | 'target', endModel?: Element,
-			 opt?: {cacheOnly?: boolean, handleBy?: string, translateBy?: boolean, tx?: number, ty?: number}): void;
+                         opt?: {cacheOnly?: boolean, handleBy?: string, translateBy?: boolean, tx?: number, ty?: number}): void;
 
         onLabelsChange(): void;
 
@@ -806,7 +806,7 @@ export namespace dia {
 
         onToolsChange(): void;
 
-	// changed is not used in function body.
+        // changed is not used in function body.
         onVerticesChange(cell: Cell, changed: any, options: object): void;
 
         pointerdown(evt: Event, x: number, y: number): void;


### PR DESCRIPTION
This adds some missing method definitions on the Cell, CellView, Element, ElementView, Link, LinkView, Graph, and Paper classes.

I've tried to clarify some of the options types that are passed into most method. I've switched uses of any over to object, since many of those uses were actually expecting an object type, not a number or string. Tested by building with grunt and compiling with tsc == 2.2.0