### PR TITLE
Typescript: add jointjs version

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1,3 +1,5 @@
+export const version: string;
+
 export namespace config {
     var useCSSSelectors: boolean;
     var classNamePrefix: string;


### PR DESCRIPTION
Add missing `<string>joint.version;` definition.