### PR TITLE
Add string [] to groupselector type to be compliant with the joint js

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -50,7 +50,7 @@ export namespace dia {
     type MarkupNodeJSON = {
         tagName: string;
         selector?: string;
-        groupSelector?: string;
+        groupSelector?: string | string[];
         namespaceURI?: string;
         className?: string;
         attributes?: attributes.NativeSVGAttributes;


### PR DESCRIPTION
As per [the docs](https://resources.jointjs.com/docs/jointjs/v3.2/joint.html#dia.Cell.markup), group selector should allow a string [] to be assigned as well. Changes were made to reflect that.