### PR TITLE
dia.Cell: improve the return type of clone()

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -210,8 +210,8 @@ export namespace dia {
             [key: string]: any;
         }
 
-        interface EmbeddableOptions extends Options {
-            deep?: boolean;
+        interface EmbeddableOptions<T = boolean> extends Options {
+            deep?: T;
         }
 
         interface DisconnectableOptions extends Options {
@@ -271,8 +271,9 @@ export namespace dia {
         attr(object: Cell.Selectors, opt?: Cell.Options): this;
         attr(key: Path, value: any, opt?: Cell.Options): this;
 
-        clone(): Cell;
-        clone(opt: Cell.EmbeddableOptions): Cell | Cell[];
+        clone(): typeof this;
+        clone(opt: Cell.EmbeddableOptions<false>): typeof this;
+        clone(opt: Cell.EmbeddableOptions<true>): Cell[];
 
         removeAttr(path: Path, opt?: Cell.Options): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -271,8 +271,8 @@ export namespace dia {
         attr(object: Cell.Selectors, opt?: Cell.Options): this;
         attr(key: Path, value: any, opt?: Cell.Options): this;
 
-        clone(): typeof this;
-        clone(opt: Cell.EmbeddableOptions<false>): typeof this;
+        clone(): this;
+        clone(opt: Cell.EmbeddableOptions<false>): this;
         clone(opt: Cell.EmbeddableOptions<true>): Cell[];
 
         removeAttr(path: Path, opt?: Cell.Options): this;


### PR DESCRIPTION
- ~~use `typeof this` as an instance of the same object (based on https://www.gitmemory.com/issue/microsoft/TypeScript/39902/856601904)~~
- return correct type based on `deep` option (either the clone of this cell, or an array of arbitrary cells)
- fixes #1437 