### PR TITLE
Geometry: declare Math fns shorthands using destructuring

### DIFF
--- a/src/g/curve.mjs
+++ b/src/g/curve.mjs
@@ -3,12 +3,13 @@ import { Rect } from './rect.mjs';
 import { Line } from './line.mjs';
 import { Polyline } from './polyline.mjs';
 
-const math = Math;
-const abs = math.abs;
-const sqrt = math.sqrt;
-const min = math.min;
-const max = math.max;
-const pow = math.pow;
+const {
+    abs,
+    sqrt,
+    min,
+    max,
+    pow
+} = Math;
 
 export const Curve = function(p1, p2, p3, p4) {
 

--- a/src/g/ellipse.mjs
+++ b/src/g/ellipse.mjs
@@ -1,10 +1,11 @@
 import { Rect } from './rect.mjs';
 import { Point } from './point.mjs';
 
-const math = Math;
-const sqrt = math.sqrt;
-const round = math.round;
-const pow = math.pow;
+const {
+    sqrt,
+    round,
+    pow
+} = Math;
 
 export const Ellipse = function(c, a, b) {
 

--- a/src/g/geometry.helpers.mjs
+++ b/src/g/geometry.helpers.mjs
@@ -1,8 +1,9 @@
 // Declare shorthands to the most used math functions.
-const math = Math;
-const round = math.round;
-const floor = math.floor;
-const PI = math.PI;
+const {
+    round,
+    floor,
+    PI
+} = Math;
 
 export const scale = {
 
@@ -52,6 +53,6 @@ export const random = function(min, max) {
         max = temp;
     }
 
-    return floor((math.random() * (max - min + 1)) + min);
+    return floor((Math.random() * (max - min + 1)) + min);
 };
 

--- a/src/g/line.bearing.mjs
+++ b/src/g/line.bearing.mjs
@@ -2,10 +2,11 @@
 // @returns {String} One of the following bearings : NE, E, SE, S, SW, W, NW, N.
 import { toDeg, toRad } from './geometry.helpers.mjs';
 
-const math = Math;
-const cos = math.cos;
-const sin = math.sin;
-const atan2 = math.atan2;
+const {
+    cos,
+    sin,
+    atan2
+} = Math;
 
 export const bearing = function(p, q) {
 

--- a/src/g/line.mjs
+++ b/src/g/line.mjs
@@ -4,9 +4,10 @@ import { bearing } from './line.bearing.mjs';
 import { squaredLength } from './line.squaredLength.mjs';
 import { length } from './line.length.mjs';
 
-const math = Math;
-const min = math.min;
-const max = math.max;
+const {
+    max,
+    min
+} = Math;
 
 export const Line = function(p1, p2) {
 

--- a/src/g/point.mjs
+++ b/src/g/point.mjs
@@ -12,17 +12,18 @@ import { bearing } from './line.bearing.mjs';
 import { squaredLength } from './line.squaredLength.mjs';
 import { length } from './line.length.mjs';
 
-const math = Math;
-const abs = math.abs;
-const cos = math.cos;
-const sin = math.sin;
-const sqrt = math.sqrt;
-const min = math.min;
-const max = math.max;
-const atan2 = math.atan2;
-const round = math.round;
-const PI = math.PI;
-const pow = math.pow;
+const {
+    abs,
+    cos,
+    sin,
+    sqrt,
+    min,
+    max,
+    atan2,
+    round,
+    pow,
+    PI
+} = Math;
 
 export const Point = function(x, y) {
 

--- a/src/g/polyline.mjs
+++ b/src/g/polyline.mjs
@@ -2,7 +2,7 @@ import { Rect } from './rect.mjs';
 import { Point } from './point.mjs';
 import { Line } from './line.mjs';
 
-const abs = Math.abs;
+const { abs } = Math;
 
 export const Polyline = function(points) {
 

--- a/src/g/rect.mjs
+++ b/src/g/rect.mjs
@@ -3,14 +3,15 @@ import { Line } from './line.mjs';
 import { Point } from './point.mjs';
 import { Ellipse } from './ellipse.mjs';
 
-const math = Math;
-const abs = math.abs;
-const cos = math.cos;
-const sin = math.sin;
-const min = math.min;
-const max = math.max;
-const round = math.round;
-const pow = math.pow;
+const {
+    abs,
+    cos,
+    sin,
+    min,
+    max,
+    round,
+    pow
+} = Math;
 
 export const Rect = function(x, y, w, h) {
 


### PR DESCRIPTION
Use destructuring assignment for a more concise and readable shorthand declaration.