### PR TITLE
dia.CellView: use util.result for presentationAttributes and initFlag

### DIFF
--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -1113,7 +1113,7 @@ export const CellView = View.extend({
     Highlighting: HighlightingTypes,
 
     addPresentationAttributes: function(presentationAttributes) {
-        return merge({}, this.prototype.presentationAttributes, presentationAttributes, function(a, b) {
+        return merge({}, result(this.prototype, 'presentationAttributes'), presentationAttributes, function(a, b) {
             if (!a || !b) return;
             if (typeof a === 'string') a = [a];
             if (typeof b === 'string') b = [b];

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -81,7 +81,7 @@ export const CellView = View.extend({
                 attributes[attribute] |= flag;
             }
         }
-        var initFlag = this.initFlag;
+        var initFlag = result(this, 'initFlag');
         if (!Array.isArray(initFlag)) initFlag = [initFlag];
         for (i = 0, n = initFlag.length; i < n; i++) {
             label = initFlag[i];

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -12,6 +12,7 @@ import {
     isEmpty,
     isString,
     toKebabCase,
+    result,
     sortedIndex,
     merge,
     uniq
@@ -66,7 +67,7 @@ export const CellView = View.extend({
         var attributes = {};
         var shift = 0;
         var i, n, label;
-        var presentationAttributes = this.presentationAttributes;
+        var presentationAttributes = result(this, 'presentationAttributes');
         for (var attribute in presentationAttributes) {
             if (!presentationAttributes.hasOwnProperty(attribute)) continue;
             var labels = presentationAttributes[attribute];

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -16,6 +16,7 @@ import {
     isString,
     normalizeEvent,
     omit,
+    result,
     merge,
     camelCase,
     cloneDeep,
@@ -1450,7 +1451,7 @@ export const Paper = View.extend({
         } else {
             view = views[cell.id] = this.createViewForModel(cell);
             view.paper = this;
-            flag = this.registerUnmountedView(view) | view.getFlag(view.initFlag);
+            flag = this.registerUnmountedView(view) | view.getFlag(result(view, 'initFlag'));
         }
         this.requestViewUpdate(view, flag, view.UPDATE_PRIORITY, opt);
         return view;


### PR DESCRIPTION
`dia.CellView`'s `presentationAttributes` and `initFlag` properties can be extended in ES6 syntax now.

```js
class MyView extends ElementView {
  initFlag() { return []; }
}
```
