### PR TITLE
Fix to get correct outPorts

### DIFF
--- a/plugins/shapes/joint.shapes.basic.js
+++ b/plugins/shapes/joint.shapes.basic.js
@@ -256,7 +256,7 @@ joint.shapes.basic.PortsModelInterface = {
             joint.util.assign(attrs, portAttributes);
         }, this);
 
-        joint.util.toArray(('outPorts')).forEach(function(portName, index, ports) {
+        joint.util.toArray(this.get('outPorts')).forEach(function(portName, index, ports) {
             var portAttributes = this.getPortAttrs(portName, index, ports.length, '.outPorts', 'out');
             this._portSelectors = this._portSelectors.concat(Object.keys(portAttributes));
             joint.util.assign(attrs, portAttributes);


### PR DESCRIPTION
A bug was introduced which removed the "this.get" from before "('outPorts')".  This caused the outPorts to be returned as each letter of 'outPorts' rather than the outPorts themselves.