### PR TITLE
dia.Paper.Options: add InteractivityOptions as function return type (Declaration files)

### DIFF
--- a/dist/joint.d.ts
+++ b/dist/joint.d.ts
@@ -1798,7 +1798,7 @@ export namespace dia {
             // interactions
             gridSize?: number;
             highlighting?: { [type: string]: highlighters.HighlighterJSON };
-            interactive?: ((cellView: CellView, event: string) => boolean) | boolean | CellView.InteractivityOptions
+            interactive?: ((cellView: CellView, event: string) => boolean | CellView.InteractivityOptions) | boolean | CellView.InteractivityOptions
             snapLinks?: boolean | { radius: number };
             markAvailable?: boolean;
             // validations


### PR DESCRIPTION
TypeScipe declaration files are missing `CellView.InteractivityOptions` for dia.Paper.Options.interactive as possible return type if using a function.