### PR TITLE
Avoid to change z values during toFront or toBack

### DIFF
--- a/docs/src/joint/api/dia/Graph/prototype/maxZIndex.html
+++ b/docs/src/joint/api/dia/Graph/prototype/maxZIndex.html
@@ -1,0 +1,1 @@
+<pre class="docs-method-signature"><code>graph.maxZIndex()</code></pre><p>Get let highest Z value in the graph (the value of the cell on front).</p>

--- a/docs/src/joint/api/dia/Graph/prototype/maxZIndex.html
+++ b/docs/src/joint/api/dia/Graph/prototype/maxZIndex.html
@@ -1,1 +1,1 @@
-<pre class="docs-method-signature"><code>graph.maxZIndex()</code></pre><p>Get let highest Z value in the graph (the value of the cell on front).</p>
+<pre class="docs-method-signature"><code>graph.maxZIndex()</code></pre><p>Get the highest Z value in the graph (the value of the cell on front).</p>

--- a/docs/src/joint/api/dia/Graph/prototype/minZIndex.html
+++ b/docs/src/joint/api/dia/Graph/prototype/minZIndex.html
@@ -1,1 +1,1 @@
-<pre class="docs-method-signature"><code>graph.minZIndex()</code></pre><p>Get let lowest Z value in the graph (the value of the cell on the back).</p>
+<pre class="docs-method-signature"><code>graph.minZIndex()</code></pre><p>Get the lowest Z value in the graph (the value of the cell on the back).</p>

--- a/docs/src/joint/api/dia/Graph/prototype/minZIndex.html
+++ b/docs/src/joint/api/dia/Graph/prototype/minZIndex.html
@@ -1,0 +1,1 @@
+<pre class="docs-method-signature"><code>graph.minZIndex()</code></pre><p>Get let lowest Z value in the graph (the value of the cell on the back).</p>

--- a/src/joint.dia.cell.js
+++ b/src/joint.dia.cell.js
@@ -178,18 +178,34 @@ joint.dia.Cell = Backbone.Model.extend({
 
             opt = opt || {};
 
-            var z = (this.graph.getLastCell().get('z') || 0) + 1;
+            var z = this.graph.maxZIndex();
 
-            this.startBatch('to-front').set('z', z, opt);
+            var cells;
 
             if (opt.deep) {
-
-                var cells = this.getEmbeddedCells({ deep: true, breadthFirst: true });
-                cells.forEach(function(cell) { cell.set('z', ++z, opt); });
-
+                cells = this.getEmbeddedCells({ deep: true, breadthFirst: true });
+                cells.unshift(this);
+            } else {
+                cells = [this];
             }
 
-            this.stopBatch('to-front');
+            z = z - cells.length + 1;
+
+            var shouldUpdate = cells.some(function(cell, index) {
+                return cell.get('z') !== z + index;
+            });
+
+            if (shouldUpdate) {
+                this.startBatch('to-front');
+
+                z = z + cells.length;
+
+                cells.forEach(function(cell, index) {
+                    cell.set('z', z + index, opt);
+                });
+
+                this.stopBatch('to-front');
+            }
         }
 
         return this;
@@ -201,17 +217,34 @@ joint.dia.Cell = Backbone.Model.extend({
 
             opt = opt || {};
 
-            var z = (this.graph.getFirstCell().get('z') || 0) - 1;
+            var z = this.graph.getCells().reduce(function (minZ, cell) {
+                return Math.min(minZ, cell.get('z'));
+            }, Infinity);
 
-            this.startBatch('to-back');
+            var cells;
 
             if (opt.deep) {
-
-                var cells = this.getEmbeddedCells({ deep: true, breadthFirst: true });
-                cells.reverse().forEach(function(cell) { cell.set('z', z--, opt); });
+                cells = this.getEmbeddedCells({ deep: true, breadthFirst: true });
+                cells.unshift(this);
+            } else {
+                cells = [this];
             }
 
-            this.set('z', z, opt).stopBatch('to-back');
+            var shouldUpdate = cells.some(function(cell, index) {
+                return cell.get('z') !== z + index;
+            });
+
+            if (shouldUpdate) {
+                this.startBatch('to-back');
+
+                z -= cells.length;
+
+                cells.forEach(function(cell, index) {
+                    cell.set('z', z + index, opt);
+                });
+
+                this.stopBatch('to-back');
+            }
         }
 
         return this;

--- a/src/joint.dia.graph.js
+++ b/src/joint.dia.graph.js
@@ -1035,7 +1035,7 @@ joint.dia.Graph = Backbone.Model.extend({
     },
 
     hasActiveBatch: function(name) {
-        if (arguments.length == 0) {
+        if (arguments.length === 0) {
             return joint.util.toArray(this._batches).some(function(batches) {
                 return batches > 0;
             });
@@ -1045,7 +1045,7 @@ joint.dia.Graph = Backbone.Model.extend({
                 return !!this._batches[name];
             }, this);
         }
-        return !!this._batches[arguments[0]];
+        return !!this._batches[name];
     }
 });
 

--- a/src/joint.dia.graph.js
+++ b/src/joint.dia.graph.js
@@ -66,7 +66,6 @@ joint.dia.Graph = Backbone.Model.extend({
         // Backbone automatically doesn't trigger re-sort if models attributes are changed later when
         // they're already in the collection. Therefore, we're triggering sort manually here.
         this.on('change:z', this._sortOnChangeZ, this);
-        this.on('batch:stop', this._onBatchStop, this);
 
         // `joint.dia.Graph` keeps an internal data structure (an adjacency list)
         // for fast graph queries. All changes that affect the structure of the graph
@@ -100,17 +99,7 @@ joint.dia.Graph = Backbone.Model.extend({
 
     _sortOnChangeZ: function() {
 
-        if (!this.hasActiveBatch('to-front') && !this.hasActiveBatch('to-back')) {
-            this.get('cells').sort();
-        }
-    },
-
-    _onBatchStop: function(data) {
-
-        var batchName = data && data.batchName;
-        if ((batchName === 'to-front' || batchName === 'to-back') && !this.hasActiveBatch(batchName)) {
-            this.get('cells').sort();
-        }
+        this.get('cells').sort();
     },
 
     _restructureOnAdd: function(cell) {
@@ -291,6 +280,12 @@ joint.dia.Graph = Backbone.Model.extend({
         }
 
         return cell;
+    },
+
+    minZIndex: function() {
+
+        var firstCell = this.get('cells').first();
+        return firstCell ? (firstCell.get('z') || 0) : 0;
     },
 
     maxZIndex: function() {
@@ -1040,13 +1035,17 @@ joint.dia.Graph = Backbone.Model.extend({
     },
 
     hasActiveBatch: function(name) {
-        if (name) {
-            return !!this._batches[name];
-        } else {
+        if (arguments.length == 0) {
             return joint.util.toArray(this._batches).some(function(batches) {
                 return batches > 0;
             });
         }
+        if (Array.isArray(name)) {
+            return name.some(function (name) {
+                return !!this._batches[name];
+            }, this);
+        }
+        return !!this._batches[arguments[0]];
     }
 });
 

--- a/src/joint.dia.paper.js
+++ b/src/joint.dia.paper.js
@@ -305,15 +305,18 @@ joint.dia.Paper = joint.mvc.View.extend({
         return V.createSVGMatrix(this.viewport.getScreenCTM());
     },
 
+    _sortDelayingBatches: ['add', 'to-front', 'to-back'],
+
     _onSort: function() {
-        if (!this.model.hasActiveBatch('add')) {
+        if (!this.model.hasActiveBatch(this._sortDelayingBatches)) {
             this.sortViews();
         }
     },
 
     _onBatchStop: function(data) {
         var name = data && data.batchName;
-        if (name === 'add' && !this.model.hasActiveBatch('add')) {
+        if (this._sortDelayingBatches.includes(name) &&
+            !this.model.hasActiveBatch(this._sortDelayingBatches)) {
             this.sortViews();
         }
     },

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -679,6 +679,28 @@ QUnit.module('basic', function(hooks) {
         assert.notEqual(r2View.$el.prevAll(r1View.$el).length, 0, 'r1 element moved back before r2 element in the DOM after toBack()');
     });
 
+    QUnit.test('toBack(), toFront() ignorable', function(assert) {
+
+        var r1 = new joint.shapes.basic.Rect;
+        var r2 = new joint.shapes.basic.Rect;
+
+        this.graph.addCell(r1);
+        this.graph.addCell(r2);
+
+        var r1Z = r1.get('z');
+        var r2Z = r2.get('z');
+
+        assert.ok(r1Z < r2Z, 'r1 z is lower than r2 z');
+
+        r2.toFront();
+
+        assert.equal(r2.get('z'), r2Z, 'r2 doesn\'t change z during a toFront() if it is already in place');
+
+        r1.toBack();
+
+        assert.equal(r1.get('z'), r1Z, 'r1 doesn\'t change z during a toBack() if it is already in place');
+    });
+
     QUnit.test('toBack(), toFront() with active batch', function(assert) {
 
         var r1 = new joint.shapes.basic.Rect;
@@ -753,6 +775,35 @@ QUnit.module('basic', function(hooks) {
         assert.equal(a1View.$el.prevAll('[data-type="basic.Rect"]').length, 0, 'a1 element moved back before a2, a3, a4, b1, b2 elements in the DOM after toBack()');
         assert.ok(a4View.$el.prev('[data-type="basic.Rect"]')[0] == a3View.el || a4View.$el.prev('[data-type="basic.Rect"]')[0] == a2View.el, 'and a4 element moved after a3 or a2 element');
         assert.ok(a2View.$el.prev('[data-type="basic.Rect"]')[0] == a1View.el || a3View.$el.prev('[data-type="basic.Rect"]')[0] == a1View.el, 'and a2 or a3 element moved just after a1 element');
+
+    });
+
+    QUnit.test('toBack(), toFront() ignore with { deep: true } option', function(assert) {
+
+        var a1 = new joint.shapes.basic.Rect;
+        var a2 = new joint.shapes.basic.Rect;
+        var a3 = new joint.shapes.basic.Rect;
+        var a4 = new joint.shapes.basic.Rect;
+
+        a1.embed(a2).embed(a3.embed(a4));
+
+        var b1 = new joint.shapes.basic.Rect;
+        var b2 = new joint.shapes.basic.Rect;
+
+        this.graph.addCells([b1, b2, a1, a2, a3, a4]);
+
+        var a1Z = a1.get('z');
+        var b1Z = b1.get('z');
+
+        assert.ok(b1Z < a1Z, "b root z is lower than a root z");
+
+        a1.toFront({ deep: true });
+
+        assert.equal(a1.get('z'), a1Z, 'a1 doesn\'t change z during a toFront() if it is already in place');
+
+        b1.toBack({ deep: true });
+
+        assert.equal(b1.get('z'), b1Z, 'b1 doesn\'t change z during a toFront() if it is already in place');
 
     });
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -115,9 +115,11 @@ export namespace dia {
 
         getCellsBBox(cells: Cell[], opt?: Cell.EmbeddableOptions): g.Rect | null;
 
-        hasActiveBatch(name?: string): boolean;
+        hasActiveBatch(name?: string | string[]): boolean;
 
         maxZIndex(): number;
+
+        minZIndex(): number;
 
         removeCells(cells: Cell[], opt?: Cell.DisconnectableOptions): this;
 


### PR DESCRIPTION
Two consecutive invocations of toFront or toBack produce a change in the
cells even though they already have the correct z values.

If the z values already satisfy the required order for toFront or toBack
they are not changed.

__Context:__
In an application I'm developing every time a user clicks on a cell i bring it to front, if the user starts clicking on the same cell over and over i get overwhelmed by `change:z` events.
