### PR TITLE
dia.CellView: update typings for ES6 class extension

### DIFF
--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -1,5 +1,6 @@
 export namespace g {
 
+    export type Shape = Path | Point | Line | Polyline | Rect | Ellipse;
     export interface PlainPoint {
 
         x: number;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -607,6 +607,15 @@ export namespace dia {
 
         type FlagLabel = string | string[];
         type PresentationAttributes = { [key: string]: FlagLabel };
+
+        type NodeData = { [key: string]: any };
+
+        type NodeMetrics = {
+            data: NodeData;
+            boundingRect: g.Rect;
+            magnetMatrix: SVGMatrix;
+            geometryShape: g.Shape;
+        }
     }
 
     abstract class CellViewGeneric<T extends Cell> extends mvc.View<T> {
@@ -615,9 +624,9 @@ export namespace dia {
 
         paper: Paper | null;
 
-        initFlag: CellView.FlagLabel;
+        initFlag(): CellView.FlagLabel;
 
-        presentationAttributes: CellView.PresentationAttributes;
+        presentationAttributes(): CellView.PresentationAttributes
 
         highlight(el?: SVGElement | JQuery | string, opt?: { [key: string]: any }): this;
 
@@ -707,11 +716,25 @@ export namespace dia {
 
         protected onmagnet(evt: dia.Event, x: number, y: number): void;
 
-        static addPresentationAttributes(attributes: CellView.PresentationAttributes): CellView.PresentationAttributes;
-
         protected getLinkEnd(magnet: SVGElement, x: number, y: number, link: dia.Link, endType: dia.LinkEnd): dia.Link.EndJSON;
 
+        protected getMagnetFromLinkEnd(end: dia.Link.EndJSON): SVGElement;
+
         protected customizeLinkEnd(end: dia.Link.EndJSON, magnet: SVGElement, x: number, y: number, link: dia.Link, endType: dia.LinkEnd): dia.Link.EndJSON;
+
+        protected cleanNodesCache(): void;
+
+        protected nodeCache(magnet: SVGElement): CellView.NodeMetrics;
+
+        protected getNodeData(magnet: SVGElement): CellView.NodeData;
+
+        protected getNodeMatrix(magnet: SVGElement): SVGMatrix;
+
+        protected getNodeBoundingRect(magnet: SVGElement): g.Rect;
+
+        protected getNodeShape(magnet: SVGElement): g.Shape;
+
+        static addPresentationAttributes(attributes: CellView.PresentationAttributes): CellView.PresentationAttributes;
     }
 
     class CellView extends CellViewGeneric<Cell> {
@@ -755,6 +778,18 @@ export namespace dia {
         protected renderJSONMarkup(markup: MarkupJSON): void;
 
         protected renderStringMarkup(markup: string): void;
+
+        protected updateTransformation(): void;
+
+        protected resize(): void;
+
+        protected translate(): void;
+
+        protected rotate(): void;
+
+        protected getTranslateString(): string;
+
+        protected getRotateString(): string;
 
         protected dragStart(evt: dia.Event, x: number, y: number): void;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -728,10 +728,6 @@ export namespace dia {
 
         protected getNodeData(magnet: SVGElement): CellView.NodeData;
 
-        protected getNodeMatrix(magnet: SVGElement): SVGMatrix;
-
-        protected getNodeBoundingRect(magnet: SVGElement): g.Rect;
-
         protected getNodeShape(magnet: SVGElement): g.Shape;
 
         static addPresentationAttributes(attributes: CellView.PresentationAttributes): CellView.PresentationAttributes;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -626,7 +626,7 @@ export namespace dia {
 
         initFlag(): CellView.FlagLabel;
 
-        presentationAttributes(): CellView.PresentationAttributes
+        presentationAttributes(): CellView.PresentationAttributes;
 
         highlight(el?: SVGElement | JQuery | string, opt?: { [key: string]: any }): this;
 

--- a/types/vectorizer.d.ts
+++ b/types/vectorizer.d.ts
@@ -210,6 +210,8 @@ export class Vectorizer {
 
     findIntersection(ref: g.PlainPoint, target: SVGElement | Vectorizer): g.PlainPoint | undefined;
 
+    toGeometryShape(): g.Shape;
+
     private setAttributes(attrs: { [key: string]: any }): this;
 
     private setAttribute(name: string, value: string): this;


### PR DESCRIPTION
Fix various issues one would face when inheriting `cellView` classes in Typescript.

```ts
class MyView extends dia.ElementView {
  presentationAttributes() {
     return { /* */ }
  }

  render() {
    /* ... */
    this.updateTransformation();
  }
}
```
