### PR TITLE
Added util ailas for _.forEach and using it to iterate over arrays

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -445,7 +445,7 @@ export const Graph = Backbone.Model.extend({
         var edges = {};
 
         if (outbound) {
-            util.forIn(this.getOutboundEdges(model.id), function(exists, edge) {
+            util.forEach(this.getOutboundEdges(model.id), function(exists, edge) {
                 if (!edges[edge]) {
                     links.push(this.getCell(edge));
                     edges[edge] = true;
@@ -453,7 +453,7 @@ export const Graph = Backbone.Model.extend({
             }.bind(this));
         }
         if (inbound) {
-            util.forIn(this.getInboundEdges(model.id), function(exists, edge) {
+            util.forEach(this.getInboundEdges(model.id), function(exists, edge) {
                 // skip links that were already added
                 // (those must be self-loop links)
                 // (because they are inbound and outbound edges of the same two elements)
@@ -480,7 +480,7 @@ export const Graph = Backbone.Model.extend({
             embeddedCells.forEach(function(cell) {
                 if (cell.isLink()) return;
                 if (outbound) {
-                    util.forIn(this.getOutboundEdges(cell.id), function(exists, edge) {
+                    util.forEach(this.getOutboundEdges(cell.id), function(exists, edge) {
                         if (!edges[edge]) {
                             var edgeCell = this.getCell(edge);
                             var sourceId = edgeCell.source().id;
@@ -499,7 +499,7 @@ export const Graph = Backbone.Model.extend({
                     }.bind(this));
                 }
                 if (inbound) {
-                    util.forIn(this.getInboundEdges(cell.id), function(exists, edge) {
+                    util.forEach(this.getInboundEdges(cell.id), function(exists, edge) {
                         if (!edges[edge]) {
                             var edgeCell = this.getCell(edge);
                             var sourceId = edgeCell.source().id;

--- a/src/util.js
+++ b/src/util.js
@@ -1673,6 +1673,7 @@ export const result = _.result;
 export const omit = _.omit;
 export const pick = _.pick;
 export const bindAll = _.bindAll;
+export const forEach = _.forEach;
 export const forIn = _.forIn;
 export const camelCase = _.camelCase;
 export const uniqueId = _.uniqueId;


### PR DESCRIPTION
tl;dr util.forIn operating on an object is optimized away when using the Clojure compiler

--

The lodash utilities forIn and forEach have slightly different purposes; forIn iterates over an objects properties and forEach iterates over an array or iterable. 

While forIn technically works for iterating over arrays, it is not ideal. In these specific cases, this.getOutboundEdges() will return an array of edges, not an object. 

These were changed from _.each into util.forIn recently in this [commit](https://github.com/clientIO/joint/commit/af22c84e838b913f09299cbbe2fa02fbfc6c4421). I believe this was an oversight since it is operating on an array not an object.

This isn't an issue for most users as it does in fact 'work'. However, my project is using the Clojure compiler to optimize our bundle (including jointjs) and the Clojure compiler is 'smart' enough to notice this mismatch. It decides that this loop will never produce useful output and optimizes most of the function away, thus always returning [] for the list of connected links.

I believe this is the simplest fix for the issue, and it works exactly the same for uncompiled users.