### PR TITLE
demo.Decorators: shape definition with decorators

### DIFF
--- a/demo/decorators/.gitignore
+++ b/demo/decorators/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+src/*.js
+dist/

--- a/demo/decorators/index.html
+++ b/demo/decorators/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>JointJS Future Element</title>
+    <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
+  </head>
+  <body>
+    <div id="paper"></div>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/demo/decorators/package.json
+++ b/demo/decorators/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "list",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jointjs": "github:clientio/joint#master"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "tsc": "tsc"
+  },
+  "devDependencies": {
+    "ts-loader": "^9.2.5",
+    "typescript": "^4.4.3",
+    "webpack": "^5.53.0",
+    "webpack-dev-server": "^4.2.1",
+    "webpack-cli": "^4.8.0"
+  }
+}

--- a/demo/decorators/package.json
+++ b/demo/decorators/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "list",
+  "name": "joint-decorators",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/demo/decorators/src/decorators.ts
+++ b/demo/decorators/src/decorators.ts
@@ -1,0 +1,94 @@
+import { dia, util } from 'jointjs';
+
+type CellDecorator = {
+    attributes: dia.Cell.Attributes;
+    presentation: string;
+    namespace: any;
+}
+
+export function cell(value: CellDecorator) {
+    const { attributes, presentation, namespace } = value;
+    return function Entity<Ctor extends { new(...args: any[]): dia.Cell }>(target: Ctor): Ctor {
+        const { markup, attrs } = fromSVG(presentation);
+        // console.log(markup, attrs);
+        // Object.defineProperty(target.prototype, 'markup', {
+        //     value: markup,
+        //     enumerable: true
+        // });
+        // Object.defineProperty(target.prototype, 'defaults', {
+        //     value: function () {
+        //         return {
+        //             // can't use super here
+        //             ...value.attributes,
+        //             attrs,
+        //         }
+        //     }
+        // });
+        // return target;
+        const type = target.name;
+        const extendedTarget = class extends target {
+            markup = markup;
+            defaults() {
+                return {
+                    ...super.defaults,
+                    ...attributes,
+                    type,
+                    attrs
+                }
+            }
+        }
+        namespace[type] = extendedTarget;
+        return extendedTarget;
+    }
+}
+
+
+function fromSVG(str: string) {
+
+    const parser = new DOMParser();
+    const type = 'text/html';
+    const document = parser.parseFromString(`<svg>${str.trim()}</svg>`, type);
+    const g =  document.documentElement.lastChild.firstChild.firstChild as Element;
+
+    const markup = [];
+    const attrs = {};
+
+    function build(node: Element, markup: Partial<dia.MarkupNodeJSON>, attrs: dia.Cell.Attributes) {
+
+        const { tagName, attributes } = node;
+
+        let selector = markup.selector;
+        if (!selector) {
+            const selectorAttribute = attributes.getNamedItem('@selector');
+            selector = (selectorAttribute ? selectorAttribute.value : util.uuid());
+        }
+
+        markup.selector = selector;
+        markup.tagName = tagName;
+
+        const nodeAttrs = {};
+        let hasNodeAttrs = false;
+        Array.from(attributes).forEach(attribute => {
+            const { name, value } = attribute;
+            if (name.startsWith('@')) return;
+            nodeAttrs[util.camelCase(name)] = value;
+            hasNodeAttrs = true;
+        });
+        if (hasNodeAttrs) {
+            attrs[selector] = nodeAttrs;
+        }
+
+        Array.from(node.children).forEach(childNode => {
+            const json: Partial<dia.MarkupNodeJSON> = { children: [] };
+            build(childNode, json, attrs);
+            markup.children.push(json as dia.MarkupNodeJSON);
+        });
+    }
+
+    build(g, { selector: 'root', children: markup }, attrs);
+
+    return {
+        markup,
+        attrs
+    };
+}

--- a/demo/decorators/src/decorators.ts
+++ b/demo/decorators/src/decorators.ts
@@ -6,7 +6,15 @@ type CellDecorator = {
     namespace: any;
 }
 
-export function cell(value: CellDecorator) {
+export function View(value: any) {
+    const { namespace } = value;
+    return function Entity<Ctor extends { new(...args: any[]): dia.CellView }>(target: Ctor): Ctor {
+        namespace[target.name] = target;
+        return target;
+    }
+}
+
+export function Model(value: CellDecorator) {
     const { attributes, presentation, namespace } = value;
     return function Entity<Ctor extends { new(...args: any[]): dia.Cell }>(target: Ctor): Ctor {
         const { markup, attrs, bindings } = fromSVG(presentation);
@@ -126,4 +134,21 @@ function build(node: Element, markup: Partial<dia.MarkupNodeJSON>, attrs: dia.Ce
         build(childNode, json, attrs, bindings);
         markup.children.push(json as dia.MarkupNodeJSON);
     });
+}
+
+export function on(eventName) {
+    return function (target, name, descriptor) {
+        if (!target.events) {
+            target.events = {};
+        }
+        if (typeof target.events === 'function') {
+            throw new Error('The on decorator is not compatible with an events method');
+            return;
+        }
+        if (!eventName) {
+            throw new Error('The on decorator requires an eventName argument');
+        }
+        target.events[eventName] = name;
+        return descriptor;
+    }
 }

--- a/demo/decorators/src/decorators.ts
+++ b/demo/decorators/src/decorators.ts
@@ -83,7 +83,6 @@ export function Model(value: CellDecorator) {
     }
 }
 
-
 function fromSVG(str: string) {
 
     const parser = new DOMParser();
@@ -171,3 +170,21 @@ export function on(eventName) {
         return descriptor;
     }
 }
+
+export function attribute(attributeName: string, type: 'set' | 'offset' | 'position' = 'set') {
+    return function (target, name, descriptor) {
+        if (!attributeName) {
+            throw new Error('The on decorator requires an eventName argument');
+        }
+        if (!target.constructor.attributes) {
+            target.constructor.attributes = {};
+        }
+        target.constructor.attributes[util.camelCase(attributeName)] = {
+            [type]: (...args) => {
+                return target[name](...args);
+            }
+        }
+        return descriptor;
+    }
+}
+

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -1,5 +1,5 @@
-import { dia, shapes } from 'jointjs';
-import { Model, View, on } from './decorators';
+import { g, dia, shapes } from 'jointjs';
+import { Model, View, on, attribute } from './decorators';
 
 const shapeNamespace = {
     ...shapes,
@@ -49,6 +49,7 @@ paper.el.style.border = `1px solid #e2e2e2`;
                 [fill]="{{primaryColor}}"
                 [stroke]="{{secondaryColor}}"
                 stroke-width="2"
+                line-style="solid"
             />
             <text @selector="label"
                 text-anchor="middle"
@@ -65,6 +66,16 @@ class TestElement extends dia.Element {
 
     logType() {
         console.log(this.get('type'));
+    }
+
+    @attribute('line-style')
+    setTestAttribute(lineStyle: string, _refBBox: g.Rect, _node: SVGElement, attrs: any) {
+        const n = attrs.strokeWidth|| 1;
+        const dasharray = {
+            'dashed': (4*n) + ',' + (2*n),
+            'dotted': n + ',' + n
+        }[lineStyle] || 'none';
+        return { 'stroke-dasharray': dasharray };
     }
 }
 
@@ -88,7 +99,12 @@ graph.fromJSON({
 
 const el1 = new TestElement({
     position: { x: 200, y: 200 },
-    lastName: 'Badman'
+    lastName: 'Badman',
+    attrs: {
+        body: {
+            lineStyle: 'dashed'
+        }
+    }
 });
 el1.addTo(graph);
 el1.logType();

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -34,8 +34,8 @@ paper.el.style.border = `1px solid #e2e2e2`;
             width: 100,
             height: 100
         },
-        color: 'lightblue',
-        textColor: 'red'
+        primaryColor: 'lightblue',
+        secondaryColor: 'red'
     },
     presentation: `
         <g title="Test SVG Markup">
@@ -44,15 +44,15 @@ paper.el.style.border = `1px solid #e2e2e2`;
                 y="0"
                 width="calc(w)"
                 height="calc(h)"
-                [fill]="color"
-                stroke="#000"
+                [fill]="primaryColor"
+                [stroke]="secondaryColor"
                 stroke-width="2"
             />
             <text @selector="label"
                 text-anchor="middle"
                 text-vertical-anchor="middle"
                 font-size="14"
-                [fill]="textColor"
+                [fill]="secondaryColor"
                 text="Hello World!"
                 transform="translate(calc(0.5*w),calc(0.5*h))"
             />
@@ -81,7 +81,9 @@ const el1 = new TestElement({
 el1.addTo(graph);
 el1.logType();
 
-el1.set('color', '#fff');
-el1.set('textColor', '#333');
+el1.set({
+    primaryColor: '#fff',
+    secondaryColor: '#333'
+});
 
 paper.unfreeze();

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -1,0 +1,84 @@
+import { dia, shapes } from 'jointjs';
+import { cell } from './decorators';
+
+const shapeNamespace = {
+    ...shapes,
+}
+
+const graph = new dia.Graph({}, { cellNamespace: shapeNamespace });
+
+const paper = new dia.Paper({
+    el: document.getElementById('paper'),
+    width: 1000,
+    height: 800,
+    model: graph,
+    frozen: true,
+    async: true,
+    defaultLink: () => new shapes.standard.Link(),
+    sorting: dia.Paper.sorting.APPROX,
+    magnetThreshold: 'onleave',
+    linkPinning: false,
+    snapLinks: true,
+    background: {
+        color: '#F3F7F6'
+    },
+    cellViewNamespace: shapeNamespace
+});
+
+paper.el.style.border = `1px solid #e2e2e2`;
+
+const color = 'lightblue';
+
+@cell({
+    namespace: shapeNamespace,
+    attributes: {
+        size: {
+            width: 100,
+            height: 100
+        }
+    },
+    presentation: `
+        <g title="Test SVG Markup">
+            <rect @selector="body"
+                x="0"
+                y="0"
+                width="calc(w)"
+                height="calc(h)"
+                fill="${color}"
+                stroke="#000"
+                stroke-width="2"
+            />
+            <text @selector="label"
+                text-anchor="middle"
+                text-vertical-anchor="middle"
+                font-size="14"
+                fill="#333"
+                text="Hello World!"
+                transform="translate(calc(0.5*w),calc(0.5*h))"
+            />
+        </g>
+    `,
+})
+class TestElement extends dia.Element {
+
+    logType() {
+        console.log(this.get('type'));
+    }
+}
+
+graph.fromJSON({
+    cells: [{ type: 'TestElement', position: { x: 50, y: 50 }}]
+});
+
+const el1 = new TestElement({
+    position: { x: 200, y: 200 },
+    attrs: {
+        label: {
+            text: 'Another hello!'
+        }
+    }
+});
+el1.addTo(graph);
+el1.logType();
+
+paper.unfreeze();

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -72,8 +72,8 @@ class TestElement extends dia.Element {
     setTestAttribute(lineStyle: string, _refBBox: g.Rect, _node: SVGElement, attrs: any) {
         const n = attrs.strokeWidth|| 1;
         const dasharray = {
-            'dashed': (4*n) + ',' + (2*n),
-            'dotted': n + ',' + n
+            'dashed': `${4*n},${2*n}`,
+            'dotted': `${n},${n}`
         }[lineStyle] || 'none';
         return { 'stroke-dasharray': dasharray };
     }

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -1,5 +1,5 @@
 import { dia, shapes } from 'jointjs';
-import { cell } from './decorators';
+import { Model, View, on } from './decorators';
 
 const shapeNamespace = {
     ...shapes,
@@ -27,7 +27,7 @@ const paper = new dia.Paper({
 
 paper.el.style.border = `1px solid #e2e2e2`;
 
-@cell({
+@Model({
     namespace: shapeNamespace,
     attributes: {
         size: {
@@ -64,6 +64,20 @@ class TestElement extends dia.Element {
     logType() {
         console.log(this.get('type'));
     }
+}
+
+
+@View({
+    namespace: shapeNamespace,
+    // model: TestElement
+})
+class TestElementView extends dia.ElementView {
+
+    @on('click')
+    onClick() {
+        console.log('click!', this.model.id);
+    }
+
 }
 
 graph.fromJSON({

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -77,6 +77,11 @@ class TestElement extends dia.Element {
         }[lineStyle] || 'none';
         return { 'stroke-dasharray': dasharray };
     }
+
+    // @pipe()
+    // uppercase(value) {
+    //     return value.toUpperCase();
+    // }
 }
 
 

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -35,7 +35,9 @@ paper.el.style.border = `1px solid #e2e2e2`;
             height: 100
         },
         primaryColor: 'lightblue',
-        secondaryColor: 'red'
+        secondaryColor: 'red',
+        firstName: 'John',
+        lastName: 'Goodman'
     },
     presentation: `
         <g title="Test SVG Markup">
@@ -44,16 +46,16 @@ paper.el.style.border = `1px solid #e2e2e2`;
                 y="0"
                 width="calc(w)"
                 height="calc(h)"
-                [fill]="primaryColor"
-                [stroke]="secondaryColor"
+                [fill]="{{primaryColor}}"
+                [stroke]="{{secondaryColor}}"
                 stroke-width="2"
             />
             <text @selector="label"
                 text-anchor="middle"
                 text-vertical-anchor="middle"
                 font-size="14"
-                [fill]="secondaryColor"
-                text="Hello World!"
+                [fill]="{{secondaryColor}}"
+                [text]="{{firstName}}\n{{lastName}}"
                 transform="translate(calc(0.5*w),calc(0.5*h))"
             />
         </g>
@@ -86,11 +88,7 @@ graph.fromJSON({
 
 const el1 = new TestElement({
     position: { x: 200, y: 200 },
-    attrs: {
-        label: {
-            text: 'Another hello!'
-        }
-    }
+    lastName: 'Badman'
 });
 el1.addTo(graph);
 el1.logType();

--- a/demo/decorators/src/index.ts
+++ b/demo/decorators/src/index.ts
@@ -27,15 +27,15 @@ const paper = new dia.Paper({
 
 paper.el.style.border = `1px solid #e2e2e2`;
 
-const color = 'lightblue';
-
 @cell({
     namespace: shapeNamespace,
     attributes: {
         size: {
             width: 100,
             height: 100
-        }
+        },
+        color: 'lightblue',
+        textColor: 'red'
     },
     presentation: `
         <g title="Test SVG Markup">
@@ -44,7 +44,7 @@ const color = 'lightblue';
                 y="0"
                 width="calc(w)"
                 height="calc(h)"
-                fill="${color}"
+                [fill]="color"
                 stroke="#000"
                 stroke-width="2"
             />
@@ -52,7 +52,7 @@ const color = 'lightblue';
                 text-anchor="middle"
                 text-vertical-anchor="middle"
                 font-size="14"
-                fill="#333"
+                [fill]="textColor"
                 text="Hello World!"
                 transform="translate(calc(0.5*w),calc(0.5*h))"
             />
@@ -80,5 +80,8 @@ const el1 = new TestElement({
 });
 el1.addTo(graph);
 el1.logType();
+
+el1.set('color', '#fff');
+el1.set('textColor', '#333');
 
 paper.unfreeze();

--- a/demo/decorators/tsconfig.json
+++ b/demo/decorators/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "sourceMap": false
+    }
+}

--- a/demo/decorators/webpack.config.js
+++ b/demo/decorators/webpack.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js']
+    },
+    entry: './src/index.ts',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+        publicPath: '/dist/'
+    },
+    mode: 'development',
+    module: {
+        rules: [
+            { test: /\.ts?$/, loader: 'ts-loader' }
+        ]
+    },
+    devServer: {
+        static: {
+            directory: __dirname,
+        },
+        compress: true
+    },
+};


### PR DESCRIPTION
Just a playground on how to define a new shapes using decorators. Trying to simplify the definition and allow SVG strings to be used as markup (it's possible right now, but the parsing slows down the applications). Any comments / ideas are welcome.

- using SVG string markup (but parse the XML only once per class)
- simple data-binding (top-level attributes to presentation attributes)
- automatic `type` from the class name.

Example: https://github.com/clientIO/joint/pull/1550/files#diff-473dd8ef0afe8fb5d73a2257dff473bd69c8653d11f6e08c8ebee61a68cd59bcR30-R67