### PR TITLE
Adding removePorts() to Element prototype

### DIFF
--- a/docs/src/joint/api/dia/Element/ports.md
+++ b/docs/src/joint/api/dia/Element/ports.md
@@ -9,7 +9,8 @@ It's easy to add ports to arbitrary shapes in JointJS. This can be done either b
 
 * [`hasPort`](#dia.Element.prototype.hasPort) / [`hasPorts`](#dia.Element.prototype.hasPorts)
 * [`addPort`](#dia.Element.prototype.addPort) / [`addPorts`](#dia.Element.prototype.addPorts)
-* [`removePort`](#dia.Element.prototype.removePort)
+* [`removePort`](#dia.Element.prototype.removePort) /
+[`removePorts`](#dia.Element.prototype.removePorts)
 * [`getPort`](#dia.Element.prototype.getPort) / [`getPorts`](#dia.Element.prototype.getPorts)
 * [`portProp`](#dia.Element.prototype.portProp)
 * [`getPortPositions`](#dia.Element.prototype.getPortPositions)

--- a/docs/src/joint/api/dia/Element/prototype/removePorts.md
+++ b/docs/src/joint/api/dia/Element/prototype/removePorts.md
@@ -1,7 +1,9 @@
-<pre class="docs-method-signature"><code>element.removePorts(ports, [opt])</code></pre>
+<pre class="docs-method-signature"><code>element.removePorts(ports [, opt])</code></pre>
 
-Takes an array of [Port interfaces](#portinterface) or `portIds` and removes them from the element. Will ignore ports specified that are not on the element. Faster than removing the ports individually.
+Remove an array of `ports` from the element.
+
+The ports can be specified as [Port interfaces](#portinterface) or `portIds`. The function skips over any ports in the array that do not exist on the element.
 
 <pre class="docs-method-signature"><code>element.removePorts([opt])</code></pre>
 
-If no array is given it will remove all ports from the element. Faster than removing the ports individually.
+If no array is provided, the function removes all ports from the element.

--- a/docs/src/joint/api/dia/Element/prototype/removePorts.md
+++ b/docs/src/joint/api/dia/Element/prototype/removePorts.md
@@ -1,0 +1,3 @@
+<pre class="docs-method-signature"><code>element.removePorts(ports, [opt])</code></pre>
+
+Takes an array of [Port interfaces](#portinterface) or `portIds` and removes them from the element. Will ignore ports specified that are not on the element. Faster than removing the ports individually.

--- a/docs/src/joint/api/dia/Element/prototype/removePorts.md
+++ b/docs/src/joint/api/dia/Element/prototype/removePorts.md
@@ -1,3 +1,7 @@
 <pre class="docs-method-signature"><code>element.removePorts(ports, [opt])</code></pre>
 
 Takes an array of [Port interfaces](#portinterface) or `portIds` and removes them from the element. Will ignore ports specified that are not on the element. Faster than removing the ports individually.
+
+<pre class="docs-method-signature"><code>element.removePorts([opt])</code></pre>
+
+If no array is given it will remove all ports from the element. Faster than removing the ports individually.

--- a/src/ports.js
+++ b/src/ports.js
@@ -418,6 +418,25 @@
             return this;
         },
 
+        removePorts: function(ports, opt) {
+
+            var options = opt || {};
+
+            if (ports.length) {
+                options.rewrite = true;
+                var remainingPorts = util.assign([], this.prop('ports/items'));
+                ports.forEach(function(port) {
+                    var id = util.isObject(port) ? port.id : port;
+                    remainingPorts = remainingPorts.filter(function(rPort) {
+                        return rPort.id !== id
+                    });
+                })
+                this.prop('ports/items', remainingPorts, options);
+            }
+
+            return this
+        },
+
         /**
          * @private
          */

--- a/src/ports.js
+++ b/src/ports.js
@@ -418,19 +418,19 @@
             return this;
         },
 
-        removePorts: function(ports, opt) {
+        removePorts: function(portsForRemoval, opt) {
 
             var options = opt || {};
 
-            if (ports.length) {
+            if (portsForRemoval.length) {
                 options.rewrite = true;
-                var remainingPorts = util.assign([], this.prop('ports/items'));
-                ports.forEach(function(port) {
-                    var id = util.isObject(port) ? port.id : port;
-                    remainingPorts = remainingPorts.filter(function(rPort) {
-                        return rPort.id !== id
-                    });
-                })
+                var currentPorts = util.assign([], this.prop('ports/items'));
+                var remainingPorts = currentPorts.filter(function(cp) {
+                    return !portsForRemoval.some(function(rp) {
+                        var rpId = util.isObject(rp) ? rp.id : rp;
+                        return cp.id === rpId;
+                    })
+                });
                 this.prop('ports/items', remainingPorts, options);
             }
 

--- a/src/ports.js
+++ b/src/ports.js
@@ -420,8 +420,10 @@
 
         removePorts: function(portsForRemoval, opt) {
 
+            var options;
+
             if (Array.isArray(portsForRemoval)) {
-                var options = opt || {};
+                options = opt || {};
 
                 if (portsForRemoval.length) {
                     options.rewrite = true;
@@ -435,7 +437,7 @@
                     this.prop('ports/items', remainingPorts, options);
                 }
             } else {
-                var options = portsForRemoval || {};
+                options = portsForRemoval || {};
                 options.rewrite = true;
                 this.prop('ports/items', [], options);
             }

--- a/src/ports.js
+++ b/src/ports.js
@@ -420,18 +420,24 @@
 
         removePorts: function(portsForRemoval, opt) {
 
-            var options = opt || {};
+            if (Array.isArray(portsForRemoval)) {
+                var options = opt || {};
 
-            if (portsForRemoval.length) {
+                if (portsForRemoval.length) {
+                    options.rewrite = true;
+                    var currentPorts = util.assign([], this.prop('ports/items'));
+                    var remainingPorts = currentPorts.filter(function(cp) {
+                        return !portsForRemoval.some(function(rp) {
+                            var rpId = util.isObject(rp) ? rp.id : rp;
+                            return cp.id === rpId;
+                        })
+                    });
+                    this.prop('ports/items', remainingPorts, options);
+                }
+            } else {
+                var options = portsForRemoval || {};
                 options.rewrite = true;
-                var currentPorts = util.assign([], this.prop('ports/items'));
-                var remainingPorts = currentPorts.filter(function(cp) {
-                    return !portsForRemoval.some(function(rp) {
-                        var rpId = util.isObject(rp) ? rp.id : rp;
-                        return cp.id === rpId;
-                    })
-                });
-                this.prop('ports/items', remainingPorts, options);
+                this.prop('ports/items', [], options);
             }
 
             return this

--- a/test/jointjs/elementPorts.js
+++ b/test/jointjs/elementPorts.js
@@ -105,6 +105,45 @@ QUnit.module('element ports', function() {
             assert.equal(shape.getPorts().length, 2);
         });
 
+        QUnit.test('removePorts', function(assert) {
+
+            var shape = create({ items: [
+                { id: 'aaa', 'group_id': 'in' },
+                { id: 'bbb', 'group_id': 'in' },
+                { id: 'xxx', 'group_id': 'in' }
+            ] });
+
+            var eventOrder = ['ports:remove', 'change:ports', 'change'];
+
+            shape.on('all', function(eventName) {
+                assert.equal(eventName, eventOrder.shift())
+            });
+
+            shape.removePorts([{ id: 'aaa' }, { id: 'bbb' }]);
+            assert.equal(shape.getPorts().length, 1);
+            assert.equal(shape.getPorts()[0].id, 'xxx');
+        });
+
+        QUnit.test('removePorts - invalid reference - should not remove them', function(assert) {
+
+            var shape = create({ items: [
+                { id: 'aaa', 'group_id': 'in' },
+                { id: 'bbb', 'group_id': 'in' },
+                { id: 'xxx', 'group_id': 'in' }
+            ] });
+
+            var eventOrder = ['ports:remove', 'change:ports', 'change'];
+
+            shape.on('all', function(eventName) {
+                assert.equal(eventName, eventOrder.shift())
+            });
+
+            shape.removePorts([{ id: 'aaa' }, { id: 'ddd' }]);
+            assert.equal(shape.getPorts().length, 2);
+            assert.equal(shape.getPorts()[0].id, 'bbb');
+            assert.equal(shape.getPorts()[1].id, 'xxx');
+        });
+
         QUnit.test('getPortIndex', function(assert) {
 
             var idObject = {};

--- a/test/jointjs/elementPorts.js
+++ b/test/jointjs/elementPorts.js
@@ -144,6 +144,24 @@ QUnit.module('element ports', function() {
             assert.equal(shape.getPorts()[1].id, 'xxx');
         });
 
+        QUnit.test('removePorts - should remove all ports when only given options', function(assert) {
+
+            var shape = create({ items: [
+                { id: 'aaa', 'group_id': 'in' },
+                { id: 'bbb', 'group_id': 'in' },
+                { id: 'xxx', 'group_id': 'in' }
+            ] });
+
+            var eventOrder = ['ports:remove', 'change:ports', 'change'];
+
+            shape.on('all', function(eventName) {
+                assert.equal(eventName, eventOrder.shift())
+            });
+
+            shape.removePorts();
+            assert.equal(shape.getPorts().length, 0);
+        });
+
         QUnit.test('getPortIndex', function(assert) {
 
             var idObject = {};

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -359,6 +359,7 @@ export namespace dia {
 
         removePort(port: string | Element.Port, opt?: Cell.Options): this;
 
+        removePorts(opt?: Cell.Options): this;
         removePorts(ports: Array<Element.Port|string>, opt?: Cell.Options): this;
 
         hasPorts(): boolean;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -359,6 +359,8 @@ export namespace dia {
 
         removePort(port: string | Element.Port, opt?: Cell.Options): this;
 
+        removePorts(ports: Array<Element.Port|string>, opt?: Cell.Options): this;
+
         hasPorts(): boolean;
 
         hasPort(id: string): boolean;


### PR DESCRIPTION
## Summary
Adding a new api to the Element prototype for batch removing ports.

## Details
This method will remove all of the specified ports (objects or portId strings) from the ports list before calling .prop().

This means a single .prop() call at the end of the batch which is much faster than removing them individually.

Additionally, it was strange that we had addPort/addPorts but only one removePort in the API.