### PR TITLE
dia.Link: set default font color for labels 

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -512,12 +512,13 @@ joint.dia.LinkView = joint.dia.CellView.extend({
                     text: {
                         textAnchor: 'middle',
                         fontSize: 14,
+                        fill: '#000000',
                         pointerEvents: 'none',
                         yAlignment: 'middle'
                     },
                     rect: {
                         ref: 'text',
-                        fill: 'white',
+                        fill: '#ffffff',
                         rx: 3,
                         ry: 3,
                         refWidth: 1,


### PR DESCRIPTION
it fixes wrong label text color in IE11 when the link is exported to PNG 