### PR TITLE
fix(routers): fix manhattan scan directions order

### DIFF
--- a/src/routers/manhattan.mjs
+++ b/src/routers/manhattan.mjs
@@ -57,8 +57,8 @@ var config = {
 
         return [
             { offsetX: step, offsetY: 0, cost: cost },
-            { offsetX: 0, offsetY: step, cost: cost },
             { offsetX: -step, offsetY: 0, cost: cost },
+            { offsetX: 0, offsetY: step, cost: cost },
             { offsetX: 0, offsetY: -step, cost: cost }
         ];
     },


### PR DESCRIPTION
# Description

A* used for manhattan router is awesome not because it's bullet proof, but because it has a couple of entry points where we can adjust its behavior. This PR targets one of those places, which is the order of an array used for scanning for the next step. As pathfinding might yield a couple of equally short routes, the results might not be what we expect. We can nudge A* to be a tad bit more predictable if we tell it to search directions based on axis instead of an array of clockwise ordered vectors. It might be a good idea to give the user an arg. to control whether it's horizontal or vertical first, but that's a topic for a different PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have [reorganized my commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) to make them [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Existing tests pass

# References:
Before:
![image (1)](https://user-images.githubusercontent.com/9550802/89020651-8eb69a00-d31f-11ea-8108-1f361b763e50.png)

After:
![image (2)](https://user-images.githubusercontent.com/9550802/89020659-90805d80-d31f-11ea-8f28-3dbb2e605bfe.png)



