### PR TITLE
Adjust center position of new scale wrt previous scale, not 1.

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1554,11 +1554,12 @@ export const Paper = View.extend({
             oy = 0;
         }
 
+        var scale = this.scale();
         var translate = this.translate();
 
         if (ox || oy || translate.tx || translate.ty) {
-            var newTx = translate.tx - ox * (sx - 1);
-            var newTy = translate.ty - oy * (sy - 1);
+            var newTx = translate.tx - ox * (sx - scale.sx);
+            var newTy = translate.ty - oy * (sy - scale.sy);
             this.translate(newTx, newTy);
         }
 


### PR DESCRIPTION
Tested locally and this now works correctly. 
A simple example: if you're already on scale 2, and trying to set the scale to 2 again, simply glancing through the previous code, you can see that it will move the origin when it shouldn't at all.