### PR TITLE
dia.Cell: fix toJSON() when defaults() is defined as a method

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -64,15 +64,16 @@ export const Cell = Backbone.Model.extend({
 
     toJSON: function() {
 
-        var defaultAttrs = this.constructor.prototype.defaults.attrs || {};
-        var attrs = this.attributes.attrs;
-        var finalAttrs = {};
+        const defaults = result(this.constructor.prototype, 'defaults');
+        const defaultAttrs = defaults.attrs || {};
+        const attrs = this.attributes.attrs;
+        const finalAttrs = {};
 
         // Loop through all the attributes and
-        // omit the default attributes as they are implicitly reconstructable by the cell 'type'.
+        // omit the default attributes as they are implicitly reconstructible by the cell 'type'.
         forIn(attrs, function(attr, selector) {
 
-            var defaultAttr = defaultAttrs[selector];
+            const defaultAttr = defaultAttrs[selector];
 
             forIn(attr, function(value, name) {
 
@@ -99,7 +100,7 @@ export const Cell = Backbone.Model.extend({
             });
         });
 
-        var attributes = cloneDeep(omit(this.attributes, 'attrs'));
+        const attributes = cloneDeep(omit(this.attributes, 'attrs'));
         attributes.attrs = finalAttrs;
 
         return attributes;

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -355,5 +355,41 @@ QUnit.module('cell', function(hooks) {
             });
         });
     });
+
+    QUnit.module('toJSON()', function() {
+
+        QUnit.test('`defaults` defined as property', function(assert) {
+
+            var El = joint.dia.Element.extend({
+                defaults: {
+                    attrs: { test1: { prop1: true }}
+                }
+            });
+
+            var el = new El({
+                id: 'el1',
+                attrs: { test1: { prop1: true }, test2: { prop2: true }}
+            });
+
+            assert.deepEqual(el.toJSON(), { id: 'el1', attrs: { test2: { prop2: true }}});
+        });
+
+        QUnit.test('`defaults()` defined as function', function(assert) {
+            var El = joint.dia.Element.extend({
+                defaults: function() {
+                    return {
+                        attrs: { test1: { prop1: true }}
+                    };
+                }
+            });
+
+            var el = new El({
+                id: 'el1',
+                attrs: { test1: { prop1: true }, test2: { prop2: true }}
+            });
+
+            assert.deepEqual(el.toJSON(), { id: 'el1', attrs: { test2: { prop2: true }}});
+        });
+    });
 });
 


### PR DESCRIPTION
Unnecessary `attrs` were present in the JSON export when `defaults()` defined as a method.

```js
var El = joint.dia.Element.extend({
   defaults: function() {
       return {
           attrs: { test1: { prop1: true }}
       };
   }
});

var el = new El({
    id: 'el1',
    attrs: { test1: { prop1: true }, test2: { prop2: true }}
});

assert.deepEqual(el.toJSON(), {
  id: 'el1',
  attrs: { test2: { prop2: true /* test1 would be redundant */ }}
});
```