### PR TITLE
dia.Cell: support custom idAttribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==",
       "requires": {
         "underscore": ">=1.8.3"
       }
@@ -13137,9 +13137,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
     },
     "underscore.string": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "joint.mjs"
   ],
   "dependencies": {
-    "backbone": "~1.4.0",
+    "backbone": "~1.4.1",
     "dagre": "~0.8.5",
     "graphlib": "~2.1.8",
     "jquery": "~3.6.0",

--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -112,9 +112,9 @@ export const Cell = Backbone.Model.extend({
 
     initialize: function(options) {
 
-        if (!options || !options.id) {
-
-            this.set('id', this.generateId(), { silent: true });
+        const idAttribute = this.getIdAttribute();
+        if (!options || !(idAttribute in options)) {
+            this.set(idAttribute, this.generateId(), { silent: true });
         }
 
         this._transitionIds = {};
@@ -122,6 +122,10 @@ export const Cell = Backbone.Model.extend({
         // Collect ports defined in `attrs` and keep collecting whenever `attrs` object changes.
         this.processPorts();
         this.on('change:attrs', this.processPorts, this);
+    },
+
+    getIdAttribute: function() {
+        return this.idAttribute || 'id';
     },
 
     generateId: function() {
@@ -473,7 +477,7 @@ export const Cell = Backbone.Model.extend({
 
             var clone = Backbone.Model.prototype.clone.apply(this, arguments);
             // We don't want the clone to have the same ID as the original.
-            clone.set('id', this.generateId());
+            clone.set(this.getIdAttribute(), this.generateId());
             // A shallow cloned element does not carry over the original embeds.
             clone.unset('embeds');
             // And can not be embedded in any cell

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -54,6 +54,39 @@ QUnit.module('cell', function(hooks) {
         });
     });
 
+    QUnit.module('backbone attributes', function() {
+        QUnit.test('idAttribute', function(assert) {
+            var graph = this.graph;
+            var paper = this.paper;
+            var id = '123';
+            var TestElement = joint.dia.Element.extend({
+                idAttribute: 'myId'
+            });
+            var el = new TestElement({ myId: id, type: 'testType', markup: [] });
+            // graph
+            el.addTo(graph);
+            assert.equal(el.id, id);
+            assert.equal(el.get('myId'), id);
+            assert.equal(el.get('id'), undefined);
+            assert.equal(graph.getCell(id), el);
+            var clone = el.clone();
+            assert.ok(clone.id);
+            assert.notEqual(clone.id, id);
+            clone.addTo(graph);
+            assert.equal(clone.get('myId'), clone.id);
+            assert.equal(clone.get('id'), undefined);
+            assert.equal(graph.getCell(clone.id), clone);
+            // paper
+            var elView = paper.findViewByModel(id);
+            assert.ok(elView);
+            assert.equal(elView.model, el);
+            // change id
+            var newId = '456';
+            clone.set('myId', newId);
+            assert.equal(graph.getCell(newId), clone);
+        });
+    });
+
     QUnit.module('lifecycle methods', function() {
         QUnit.test('sanity', function(assert) {
             var spyPreinitilize = sinon.spy(joint.dia.Cell.prototype, 'preinitialize');


### PR DESCRIPTION
Requires Backbone [changes](https://github.com/jashkenas/backbone/commit/0b1c2e3fce3156fcb9819b8bbf8885456e4e1055) to be released.

Add support for custom `idAttribute`.
```ts
const MyCell = joint.dia.Cell.extend({ idAttribute: 'myId' });
const cell = new MyCell({ myId: '123'});
cell.addTo(graph);
// Assert:
graph.getCell('123') === cell
```