### PR TITLE
routers.Manhattan: add isPointObstacle option

### DIFF
--- a/docs/src/joint/api/routers/manhattan.html
+++ b/docs/src/joint/api/routers/manhattan.html
@@ -46,6 +46,11 @@
         <td><i>Array&lt;string&gt;</i></td>
         <td>An array that specifies the possible ending directions to an element. Change this in situations where you need the link to, for example, always end at the bottom of the source element (then, the value would be <code>['bottom']</code>). Default is <code>['left', 'right', 'top', 'bottom']</code> (all directions allowed).</td>
     </tr>
+    <tr>
+        <th>isPointObstacle</th>
+        <td><i>(point) => boolean</i></td>
+        <td>A function that determines whether a given point is an obstacle or not. If used, the <i>padding</i>, <i>excludeEnds</i> and <i>excludeTypes</i> options are ignored.</td>
+    </tr>
 </table>
 
 <p>Example:</p>

--- a/src/routers/manhattan.mjs
+++ b/src/routers/manhattan.mjs
@@ -557,7 +557,7 @@ function getRectPoints(anchor, bbox, directionList, grid, opt) {
 
 // finds the route between two points/rectangles (`from`, `to`) implementing A* algorithm
 // rectangles get rect points assigned by getRectPoints()
-function findRoute(from, to, map, opt) {
+function findRoute(from, to, isPointObstacle, opt) {
 
     var precision = opt.precision;
 
@@ -605,8 +605,8 @@ function findRoute(from, to, map, opt) {
     }
 
     // take into account only accessible rect points (those not under obstacles)
-    startPoints = startPoints.filter(p => map.isPointAccessible(p));
-    endPoints = endPoints.filter(p => map.isPointAccessible(p));
+    startPoints = startPoints.filter(p => !isPointObstacle(p));
+    endPoints = endPoints.filter(p => !isPointObstacle(p));
 
     // Check that there is an accessible route point on both sides.
     // Otherwise, use fallbackRoute().
@@ -701,7 +701,7 @@ function findRoute(from, to, map, opt) {
                 var neighborKey = getKey(neighborPoint);
 
                 // Closed points from the openSet were already evaluated.
-                if (openSet.isClose(neighborKey) || !map.isPointAccessible(neighborPoint)) continue;
+                if (openSet.isClose(neighborKey) || isPointObstacle(neighborPoint)) continue;
 
                 // We can only enter end points at an acceptable angle.
                 if (endPointsKeys.indexOf(neighborKey) >= 0) { // neighbor is an end point
@@ -785,15 +785,13 @@ function router(vertices, opt, linkView) {
     //var targetAnchor = getTargetAnchor(linkView, opt);
 
     // pathfinding
-    let map;
-    const { isPointObstacle } = opt;
-    if (typeof isPointObstacle === 'function') {
-        map = {
-            isPointAccessible: point => !isPointObstacle(point)
-        };
+    let isPointObstacle;
+    if (typeof opt.isPointObstacle === 'function') {
+        isPointObstacle = opt.isPointObstacle;
     } else {
-        map = new ObstacleMap(opt);
+        const map = new ObstacleMap(opt);
         map.build(linkView.paper.model, linkView.model);
+        isPointObstacle = (point) => !map.isPointAccessible(point);
     }
 
     var oldVertices = util.toArray(vertices).map(g.Point);
@@ -832,7 +830,7 @@ function router(vertices, opt, linkView) {
         }
 
         // if partial route has not been calculated yet use the main routing method to find one
-        partialRoute = partialRoute || findRoute.call(linkView, from, to, map, opt);
+        partialRoute = partialRoute || findRoute.call(linkView, from, to, isPointObstacle, opt);
 
         if (partialRoute === null) { // the partial route cannot be found
             return opt.fallbackRouter(vertices, opt, linkView);

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -318,6 +318,25 @@ QUnit.module('routers', function(hooks) {
         assert.checkDataPath(d, 'M 20 70 L 0 70 L 0 10 L 760 10 L 760 70 L 740 70',
             'Set startDirections & endDirections parameters makes routing starts and ends from/to the given direction.');
 
+
+        var spyIsPointObstacle = sinon.spy(function() { return false; });
+
+        l0.set({
+            vertices: [],
+            router: {
+                name: 'manhattan',
+                args: {
+                    isPointObstacle: spyIsPointObstacle
+                }
+            }
+        });
+
+        d = v0.$('.connection').attr('d');
+
+        assert.ok(spyIsPointObstacle.called);
+        assert.ok(spyIsPointObstacle.alwaysCalledWithExactly(sinon.match.instanceOf(g.Point)));
+        assert.checkDataPath(d, 'M 140 70 L 620 70','isPointObstacle option is taken into account');
+
     });
 
     QUnit.test('metro routing', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -2959,7 +2959,8 @@ export namespace routers {
         excludeTypes?: string[];
         startDirections?: dia.OrthogonalDirection[];
         endDirections?: dia.OrthogonalDirection[];
-    }
+        isPointObstacle?: (point: dia.Point) => boolean;
+    };
 
     interface OrthogonalRouterArguments {
         elementPadding?: number;


### PR DESCRIPTION
As per https://github.com/clientIO/joint/issues/1412 discussion.

```js
const obstacleMap = createObstacleMap(); // any implementation of the obstacle map
const paper = new dia.Paper({
  /* ... */
  defaultRouter: (vertices, opt, linkView) => {
    const isPointObstacle = (point) => obstacleMap.isPointObstacle(point);
    return routers.manhattan(vertices, { ...opt, isPointObstacle }, linkView);
 }
});
```