### PR TITLE
fix paper.findViewByModel()

### DIFF
--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -855,7 +855,7 @@ joint.dia.Paper = joint.mvc.View.extend({
     // Find a view for a model `cell`. `cell` can also be a string or number representing a model `id`.
     findViewByModel: function(cell) {
 
-        var id = joint.util.isObject(cell) ? cell.id : cell;
+        var id = (joint.util.isString(cell) || joint.util.isNumber(cell)) ? cell : cell.id;
 
         return this._views[id];
     },

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -855,7 +855,7 @@ joint.dia.Paper = joint.mvc.View.extend({
     // Find a view for a model `cell`. `cell` can also be a string or number representing a model `id`.
     findViewByModel: function(cell) {
 
-        var id = (joint.util.isString(cell) || joint.util.isNumber(cell)) ? cell : cell.id;
+        var id = (joint.util.isString(cell) || joint.util.isNumber(cell)) ? cell : (cell && cell.id);
 
         return this._views[id];
     },

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -852,10 +852,10 @@ joint.dia.Paper = joint.mvc.View.extend({
         return undefined;
     },
 
-    // Find a view for a model `cell`. `cell` can also be a string representing a model `id`.
+    // Find a view for a model `cell`. `cell` can also be a string or number representing a model `id`.
     findViewByModel: function(cell) {
 
-        var id = joint.util.isString(cell) ? cell : cell.id;
+        var id = joint.util.isObject(cell) ? cell.id : cell;
 
         return this._views[id];
     },


### PR DESCRIPTION
# Issue
https://github.com/clientIO/joint/issues/677

# Summary
- When typeof cell is number, then error occurs... So I changed `paper.findViewByModel()`.
- I also make `paper.findViewByModel()` not throwing an exception when called with a falsy value.
~~- (We can use boolean values as a side effect... Shoud we check it?)~~

Please review this p-r :)