### PR TITLE
 dia.Paper: add validateUnembedding() option

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/options/validateUnembedding.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/validateUnembedding.html
@@ -1,0 +1,10 @@
+<code>validateUnembedding</code> - a function that allows you to control which elements can be unembedded when the paper is put into the <code>embeddingMode</code> <i>(see above)</i>.
+<br>
+The function signature is <code>function(childView)</code> and should return
+<code>true</code> if the <code>childView</code> element can be unembedded from the parent and become a new root.
+<br>
+By default, all elements can become roots (the function returns <code>true</code> no matter what).
+<br>
+The callback is called at the end of drag & drop action and if <code>false</code> is returned, the position of the element, as well the parent reference is reverted to the values before dragging.
+<br>
+The callback is called only on elements which were previously embedded in another element.

--- a/docs/src/joint/api/dia/Paper/prototype/options/validateUnembedding.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/validateUnembedding.html
@@ -5,6 +5,6 @@ The function signature is <code>function(childView)</code> and should return
 <br>
 By default, all elements can become roots (the function returns <code>true</code> no matter what).
 <br>
-The callback is called at the end of drag & drop action and if <code>false</code> is returned, the position of the element, as well the parent reference is reverted to the values before dragging.
+The callback is called at the end of drag & drop action and if <code>false</code> is returned, the position of the element, as well as the parent reference is reverted to the values before dragging.
 <br>
 The callback is called only on elements which were previously embedded in another element.

--- a/src/dia/ElementView.mjs
+++ b/src/dia/ElementView.mjs
@@ -1,5 +1,5 @@
 import { config } from '../config/index.mjs';
-import { assign, invoke, isFunction, toArray } from '../util/index.mjs';
+import { assign, isFunction, toArray } from '../util/index.mjs';
 import { CellView } from './CellView.mjs';
 import { Cell } from './Cell.mjs';
 import V from '../V/index.mjs';

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -189,6 +189,12 @@ export const Paper = View.extend({
             return true;
         },
 
+        // Check whether to allow or disallow an embedded element to be unembedded / to become a root.
+        validateUnembedding: function(childView) {
+            // by default all elements can become roots
+            return true;
+        },
+
         // Determines the way how a cell finds a suitable parent when it's dragged over the paper.
         // The cell with the highest z-index (visually on the top) will be chosen.
         findParentBy: 'bbox', // 'bbox'|'center'|'origin'|'corner'|'topRight'|'bottomLeft'

--- a/test/jointjs/embedding.js
+++ b/test/jointjs/embedding.js
@@ -135,6 +135,17 @@ QUnit.module('embedding', function(hooks) {
         assert.ok(r2.isEmbeddedIn(r1));
         assert.equal(r2.parent(), r1.id);
         assert.deepEqual(r2.position().toJSON(), newPosition1); // not newPosition2
+
+        // Try to Unembedded (And remove when invalid)
+        assert.ok(graph.getCell(r2.id));
+        evt = { target: paper.el };
+        v2.eventData(evt, { whenNotAllowed: 'remove' });
+        v2.pointerdown(evt, newPosition1.x, newPosition1.y);
+        v2.pointermove(evt, newPosition2.x, newPosition2.y);
+        v2.pointerup(evt, newPosition2.x, newPosition2.y);
+
+        assert.ok(validateUnembeddingSpy.calledThrice);
+        assert.notOk(graph.getCell(r2.id));
     });
 
     QUnit.test('passing UI flag', function(assert) {

--- a/test/jointjs/embedding.js
+++ b/test/jointjs/embedding.js
@@ -8,7 +8,7 @@ QUnit.module('embedding', function(hooks) {
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
             el: $paper,
-            gridSize: 10,
+            gridSize: 1,
             model: this.graph,
             embeddingMode: true
         });
@@ -63,6 +63,78 @@ QUnit.module('embedding', function(hooks) {
         v2.pointerup(evt, 100, 100);
 
         assert.notEqual(r2.get('parent'), r1.id, 'validating function denying all element pairs provided: element not embedded.');
+    });
+
+    QUnit.test('validateUnembedding option', function(assert) {
+
+        var evt;
+        var paper = this.paper;
+        var graph = this.graph;
+        var unembeddingIsValid = true;
+        var validateUnembeddingSpy = sinon.spy(function() {
+            return unembeddingIsValid;
+        });
+
+        paper.options.validateUnembedding = validateUnembeddingSpy;
+
+        var r1 = new joint.shapes.standard.Rectangle({
+            position: { x: 100, y: 101 },
+            size: { width: 100, height: 100 }
+        });
+        var r2 = new joint.shapes.standard.Rectangle({
+            position: { x: 500, y: 501 },
+            size: { width: 100, height: 100 }
+        });
+
+        graph.addCells([r1, r2]);
+
+        var v1 = r1.findView(paper);
+        var v2 = r2.findView(paper);
+
+        // Make sure validateUnembedding() is not called when embedding
+        var newPosition0 = { x: 100, y: 101 };
+
+        evt = { target: v1.el };
+        v2.pointerdown(evt, r2.attributes.position.x, r2.attributes.position.y);
+        v2.pointermove(evt, newPosition0.x, newPosition0.y);
+        v2.pointerup(evt, newPosition0.x, newPosition0.y);
+
+        assert.equal(r2.parent(), r1.id);
+        assert.ok(validateUnembeddingSpy.notCalled);
+
+        // Try To Unembed (Valid)
+        unembeddingIsValid = true;
+        var newPosition1 = { x: 300, y: 301 };
+
+        evt = { target: paper.el };
+        v2.pointerdown(evt, newPosition0.x, newPosition0.y);
+        v2.pointermove(evt, newPosition1.x, newPosition1.y);
+        v2.pointerup(evt, newPosition1.x, newPosition1.y);
+
+        assert.ok(validateUnembeddingSpy.calledOnce);
+        assert.ok(validateUnembeddingSpy.calledOn(paper));
+        assert.ok(validateUnembeddingSpy.calledWithExactly(v2));
+        assert.notOk(r2.isEmbeddedIn(r1));
+        assert.notEqual(r2.parent(), r1.id);
+        assert.deepEqual(r2.position().toJSON(), newPosition1);
+
+        // Try To Unembed (Invalid)
+        unembeddingIsValid = false;
+        r1.embed(r2);
+        var newPosition2 = { x: 600, y: 601 };
+
+        evt = { target: paper.el };
+        v2.pointerdown(evt, newPosition1.x, newPosition1.y);
+        v2.pointermove(evt, newPosition2.x, newPosition2.y);
+        v2.pointerup(evt, newPosition2.x, newPosition2.y);
+
+        assert.ok(validateUnembeddingSpy.calledTwice);
+        assert.ok(validateUnembeddingSpy.calledOn(paper));
+        assert.ok(validateUnembeddingSpy.calledWithExactly(v2));
+        // make sure the position and the parent are reverted
+        assert.ok(r2.isEmbeddedIn(r1));
+        assert.equal(r2.parent(), r1.id);
+        assert.deepEqual(r2.position().toJSON(), newPosition1); // not newPosition2
     });
 
     QUnit.test('passing UI flag', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1058,7 +1058,8 @@ export namespace dia {
             embeddingMode?: boolean;
             frontParentOnly?: boolean,
             findParentBy?: 'bbox' | 'center' | 'origin' | 'corner' | 'topRight' | 'bottomLeft' | ((elementView: ElementView) => Element[]);
-            validateEmbedding?: (childView: ElementView, parentView: ElementView) => boolean;
+            validateEmbedding?: (this: Paper, childView: ElementView, parentView: ElementView) => boolean;
+            validateUnembedding?: (this: Paper, childView: ElementView) => boolean;
             // default views, models & attributes
             cellViewNamespace?: any;
             highlighterNamespace?: any;


### PR DESCRIPTION
Add missing validation callback for `embeddingMode` to check if an element can become a new root (to be un-embedded from a parent and become an element without parent).

If invalid -> the position and parent-child relationship is reverted to the state before user interaction.

Rappid Stencil (or an element palette) should take this option into account when an element is dropped from the stencil and the `embeddingMode` is on.