### PR TITLE
dia.Paper: skip update of connected links when isolate flag used

### DIFF
--- a/docs/src/joint/api/dia/Element/prototype/prop.html
+++ b/docs/src/joint/api/dia/Element/prototype/prop.html
@@ -28,5 +28,10 @@ element.prop('custom/state', { isActive: false }, { rewrite: true });
         }
     },
     "attrs": {}
-}   
+}
 </code></pre>
+
+
+<p><i>Advanced:</i> Pass <code>{ isolate: true }</code> if the property change does not affect the connected links. Typically, changing the element fill color has zero effect on attached links. By default, the element and all connected links are updated.</p>
+
+<pre><code>element.attr(['body', 'fill'], 'red', { isolate: true });</code></pre>

--- a/docs/src/joint/api/dia/Link/prototype/prop.html
+++ b/docs/src/joint/api/dia/Link/prototype/prop.html
@@ -28,5 +28,10 @@ link.prop('custom/state', { isActive: false }, { rewrite: true });
         }
     },
     "attrs": {}
-} 
+}
 </code></pre>
+
+
+<p><i>Advanced:</i> Pass <code>{ isolate: true }</code> if the property change does not affect the connected links. Typically, changing the link color has zero effect on attached links. By default, the link and all connected links are updated.</p>
+
+<pre><code>link.attr(['line', 'stroke'], 'red', { isolate: true });</code></pre>

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -237,7 +237,11 @@ export const Paper = View.extend({
 
         // no docs yet
         onViewUpdate: function(view, flag, priority, opt, paper) {
-            if ((flag & view.FLAG_INSERT) || opt.mounting) return;
+            // Do not update connected links when:
+            // 1. the view was just inserted (added to the graph and rendered)
+            // 2. the view was just mounted (added back to the paper by viewport function)
+            // 3. the change was marked as `isolate`.
+            if ((flag & view.FLAG_INSERT) || opt.mounting || opt.isolate) return;
             paper.requestConnectedLinksUpdate(view, priority, opt);
         },
 

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -1473,23 +1473,37 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
         QUnit.module('flags', function() {
 
-            QUnit.module('isolate', function() {
+            QUnit.module('isolate', function(hooks) {
 
-                [{ value: true, expected: 1 }, { value: false, expected: 2 }].forEach(function(testCase) {
-                    var testValue = testCase.value;
-                    var expected = testCase.expected;
-                    QUnit.test(testValue, function(assert) {
-                        addCells(graph, { async: false });
-                        var element = graph.getElements()[0];
-                        element.attr(['body', 'fill'], 'red', { isolate: testValue });
-                        var done = assert.async();
-                        var renderDoneSpy = sinon.spy(function(stats) {
-                            assert.equal(stats.updated, expected);
+                var element;
+
+                hooks.beforeEach(function() {
+                    addCells(graph, { async: false });
+                    element = graph.getElements()[0];
+                    paper.freeze();
+                });
+
+                QUnit.test('true', function(assert) {
+                    var done = assert.async();
+                    assert.expect(1);
+                    element.attr(['body', 'fill'], 'red', { isolate: true });
+                    paper.unfreeze({
+                        afterRender: function(stats) {
+                            assert.equal(stats.updated, 1);
                             done();
-                        });
-                        paper.unfreeze({
-                            afterRender: renderDoneSpy
-                        });
+                        }
+                    });
+                });
+
+                QUnit.test('false', function(assert) {
+                    var done = assert.async();
+                    assert.expect(1);
+                    element.attr(['body', 'fill'], 'red', { isolate: false });
+                    paper.unfreeze({
+                        afterRender: function(stats) {
+                            assert.equal(stats.updated, 2);
+                            done();
+                        }
                     });
                 });
             });

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -9,7 +9,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         return V(paper.cells).children().length;
     }
 
-    function addCells(graph) {
+    function addCells(graph, opt) {
         var rect1 = new joint.shapes.standard.Rectangle();
         var rect2 = new joint.shapes.standard.Rectangle();
         var link = new joint.shapes.standard.Link();
@@ -20,9 +20,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         link.source(rect1);
         link.target(rect2);
         link.vertices([{ x: 0, y: 300 }]);
-        rect1.addTo(graph);
-        rect2.addTo(graph);
-        link.addTo(graph);
+        rect1.addTo(graph, opt);
+        rect2.addTo(graph, opt);
+        link.addTo(graph, opt);
     }
 
     hooks.beforeEach(function() {
@@ -1469,6 +1469,30 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
             });
 
+        });
+
+        QUnit.module('flags', function() {
+
+            QUnit.module('isolate', function() {
+
+                [{ value: true, expected: 1 }, { value: false, expected: 2 }].forEach(function(testCase) {
+                    var testValue = testCase.value;
+                    var expected = testCase.expected;
+                    QUnit.test(testValue, function(assert) {
+                        addCells(graph, { async: false });
+                        var element = graph.getElements()[0];
+                        element.attr(['body', 'fill'], 'red', { isolate: testValue });
+                        var done = assert.async();
+                        var renderDoneSpy = sinon.spy(function(stats) {
+                            assert.equal(stats.updated, expected);
+                            done();
+                        });
+                        paper.unfreeze({
+                            afterRender: renderDoneSpy
+                        });
+                    });
+                });
+            });
         });
     });
 });

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -64,6 +64,7 @@ export namespace dia {
 
     interface ModelSetOptions extends Backbone.ModelSetOptions {
         dry?:  boolean;
+        isolate?: boolean;
         [key: string]: any;
     }
 


### PR DESCRIPTION
```js
// to improve the update performance instruct the paper to update only the element
// and not the connected links
element.attr(['body', 'fill'], 'red', { isolate: true });
```