### PR TITLE
Fixes the allows label options in the TypeScript definitions.  

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -318,10 +318,16 @@ export namespace dia {
         };
     }
 
+    interface LabelPosition {
+      distance: number;
+      offset: number | { x: number; y: number; }
+    }
+
     interface Label {
-        position: number;
+        position: LabelPosition | number;
         attrs?: TextAttrs;
     }
+
     interface LinkAttributes extends CellAttributes {
         source?: Point | { id: string, selector?: string, port?: string };
         target?: Point | { id: string, selector?: string, port?: string };


### PR DESCRIPTION
This is now in line with the documentation described here: https://resources.jointjs.com/docs/jointjs/v1.1/joint.html#dia.Link.prototype.label

While the example only shows a `number` for position, it can actually be an object with distance and offset.