### PR TITLE
Fix: Arrowhead linktool: prevent other linkTools from being displayed after mouseleave

### DIFF
--- a/docs/src/joint/api/dia/LinkView/prototype/addTools.html
+++ b/docs/src/joint/api/dia/LinkView/prototype/addTools.html
@@ -32,3 +32,5 @@ paper.on('link:mouseenter', function(linkView) {
 paper.on('link:mouseleave', function(linkView) {
     linkView.hideTools();
 });</code></pre>
+
+<p>Note that the above example may not work as expected if <code>toolsView</code> includes the <code>SourceArrowhead</code> <a href="#linkTools.SourceArrowhead">tool</a> and/or the <code>TargetArrowhead</code> <a href="#linkTools.TargetArrowhead">tool</a> - the link tools view might not be hidden when the link is reconnected to a topic. See our <a href="http://resources.jointjs.com/tutorial/link-tools.html">link tools tutorial</a> for more information.</p>

--- a/docs/src/joint/api/dia/ToolsView/prototype/blurTools.html
+++ b/docs/src/joint/api/dia/ToolsView/prototype/blurTools.html
@@ -1,0 +1,4 @@
+<pre class="docs-method-signature"><code>toolsView.blurTools()</code></pre>
+<p>Stop focusing any tools within this tools view.</p>
+
+<p>This function reverses the effect of the <code>toolsView.focusTool</code> <a href="#dia.ToolsView.prototype.focusTool">function</a> applied to any tool in this tools view.</p>

--- a/docs/src/joint/api/dia/ToolsView/prototype/focusTool.html
+++ b/docs/src/joint/api/dia/ToolsView/prototype/focusTool.html
@@ -3,4 +3,4 @@
 
 <p>When a tool is <q>focused</q>, all other tools within this tools view are hidden and the tool's opacity is changed according to the tool's <code>focusOpacity</code> option. Only one tool can be focused at a time; the focus passes to the last tool within this tools view with which the <code>focusTool</code> function was called.</p>
 
-<p>The effect of this function can be reversed by the <code>toolsView.blurTool</code> <a href="#dia.ToolsView.prototype.blurTool">function</a>.</p>
+<p>The effect of this function can be reversed for a single <code>tool</code> by the <code>toolsView.blurTool</code> <a href="#dia.ToolsView.prototype.blurTool">function</a>. All tools can be unfocused by the <code>toolsView.blurTools</code> <a href="#dia.ToolsView.prototype.blurTools">function</a>.</p>

--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -89,6 +89,19 @@ export const ToolsView = mvc.View.extend({
         return this;
     },
 
+    blurTools: function() {
+        var tools = this.tools;
+        if (!tools) return this;
+        for (var i = 0, n = tools.length; i < n; i++) {
+            var tool = tools[i];
+            if (!tool.isVisible()) {
+                tool.show();
+                tool.update();
+            }
+        }
+        return this;
+    },
+
     hide: function() {
         return this.focusTool(null);
     },
@@ -98,9 +111,9 @@ export const ToolsView = mvc.View.extend({
     },
 
     onRemove: function() {
-
         var tools = this.tools;
         if (!tools) return this;
+        this.blurTools();
         for (var i = 0, n = tools.length; i < n; i++) {
             tools[i].remove();
         }

--- a/tutorials/element-tools.html
+++ b/tutorials/element-tools.html
@@ -172,6 +172,12 @@ paper.on('element:mouseleave', function(elementView) {
                     - removes tools from all element and link views.</li>
             </ul>
 
+            <p>Note that our example toggles visibility of element tools by using the
+                <code>showTools()</code>/<code>hideTools()</code> functions.
+                Element tools may also be toggled by <code>addTools()</code>/<code>removeTools()</code> functions, which
+                are demonstrated in the <a href="link-tools.html#interaction">link tools tutorial</a>.
+                For element tools, there is no practical difference between the two approaches.</p>
+
             <h3 id="custom-button">Custom Buttons</h3>
 
             <p>It is possible to create <a href="/docs/jointjs#elementTools.Button" target="_blank">custom buttons</a> to

--- a/tutorials/js/link-tools-interaction.js
+++ b/tutorials/js/link-tools-interaction.js
@@ -94,15 +94,11 @@
         ]
     });
 
-    var linkView = link.findView(paper);
-    linkView.addTools(toolsView);
-    linkView.hideTools();
-
     paper.on('link:mouseenter', function(linkView) {
-        linkView.showTools();
+        linkView.addTools(toolsView);
     });
 
     paper.on('link:mouseleave', function(linkView) {
-        linkView.hideTools();
+        linkView.removeTools();
     });
 }());

--- a/tutorials/link-tools.html
+++ b/tutorials/link-tools.html
@@ -173,17 +173,17 @@ linkView.addTools(toolsView);</code></pre>
 
             <h3 id="interaction">Interaction</h3>
 
-            <p>You can easily toggle visibility of link tools using the
+            <p>You can easily toggle link tools using the
                 <code>'link:mouseenter'</code>/<code>'link:mouseleave'</code> Paper events:</p>
 
             <div class="paper" id="paper-link-tools-interaction"></div>
 
             <pre><code>paper.on('link:mouseenter', function(linkView) {
-    linkView.showTools();
+    linkView.addTools(toolsView);
 });
 
 paper.on('link:mouseleave', function(linkView) {
-    linkView.hideTools();
+    linkView.removeTools();
 });</code></pre>
 
             <p>JointJS source code: <a href="js/link-tools-interaction.js" target="_blank">link-tools-interaction.js</a></p>
@@ -201,16 +201,27 @@ paper.on('link:mouseleave', function(linkView) {
             </ul>
 
             <p>These functions can also help to make anchor handles (which usually lie outside the path but inside an
-                element) more accessible to users - by hiding link tools only if the mouse pointer enters a blank area
+                element) more accessible to users - by removing link tools only if the mouse pointer enters a blank area
                 of the paper:</p>
 
             <pre><code>paper.on('link:mouseenter', function(linkView) {
-    linkView.showTools();
+    linkView.addTools(toolsView);
 });
 
 paper.on('blank:mouseover', function() {
-    paper.hideTools();
+    paper.removeTools();
 });</code></pre>
+
+            <p>Note that our example toggles visibility of link tools by using the
+                <code>addTools()</code>/<code>removeTools()</code> functions, and not
+                <code>showTools()</code>/<code>hideTools()</code> which we have seen in the
+                <a href="element-tools.html#interaction">element tools tutorial</a>.
+                This is necessary because the tools view in our tutorial includes the <code>SourceArrowhead</code> and
+                <code>TargetArrowhead</code> tools, which may cause the link tools view to not be hidden as expected
+                when the link is reconnected to a topic.
+                Tools views without those two tools may use the <code>showTools()</code>/<code>hideTools()</code>
+                approach illustrated in the <a href="element-tools.html#interaction">element tools tutorial</a> without
+                issue.</p>
 
             <h3 id="custom-button">Custom Buttons</h3>
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1405,6 +1405,8 @@ export namespace dia {
 
         blurTool(tool: ToolView): this;
 
+        blurTools(): this;
+
         show(): this;
 
         hide(): this;


### PR DESCRIPTION
Fixes #1334 