### PR TITLE
dia.Graph: fix order of cells in getElements() and getLinks()

### DIFF
--- a/docs/src/joint/api/dia/Graph/prototype/getCells.html
+++ b/docs/src/joint/api/dia/Graph/prototype/getCells.html
@@ -1,1 +1,1 @@
-<pre class="docs-method-signature"><code>graph.getCells()</code></pre><p>Get all the elements and links in the graph.</p>
+<pre class="docs-method-signature"><code>graph.getCells()</code></pre><p>Return an array of all elements and links in the graph. The cells are sorted by their <code>z</code> index (the smallest <code>z</code> being first).</p>

--- a/docs/src/joint/api/dia/Graph/prototype/getElements.html
+++ b/docs/src/joint/api/dia/Graph/prototype/getElements.html
@@ -1,1 +1,1 @@
-<pre class="docs-method-signature"><code>graph.getElements()</code></pre><p>Get all the elements in the graph (i.e. omit links).</p>
+<pre class="docs-method-signature"><code>graph.getElements()</code></pre><p>Return an array of all elements in the graph. The elements are sorted by their <code>z</code> index (the smallest <code>z</code> being first).</p>

--- a/docs/src/joint/api/dia/Graph/prototype/getLinks.html
+++ b/docs/src/joint/api/dia/Graph/prototype/getLinks.html
@@ -1,1 +1,1 @@
-<pre class="docs-method-signature"><code>graph.getLinks()</code></pre><p>Get all the links in the graph (i.e. omit elements).</p>
+<pre class="docs-method-signature"><code>graph.getLinks()</code></pre><p>Return an array of all links in the graph. The links are sorted by their <code>z</code> index (the smallest <code>z</code> being first).</p>

--- a/src/dia/Graph.mjs
+++ b/src/dia/Graph.mjs
@@ -410,12 +410,12 @@ export const Graph = Backbone.Model.extend({
 
     getElements: function() {
 
-        return Object.keys(this._nodes).map(this.getCell, this);
+        return this.get('cells').filter(cell => cell.isElement());
     },
 
     getLinks: function() {
 
-        return Object.keys(this._edges).map(this.getCell, this);
+        return this.get('cells').filter(cell => cell.isLink());
     },
 
     getFirstCell: function() {

--- a/test/jointjs/graph.js
+++ b/test/jointjs/graph.js
@@ -463,6 +463,33 @@ QUnit.module('graph', function(hooks) {
             'getElements() returns only the elements in the graph');
     });
 
+    QUnit.test('graph.getElements() cells order', function(assert) {
+
+        var graph = this.graph;
+        var r1 = new joint.shapes.standard.Rectangle({ id: 'r1', z: 3 });
+        var r2 = new joint.shapes.standard.Rectangle({ id: 'r2', z: 2 });
+        var r3 = new joint.shapes.standard.Rectangle({ id: 'r3', z: 1 });
+
+        graph.addCells([r1, r2, r3]);
+
+        assert.deepEqual(_.map(graph.getCells(), 'id'), ['r3', 'r2', 'r1']);
+        assert.deepEqual(_.map(graph.getElements(), 'id'), ['r3', 'r2', 'r1']);
+    });
+
+
+    QUnit.test('graph.getLinks() cells order', function(assert) {
+
+        var graph = this.graph;
+        var l1 = new joint.shapes.standard.Link({ id: 'l1', z: 3 });
+        var l2 = new joint.shapes.standard.Link({ id: 'l2', z: 2 });
+        var l3 = new joint.shapes.standard.Link({ id: 'l3', z: 1 });
+
+        graph.addCells([l1, l2, l3]);
+
+        assert.deepEqual(_.map(graph.getCells(), 'id'), ['l3', 'l2', 'l1']);
+        assert.deepEqual(_.map(graph.getLinks(), 'id'), ['l3', 'l2', 'l1']);
+    });
+
     QUnit.test('graph.getCommonAncestor()', function(assert) {
 
         var r1 = new joint.shapes.basic.Rect;


### PR DESCRIPTION
- Fixes an issue with embedding mode, which relies on `getElements()` returning the elements in the graph collection order (the elements being sorted by their `z`). The current solution returned the elements (links) in unspecified order (based on object properties order).
- Improve performance for typical graphs where number of elements is similar to number of links (https://jsfiddle.net/kumilingus/L48xyr1f/)
 