### PR TITLE
Use var to declare vars the first time they are used

### DIFF
--- a/src/geometry.js
+++ b/src/geometry.js
@@ -1449,7 +1449,7 @@ var g = (function() {
             var start = this.start;
             var end = this.end;
 
-            fromStart = true;
+            var fromStart = true;
             if (length < 0) {
                 fromStart = false; // negative lengths mean start calculation from end point
                 length = -length; // absolute value

--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -208,7 +208,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (name === undefined) {
-            router = this.get('router');
+            var router = this.get('router');
             if (!router) {
                 if (this.get('manhattan')) return { name: 'orthogonal' }; // backwards compatibility
                 return null;
@@ -229,7 +229,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (name === undefined) {
-            connector = this.get('connector');
+            var connector = this.get('connector');
             if (!connector) {
                 if (this.get('smooth')) return { name: 'smooth' }; // backwards compatibility
                 return null;
@@ -266,7 +266,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (arguments.length === 0) {
-            labels = this.get('labels');
+            var labels = this.get('labels');
             if (!Array.isArray(labels)) return [];
             return labels.slice();
         }
@@ -323,7 +323,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (arguments.length === 0) {
-            vertices = this.get('vertices');
+            var vertices = this.get('vertices');
             if (!Array.isArray(vertices)) return [];
             return vertices.slice();
         }

--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -266,7 +266,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (arguments.length === 0) {
-            var labels = this.get('labels');
+            labels = this.get('labels');
             if (!Array.isArray(labels)) return [];
             return labels.slice();
         }
@@ -323,7 +323,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (arguments.length === 0) {
-            var vertices = this.get('vertices');
+            vertices = this.get('vertices');
             if (!Array.isArray(vertices)) return [];
             return vertices.slice();
         }


### PR DESCRIPTION
This fixes several errors of the form: `ReferenceError: assignment to undeclared variable router`