### PR TITLE
dia.Paper: add allowNegativeBottomRight option to fitToContent()

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
+++ b/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
@@ -14,6 +14,13 @@
       <li><code>'any'</code> – the method recognizes all of paper content. The origin of the resulting paper will be at the origin of the content.</li>
     </ul>
   </li>
+  <li><code>opt.allowNegativeBottomRight</code> - can the bottom-right corner of the resulting paper have negative coordinates? By default, the paper area always contains point (0,0). i.e. <code>false</code>.
+<pre><code>// Resize the paper to match the tight bounding box of the content regardless of its position.
+paper.fitToContent({
+  allowNewOrigin: 'any',
+  allowNegativeBottomRight: true
+});</code></pre>
+  </li>
   <li><code>opt.minWidth</code> and <code>opt.minHeight</code> – define the minimum width and height of the resulting paper after fitting it to content.</li>
   <li><code>opt.maxWidth</code> and <code>opt.maxHeight</code> – define the maximum width and height of the resulting paper.
   after fitting it to content.</li>

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1175,6 +1175,7 @@ export const Paper = View.extend({
         var minHeight = Math.max(opt.minHeight || 0, gridHeight);
         var maxWidth = opt.maxWidth || Number.MAX_VALUE;
         var maxHeight = opt.maxHeight || Number.MAX_VALUE;
+        var newOrigin = opt.allowNewOrigin;
 
         padding = normalizeSides(padding);
 
@@ -1190,19 +1191,25 @@ export const Paper = View.extend({
         area.width *= sx;
         area.height *= sy;
 
-        var calcWidth = Math.ceil((area.width + area.x) / gridWidth) * gridWidth;
-        var calcHeight = Math.ceil((area.height + area.y) / gridHeight) * gridHeight;
+        var calcWidth = Math.ceil((area.width + area.x) / gridWidth);
+        var calcHeight = Math.ceil((area.height + area.y) / gridHeight);
+        if (!opt.allowNegativeBottomRight) {
+            calcWidth = Math.max(calcWidth, 1);
+            calcHeight = Math.max(calcHeight, 1);
+        }
+        calcWidth *= gridWidth;
+        calcHeight *= gridHeight;
 
         var tx = 0;
         var ty = 0;
 
-        if ((opt.allowNewOrigin == 'negative' && area.x < 0) || (opt.allowNewOrigin == 'positive' && area.x >= 0) || opt.allowNewOrigin == 'any') {
+        if ((newOrigin === 'negative' && area.x < 0) || (newOrigin === 'positive' && area.x >= 0) || newOrigin === 'any') {
             tx = Math.ceil(-area.x / gridWidth) * gridWidth;
             tx += padding.left;
             calcWidth += tx;
         }
 
-        if ((opt.allowNewOrigin == 'negative' && area.y < 0) || (opt.allowNewOrigin == 'positive' && area.y >= 0) || opt.allowNewOrigin == 'any') {
+        if ((newOrigin === 'negative' && area.y < 0) || (newOrigin === 'positive' && area.y >= 0) || newOrigin === 'any') {
             ty = Math.ceil(-area.y / gridHeight) * gridHeight;
             ty += padding.top;
             calcHeight += ty;

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -173,6 +173,309 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'any': {
                         x: -200,
                         y: -200,
+                        width: 201,
+                        height: 201
+                    },
+                    'negative': {
+                        x: -200,
+                        y: -200,
+                        width: 201,
+                        height: 201
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1,
+                    }
+                }
+            }, {
+                name: '-200@-200 100x100',
+                grid: 1,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1
+                    },
+                    'any': {
+                        x: -200,
+                        y: -200,
+                        width: 201,
+                        height: 201
+                    },
+                    'negative': {
+                        x: -200,
+                        y: -200,
+                        width: 201,
+                        height: 201
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1,
+                    }
+                }
+            }, {
+                name: '-200@-200 100x100, grid: 300',
+                grid: 300,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'negative': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }, {
+                name: '-100@-100 200x200',
+                grid: 1,
+                contentArea: {
+                    x: -100,
+                    y: -100,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 100
+                    },
+                    'any': {
+                        x: -100,
+                        y: -100,
+                        width: 200,
+                        height: 200
+                    },
+                    'negative': {
+                        x: -100,
+                        y: -100,
+                        width: 200,
+                        height: 200
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 100
+                    }
+                }
+            }, {
+                name: '-100@-100 200x200, grid: 300',
+                grid: 300,
+                contentArea: {
+                    x: -100,
+                    y: -100,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'negative': {
+                        x: -300,
+                        y: -300,
+                        width: 600,
+                        height: 600
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }, {
+                name: '200@200 100x100',
+                grid: 1,
+                contentArea: {
+                    x: 200,
+                    y: 200,
+                    width: 100,
+                    height: 100
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'any': {
+                        x: 200,
+                        y: 200,
+                        width: 100,
+                        height: 100
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 300,
+                        height: 300
+                    },
+                    'positive': {
+                        x: 200,
+                        y: 200,
+                        width: 100,
+                        height: 100
+                    }
+                }
+            }, {
+                name: '200@200 100x100',
+                grid: 150,
+                contentArea: {
+                    x: 200,
+                    y: 200,
+                    width: 120,
+                    height: 120
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 450,
+                        height: 450
+                    },
+                    'any': {
+                        x: 150,
+                        y: 150,
+                        width: 300,
+                        height: 300
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 450,
+                        height: 450
+                    },
+                    'positive': {
+                        x: 150,
+                        y: 150,
+                        width: 300,
+                        height: 300
+                    }
+                }
+            }].forEach(function(testCase) {
+                var expectedAreas = testCase.expectedAreas;
+                Object.keys(expectedAreas).forEach(function(origin) {
+                    QUnit.test(testCase.name + ', origin: ' + origin, function(assert) {
+                        var grid = testCase.grid;
+                        var area = paper.fitToContent({
+                            contentArea: testCase.contentArea,
+                            allowNewOrigin: origin,
+                            gridWidth: grid,
+                            gridHeight: grid
+                        });
+                        var expectedArea = expectedAreas[origin];
+                        assert.deepEqual(area.toJSON(), expectedArea, 'Result of paper.fitToContent()');
+                        assert.deepEqual(paper.getArea().toJSON(), expectedArea, 'Result of paper.getArea()');
+                        assert.equal(area.width % grid, 0, 'Width is multiple of grid');
+                        assert.equal(area.height % grid, 0, 'Height is multiple of grid');
+                    });
+                });
+            });
+        });
+
+        QUnit.module('fitToContent() > options > allowNegativeBottomRight = true', function() {
+
+            [{
+                name: '0@0 200x200',
+                grid: 1,
+                contentArea: {
+                    x: 0,
+                    y: 0,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'any': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'negative': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200
+                    },
+                    'positive': {
+                        x: 0,
+                        y: 0,
+                        width: 200,
+                        height: 200,
+                    }
+                }
+            }, {
+                name: '-200@-200 200x200',
+                grid: 1,
+                contentArea: {
+                    x: -200,
+                    y: -200,
+                    width: 200,
+                    height: 200
+                },
+                expectedAreas: {
+                    'default': {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1
+                    },
+                    'any': {
+                        x: -200,
+                        y: -200,
                         width: 200,
                         height: 200
                     },
@@ -407,6 +710,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         var area = paper.fitToContent({
                             contentArea: testCase.contentArea,
                             allowNewOrigin: origin,
+                            allowNegativeBottomRight: true,
                             gridWidth: grid,
                             gridHeight: grid
                         });

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1077,6 +1077,7 @@ export namespace dia {
             gridHeight?: number;
             padding?: Padding;
             allowNewOrigin?: 'negative' | 'positive' | 'any';
+            allowNegativeBottomRight?: boolean;
             minWidth?: number;
             minHeight?: number;
             maxWidth?: number;


### PR DESCRIPTION
Fixes #1441, which introduced a breaking change. A new option needs to be added to allow the new behaviour - allowing the bottom right corner of the paper to have negative coordinates after `fitToContent()`.

```js
graph.addCell({
  type: 'standard.Rectangle',
  size: { width: 10, height: 10 },
  position: { x: -100, y: -100 }
});

const area1 = paper.fitToContent({
  allowNewOrigin: 'any'
  // allowNegativeBottomRight: false
});
// The bottom-right corner has always positive coordinates
// assert.equal(area1, { x: -100, y: -100, width: 101, height: 101 });



const area2 = paper.fitToContent({
  allowNewOrigin: 'any',
  allowNegativeBottomRight: true
});
// Resize the paper to match the tight bounding box of the content regardless of its position.
// assert.equal(area2, { x: -100, y: -100, width: 10, height: 10 });
```


