### PR TITLE
TS: define, update ts demo 

### DIFF
--- a/demo/ts-demo/custom.ts
+++ b/demo/ts-demo/custom.ts
@@ -1,0 +1,45 @@
+import * as joint from '../../build/joint';
+
+// extend joint.shapes namespace
+declare module '../../build/joint' {
+    namespace shapes {
+        namespace app {
+            class CustomRect extends joint.shapes.basic.Rect {
+                test(): void;
+
+                static staticTest(): void;
+            }
+
+            class Link extends joint.dia.Link {
+            }
+        }
+    }
+}
+
+joint.shapes.basic.Rect.define('app.Link', {
+    attrs: {
+        '.connection': {
+            stroke: '#222138',
+            strokeDasharray: '0',
+            strokeWidth: 1,
+            fill: 'none'
+        }
+    }
+});
+
+joint.shapes.basic.Rect.define('app.CustomRect', {
+    attrs: {
+        rect: {
+            fill: 'red'
+        }
+    }
+}, {
+    test: function () {
+        console.log("test");
+    }
+}, {
+    staticTest: function () {
+        console.log('staticTest');
+    }
+});
+

--- a/demo/ts-demo/index.ts
+++ b/demo/ts-demo/index.ts
@@ -1,17 +1,18 @@
 import * as joint from "../../build/joint";
+import './custom';
 import {V, g} from "../../build/joint";
 import * as $ from "jquery";
 
-const body = $('body');
+const $body = $('body');
 const svg = joint.V('svg');
-const rect = V('rect').attr({fill: 'red', width: 80, height: 50});
-const ellipse = V('ellipse').attr({fill: 'green', rx: 100, ry: 50, cx: 200, cy: 80, x: 20, y: 30});
+const svgRect = V('rect').attr({fill: 'red', width: 80, height: 50});
+const svgEllipse = V('ellipse').attr({fill: 'green', rx: 100, ry: 50, cx: 200, cy: 80, x: 20, y: 30});
 
-svg.append(rect);
-svg.append(ellipse.node);
+svg.append(svgRect);
+svg.append(svgEllipse.node);
 
-body.append($('<h3/>').text('Example SVG created by Vectorizer'));
-body.append(svg.node);
+$body.append($('<h3/>').text('Example SVG created by Vectorizer'));
+$body.append(svg.node);
 
 const graph = new joint.dia.Graph;
 const paper = new joint.dia.Paper({
@@ -21,13 +22,35 @@ const paper = new joint.dia.Paper({
     gridSize: 20,
     model: graph,
     markAvailable: true,
-    linkConnectionPoint: joint.util.shapePerimeterConnectionPoint
+    defaultLink: new joint.shapes.app.Link()
 });
 
-const a = new joint.shapes.basic.Rect({
-    position: {x: 50, y: 50},
-    size: {width: 100, height: 40},
-    attrs: {text: {text: 'basic.Rect'}}
+let rect = new joint.shapes.basic.Rect()
+    .position(10, 10)
+    .size(100, 100)
+    .addTo(graph)
+
+
+// declare a new shape using the `define`
+var Circle = joint.shapes.basic.Circle.define('CustomCircle', {
+    attrs: {
+        circle: {fill: 'purple'}
+    }
 });
-graph.addCell(a);
+
+let circle = new Circle()
+    .position(150, 50)
+    .size(50, 50)
+    .addTo(graph);
+
+// create the CustomRect - it's defined in the custom.ts
+let customRect = new joint.shapes.app.CustomRect()
+    .position(50, 50)
+    .size(100, 100)
+    .addTo(graph);
+
+
+customRect.test();
+joint.shapes.app.CustomRect.staticTest()
+
 

--- a/demo/ts-demo/package.json
+++ b/demo/ts-demo/package.json
@@ -3,8 +3,8 @@
         "start": "webpack"
     },
     "devDependencies": {
-        "ts-loader": "2.0.3",
-        "typescript": "2.2.2",
-        "webpack": "2.3.1"
+        "ts-loader": "2.3.7",
+        "typescript": "2.5.3",
+        "webpack": "3.7.1"
     }
 }

--- a/demo/ts-demo/tsconfig.json
+++ b/demo/ts-demo/tsconfig.json
@@ -1,7 +1,7 @@
 {
-	"compilerOptions": {
-		"module": "es6",
-		"noImplicitAny" : true
-	},
-	"compileOnSave": false
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true
+    },
+    "compileOnSave": false
 }

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -202,12 +202,16 @@ export namespace dia {
 
         unembed(cell: Cell, options?: object): this;
 
-        static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): any;
+        static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): CellConstructor<Cell>;
 
         /**
          * @deprecated
          */
         protected processPorts(): void;
+    }
+
+    interface CellConstructor<T extends Backbone.Model> {
+        new (options?: { id: string }): T
     }
 
     type Padding = number | {
@@ -294,6 +298,8 @@ export namespace dia {
         getPortIndex(port: string | Port): number;
 
         portProp(portId: string, path: any, value?: any, opt?: any): dia.Element;
+
+        static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): CellConstructor<Element>;
     }
 
     interface CSSSelector {
@@ -370,6 +376,8 @@ export namespace dia {
         scale(sx: number, sy: number, origin: Point | g.Point | string, opt?: object): this;
 
         translate(tx: number, ty: number, options?: object): this;
+
+        static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): CellConstructor<Link>;
     }
 
     interface ManhattanRouterArgs {


### PR DESCRIPTION
- demostration of extending the `joint.shapes` namespace, using the `define` method. 
The problematic part is declaring a module. Is it possible to use the `define` without the declaration? 

```
declare module '../../build/joint' {
    namespace shapes {
        namespace app {
            class CustomRect extends joint.shapes.basic.Rect {
                test(): void;
                static staticTest(): void;
            }
        }
    }
}
```