### PR TITLE
dia.Paper: fix fitToContent() when the content has negative coordinates

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1169,7 +1169,12 @@ export const Paper = View.extend({
             padding = padding || 0;
         }
 
-        // Calculate the paper size to accomodate all the graph's elements.
+        // Calculate the paper size to accommodate all the graph's elements.
+
+        var minWidth = Math.max(opt.minWidth || 0, gridWidth);
+        var minHeight = Math.max(opt.minHeight || 0, gridHeight);
+        var maxWidth = opt.maxWidth || Number.MAX_VALUE;
+        var maxHeight = opt.maxHeight || Number.MAX_VALUE;
 
         padding = normalizeSides(padding);
 
@@ -1185,8 +1190,8 @@ export const Paper = View.extend({
         area.width *= sx;
         area.height *= sy;
 
-        var calcWidth = Math.max(Math.ceil((area.width + area.x) / gridWidth), 1) * gridWidth;
-        var calcHeight = Math.max(Math.ceil((area.height + area.y) / gridHeight), 1) * gridHeight;
+        var calcWidth = Math.ceil((area.width + area.x) / gridWidth) * gridWidth;
+        var calcHeight = Math.ceil((area.height + area.y) / gridHeight) * gridHeight;
 
         var tx = 0;
         var ty = 0;
@@ -1207,18 +1212,18 @@ export const Paper = View.extend({
         calcHeight += padding.bottom;
 
         // Make sure the resulting width and height are greater than minimum.
-        calcWidth = Math.max(calcWidth, opt.minWidth || 0);
-        calcHeight = Math.max(calcHeight, opt.minHeight || 0);
+        calcWidth = Math.max(calcWidth, minWidth);
+        calcHeight = Math.max(calcHeight, minHeight);
 
         // Make sure the resulting width and height are lesser than maximum.
-        calcWidth = Math.min(calcWidth, opt.maxWidth || Number.MAX_VALUE);
-        calcHeight = Math.min(calcHeight, opt.maxHeight || Number.MAX_VALUE);
+        calcWidth = Math.min(calcWidth, maxWidth);
+        calcHeight = Math.min(calcHeight, maxHeight);
 
         var computedSize = this.getComputedSize();
         var dimensionChange = calcWidth != computedSize.width || calcHeight != computedSize.height;
         var originChange = tx != currentTranslate.tx || ty != currentTranslate.ty;
 
-        // Change the dimensions only if there is a size discrepency or an origin change
+        // Change the dimensions only if there is a size discrepancy or an origin change
         if (originChange) {
             this.translate(tx, ty);
         }

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -117,6 +117,309 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             });
         });
 
+        QUnit.module('fitToContent() > options', function() {
+
+            [{
+                name: '0@0 200x200',
+                grid: 1,
+                contentArea: {
+                    x: 0,
+                    y: 0,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'any': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200,
+                    }
+                }
+            }, {
+                name: '-200@-200 200x200',
+                grid: 1,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1
+                    },
+                    'any': {
+                        x: -200,
+                        y: -200,
+                        width: 200,
+                        height: 200
+                    },
+                    'negative': {
+                        x: -200,
+                        y: -200,
+                        width: 200,
+                        height: 200
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1,
+                    }
+                }
+            }, {
+                name: '-200@-200 100x100',
+                grid: 1,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1
+                    },
+                    'any': {
+                        x: -200,
+                        y: -200,
+                        width: 100,
+                        height: 100
+                    },
+                    'negative': {
+                        x: -200,
+                        y: -200,
+                        width: 100,
+                        height: 100
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1,
+                    }
+                }
+            }, {
+                name: '-200@-200 100x100, grid: 300',
+                grid: 300,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: -300,
+                        y: -300,
+                        width: 300,
+                        height: 300
+                    },
+                    'negative': {
+                        x: -300,
+                        y: -300,
+                        width: 300,
+                        height: 300
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }, {
+                name: '-100@-100 200x200',
+                grid: 1,
+                contentArea: {
+                    x: -100,
+                    y: -100,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 100
+                    },
+                    'any': {
+                        x: -100,
+                        y: -100,
+                        width: 200,
+                        height: 200
+                    },
+                    'negative': {
+                        x: -100,
+                        y: -100,
+                        width: 200,
+                        height: 200
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 100
+                    }
+                }
+            }, {
+                name: '-100@-100 200x200, grid: 300',
+                grid: 300,
+                contentArea: {
+                    x: -100,
+                    y: -100,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'negative': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }, {
+                name: '200@200 100x100',
+                grid: 1,
+                contentArea: {
+                    x: 200,
+                    y: 200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: 200,
+                        y: 200,
+                        width: 100,
+                        height: 100
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'positive': {
+                        x: 200,
+                        y: 200,
+                        width: 100,
+                        height: 100
+                    }
+                }
+            }, {
+                name: '200@200 100x100',
+                grid: 150,
+                contentArea: {
+                    x: 200,
+                    y: 200,
+                    width: 120,
+                    height: 120
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 450,
+                        height: 450
+                    },
+                    'any': {
+                        x: 150,
+                        y: 150,
+                        width: 300,
+                        height: 300
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 450,
+                        height: 450
+                    },
+                    'positive': {
+                        x: 150,
+                        y: 150,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }].forEach(function(testCase) {
+                var expectedAreas = testCase.expectedAreas;
+                Object.keys(expectedAreas).forEach(function(origin) {
+                    QUnit.test(testCase.name + ', origin: ' + origin, function(assert) {
+                        var grid = testCase.grid;
+                        var area = paper.fitToContent({
+                            contentArea: testCase.contentArea,
+                            allowNewOrigin: origin,
+                            gridWidth: grid,
+                            gridHeight: grid
+                        });
+                        var expectedArea = expectedAreas[origin];
+                        assert.deepEqual(area.toJSON(), expectedArea, 'Result of paper.fitToContent()');
+                        assert.deepEqual(paper.getArea().toJSON(), expectedArea, 'Result of paper.getArea()');
+                        assert.equal(area.width % grid, 0, 'Width is multiple of grid');
+                        assert.equal(area.height % grid, 0, 'Height is multiple of grid');
+                    });
+                });
+            });
+        });
+
         QUnit.module('fitToContent() > options > useModelGeometry', function() {
 
             [0.5, 1, 2].forEach(function(scale) {


### PR DESCRIPTION
The `fitToContent()`method didn't work correctly when the content's bottom-right corner had a negative coordinate (either `x`, `y` or both).
```js
paper.scale(1);
const area = paper.fitToContent({
  contentArea: { x: -300, y: -300, width: 200, height: 200 }, // bottom-right is x=-100 and y=-100
  padding: 0,
  allowNewOrigin: 'any'
});
// Assert: `area` is { x: -300, y: -300, width: 200, height: 200 }
```

Also, in edge-case situations the resulting size might not had fall into the given grid but `{ x: 0, y: 0, width: 1, height: 1}` was always returned.

Missing tests for the most of the cases were added.



