### PR TITLE
Support scientific notation in paths

### DIFF
--- a/src/geometry.js
+++ b/src/geometry.js
@@ -1718,14 +1718,14 @@ var g = {};
 
         var path = new Path();
 
-        var commandRe = /(?:[a-zA-Z] *)(?:(?:-?\d+(?:\.\d+)? *,? *)|(?:-?\.\d+ *,? *))+|(?:[a-zA-Z] *)(?! |\d|-|\.)/g;
+        var commandRe = /(?:[a-zA-Z] *)(?:(?:-?\d+(?:\.\d+)?(?:e[-+]?\d+)? *,? *)|(?:-?\.\d+ *,? *))+|(?:[a-zA-Z] *)(?! |\d|-|\.)/g;
         var commands = pathData.match(commandRe);
 
         var numCommands = commands.length;
         for (var i = 0; i < numCommands; i++) {
 
             var command = commands[i];
-            var argRe = /(?:[a-zA-Z])|(?:(?:-?\d+(?:\.\d+)?))|(?:(?:-?\.\d+))/g;
+            var argRe = /(?:[a-zA-Z])|(?:(?:-?\d+(?:\.\d+)?(?:e[-+]?\d+)?))|(?:(?:-?\.\d+))/g;
             var args = command.match(argRe);
 
             var segment = Path.createSegment.apply(this, args); // args = [type, coordinate1, coordinate2...]

--- a/test/geometry/path.js
+++ b/test/geometry/path.js
@@ -487,6 +487,40 @@ QUnit.module('path', function(hooks) {
             assert.equal(path.segments[4].end.toString(), '51@51');
             assert.equal(path.segments[5].start.toString(), '51@51');
             assert.equal(path.segments[5].end.toString(), '52@52');
+
+            // scientific notation
+            path = new g.Path('M 0 0 L 9.02e-17 -9.02e-7 L 1e-7 -1e-17 L 12.3e55 -12.3e+5 L 12e+55 -12e55');
+            assert.ok(path instanceof g.Path, 'returns instance of g.Path');
+            assert.ok(typeof path.segments !== 'undefined', 'has "segments" property');
+            assert.ok(Array.isArray(path.segments));
+            assert.equal(path.segments.length, 5);
+            assert.ok(path.segments[0] instanceof g.Path.segmentTypes.M);
+            assert.ok(path.segments[1] instanceof g.Path.segmentTypes.L);
+            assert.ok(path.segments[2] instanceof g.Path.segmentTypes.L);
+            assert.ok(path.segments[3] instanceof g.Path.segmentTypes.L);
+            assert.ok(path.segments[4] instanceof g.Path.segmentTypes.L);
+            assert.equal(path.segments[0].end.toString(), '0@0');
+            assert.equal(path.segments[1].start.toString(), '0@0');
+
+            var coords = path.segments[1].end.toString().split('@');
+            assert.equal(coords.length, 2);
+            assert.equal(Number(coords[0]), 9.02e-17);
+            assert.equal(Number(coords[1]), -9.02e-7);
+
+            coords = path.segments[2].end.toString().split('@');
+            assert.equal(coords.length, 2);
+            assert.equal(Number(coords[0]), 1e-7);
+            assert.equal(Number(coords[1]), -1e-17);
+
+            coords = path.segments[3].end.toString().split('@');
+            assert.equal(coords.length, 2);
+            assert.equal(Number(coords[0]), 12.3e55);
+            assert.equal(Number(coords[1]), -12.3e5);
+
+            coords = path.segments[4].end.toString().split('@');
+            assert.equal(coords.length, 2);
+            assert.equal(Number(coords[0]), 12e55);
+            assert.equal(Number(coords[1]), -12e55);
         });
     });
 


### PR DESCRIPTION
SVG supports this, and in some cases, V.normalizePathData() can produce almost-zero numbers that use scientific notation. This means that calling V.toGeometryShape() on a path can result in a V.normalizePathData() call that introduces scientific notation to the path, so without supporting scientific notation in the path parsing, the user can get an `e is not a recognized path segment type` error from deep inside joint code.