### PR TITLE
dia.Paper: fix update priority stats

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -863,6 +863,7 @@ export const Paper = View.extend({
                     stats.priority = data.priority;
                     this.notifyAfterRender(stats, opt);
                     data.processed = 0;
+                    data.priority = MIN_PRIORITY;
                     updates.count = 0;
                 } else {
                     data.processed = processed;
@@ -917,7 +918,7 @@ export const Paper = View.extend({
         if (typeof postponeViewFn !== 'function') postponeViewFn = null;
         var priorityIndexes = Object.keys(priorities); // convert priorities to a dense array
         main: for (var i = 0, n = priorityIndexes.length; i < n; i++) {
-            var priority = priorityIndexes[i];
+            var priority = +priorityIndexes[i];
             var priorityUpdates = priorities[priority];
             for (var cid in priorityUpdates) {
                 if (updateCount >= batchSize) {


### PR DESCRIPTION
Make sure that the `stats.priority` always points to the highest priority of all updates done between `beforeRender` and `afterRender`.

```js
// Assert: paper.hasScheduledUpdates() === true
paper.requestViewUpdate(view1, flags1, priority1);
paper.requestViewUpdate(view2, flags2, priority2);
paper.unfreeze({
  afterRender: stats => {
     // Note: The highest priority is the lowest number.
     // Assert: stats.priority === Math.min(priority1, priority2);
   }
});
```