### PR TITLE
util.setByPath() - prevent prototype pollution

### DIFF
--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -140,6 +140,9 @@ export const getByPath = function(obj, path, delimiter) {
 const isGetSafe = function(obj, key) {
     // Prevent prototype pollution
     // https://snyk.io/vuln/SNYK-JS-JSON8MERGEPATCH-1038399
+    if (typeof key !== 'string' && typeof key !== 'number') {
+        key = String(key);
+    }
     if (key === 'constructor' && typeof obj[key] === 'function') {
         return false;
     }

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -336,7 +336,11 @@ QUnit.module('util', function(hooks) {
             assert.deepEqual(joint.util.setByPath({ object: {}}, 'object/1', 'property'), { object: { '1': 'property' }}, 'define property');
         });
 
-        ['__proto__/polluted', 'constructor/prototype/polluted'].forEach(function(path) {
+        [
+            '__proto__/polluted',
+            'constructor/prototype/polluted',
+            [['__proto__'], 'polluted']
+        ].forEach(function(path) {
             QUnit.test('setting "' + path + '" does not pollute prototype' , function(assert) {
                 var obj = {};
                 assert.notOk(obj.polluted);


### PR DESCRIPTION
```js
const a = {};
const b = {};
util.setByPath(a, [['__proto__'], 'polluted'], true);
// Assert: b.polluted !== true
```