### PR TITLE
dia.Cell: stop merging arrays attributes inside of the constructor

### DIFF
--- a/src/joint.dia.cell.js
+++ b/src/joint.dia.cell.js
@@ -16,8 +16,13 @@ joint.dia.Cell = Backbone.Model.extend({
         if (options && options.parse) attrs = this.parse(attrs, options) || {};
         if ((defaults = joint.util.result(this, 'defaults'))) {
             //<custom code>
-            // Replaced the call to _.defaults with joint.util.merge.
-            attrs = joint.util.merge({}, defaults, attrs);
+            // Replaced the call to _.defaults with _.merge.
+            attrs = joint.util.merge({}, defaults, attrs, function(objectValue, sourceValue) {
+                // Do not merge arrays
+                if (Array.isArray(objectValue)) {
+                    return sourceValue;
+                }
+            });
             //</custom code>
         }
         this.set(attrs, options);


### PR DESCRIPTION
```javascript
var MyCell = joint.dia.Cell.extend({ attribute: ['value'] });
var myCell = new MyCell({ attribute: [] });
// Previously
console.log(myCell.get('attribute')) // output `['value']`
// After this change
console.log(myCell.get('attribute')) // output `[]`
```
* [ ] make it optional to easily maintain backwards compatibility
* [ ] define the customizer function on prototype/constructor to avoid function creation when constructing a cell