### PR TITLE
Updated typings and initializes _V cache on render of links with MarkupJSON

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -761,6 +761,7 @@ joint.dia.LinkView = joint.dia.CellView.extend({
         var doc = this.parseDOMJSON(markup, this.el);
         // Selectors
         this.selectors = doc.selectors;
+        Object.keys(this.selectors).forEach((key) => this._V[key] = V(this.selectors[key]));
         // Fragment
         this.vel.append(doc.fragment);
     },

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -470,7 +470,7 @@ export namespace dia {
 
     class Link extends Cell {
 
-        markup: string;
+        markup: string | MarkupJSON;
         toolMarkup: string;
         doubleToolMarkup?: string;
         vertexMarkup: string;


### PR DESCRIPTION
Links can be specified using the MarkupJSON format instead of a xml string. This does produce faster rendering since it doesn't need to re-parse the string every time which is great.

However, I noticed that links built this way do not get moved by directedGraph.layoutGraph(). Digging into it it seems to be cause the renderJSON function doesn't actually build the _V vector cache of the svg elements, which directedGraph uses to layout the edges.

This should emulate the behavior of renderMarkup. Though the only difference is that the _V cache will contain one extra element for 'root'.

I also updated the typings so that MarkupJSON can be used from typescript