### PR TITLE
elementTools.Remove: fix example in documentation

### DIFF
--- a/docs/src/joint/api/elementTools/Remove.html
+++ b/docs/src/joint/api/elementTools/Remove.html
@@ -25,8 +25,8 @@
         <td><i>function</i></td>
         <td>What should happen when the user clicks the remove button? Default:
 
-            <pre><code>function(evt, linkView, toolView) {
-    linkView.model.remove({ ui: true, tool: toolView.cid });
+            <pre><code>function(evt, elementView, toolView) {
+    elementView.model.remove({ ui: true, tool: toolView.cid });
 }</code></pre>
     </tr>
     <tr>


### PR DESCRIPTION
The element tool will pass a link view to the remove action, right?