### PR TITLE
dia.Cell: support preinitilize() lifecycle method

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -42,6 +42,10 @@ export const Cell = Backbone.Model.extend({
 
         var defaults;
         var attrs = attributes || {};
+        if (typeof this.preinitialize === 'function') {
+            // Check to support an older version of Backbone (prior v1.4)
+            this.preinitialize.apply(this, arguments);
+        }
         this.cid = uniqueId('c');
         this.attributes = {};
         if (options && options.collection) this.collection = options.collection;

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -54,6 +54,19 @@ QUnit.module('cell', function(hooks) {
         });
     });
 
+    QUnit.module('lifecycle methods', function() {
+        QUnit.test('sanity', function(assert) {
+            var spyPreinitilize = sinon.spy(joint.dia.Cell.prototype, 'preinitialize');
+            var spyInitilize = sinon.spy(joint.dia.Cell.prototype, 'initialize');
+            new joint.dia.Cell({ testAttribute: true }, { testOption: true });
+            assert.equal(spyPreinitilize.callCount, 1);
+            assert.ok(spyPreinitilize.calledWithExactly({ testAttribute: true }, { testOption: true }));
+            assert.equal(spyInitilize.callCount, 1);
+            assert.ok(spyInitilize.calledWithExactly({ testAttribute: true }, { testOption: true }));
+            assert.ok(spyPreinitilize.calledBefore(spyInitilize));
+        });
+    });
+
     QUnit.module('parent', function(hooks) {
 
         QUnit.test('parent', function(assert) {


### PR DESCRIPTION
From version 1.4 Backbone [added a preinitialize() method to allow for true instance properties and ES6 classes](https://github.com/jashkenas/backbone/pull/3827). Since JointJS overrides `dia.Cell` constructor, this PR makes sure the lifecycle method is called.

