### PR TITLE
Geometry: fix TS polyline constructor

### DIFF
--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -526,7 +526,7 @@ export namespace g {
 
         constructor();
         constructor(svgString: string);
-        constructor(points: Point[]);
+        constructor(points: PlainPoint[]);
 
         bbox(): Rect | null;
 


### PR DESCRIPTION
Fix incorrect `Polyline` constructor type defintion.
```js
 // Use of g.PlainPoints[] is now supported
const p1 = new g.Polyline([{ x: 1, y: 1}, { x: 2, y: 2 }]);
// Use g.Points[] remains supported
const p2 = new g.Polyline([new g.Point(1, 1), new g.Point(2, 2)]);
```