### PR TITLE
util.breakText: fix wrapping when the last word contains a hyphen

### DIFF
--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -474,7 +474,7 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
     var separator = opt.separator || ' ';
     var eol = opt.eol || '\n';
-    var hyphen = opt.hyphen ? new RegExp(opt.hyphen) : /[\-]/;
+    var hyphen = opt.hyphen ? new RegExp(opt.hyphen) : /[^\w\d]/;
     var maxLineCount = opt.maxLineCount;
     if (!isNumber(maxLineCount)) maxLineCount = Infinity;
 
@@ -565,7 +565,7 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
                         // move last letter to the beginning of the next word
                         words[i] = word.substring(0, p);
-                        words[i + 1] = word.substring(p) + (words[i + 1] ? words[i + 1] : '');
+                        words[i + 1] = word.substring(p) + (words[i + 1] === undefined ? '' : words[i + 1]);
 
                     } else {
 

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -474,7 +474,7 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
     var separator = opt.separator || ' ';
     var eol = opt.eol || '\n';
-    var hyphen = opt.hyphen ? new RegExp(opt.hyphen) : /[^\w\d]/;
+    var hyphen = opt.hyphen ? new RegExp(opt.hyphen) : /[\-]/;
     var maxLineCount = opt.maxLineCount;
     if (!isNumber(maxLineCount)) maxLineCount = Infinity;
 
@@ -565,7 +565,7 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
                         // move last letter to the beginning of the next word
                         words[i] = word.substring(0, p);
-                        words[i + 1] = word.substring(p) + words[i + 1];
+                        words[i + 1] = word.substring(p) + (words[i + 1] ? words[i + 1] : '');
 
                     } else {
 

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -189,12 +189,28 @@ QUnit.module('util', function(hooks) {
         QUnit.test('hyphen', function(assert) {
 
             var WIDTH = 50;
-            var t, r;
+            var t, t2, t3, t4, r;
 
             t = 'test-hyphen';
+            t2 = 'asdfWETUIOPj[JF';
+            t3 = 'as[dsdfgdfWETUfIOPj';
+            t4 = 'WETUIOP[JF';
 
             r = joint.util.breakText(t, { width: 2 * WIDTH }, styles);
             assert.equal(r, 'test-hyphen');
+
+            // by default characters that are not letters or number are treated as hyphens
+            r = joint.util.breakText(t2, { width: 2 * WIDTH }, styles);
+            assert.equal(r, 'asdfWETUIOPj[\nJF', 'Inserts new line character after "[" character.');
+
+            r = joint.util.breakText(t3, { width: 2 * WIDTH + 20 }, styles);
+            assert.equal(r, 'as[\ndsdfgdfWETUfIOPj', 'Inserts new line character after "[" character.');
+
+            r = joint.util.breakText(t3, { width: 2 * WIDTH }, styles);
+            assert.equal(r, 'as[\ndsdfgdfWETUfI\nOPj', 'Inserts two new line characters, one after "[" and one in second line when text is too long.');
+
+            r = joint.util.breakText(t4, { width: 2 * WIDTH }, styles);
+            assert.equal(r, 'WETUIOP[JF', 'Does not insert new line character when text fits in a single line.');
 
             r = joint.util.breakText(t, { width: WIDTH }, styles);
             assert.equal(r, 'test-\nhyphen');

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -199,7 +199,6 @@ QUnit.module('util', function(hooks) {
             r = joint.util.breakText(t, { width: 2 * WIDTH }, styles);
             assert.equal(r, 'test-hyphen');
 
-            // by default characters that are not letters or number are treated as hyphens
             r = joint.util.breakText(t2, { width: 2 * WIDTH }, styles);
             assert.equal(r, 'asdfWETUIOPj[\nJF', 'Inserts new line character after "[" character.');
 


### PR DESCRIPTION
Fixing https://github.com/clientIO/joint/issues/1460.

```js
// Make sure the resulting string does not contain `undefined` when the last word has a hyphen
joint.util.breakText('word1-word1', { width });
joint.util.breakText('word1 word2-word2', { width });
joint.util.breakText('word1 word2 word3-word3', { width });
```