### PR TITLE
dia.Paper: add routerNamespace and connectorNamespace options

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/options/anchorNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/anchorNamespace.html
@@ -1,0 +1,4 @@
+<code>anchorNamespace</code> - built-in <a href="#anchors">anchors</a> are defined by default on the <code>joint.anchors</code> namespace. 
+                                It is also possible to define custom anchors on this namespace. If you would like JointJS to look for anchor
+                                definitions under a different namespace, you can set the <code>anchorNamespace</code> option to your desired 
+                                namespace.

--- a/docs/src/joint/api/dia/Paper/prototype/options/connectionPointNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/connectionPointNamespace.html
@@ -1,0 +1,5 @@
+<code>connectionPointNamespace</code> - built-in <a href="#connectionPoints">connectionPoints</a> are defined by default on the 
+                                        <code>joint.connectionPoints</code> namespace. It is also possible to define custom connectionPoints
+                                        on this namespace. If you would like JointJS to look for connectionPoint definitions under a different 
+                                        namespace, you can set the <code>connectionPointNamespace</code> option to your desired 
+                                        namespace.

--- a/docs/src/joint/api/dia/Paper/prototype/options/connectorNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/connectorNamespace.html
@@ -1,0 +1,15 @@
+<code>connectorNamespace</code> - this option allows the user specify a custom link connector namespace right in the paper options.
+                                This works in tandem with the<a href="#dia.Paper.prototype.options.defaultConnector">defaultConnector</a> option.
+                                If a user provides an object <code>{ name: 'customConnector' }</code> as the defaultConnector, the paper will
+                                look for this connector in the provided <code>connectorNamespace</code>. The default connector used is <i>'normal'</i>.
+
+<pre><code>
+    const customNamespace = {};
+
+    new joint.dia.Paper({
+        defaultConnector: { name: 'customConnector' },
+        connectorNamespace: customNamespace,
+    });
+
+    // the paper looks for the connector under customNamespace['customConnector']
+}</code></pre>

--- a/docs/src/joint/api/dia/Paper/prototype/options/connectorNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/connectorNamespace.html
@@ -1,15 +1,4 @@
-<code>connectorNamespace</code> - this option allows the user specify a custom link connector namespace right in the paper options.
-                                This works in tandem with the<a href="#dia.Paper.prototype.options.defaultConnector">defaultConnector</a> option.
-                                If a user provides an object <code>{ name: 'customConnector' }</code> as the defaultConnector, the paper will
-                                look for this connector in the provided <code>connectorNamespace</code>. The default connector used is <i>'normal'</i>.
-
-<pre><code>
-    const customNamespace = {};
-
-    new joint.dia.Paper({
-        defaultConnector: { name: 'customConnector' },
-        connectorNamespace: customNamespace,
-    });
-
-    // the paper looks for the connector under customNamespace['customConnector']
-}</code></pre>
+<code>connectorNamespace</code> - built-in <a href="#connectors">connectors</a> are defined by default on the <code>joint.connectors</code> namespace. 
+                                It is also possible to define custom connectors on this namespace. If you would like JointJS to look for connector
+                                definitions under a different namespace, you can set the <code>connectorNamespace</code> option to your desired 
+                                namespace.

--- a/docs/src/joint/api/dia/Paper/prototype/options/highlighterNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/highlighterNamespace.html
@@ -1,0 +1,5 @@
+<code>highlighterNamespace</code> - built-in <a href="#highlighters">highlighters</a> are defined by default on the 
+                                    <code>joint.highlighters</code> namespace. Existing and custom highlighters are defined by extending
+                                    the <a href="#dia.HighlighterView">base class</a>. If you would like JointJS to look for highlighter 
+                                    definitions under a different namespace, you can set the <code>highlighterNamespace</code> option 
+                                    to your desired namespace.

--- a/docs/src/joint/api/dia/Paper/prototype/options/linkAnchorNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/linkAnchorNamespace.html
@@ -1,0 +1,4 @@
+<code>linkAnchorNamespace</code> - built-in <a href="#linkAnchors">linkAnchors</a> are defined by default on the <code>joint.linkAnchors</code> 
+                                    namespace. It is also possible to define custom linkAnchors on this namespace. If you would like JointJS to 
+                                    look for linkAnchor definitions under a different namespace, you can set the <code>linkAnchorNamespace</code> 
+                                    option to your desired namespace.

--- a/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
@@ -1,3 +1,16 @@
-<code>routerNamespace</code> - this option allows the user specify an existing or custom link router Namespace right in the paper options.
-                                This will overide the <a href="#dia.Paper.prototype.options.defaultRouter">defaultRouter</a> option.
+<code>routerNamespace</code> - this option allows the user specify a custom link router namespace right in the paper options.
+                                This works in tandem with the<a href="#dia.Paper.prototype.options.defaultRouter">defaultRouter</a> option.
+                                If a user provides an object <code>{ name: 'customRouter' }</code> as the defaultRouter, the paper will
+                                look for this router in the provided <code>routerNamespace</code>. The default router used is <i>'normal'</i>.
+
+<pre><code>
+    const customNamespace = {};
+
+    new joint.dia.Paper({
+        defaultRouter: { name: 'customRouter' },
+        routerNamespace: customNamespace,
+    });
+
+    // the paper looks for the router under customNamespace['customRouter']
+}</code></pre>
                 

--- a/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
@@ -2,5 +2,3 @@
                                 It is also possible to define custom routers on this namespace. If you would like JointJS to look for router
                                 definitions under a different namespace, you can set the <code>routerNamespace</code> option to your desired 
                                 namespace.
-
-                

--- a/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
@@ -1,0 +1,3 @@
+<code>routerNamespace</code> - this option allows the user specify an existing or custom link router Namespace right in the paper options.
+                                This will overide the <a href="#dia.Paper.prototype.options.defaultRouter">defaultRouter</a> option.
+                

--- a/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/routerNamespace.html
@@ -1,16 +1,6 @@
-<code>routerNamespace</code> - this option allows the user specify a custom link router namespace right in the paper options.
-                                This works in tandem with the<a href="#dia.Paper.prototype.options.defaultRouter">defaultRouter</a> option.
-                                If a user provides an object <code>{ name: 'customRouter' }</code> as the defaultRouter, the paper will
-                                look for this router in the provided <code>routerNamespace</code>. The default router used is <i>'normal'</i>.
+<code>routerNamespace</code> - built-in <a href="#routers">routers</a> are defined by default on the <code>joint.routers</code> namespace. 
+                                It is also possible to define custom routers on this namespace. If you would like JointJS to look for router
+                                definitions under a different namespace, you can set the <code>routerNamespace</code> option to your desired 
+                                namespace.
 
-<pre><code>
-    const customNamespace = {};
-
-    new joint.dia.Paper({
-        defaultRouter: { name: 'customRouter' },
-        routerNamespace: customNamespace,
-    });
-
-    // the paper looks for the router under customNamespace['customRouter']
-}</code></pre>
                 

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1314,12 +1314,17 @@ export const LinkView = CellView.extend({
 
         vertices || (vertices = []);
 
-        var namespace = routers;
+        var namespace;
         var router = this.model.router();
         var defaultRouter = this.paper.options.defaultRouter;
+        var routerNamespace = this.paper.options.routerNamespace;
+
+        if (routerNamespace) namespace = routerNamespace;
+        else namespace = routers;
 
         if (!router) {
-            if (defaultRouter) router = defaultRouter;
+            if (routerNamespace) router = routerNamespace;
+            else if (defaultRouter) router = defaultRouter;
             else return vertices.map(Point); // no router specified
         }
 

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1345,7 +1345,7 @@ export const LinkView = CellView.extend({
     // between `source` and `target`.
     findPath: function(route, sourcePoint, targetPoint) {
 
-        var namespace = connectors;
+        var namespace = this.paper.options.connectorNamespace || connectors;
         var connector = this.model.connector();
         var defaultConnector = this.paper.options.defaultConnector;
 

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1314,17 +1314,12 @@ export const LinkView = CellView.extend({
 
         vertices || (vertices = []);
 
-        var namespace;
+        var namespace = this.paper.options.routerNamespace || routers;
         var router = this.model.router();
         var defaultRouter = this.paper.options.defaultRouter;
-        var routerNamespace = this.paper.options.routerNamespace;
-
-        if (routerNamespace) namespace = routerNamespace;
-        else namespace = routers;
 
         if (!router) {
-            if (routerNamespace) router = routerNamespace;
-            else if (defaultRouter) router = defaultRouter;
+            if (defaultRouter) router = defaultRouter;
             else return vertices.map(Point); // no router specified
         }
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -255,6 +255,8 @@ export const Paper = View.extend({
 
         cellViewNamespace: null,
 
+        routerNamespace: null,
+
         highlighterNamespace: highlighters,
 
         anchorNamespace: anchors,

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -257,6 +257,8 @@ export const Paper = View.extend({
 
         routerNamespace: null,
 
+        connectorNamespace: null,
+
         highlighterNamespace: highlighters,
 
         anchorNamespace: anchors,

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1056,13 +1056,14 @@ export namespace dia {
             linkView?: typeof LinkView | ((link: Link) => typeof LinkView);
             // embedding
             embeddingMode?: boolean;
-            frontParentOnly?: boolean,
+            frontParentOnly?: boolean;
             findParentBy?: 'bbox' | 'center' | 'origin' | 'corner' | 'topRight' | 'bottomLeft' | ((elementView: ElementView) => Element[]);
             validateEmbedding?: (this: Paper, childView: ElementView, parentView: ElementView) => boolean;
             validateUnembedding?: (this: Paper, childView: ElementView) => boolean;
             // default views, models & attributes
             cellViewNamespace?: any;
             routerNamespace?: any;
+            connectorNamespace?: any;
             highlighterNamespace?: any;
             anchorNamespace?: any;
             linkAnchorNamespace?: any,

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1062,6 +1062,7 @@ export namespace dia {
             validateUnembedding?: (this: Paper, childView: ElementView) => boolean;
             // default views, models & attributes
             cellViewNamespace?: any;
+            routerNamespace?: any;
             highlighterNamespace?: any;
             anchorNamespace?: any;
             linkAnchorNamespace?: any,


### PR DESCRIPTION
- allow custom routers and connectors to be defined in ESM
- document missing namespace options (`anchorNamespace`, `connectionPointNamespace`, `linkAnchorNamespace`, `highlighterNamespace`)