### PR TITLE
docs: Fix a few typos

### DIFF
--- a/demo/erd/src/erd.js
+++ b/demo/erd/src/erd.js
@@ -24,7 +24,7 @@ var highlighter = V('path', {
     'pointer-events': 'none'
 });
 
-// Define a specific highligthing path for every shape.
+// Define a specific highlighting path for every shape.
 
 erd.Attribute.prototype.getHighlighterPath = function(w, h) {
 

--- a/demo/logic/src/logic.js
+++ b/demo/logic/src/logic.js
@@ -90,7 +90,7 @@ joint.shapes.logic.Output.prototype.onSignal = function(signal) {
     toggleLive(this, signal);
 };
 
-// diagramm setup
+// diagram setup
 
 var gates = {
     repeater: new joint.shapes.logic.Repeater({ position: { x: 410, y: 25 }}),

--- a/test/geometry/path.js
+++ b/test/geometry/path.js
@@ -990,7 +990,7 @@ QUnit.module('path', function(hooks) {
             assert.ok(segment instanceof g.Path.segmentTypes.z);
             clonedPath = path.clone();
             clonedPath.appendSegment(segment);
-            // lowecase `z` still translates into capital `Z`
+            // lowercase `z` still translates into capital `Z`
             assert.equal(clonedPath.toString(), 'Z');
 
             // closepath -> no arguments (correct)

--- a/test/jointjs/links.js
+++ b/test/jointjs/links.js
@@ -935,7 +935,7 @@ QUnit.module('links', function(hooks) {
         assert.equal(linkView.sourceMagnet, myrectView.$('text')[0], 'source selector points to the magnet element');
         assert.equal(linkView.targetMagnet, myrect2View.$('text')[0], 'target selector points to the magnet element');
 
-        // The functionality below is not implemented, hence skiping the test.
+        // The functionality below is not implemented, hence skipping the test.
         // myrect.attr('text', { port: 'port3' });
         // equal(link.get('source').port, 'port3', 'changing port on an element automatically changes the same port on a link');
     });

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -1531,7 +1531,7 @@ QUnit.module('paper', function(hooks) {
 
                 var drawGridTestFixtures = [
                     { name: 'doubleMesh', args: { color: 'red', thickness: 11 }}, //update first layer
-                    { name: 'doubleMesh', args: [{ color: 'red', thickness: 11 }, { color: 'black', thickness: 55 }] }, //udate both alyers
+                    { name: 'doubleMesh', args: [{ color: 'red', thickness: 11 }, { color: 'black', thickness: 55 }] }, //update both layers
                     { name: 'doubleMesh', color: 'red', thickness: 11 } // update firs layer
                 ];
 


### PR DESCRIPTION
There are small typos in:
- demo/erd/src/erd.js
- demo/logic/src/logic.js
- test/geometry/path.js
- test/jointjs/links.js
- test/jointjs/paper.js

Fixes:
- Should read `update` rather than `udate`.
- Should read `layers` rather than `alyers`.
- Should read `skipping` rather than `skiping`.
- Should read `lowercase` rather than `lowecase`.
- Should read `highlighting` rather than `highligthing`.
- Should read `diagram` rather than `diagramm`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md