### PR TITLE
highlighters.Stroke: fix for magnets inside scalable group and with z…

### DIFF
--- a/plugins/highlighters/joint.highlighters.stroke.js
+++ b/plugins/highlighters/joint.highlighters.stroke.js
@@ -60,19 +60,25 @@ joint.highlighters.stroke = {
             'fill': 'none'
         }).attr(options.attrs);
 
-        highlightVel.transform(cellView.el.getCTM().inverse());
-        highlightVel.transform(magnetEl.getCTM());
+        var highlightMatrix = magnetVel.getTransformToElement(cellView.el);
 
+        // Add padding to the highlight element.
         var padding = options.padding;
         if (padding) {
 
             magnetBBox || (magnetBBox = magnetVel.bbox(true));
-            // Add padding to the highlight element.
+
             var cx = magnetBBox.x + (magnetBBox.width / 2);
             var cy = magnetBBox.y + (magnetBBox.height / 2);
-            var sx = (magnetBBox.width + padding) / magnetBBox.width;
-            var sy = (magnetBBox.height + padding) / magnetBBox.height;
-            highlightVel.transform({
+
+            magnetBBox = V.transformRect(magnetBBox, highlightMatrix);
+
+            var width = Math.max(magnetBBox.width, 1);
+            var height = Math.max(magnetBBox.height, 1);
+            var sx = (width + padding) / width;
+            var sy = (height + padding) / height;
+
+            var paddingMatrix = V.createSVGMatrix({
                 a: sx,
                 b: 0,
                 c: 0,
@@ -80,7 +86,11 @@ joint.highlighters.stroke = {
                 e: cx - sx * cx,
                 f: cy - sy * cy
             });
+
+            highlightMatrix = highlightMatrix.multiply(paddingMatrix);
         }
+
+        highlightVel.transform(highlightMatrix);
 
         // joint.mvc.View will handle the theme class name and joint class name prefix.
         var highlightView = this._views[id] = new joint.mvc.View({


### PR DESCRIPTION
…ero width or height

Test cases: `stroke` highlight with padding.
```
// inside scalable group
new joint.shapes.basic.Rect({ attrs: { rect: { width: 1, height: 1, magnet: true  }}}).size(100,100);
// zero or low dimension
new joint.shapes.basic.Path({ attrs: { path: { d: 'M 0 0 100 0', magnet: true  }}}).size(100,100);
new joint.shapes.basic.Path({ attrs: { path: { d: 'M 0 0 100 1', magnet: true  }}}).size(100,100);
```