### PR TITLE
dia.Paper: fix embedding mode with rotated elements

### DIFF
--- a/docs/src/geometry/api/g/Rect/prototype/rotateAroundCenter.html
+++ b/docs/src/geometry/api/g/Rect/prototype/rotateAroundCenter.html
@@ -1,0 +1,2 @@
+<pre class="docs-method-signature"><code>rect.rotateAroundCenter(angle)</code></pre>
+<p>Rotates the rectangle around its center. The method updates the size and the position to match the bounding box of the rotated rectangle.</p>

--- a/docs/src/joint/api/dia/Element/prototype/getBBox.html
+++ b/docs/src/joint/api/dia/Element/prototype/getBBox.html
@@ -4,7 +4,7 @@
 <p>Keep in mind that this function reports the dimensions of the element's model, not the dimensions of the element's view. (For example, the model bounding box does not include any associated ports). See the documentation of the <code>elementView.getBBox</code> <a href="#dia.ElementView.prototype.getBBox">function</a> for details about the differences.</p>
 
 <pre><code>if (element1.getBBox().intersect(element2.getBBox())) {
-    // elements intersect
+    // intersection of the two elements
 }</code></pre>
 
 <table>

--- a/docs/src/joint/api/dia/Element/prototype/getBBox.html
+++ b/docs/src/joint/api/dia/Element/prototype/getBBox.html
@@ -1,9 +1,18 @@
-<pre class="docs-method-signature"><code>element.getBBox()</code></pre>
-<p>Return the bounding box of the element model, represented as a <code>g.Rect</code>.</p>
-
-<p>Keep in mind that this function reports the dimensions of the element's model, not the dimensions of the element's view. (For example, the model bounding box does not include any associated ports). See the documentation of the <code>elementView.getBBox</code> <a href="#dia.ElementView.prototype.getBBox">function</a> for details about the differences.</p>
-
-<p>Example usage:</p>
-<pre><code>if (element1.getBBox().intersect(element2.getBBox())) {
-    // intersection of the two elements
+<pre class="docs-method-signature"><code>element.getBBox([opt])</code></pre>
+<p>Returns an element's bounding box represented as a <code>g.Rect</code> object (see <a href="http://www.daviddurman.com/hidden-gold-of-jointjs-the-geometry-library.html">geometry library</a>).</p><pre><code>if (element1.getBBox().intersect(element2.getBBox())) {
+    // elements intersect
 }</code></pre>
+<table>
+    <tr>
+        <th>opt</th>
+        <th>description</th>
+    </tr>
+    <tr>
+        <td>deep</td>
+        <td>Return the union of the element's bounding box and all the elements embedded into it.</td>
+    </tr>
+    <tr>
+        <td>rotate</td>
+        <td>Return the bounding box after the element's rotation.</td>
+    </tr>
+</table>

--- a/docs/src/joint/api/dia/Element/prototype/getBBox.html
+++ b/docs/src/joint/api/dia/Element/prototype/getBBox.html
@@ -1,7 +1,12 @@
 <pre class="docs-method-signature"><code>element.getBBox([opt])</code></pre>
-<p>Returns an element's bounding box represented as a <code>g.Rect</code> object (see <a href="http://www.daviddurman.com/hidden-gold-of-jointjs-the-geometry-library.html">geometry library</a>).</p><pre><code>if (element1.getBBox().intersect(element2.getBBox())) {
+<p>Returns an element's bounding box represented as a <code>g.Rect</code> object.</p>
+
+<p>Keep in mind that this function reports the dimensions of the element's model, not the dimensions of the element's view. (For example, the model bounding box does not include any associated ports). See the documentation of the <code>elementView.getBBox</code> <a href="#dia.ElementView.prototype.getBBox">function</a> for details about the differences.</p>
+
+<pre><code>if (element1.getBBox().intersect(element2.getBBox())) {
     // elements intersect
 }</code></pre>
+
 <table>
     <tr>
         <th>opt</th>

--- a/docs/src/joint/api/dia/Element/prototype/getBBox.html
+++ b/docs/src/joint/api/dia/Element/prototype/getBBox.html
@@ -1,5 +1,5 @@
 <pre class="docs-method-signature"><code>element.getBBox([opt])</code></pre>
-<p>Returns an element's bounding box represented as a <code>g.Rect</code> object.</p>
+<p>Return the bounding box of the element model, represented as a <code>g.Rect</code>.</p>
 
 <p>Keep in mind that this function reports the dimensions of the element's model, not the dimensions of the element's view. (For example, the model bounding box does not include any associated ports). See the documentation of the <code>elementView.getBBox</code> <a href="#dia.ElementView.prototype.getBBox">function</a> for details about the differences.</p>
 

--- a/src/dia/Element.mjs
+++ b/src/dia/Element.mjs
@@ -400,25 +400,27 @@ export const Element = Cell.extend({
         return normalizeAngle(this.get('angle') || 0);
     },
 
-    getBBox: function(opt) {
+    getBBox: function(opt = {}) {
 
-        opt = opt || {};
+        const { graph, attributes } = this;
+        const { deep, rotate } = opt;
 
-        if (opt.deep && this.graph) {
-
-            // Get all the embedded elements using breadth first algorithm,
-            // that doesn't use recursion.
-            var elements = this.getEmbeddedCells({ deep: true, breadthFirst: true });
+        if (deep && graph) {
+            // Get all the embedded elements using breadth first algorithm.
+            const elements = this.getEmbeddedCells({ deep: true, breadthFirst: true });
             // Add the model itself.
             elements.push(this);
-
-            return this.graph.getCellsBBox(elements);
+            // Note: the default of getCellsBBox() is rotate=true and can't be
+            // changed without a breaking change
+            return graph.getCellsBBox(elements, opt);
         }
 
-        var position = this.get('position');
-        var size = this.get('size');
-
-        return new Rect(position.x, position.y, size.width, size.height);
+        const { angle = 0, position: { x, y }, size: { width, height }} = attributes;
+        const bbox = new Rect(x, y, width, height);
+        if (rotate) {
+            bbox.rotateAroundCenter(angle);
+        }
+        return bbox;
     },
 
     getPointFromConnectedLink: function(link, endType) {

--- a/src/dia/Graph.mjs
+++ b/src/dia/Graph.mjs
@@ -991,10 +991,10 @@ export const Graph = Backbone.Model.extend({
     },
 
     // Return the bounding box of all cells in array provided.
-    getCellsBBox: function(cells, opt) {
-        const cellBBoxOpt = util.assign({ rotate: true }, opt);
+    getCellsBBox: function(cells, opt = {}) {
+        const { rotate = true } = opt;
         return util.toArray(cells).reduce(function(memo, cell) {
-            const rect = cell.getBBox(cellBBoxOpt);
+            const rect = cell.getBBox({ rotate });
             if (!rect) return memo;
             if (memo) {
                 return memo.union(rect);

--- a/src/g/rect.mjs
+++ b/src/g/rect.mjs
@@ -91,15 +91,22 @@ Rect.prototype = {
     // Find my bounding box when I'm rotated with the center of rotation in the center of me.
     // @return r {rectangle} representing a bounding box
     bbox: function(angle) {
+        return this.clone().rotateAroundCenter(angle);
+    },
 
-        if (!angle) return this.clone();
-
-        var theta = toRad(angle);
-        var st = abs(sin(theta));
-        var ct = abs(cos(theta));
-        var w = this.width * ct + this.height * st;
-        var h = this.width * st + this.height * ct;
-        return new Rect(this.x + (this.width - w) / 2, this.y + (this.height - h) / 2, w, h);
+    rotateAroundCenter: function(angle) {
+        if (!angle) return this;
+        const { width, height } = this;
+        const theta = toRad(angle);
+        const st = abs(sin(theta));
+        const ct = abs(cos(theta));
+        const w = width * ct + height * st;
+        const h = width * st + height * ct;
+        this.x += (width - w) / 2;
+        this.y += (height - h) / 2;
+        this.width = w;
+        this.height = h;
+        return this;
     },
 
     bottomLeft: function() {

--- a/test/geometry/rect.js
+++ b/test/geometry/rect.js
@@ -110,6 +110,22 @@ QUnit.module('rect', function() {
 
         QUnit.module('bbox()', function() {
 
+            QUnit.test('returns a rotated rectangle', function(assert) {
+                var r1 = new g.Rect(10, 20, 30, 40);
+                var r2 = r1.bbox(90);
+                assert.notEqual(r1, r2);
+                assert.ok(r1.round().equals(new g.Rect(10, 20, 30, 40)));
+                assert.ok(r2.round().equals(new g.Rect(5, 25, 40, 30)));
+            });
+        });
+
+        QUnit.module('rotateAroundCenter()', function() {
+
+            QUnit.test('rotates the rectangle', function(assert) {
+                var r = new g.Rect(10, 20, 30, 40);
+                r.rotateAroundCenter(90);
+                assert.ok(r.round().equals(new g.Rect(5, 25, 40, 30)));
+            });
         });
 
         QUnit.module('bottomLeft()', function() {

--- a/test/jointjs/graph.js
+++ b/test/jointjs/graph.js
@@ -850,32 +850,51 @@ QUnit.module('graph', function(hooks) {
         });
     });
 
-    QUnit.test('graph.findModelsUnderElement()', function(assert) {
+    QUnit.module('graph.findModelsUnderElement()', function() {
 
-        var rect = new joint.shapes.basic.Rect({
-            size: { width: 100, height: 100 },
-            position: { x: 100, y: 100 }
+        QUnit.test('sanity', function(assert) {
+
+            var rect = new joint.shapes.basic.Rect({
+                size: { width: 100, height: 100 },
+                position: { x: 100, y: 100 }
+            });
+
+            var under = rect.clone();
+            var away = rect.clone().translate(200, 200);
+
+            this.graph.addCells([rect, under, away]);
+
+            assert.deepEqual(this.graph.findModelsUnderElement(away), [], 'There are no models under the element.');
+            assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is a model under the element.');
+
+            under.translate(50, 50);
+
+            assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'origin' }), [], 'There is no model under the element if searchBy origin option used.');
+            assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'corner' }), [under], 'There is a model under the element if searchBy corner options used.');
+
+            var embedded = rect.clone().addTo(this.graph);
+            rect.embed(embedded);
+
+            assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is 1 model under the element found and 1 embedded element is omitted.');
+            assert.deepEqual(this.graph.findModelsUnderElement(under), [rect, embedded], 'There are 2 models under the element. Parent and its embed.');
+            assert.deepEqual(this.graph.findModelsUnderElement(embedded), [rect, under], 'There are 2 models under the element. The element\'s parent and one other element.');
         });
 
-        var under = rect.clone();
-        var away = rect.clone().translate(200, 200);
+        QUnit.test('rotated elements', function(assert) {
 
-        this.graph.addCells([rect, under, away]);
-
-        assert.deepEqual(this.graph.findModelsUnderElement(away), [], 'There are no models under the element.');
-        assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is a model under the element.');
-
-        under.translate(50, 50);
-
-        assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'origin' }), [], 'There is no model under the element if searchBy origin option used.');
-        assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'corner' }), [under], 'There is a model under the element if searchBy corner options used.');
-
-        var embedded = rect.clone().addTo(this.graph);
-        rect.embed(embedded);
-
-        assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is 1 model under the element found and 1 embedded element is omitted.');
-        assert.deepEqual(this.graph.findModelsUnderElement(under), [rect, embedded], 'There are 2 models under the element. Parent and its embed.');
-        assert.deepEqual(this.graph.findModelsUnderElement(embedded), [rect, under], 'There are 2 models under the element. The element\'s parent and one other element.');
+            var graph =this.graph;
+            var rect1 = new joint.shapes.standard.Rectangle({ size: { width: 10, height: 100 }});
+            var rect2 = rect1.clone().translate(30, 30);
+            graph.addCells([rect1, rect2]);
+            assert.deepEqual(graph.findModelsUnderElement(rect1), []);
+            rect1.set('angle', 90);
+            assert.deepEqual(graph.findModelsUnderElement(rect1), [rect2]);
+            rect2.set('angle', 90);
+            // there is no intersection when both elements are rotated
+            assert.deepEqual(graph.findModelsUnderElement(rect1), []);
+            rect1.set('angle', 0);
+            assert.deepEqual(graph.findModelsUnderElement(rect1), [rect2]);
+        });
     });
 
     QUnit.test('graph.options: cellNamespace', function(assert) {

--- a/test/jointjs/graph.js
+++ b/test/jointjs/graph.js
@@ -882,7 +882,7 @@ QUnit.module('graph', function(hooks) {
 
         QUnit.test('rotated elements', function(assert) {
 
-            var graph =this.graph;
+            var graph = this.graph;
             var rect1 = new joint.shapes.standard.Rectangle({ size: { width: 10, height: 100 }});
             var rect2 = rect1.clone().translate(30, 30);
             graph.addCells([rect1, rect2]);

--- a/test/ts/index.test.ts
+++ b/test/ts/index.test.ts
@@ -85,7 +85,7 @@ graph.addCell({
 
 // `cells` attribute is a collection of cells
 const cell = graph.get('cells').at(0);
-cell.getBBox().inflate(5);
+(<joint.dia.Element>cell).getBBox({ rotate: true }).inflate(5);
 
 // ModelSetOptions
 graph.set('test', true, { dry: true });

--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -590,6 +590,8 @@ export namespace g {
 
         bbox(angle?: number): Rect;
 
+        rotateAroundCenter(angle: number): this;
+
         bottomLeft(): Point;
 
         bottomLine(): Line;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -463,6 +463,10 @@ export namespace dia {
             restrictedArea?: BBox;
             transition?: Cell.TransitionOptions;
         }
+
+        interface BBoxOptions extends EmbeddableOptions {
+            rotate?: boolean;
+        }
     }
 
     class Element<A = Element.Attributes, S = dia.ModelSetOptions> extends Cell<A, S> {
@@ -489,7 +493,7 @@ export namespace dia {
 
         fitEmbeds(opt?: { deep?: boolean, padding?: Padding }): this;
 
-        getBBox(opt?: Cell.EmbeddableOptions): g.Rect;
+        getBBox(opt?: Element.BBoxOptions): g.Rect;
 
         addPort(port: Element.Port, opt?: S): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -464,7 +464,7 @@ export namespace dia {
             transition?: Cell.TransitionOptions;
         }
 
-        interface BBoxOptions extends EmbeddableOptions {
+        interface BBoxOptions extends Cell.EmbeddableOptions {
             rotate?: boolean;
         }
     }


### PR DESCRIPTION
Fixes the issue when the user tries embedding an element into another element with non-zero angle.

- **dia.Graph** - `findModelsInArea()`, `findModelsUnderElement()`, `findModelFromPoint()` take the element's rotation into account
- **dia.Element** - add `rotate` option for `getBBox()` (to return the bounding box of the rotated element's model)
- **Geometry** - add `Rect.prototype.rotateAroundCenter()` method (in-place alternative for`Rect.prototype.bbox(angle)`)