### PR TITLE
dia.Element: fix port position TS def

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -352,10 +352,14 @@ export namespace dia {
         interface Attributes extends GenericAttributes<Cell.Selectors> {
         }
 
-        type PositionType = string | {
+        type PortPositionCallback = (ports: Port[], bbox: g.Rect) => dia.Point[];
+
+        interface PortPositionJSON {
             name?: string,
             args?: { [key: string]: any }
         }
+
+        type PositionType = string | PortPositionCallback | PortPositionJSON;
 
         interface PortGroup {
             position?: PositionType,


### PR DESCRIPTION
Allow the port position to be defined as a function. 
```ts
(ports: Port[], bbox: g.Rect) => dia.Point[];
```