### PR TITLE
dia.Cell: fix stopTransitions() without path argument, stopping the t…

### DIFF
--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -1628,6 +1628,27 @@ QUnit.module('basic', function(hooks) {
         }, 300);
     });
 
+    QUnit.test('transition: stopTransitions()', function(assert) {
+        assert.expect(6);
+        var done = assert.async();
+        var el = new joint.shapes.standard.Rectangle({ test1: 0, test2: 0, test3: 0 });
+        this.graph.addCell(el);
+        el.transition('test1', 100);
+        el.transition('test2', 100);
+        el.transition('test3', 100);
+        assert.equal(el.getTransitions().length, 3);
+        el.stopTransitions('test2');
+        assert.equal(el.getTransitions().length, 2);
+        el.stopTransitions();
+        assert.equal(el.getTransitions().length, 0);
+        setTimeout(function() {
+            assert.equal(el.attributes.test1, 0);
+            assert.equal(el.attributes.test2, 0);
+            assert.equal(el.attributes.test3, 0);
+            done();
+        }, 200);
+    });
+
     QUnit.test('cell.getAncestors()', function(assert) {
 
         var r0 = new joint.shapes.basic.Rect;


### PR DESCRIPTION
…ransition does not require waiting for the transition to start

1.  fix `stopTransitions()` without `path` argument
```js
// Assert: does not throw an exception
element.stopTransitions();
```
2. stopping the transition does not require waiting for the transition to start
```js
element.transition('attribute1', endValue, { delay: 400 });
// Assert: this stops the transition even though it didn't start yet
element.stopTransition('attribute1');
```