### PR TITLE
dia.ElementView: prevent unnecesary reparenting after invalid unembed…

### DIFF
--- a/src/dia/ElementView.mjs
+++ b/src/dia/ElementView.mjs
@@ -492,6 +492,7 @@ export const ElementView = CellView.extend({
                 !validateUnembedding.call(paper, this)
             ) {
                 this._disallowUnembed(data);
+                return;
             }
         }
 


### PR DESCRIPTION
…ding

No need to re-parent links when the un-embedding is reverted to the previous state.