### PR TITLE
dia.HighlighterView: fix options TS def

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1493,9 +1493,9 @@ export namespace dia {
 
         type NodeSelector = string | SVGElement | NodeSelectorJSON;
 
-        type Options = {
+        interface Options extends mvc.ViewOptions<undefined> {
             layer?: dia.Paper.Layers | string | null;
-        };
+        }
     }
 
     class HighlighterView<Options = HighlighterView.Options> extends mvc.View<undefined> {


### PR DESCRIPTION
Allow other `mvc.View` [options](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/backbone/index.d.ts#L534-L544) to be used in `dia.HighighterView`.