### PR TITLE
Support inserting port at position

### DIFF
--- a/src/dia/ports.mjs
+++ b/src/dia/ports.mjs
@@ -335,6 +335,26 @@ export const elementPortPrototype = {
     },
 
     /**
+     * @param {string|Port|number} before
+     * @param {object} port
+     * @param {object} [opt]
+     * @returns {joint.dia.Element}
+     */
+    insertPort: function(before, port, opt) {
+        const index = (typeof before === 'number') ? before : this.getPortIndex(before);
+
+        if (!util.isObject(port) || Array.isArray(port)) {
+            throw new Error('dia.Element: insertPort requires an object.');
+        }
+
+        var ports = util.assign([], this.prop('ports/items'));
+        ports.splice(index, 0, port);
+        this.prop('ports/items', ports, opt);
+
+        return this;
+    },
+
+    /**
      * @param {string} portId
      * @param {string|object=} path
      * @param {*=} value

--- a/test/jointjs/elementPorts.js
+++ b/test/jointjs/elementPorts.js
@@ -66,6 +66,47 @@ QUnit.module('element ports', function() {
             assert.ok(typeof shape.getPorts()[0].id === 'string');
         });
 
+        QUnit.test('insertPort by index', function(assert) {
+
+            var shape = create({ items: [{ group: 'in' }] });
+
+            var eventOrder = ['ports:add', 'change:ports', 'change'];
+
+            shape.on('all', function(eventName) {
+                assert.equal(eventName, eventOrder.shift());
+            });
+
+            shape.insertPort(0, { id: 'a' });
+
+            assert.equal(shape.getPorts().length, 2);
+            assert.equal(shape.getPorts()[0].id, 'a');
+            assert.ok(typeof shape.getPorts()[1].id === 'string');
+        });
+
+        QUnit.test('insertPort by port', function(assert) {
+
+            var shape = create({ items: [{ group: 'in' }] });
+
+            shape.insertPort(shape.getPorts()[0], { id: 'a' });
+
+            assert.equal(shape.getPorts().length, 2);
+            assert.equal(shape.getPorts()[0].id, 'a');
+            assert.ok(typeof shape.getPorts()[1].id === 'string');
+        });
+
+        QUnit.test('insertPort by id', function(assert) {
+
+            var shape = create({ items: [{ group: 'in' }] });
+            
+            shape.insertPort(0, { id: 'a' });
+            shape.insertPort('a', { id: 'b' });
+
+            assert.equal(shape.getPorts().length, 3);
+            assert.equal(shape.getPorts()[0].id, 'b');
+            assert.equal(shape.getPorts()[1].id, 'a');
+            assert.ok(typeof shape.getPorts()[2].id === 'string');
+        });
+
         QUnit.test('remove port - by object', function(assert) {
 
             var shape = create({ items: [{ id: 'aaa', 'group': 'in' }, { id: 'xxx', 'group': 'in' }] });


### PR DESCRIPTION
I've added the possibility to insert ports at specific indexes. This is important if we want to allow dynamic port additions to be possible while having a logically sorted list of ports.

![PoC](https://user-images.githubusercontent.com/15357734/99550119-a68f5800-29ba-11eb-95ab-914f040d1f5a.gif)

Hope you guys like it!