### PR TITLE
dia.Paper: cancel previous background image load

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -14,6 +14,7 @@ import {
     getByPath,
     sortElements,
     isString,
+    guid,
     normalizeEvent,
     omit,
     result,
@@ -2481,6 +2482,11 @@ export const Paper = View.extend({
             return;
         }
 
+        if (!this._background || this._background.id !== opt.id) {
+            // Draw only the last image requested (see drawBackground())
+            return;
+        }
+
         opt = opt || {};
 
         var backgroundImage;
@@ -2547,6 +2553,7 @@ export const Paper = View.extend({
 
         if (opt.image) {
             opt = this._background = cloneDeep(opt);
+            guid(opt);
             var img = document.createElement('img');
             img.onload = this.drawBackgroundImage.bind(this, img, opt);
             img.src = opt.image;

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -1770,6 +1770,28 @@ QUnit.module('paper', function(hooks) {
             );
         });
 
+        QUnit.test('image cancellation', function(assert) {
+
+            assert.expect(1);
+
+            var done = assert.async();
+            var paper = this.paper;
+
+            paper.drawBackground({ image: bgImageDataURL });
+            paper.drawBackground({ image: null });
+
+            setTimeout(
+                function() {
+                    assert.equal(
+                        getUrlFromAttribute(paper.$background.css('backgroundImage')),
+                        null
+                    );
+                    done();
+                },
+                0
+            );
+        });
+
         QUnit.test('opacity', function(assert) {
 
             assert.expect(1);


### PR DESCRIPTION
```js
paper.drawBackground({ image: 'background.png' }); 
paper.drawBackground({ image: null });
// Assert: no image is displayed as paper background
```
