### PR TITLE
Vectorizer: fix multi-line text line heights when 100% of a line is a…

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -425,7 +425,7 @@ const V = (function() {
                 if (includeAnnotationIndices) vTSpan.attr('annotations', annotation.annotations);
                 // Check for max font size
                 fontSize = parseFloat(annotationAttrs['font-size']);
-                if (fontSize === undefined) fontSize = baseSize;
+                if (!isFinite(fontSize)) fontSize = baseSize;
                 if (fontSize && fontSize > maxFontSize) maxFontSize = fontSize;
             } else {
                 if (eol && j === lastJ) annotation += eol;

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -250,7 +250,6 @@ QUnit.module('vectorizer', function(hooks) {
 
         QUnit.test('line height', function(assert) {
 
-            var svg = getSvg();
             var t = V('text', { 'font-size': 20 });
             var linesDy;
             var text = 'abcd\nefgh';
@@ -291,8 +290,6 @@ QUnit.module('vectorizer', function(hooks) {
                 return vTSpan.attr('dy');
             });
             assert.deepEqual(linesDy, ['0', '36']); // max font-size * 1.2
-
-            svg.remove();
         });
 
         QUnit.test('custom EOL', function(assert) {

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -248,6 +248,53 @@ QUnit.module('vectorizer', function(hooks) {
             svg.remove();
         });
 
+        QUnit.test('line height', function(assert) {
+
+            var svg = getSvg();
+            var t = V('text', { 'font-size': 20 });
+            var linesDy;
+            var text = 'abcd\nefgh';
+            var annotations = [
+                { start: 0, end: 4, attrs: { fill: 'red' }},
+                { start: 5, end: 9, attrs: { fill: 'blue' }}
+            ];
+
+            t.text(text, {
+                lineHeight: '2.1em',
+                annotations: annotations
+            });
+
+            linesDy = t.children().map(function(vTSpan) {
+                return vTSpan.attr('dy');
+            });
+            assert.deepEqual(linesDy, ['0', '2.1em']); // hard-coded line-height
+
+            t.text(text, {
+                lineHeight: 'auto',
+                annotations: annotations
+            });
+
+            linesDy = t.children().map(function(vTSpan) {
+                return vTSpan.attr('dy');
+            });
+            assert.deepEqual(linesDy, ['0', '24']); // base font-size * 1.2
+
+            t.text(text, {
+                lineHeight: 'auto',
+                annotations: [
+                    { start: 0, end: 4, attrs: { fill: 'red' }},
+                    { start: 5, end: 9, attrs: { fill: 'blue', 'font-size': 30 }}
+                ]
+            });
+
+            linesDy = t.children().map(function(vTSpan) {
+                return vTSpan.attr('dy');
+            });
+            assert.deepEqual(linesDy, ['0', '36']); // max font-size * 1.2
+
+            svg.remove();
+        });
+
         QUnit.test('custom EOL', function(assert) {
 
             var svg = getSvg();


### PR DESCRIPTION
…nnotated

```js
  V('text', { 'font-size': 20 }).text('line\nline', {
       lineHeight: 'auto',
       annotations: [
          { start: 0, end: 4, attrs: { fill: 'red' }},
          // the line has blue annotation from start to end and no font-size defined
          { start: 5, end: 9, attrs: { fill: 'blue' }}
      ]
  });
  // Assert: the line height is based on the `font-size` defined on the text (20)
```