### PR TITLE
Add a browser key to point to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "version": "3.0.3",
   "main": "./dist/joint.min.js",
+  "browser": "./dist/joint.min.js",
   "style": "./dist/joint.min.css",
   "types": "./dist/joint.d.ts",
   "module": "./joint.mjs",


### PR DESCRIPTION
By default webpack look for browser, module, main. It is desirable to use the dist for web builds.

Currently, jointjs blow up in ie 11 because it's using the mjs module entry point.