### PR TITLE
Updates typescript dependency to the latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "should": "11.0.0",
     "sinon": "1.17.5",
     "time-grunt": "1.4.0",
-    "typescript": "2.1.6",
+    "typescript": "2.5.3",
     "webdriverio": "4.0.8",
     "webpack": "2.6.1",
     "webpack-dev-server": "2.4.0"


### PR DESCRIPTION
So that things like 'object' are syntactically valid. They did not exists in 2.1.6.