### PR TITLE
dia.attributes: support negative number addition/subtraction in calc(…

### DIFF
--- a/src/dia/attributes/calc.mjs
+++ b/src/dia/attributes/calc.mjs
@@ -8,7 +8,7 @@ const props = {
 const propsList = Object.keys(props).map(key => props[key]).join('');
 const numberPattern = '[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?';
 const findSpacesRegex = /\s/g;
-const parseExpressionRegExp = new RegExp(`^(${numberPattern}\\*)?([${propsList}])([-+]${numberPattern})?$`, 'g');
+const parseExpressionRegExp = new RegExp(`^(${numberPattern}\\*)?([${propsList}])([-+]{1,2}${numberPattern})?$`, 'g');
 
 function throwInvalid(expression) {
     throw new Error(`Invalid calc() expression: ${expression}`);
@@ -44,7 +44,21 @@ export function evalCalcExpression(expression, bbox) {
             break;
         }
     }
-    return parseFloat(multiply) * dimension + parseFloat(add);
+    return parseFloat(multiply) * dimension + evalAddExpression(add);
+}
+
+function evalAddExpression(addExpression) {
+    if (!addExpression) return 0;
+    const [sign] = addExpression;
+    switch (sign) {
+        case '+': {
+            return parseFloat(addExpression.substr(1));
+        }
+        case '-': {
+            return -parseFloat(addExpression.substr(1));
+        }
+    }
+    return parseFloat(addExpression);
 }
 
 export function isCalcAttribute(value) {

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -2,7 +2,7 @@ QUnit.module('Attributes', function() {
 
     QUnit.module('getAttributeDefinition()', function() {
 
-        QUnit.test('will find correct defintion', function(assert) {
+        QUnit.test('will find correct definition', function(assert) {
 
             joint.dia.attributes.globalTest = 'global';
             joint.dia.attributes.priority = 'lower';
@@ -353,6 +353,8 @@ QUnit.module('Attributes', function() {
                 ['calc(h-10)', String(HEIGHT - 10)],
                 ['calc(2*w+10)', String(WIDTH * 2 + 10)],
                 ['calc(2*h+10)', String(HEIGHT * 2 + 10)],
+                ['calc(w+-10)', String(WIDTH - 10)],
+                ['calc(h--10)', String(HEIGHT + 10)],
                 // spaces
                 ['calc( 2 * w + 10 )', String(WIDTH * 2 + 10)],
                 ['calc( 2 * h + 10 )', String(HEIGHT * 2 + 10)],


### PR DESCRIPTION
…) expression

Support `calc()` expression in these forms:
```js
calc(multipy * property - -number)
calc(multiply * propery + -number)
```

This is common when values are inserted into the `calc()` expression via template literals.
```js
const offset = -20;
const d = `M 0 0 calc(w-${offset}) 0`;
const d = `M 0 0 calc(w+${offset}) 0`;
```