### PR TITLE
Fix typescript --noImplicitAny errors

### DIFF
--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -44,7 +44,7 @@ export namespace g {
         a: number;
         b: number;
 
-        constructor(c, a, b);
+        constructor(center: Ellipse | Point, a: number, b: number);
 
         bbox(): Rect;
 
@@ -158,7 +158,7 @@ export namespace g {
         width: number;
         height: number;
 
-        constructor(x?: number | dia.BBox, y?: number, w?: number, h?: number);
+        constructor(x?: number | dia.BBox, y?: number, width?: number, height?: number);
 
         bbox(angle: number): Rect;
 
@@ -235,6 +235,6 @@ export namespace g {
     function point(xy: string): Point;
     function point(point: dia.Point): Point;
 
-    function rect(x: number, y: number, w: number, h: number): Rect;
+    function rect(x: number, y: number, width: number, height: number): Rect;
     function rect(rect: dia.BBox): Rect;
 }


### PR DESCRIPTION
I've fixed the last implicit any errors in the `geometry.d.ts` file and updated the complete `joint.d.ts` file in the dist folder.

This pr closes #575