### PR TITLE
types: fix interactive callback return type

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -932,7 +932,7 @@ export namespace dia {
             // interactions
             gridSize?: number;
             highlighting?: { [type: string]: highlighters.HighlighterJSON };
-            interactive?: ((cellView: CellView, event: string) => boolean) | boolean | CellView.InteractivityOptions
+            interactive?: ((cellView: CellView, event: string) => boolean | CellView.InteractivityOptions) | boolean | CellView.InteractivityOptions
             snapLinks?: boolean | { radius: number };
             markAvailable?: boolean;
             // validations


### PR DESCRIPTION
The current return type when interactive is a function is `boolean`, but it can also be a `CellView.InteractivityOptions`.

Here is where it is used
https://github.com/clientIO/joint/blob/11a576dcacce1000ca4ee7104be880e66daaa2a5/src/dia/CellView.mjs#L175-L183

This fixes the typing so that an `CellView.InteractivityOptions` can be returned from the callback