### PR TITLE
Fix normalizing paths with zero-radius arcs

### DIFF
--- a/src/vectorizer.js
+++ b/src/vectorizer.js
@@ -2348,7 +2348,14 @@ const V = (function() {
                         break;
 
                     case 'A':
-                        path = ['C'].concat(a2c.apply(0, [d.x, d.y].concat(path.slice(1))));
+                        if (parseFloat(path[1]) === 0 || parseFloat(path[2]) === 0) {
+                            // https://www.w3.org/TR/SVG/paths.html#ArcOutOfRangeParameters
+                            // "If either rx or ry is 0, then this arc is treated as a
+                            // straight line segment (a "lineto") joining the endpoints."
+                            path = ['L', path[6], path[7]];
+                        } else {
+                            path = ['C'].concat(a2c.apply(0, [d.x, d.y].concat(path.slice(1))));
+                        }
                         break;
 
                     case 'S':

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -1248,6 +1248,10 @@ QUnit.module('vectorizer', function(hooks) {
 
             assert.equal(V.normalizePathData('X M 10 10'), 'M 10 10'); // mixing invalid and valid commands
             assert.equal(V.normalizePathData('X M 10 10 X L 20 20'), 'M 10 10 L 20 20'); // invalid commands interspersed with valid commands
+
+            assert.equal(V.normalizePathData('A 0 3 0 0 1 10 15'), 'M 0 0 L 10 15'); // 0 x radius
+            assert.equal(V.normalizePathData('A 3 0 0 0 1 10 15'), 'M 0 0 L 10 15'); // 0 y radius
+            assert.equal(V.normalizePathData('A 0 0 0 0 1 10 15'), 'M 0 0 L 10 15'); // 0 x and y radii
         });
 
         QUnit.test('path segment reconstruction', function(assert) {


### PR DESCRIPTION
The path normalizing code was not checking the radii for zero, and was ending up with NaN in path instructions in this case. W3C (https://www.w3.org/TR/SVG/paths.html#ArcOutOfRangeParameters) instructs user agents to treat it as a lineto in this case.