### PR TITLE
tutorials: add calc() to tutorials  

### DIFF
--- a/tutorials/custom-elements.html
+++ b/tutorials/custom-elements.html
@@ -40,7 +40,7 @@
             <p><i>
                 This is the fourth article of the intermediate section of the JointJS tutorial. Return to 
                 <a href="serialization.html">serialization</a>. See <a href="intermediate.html">index</a> 
-                of all intermediate articles.
+                of basic and intermediate articles.
             </i></p>
 
             <p>JointJS comes with several collections of built-in element shapes.

--- a/tutorials/custom-elements.html
+++ b/tutorials/custom-elements.html
@@ -37,9 +37,11 @@
 
             <h2>Custom Elements</h2>
 
-            <p>This is the fourth article of the intermediate section of the JointJS tutorial.
-                <a href="serialization.html">Go back to serialization.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the fourth article of the intermediate section of the JointJS tutorial. Return to 
+                <a href="serialization.html">serialization</a>. See <a href="intermediate.html">index</a> 
+                of all intermediate articles.
+            </i></p>
 
             <p>JointJS comes with several collections of built-in element shapes.
                 We already saw two members of the <code>joint.shapes.standard</code> collection in the basic
@@ -86,15 +88,15 @@
                 functions</a>.</li>
             </ul>
 
-            <p>Let us use the familiar
+            <p>Let's use the familiar
                 <a href="/docs/jointjs#shapes.standard.Rectangle" target="_blank"><code>joint.shapes.standard.Rectangle</code></a>
                 shape definition as an example:</p>
 
             <pre><code>joint.dia.Element.define('standard.Rectangle', {
     attrs: {
         body: {
-            refWidth: '100%',
-            refHeight: '100%',
+            width: 'calc(w)',
+            height: 'calc(h)',
             strokeWidth: 2,
             stroke: '#000000',
             fill: '#FFFFFF'
@@ -102,8 +104,8 @@
         label: {
             textVerticalAnchor: 'middle',
             textAnchor: 'middle',
-            refX: '50%',
-            refY: '50%',
+            x: 'calc(0.5*w)',
+            y: 'calc(0.5*h)',
             fontSize: 14,
             fill: '#333333'
         }
@@ -131,9 +133,9 @@
             <p>Markup is usually provided inside the third argument of the <code>define()</code> function (prototype
                 properties) for improved performance.
                 (This is because markup is something that all instances of the element type are expected to have in
-                common, so inheriting from subtype prototype is more efficient.
+                common, so inheriting from the subtype prototype is more efficient.
                 Nevertheless, it is still possible to provide custom markup to individual instances of your class by
-                providing individual <code>markup</code> later.)</p>
+                providing individual <code>markup</code> later).</p>
 
             <p>The <code>markup</code> property is specified as a JSON array.
                 Each member of the array is taken to define one subelement of the new shape.
@@ -180,7 +182,7 @@
             <p>Default attributes are usually provided inside the second argument of the <code>define()</code> function
                 (default instance properties).
                 (This is because all instances of the element type are expected to have their own individual attributes,
-                so inheriting from the prototype is likely to cause unnecessary overhead.)</p>
+                so inheriting from the prototype is likely to cause unnecessary overhead).</p>
 
             <p>In the <code>attrs</code> object, keys correspond to subelement selectors, as defined in the
                 <a href="#markup">markup</a>.
@@ -188,23 +190,23 @@
                 Each of these attributes can be a native SVG attribute or a <a href="special-attributes.html">JointJS
                 special attribute</a>.</p>
 
-            <p>In <code>joint.shapes.standard.Rectangle</code>, we can see that the subelement referenced by
+            <p>
+                In <code>joint.shapes.standard.Rectangle</code>, we can see that the subelement referenced by
                 <code>body</code> (i.e. the SVGRectElement component of the shape) has its default width and height set
-                in terms of the model size (using the
-                <a href="special-attributes.html#relative-dimensions">relative-dimension special attributes</a>
-                <code>refWidth</code>/<code>refHeight</code>),
-                alongside the fill and stroke styling.
+                in terms of the shape model size (using the <code>calc()</code> function). Read more about <code>calc()</code>
+                in our <a target="_blank" href="https://resources.jointjs.com/docs/jointjs/v3.4/joint.html#dia.attributes">attributes</a> 
+                documentation. Alongside sizing, you can see the fill and stroke styling.
                 The <code>label</code> subelement (the SVGTextElement component of the shape) has its text anchor set to
-                the center of the text bbox; that point is then positioned into the center of the model bbox by the
-                <a href="special-attributes.html#relative-dimensions">two relative-position special attributes</a>
-                <code>refX</code>/<code>refY</code>.
-                Its font size is specified, and the font fill color:</p>
+                the center of the text bbox; that point is then positioned into the center of the model bbox by <code>x</code>
+                and <code>y</code> attributes.
+                Its font size is specified, and the font fill color:
+            </p>
 
             <pre><code>{
     attrs: {
         body: {
-            refWidth: '100%',
-            refHeight: '100%',
+            width: 'calc(w)',
+            height: 'calc(h)',
             strokeWidth: 2,
             stroke: '#000000',
             fill: '#FFFFFF'
@@ -212,8 +214,8 @@
         label: {
             textVerticalAnchor: 'middle',
             textAnchor: 'middle',
-            refX: '50%',
-            refY: '50%',
+            x: 'calc(0.5*w)',
+            y: 'calc(0.5*h)',
             fontSize: 14,
             fill: '#333333'
         }
@@ -231,31 +233,32 @@
                 Here, that subelement is the <code>body</code> subelement.</p>
 
             <p>There does not need to be a direct mapping between model size and any visible subelements.
-                It is perfectly possible to replace the <code>refWidth</code>/<code>refHeight</code> relative
-                attributes with the native SVG (absolute) <code>width</code>/<code>height</code>; this would create a
+                It is perfectly possible to replace relative sizing using <code>calc()</code> with regular values
+                for <code>width</code> and <code>height</code> respectively; this would create a
                 subelement with constant dimensions - 20px by 20px, for example - regardless of model size.
                 That may be ideal for control buttons.</p>
 
-            <p>Similarly, the position of <code>label</code> anchor is defined in terms of model size and position.
+            <p>Similarly, the position of the <code>label</code> anchor is defined in terms of model size and position.
                 Model position is modified by calling the
                 <a href="/docs/jointjs#dia.Element.prototype.position"><code>element.position()</code></a> function on
                 an instance of <code>joint.shapes.standard.Rectangle</code>.
                 For example, if we called <code>element.position(-100, -100)</code>, the origin of the reference
                 coordinates would move to the point (-100,-100) on the paper.</p>
 
-            <p>We can see that the anchor of the <code>label</code> of <code>joint.shapes.standard.Rectangle</code> is
-                placed at <code>refX: '50%'</code>,<code>refY: '50%'</code> by default.
-                The percentages refer to model size; thus, if model size were kept at (100,100), they would mean that
-                the anchor of the <code>label</code> will be offset from the reference origin by (50,50).
-                Thus, if model position were (-100,-100) and size were (100, 100), the label anchor would be positioned
-                at (-50,-50).</p>
+            <p>
+                We can see that the anchor of the <code>label</code> of <code>joint.shapes.standard.Rectangle</code>
+                in our example is placed centrally. We use <code>calc()</code> to place the label relative to our
+                shape model. If the model size was kept at (100, 100), that would mean that the anchor of the label 
+                will be offset from the reference origin by (50, 50) when using <code>x: 'calc(0.5*w)'</code> and 
+                <code>y: 'calc(0.5*h)'</code>.
+            </p>
 
             <p>Relative positioning and sizing of elements is explained in more detail in a
                 <a href="special-attributes.html#relative-dimensions">separate section of the tutorial</a>.</p>
 
             <h3 id="static-properties">Static Properties</h3>
 
-            <p>Static properties are not used by <code>joint.shapes.standard.Rectangle</code>, but let us discuss them a
+            <p>Static properties are not used by <code>joint.shapes.standard.Rectangle</code>, but let's discuss them a
                 little bit to gain a complete overview of custom elements.</p>
 
             <p>Imagine we wanted to define our own subtype of <code>joint.shapes.standard.Rectangle</code> (which we
@@ -277,10 +280,10 @@
 
             <h3 id="example">Example</h3>
 
-            <p>Let us apply everything we learned so far and create a new
-                <cdoe>joint.shapes.examples.CustomRectangle</cdoe> class based on
+            <p>Let's apply everything we learned so far and create a new
+                <code>joint.shapes.examples.CustomRectangle</code> class based on
                 <code>joint.shapes.standard.Rectangle</code>.
-                Keep in mind that the provided instance properties are mixined with the parent definition, but prototype
+                Keep in mind that the provided instance properties are mixed with the parent definition, but prototype
                 and static properties are not.
                 This means that it is enough for us to record only the attributes that changed in the definition of the
                 custom element subtype (however, if we wanted to change the markup, we would have to do so
@@ -296,7 +299,7 @@
         },
         label: {
             textAnchor: 'left', // align text to left
-            refX: 10, // offset text from right edge of model bbox
+            x: 10, // offset text from right edge of model bbox
             fill: 'white',
             fontSize: 18
         }

--- a/tutorials/custom-elements.html
+++ b/tutorials/custom-elements.html
@@ -194,7 +194,7 @@
                 In <code>joint.shapes.standard.Rectangle</code>, we can see that the subelement referenced by
                 <code>body</code> (i.e. the SVGRectElement component of the shape) has its default width and height set
                 in terms of the shape model size (using the <code>calc()</code> function). Read more about <code>calc()</code>
-                in our <a target="_blank" href="https://resources.jointjs.com/docs/jointjs/v3.4/joint.html#dia.attributes">attributes</a> 
+                in our <a target="_blank" href="/docs/jointjs#dia.attributes">attributes</a> 
                 documentation. Alongside sizing, you can see the fill and stroke styling.
                 The <code>label</code> subelement (the SVGTextElement component of the shape) has its text anchor set to
                 the center of the text bbox; that point is then positioned into the center of the model bbox by <code>x</code>
@@ -338,9 +338,32 @@
     }
 });</code></pre>
 
+            <p>
+                We add our shapes to the graph in the same manner described in our basic <a href="graph-and-paper.html">Graph & Paper</a>
+                tutorial. In the code below, we add a <code>joint.shapes.standard.Rectangle</code> with rounded corners and
+                a Multiline label. The Multiline label respects the <code>x</code> and <code>y</code> values that we 
+                calculated with the <code>calc()</code> function earlier.
+            </p>
+
+            <pre><code>var rect2 = new joint.shapes.standard.Rectangle();
+rect2.position(50, 125);
+rect2.resize(500, 50);
+rect2.attr({
+    body: {
+        rx: 10, // add a corner radius
+        ry: 10,
+        fill: '#ADD8E6'
+    },
+    label: {
+        text: 'shapes.\nstandard.Rectangle()' // add Multiline label with Newline character
+    }
+});
+rect2.addTo(graph);
+            </code></pre>
+
             <p>The following example shows the default look of <code>joint.shapes.standard.Rectangle</code> (i.e. with
-                no instance attributes set) alongside the default look of our custom element and the randomized results
-                of the <code>createRandom()</code> constructor function.
+                no instance attributes set), and the Multiline label example above. Alongside those, you can see the default 
+                look of our custom element, and the randomized results of the <code>createRandom()</code> constructor function.
                 Try <a onClick="window.location.reload()" style="cursor: pointer">refreshing the page</a> to see
                 <code>createRandom()</code> in action.</p>
 

--- a/tutorials/custom-elements.html
+++ b/tutorials/custom-elements.html
@@ -283,7 +283,7 @@
             <p>Let's apply everything we learned so far and create a new
                 <code>joint.shapes.examples.CustomRectangle</code> class based on
                 <code>joint.shapes.standard.Rectangle</code>.
-                Keep in mind that the provided instance properties are mixed with the parent definition, but prototype
+                Keep in mind that the provided instance properties are mixined with the parent definition, but prototype
                 and static properties are not.
                 This means that it is enough for us to record only the attributes that changed in the definition of the
                 custom element subtype (however, if we wanted to change the markup, we would have to do so

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -301,8 +301,8 @@
             <h3 id="example">Example</h3>
 
             <p>Let us apply everything we learned so far and create a new
-                <cdoe>joint.shapes.examples.CustomLink</cdoe> class based on <code>joint.shapes.standard.Link</code>.
-                Keep in mind that the provided instance properties are mixined with the parent definition, but prototype
+                <code>joint.shapes.examples.CustomLink</code> class based on <code>joint.shapes.standard.Link</code>.
+                Keep in mind that the provided instance properties are mixed with the parent definition, but prototype
                 and static properties are not.
                 This means that it is enough for us to record only the attributes that changed in the definition of the
                 custom element subtype (however, if we wanted to change the markup, we would have to do so

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -37,14 +37,15 @@
 
             <h2>Custom Links</h2>
 
-            <p>This is the fifth article of the intermediate section of the JointJS tutorial.
-                <a href="custom-elements.html">Go back to custom elements.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the fifth article of the intermediate section of the JointJS tutorial. Return to 
+                <a href="custom-elements.html">custom elements</a>. See <a href="intermediate.html">index</a>
+                of intermediate articles.
+            </i></p>
 
             <p>JointJS comes with several built-in link shapes; we have already encountered
-                <code>joint.shapes.standard.Link</code> in the <a href="links.html">basic links</a> tutorial.</p>
-
-            <p>However, builtin link definitions are not as plentiful as element definitions.
+                <code>joint.shapes.standard.Link</code> in the <a href="links.html">basic links</a> tutorial.
+                However, built-in link definitions are not as plentiful as element definitions.
                 It is thus very possible that you will find the need to define your own custom link type.
                 Creating custom links is very similar to <a href="custom-elements.html">creating custom elements</a>,
                 with a few differences.
@@ -135,9 +136,9 @@
             <p>Markup is usually provided inside the third argument of the <code>define()</code> function (prototype
                 properties) for improved performance.
                 (This is because markup is something that all instances of the link type are expected to have in
-                common, so inheriting from subtype prototype is more efficient.
+                common, so inheriting from the subtype prototype is more efficient.
                 Nevertheless, it is still possible to provide custom markup to individual instances of your class by
-                providing individual <code>markup</code> later.)</p>
+                providing individual <code>markup</code> later).</p>
 
             <p>The <code>markup</code> property is specified as a JSON array.
                 Each member of the array is taken to define one subelement of the new shape.
@@ -178,7 +179,7 @@
                 of each instance having their own copy because it avoids unnecessary iterations in the cell attributes
                 update loop.
                 (Nevertheless, again, it is possible to overwrite these prototype attributes by individual instance
-                attributes if absolutely necessary.)</p>
+                attributes if absolutely necessary).</p>
 
             <p>In our example, <code>markup.attributes</code> are used to reflect the intended use of the two
                 subelements of the link, which is not expected to change - <code>wrapper</code> has a transparent stroke
@@ -189,8 +190,8 @@
 
             <p>An important caveat is that <code>markup.attributes</code> can only store <i>native SVG attributes</i>,
                 not JointJS attrs.
-                This means that JointJS special attributes are not recognized (since <code>markup.attributes</code> are
-                supposed not to change, they would not be able to reflect possible changes in referenced subelements or in the
+                This means that JointJS special attributes are not recognized (since <code>markup.attributes</code> are not
+                supposed to change, they would not be able to reflect possible changes in referenced subelements or in the
                 size/position of model bbox).
                 Additionally, this means that there is no JointJS kebab-case translation of attribute names; thus, using
                 quotes around all attribute names is encouraged in this context, to communicate these restrictions to
@@ -202,7 +203,7 @@
             <p>Default attributes are usually provided inside the second argument of the <code>define()</code> function
                 (default instance properties).
                 (This is because all instances of the link type are expected to have their own individual attributes, so
-                inheriting from the prototype is likely to cause unnecessary overhead.)</p>
+                inheriting from the prototype is likely to cause unnecessary overhead).</p>
 
             <p>In the <code>attrs</code> object, keys correspond to subelement selectors, as defined in the
                 <a href="#markup">markup</a>.
@@ -277,7 +278,7 @@
 
             <h3 id="static-properties">Static Properties</h3>
 
-            <p>Static properties are not used by <code>joint.shapes.standard.Link</code>, but let us discuss them a
+            <p>Static properties are not used by <code>joint.shapes.standard.Link</code>, but let's discuss them a
                 little bit to gain a complete overview of custom links.</p>
 
             <p>Similarly to our <a href="custom-elements.html#static-properties">custom element example</a>, imagine we
@@ -344,10 +345,10 @@
                 fill: 'white',
                 stroke: 'cornflowerblue',
                 strokeWidth: 2,
-                refWidth: '120%',
-                refHeight: '120%',
-                refX: '-10%',
-                refY: '-10%'
+                width: 'calc(w+calc(0.2*w))',
+                height: 'calc(h+calc(0.2*h))',
+                x: '-calc(0.6*w)',
+                y: '-calc(0.6*h)'
             }
         },
         position: {

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -345,10 +345,10 @@
                 fill: 'white',
                 stroke: 'cornflowerblue',
                 strokeWidth: 2,
-                width: 'calc(w+calc(0.2*w))',
-                height: 'calc(h+calc(0.2*h))',
-                x: '-calc(0.6*w)',
-                y: '-calc(0.6*h)'
+                width: 'calc(1.2*w)',
+                height: 'calc(1.2*h)',
+                x: 'calc(x-7)',
+                y: 'calc(y-1)'
             }
         },
         position: {

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -347,8 +347,8 @@
                 strokeWidth: 2,
                 width: 'calc(1.2*w)',
                 height: 'calc(1.2*h)',
-                x: 'calc(x-7)',
-                y: 'calc(y-1)'
+                x: 'calc(x-calc(0.1*w))',
+                y: 'calc(y-calc(0.1*h))'
             }
         },
         position: {

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -302,7 +302,7 @@
 
             <p>Let us apply everything we learned so far and create a new
                 <code>joint.shapes.examples.CustomLink</code> class based on <code>joint.shapes.standard.Link</code>.
-                Keep in mind that the provided instance properties are mixed with the parent definition, but prototype
+                Keep in mind that the provided instance properties are mixined with the parent definition, but prototype
                 and static properties are not.
                 This means that it is enough for us to record only the attributes that changed in the definition of the
                 custom element subtype (however, if we wanted to change the markup, we would have to do so

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -40,7 +40,7 @@
             <p><i>
                 This is the fifth article of the intermediate section of the JointJS tutorial. Return to 
                 <a href="custom-elements.html">custom elements</a>. See <a href="intermediate.html">index</a>
-                of intermediate articles.
+                of basic and intermediate articles.
             </i></p>
 
             <p>JointJS comes with several built-in link shapes; we have already encountered

--- a/tutorials/element-tools.html
+++ b/tutorials/element-tools.html
@@ -35,9 +35,11 @@
 
             <h2>Element Tools</h2>
 
-            <p>This is the seventh article of the intermediate section of the JointJS tutorial.
-                <a href="link-labels.html">Go back to link labels.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the seventh article of the intermediate section of the JointJS tutorial. Return to
+                <a href="link-labels.html">link labels</a>.
+                See <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p>JointJS allows creating fully customizable <a href="/docs/jointjs#elementTools" target="_blank">user
                 interaction tools for your elements</a>.

--- a/tutorials/events.html
+++ b/tutorials/events.html
@@ -35,9 +35,11 @@
 
             <h2>Events</h2>
 
-            <p>This is the second article of the intermediate section of the JointJS tutorial.
-                <a href="special-attributes.html">Go back to special attributes.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the second article of the intermediate section of the JointJS tutorial. Return to
+                <a href="special-attributes.html">special attributes</a>.
+                See <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p>JointJS offers several different ways to enable user interaction.
                 Events are triggered on your paper, on individual element/link views.</p>

--- a/tutorials/events.html
+++ b/tutorials/events.html
@@ -44,14 +44,14 @@
             <p>JointJS offers several different ways to enable user interaction.
                 Events are triggered on your paper, on individual element/link views.</p>
 
-            <h3 id="paper-events">Builtin Paper Events</h3>
+            <h3 id="paper-events">Built-in Paper Events</h3>
 
-            <p>Paper automatically triggers several builtin events upon user interaction.
+            <p>Paper automatically triggers several built-in events upon user interaction.
                 These include pointerdown, double click and right click events, as well as link connection or cell
                 highlighting events.
-                You can find the full list in <a href="/docs/jointjs#dia.Paper.events" target="_blank">Paper
+                You can find the full list in the <a href="/docs/jointjs#dia.Paper.events" target="_blank">Paper
                 documentation</a>.
-                Reacting on any of these events is as simple as adding a listener on your paper; this is the easiest way
+                Reacting to any of these events is as simple as adding a listener on your paper; this is the easiest way
                 to detect one type of interaction on all instances of a component.</p>
 
             <p>For example, the event <code>'link:pointerdblclick'</code> is triggered when a double click is detected
@@ -74,28 +74,28 @@
 
     this.drawBackground({
         color: 'orange'
-    })
+    });
 });
 
 paper.on('element:pointerdblclick', function(elementView) {
     resetAll(this);
 
     var currentElement = elementView.model;
-    currentElement.attr('body/stroke', 'orange')
+    currentElement.attr('body/stroke', 'orange');
 });
 
 paper.on('link:pointerdblclick', function(linkView) {
     resetAll(this);
 
     var currentLink = linkView.model;
-    currentLink.attr('line/stroke', 'orange')
+    currentLink.attr('line/stroke', 'orange');
     currentLink.label(0, {
         attrs: {
             body: {
                 stroke: 'orange'
             }
         }
-    })
+    });
 });
 
 paper.on('cell:pointerdblclick', function(cellView) {
@@ -110,7 +110,7 @@ paper.on('cell:pointerdblclick', function(cellView) {
 function resetAll(paper) {
     paper.drawBackground({
         color: 'white'
-    })
+    });
 
     var elements = paper.model.getElements();
     for (var i = 0, ii = elements.length; i < ii; i++) {
@@ -128,7 +128,7 @@ function resetAll(paper) {
                     stroke: 'black'
                 }
             }
-        })
+        });
     }
 }</code></pre>
 
@@ -152,16 +152,16 @@ function resetAll(paper) {
                 interaction options is better practice in JavaScript than having dozens of listeners for individual
                 views.</p>
 
-            <h3 id="graph-events">Builtin Graph Events</h3>
+            <h3 id="graph-events">Built-in Graph Events</h3>
 
-            <p>The Graph model comes with several builtin events as well.
+            <p>The Graph model comes with several built-in events as well.
                 These events react to changes in the cell model's properties, including position, size, attributes, and
                 status of JointJS transitions.
                 JointJS documentation contains a generic list of
-                <a href="/docs/jointjs#dia.Graph.events" target="_blank">Graph events</a> you can react on, alongside
+                <a href="/docs/jointjs#dia.Graph.events" target="_blank">Graph events</a> you can react to, alongside
                 more specific lists for <a href="/docs/jointjs#dia.Element.events" target="_blank">Element events</a>
                 and <a href="/docs/jointjs#dia.Link.events" target="_blank">Link events</a>.
-                To react on these events, add a listener on your Graph model.</p>
+                To react to these events, add a listener on your Graph model.</p>
 
             <p>In the following example, the event <code>'change:position'</code> is triggered on the element when it is
                 moved; we determine the new position of the element's center and write it into its text label.
@@ -196,8 +196,8 @@ graph.on('change:target', function(cell) {
                 In our example, we were able to assume that the received <code>cell</code> model is of the type Element
                 and Link, respectively, because <code>Link</code> objects do not trigger <code>'change:position'</code>
                 events, and <code>Element</code> objects do not trigger <code>'change:target'</code>.
-                Keep in mind that some Graph events can be triggered on both data types, however (e.g.
-                <code>'change:attrs'</code>); depending on what you are trying to do, you might need to check the actual
+                Keep in mind that some Graph events can be triggered on both data types (e.g.
+                <code>'change:attrs'</code>). However, depending on what you are trying to do, you might need to check the actual
                 <code>cell</code> data type first.</p>
 
             <p>Other graph event listeners are provided with different parameters.
@@ -207,7 +207,7 @@ graph.on('change:target', function(cell) {
                 (<code>callback(cell, newCells)</code>), whereas the <code>'graph:remove'</code> event listeners receive
                 the removed cell and the <i>original</i> cells array (<code>callback(cell, oldCells)</code>).</p>
 
-            <p>Similarly to builtin paper events, these events are also triggered on the individual <code>cell</code>
+            <p>Similarly to built-in paper events, these events are also triggered on the individual <code>cell</code>
                 (element or link model) the user interacted with.
                 Therefore, you could achieve the same functionality as above by adding a listener on every element and
                 link separately.
@@ -260,8 +260,8 @@ graph.on('change:target', function(cell) {
                 <code>button</code> subelement.
                 We attach a custom event <code>'element:button:pointerdown'</code> to the <code>button</code> and listen
                 for it.
-                When <code>button</code> is pressed, the element's <code>body</code> and <code>label</code> are hidden
-                (<q>minimized</q>), and the symbol in the button is changed to indicate that the element can be now be
+                When the <code>button</code> is pressed, the element's <code>body</code> and <code>label</code> are hidden
+                (<q>minimized</q>), and the symbol in the button is changed to indicate that the element can now be
                 unminimized:</p>
 
             <div class="paper" id="paper-events-event-attribute"></div>
@@ -269,8 +269,8 @@ graph.on('change:target', function(cell) {
             <pre><code>var CustomElement = joint.dia.Element.define('examples.CustomElement', {
     attrs: {
         body: {
-            refWidth: '100%',
-            refHeight: '100%',
+            width: 'calc(w)',
+            height: 'calc(h)',
             strokeWidth: 2,
             stroke: 'black',
             fill: 'white'
@@ -278,23 +278,22 @@ graph.on('change:target', function(cell) {
         label: {
             textVerticalAnchor: 'middle',
             textAnchor: 'middle',
-            refX: '50%',
-            refY: '50%',
+            x: 'calc(0.5*w)',
+            y: 'calc(0.5*h)',
             fontSize: 14,
             fill: 'black'
         },
         button: {
             cursor: 'pointer',
-            ref: 'buttonLabel',
-            refWidth: '150%',
-            refHeight: '150%',
-            refX: '-25%',
-            refY: '-25%'
+            width: 'calc(0.14*w)',
+            height: 'calc(0.45*h)',
+            x: 'calc(w-7)',
+            y: '-calc(0.25*h)'
         },
         buttonLabel: {
             pointerEvents: 'none',
-            refX: '100%',
-            refY: 0,
+            x: 'calc(w)',
+            y: 0,
             textAnchor: 'middle',
             textVerticalAnchor: 'middle'
         }
@@ -372,11 +371,11 @@ paper.on('element:button:pointerdown', function(elementView, evt) {
 
             <ul>
                 <li><a href="/docs/jointjs#dia.Paper.prototype.options.elementView" target="_blank"><code>elementView</code></a>
-                    - sets the ElementView to use to render Element models on this paper.
+                    - sets the ElementView to use for rendering Element models on this paper.
                     Defaults to
                     <a href="/docs/jointjs#dia.ElementView" target="_blank"><code>joint.dia.ElementView</code></a>.</li>
                 <li><a href="/docs/jointjs#dia.Paper.prototype.options.linkView" target="_blank"><code>linkView</code></a>
-                    - sets the LinkView to use to render Link models. Defaults to
+                    - sets the LinkView to use for rendering Link models. Defaults to
                     <a href="/docs/jointjs#dia.LinkView" target="_blank"><code>joint.dia.LinkView</code></a>.</li>
             </ul>
 
@@ -411,7 +410,7 @@ paper.on('element:button:pointerdown', function(elementView, evt) {
 
             <h3 id="custom-view-events-propagation">Custom View Event Propagation</h3>
 
-            <p>You can maintain recognition of the event by the <a href="#paper-events">builtin paper mechanism</a>
+            <p>You can maintain recognition of the event by the <a href="#paper-events">built-in paper mechanism</a>
                 if you notify the CellView and Paper about the event.
                 For example, in our custom ElementView pointerdblclick handler, we would include this:</p>
 

--- a/tutorials/events.html
+++ b/tutorials/events.html
@@ -288,8 +288,8 @@ graph.on('change:target', function(cell) {
             ref: 'buttonLabel',
             width: 'calc(1.5*w)',
             height: 'calc(1.5*h)',
-            x: 'calc(x-2)',
-            y: 'calc(y-2)'
+            x: 'calc(x-calc(0.25*w))',
+            y: 'calc(y-calc(0.25*h))'
         },
         buttonLabel: {
             pointerEvents: 'none',

--- a/tutorials/events.html
+++ b/tutorials/events.html
@@ -285,10 +285,11 @@ graph.on('change:target', function(cell) {
         },
         button: {
             cursor: 'pointer',
-            width: 'calc(0.14*w)',
-            height: 'calc(0.45*h)',
-            x: 'calc(w-7)',
-            y: '-calc(0.25*h)'
+            ref: 'buttonLabel',
+            width: 'calc(1.5*w)',
+            height: 'calc(1.5*h)',
+            x: 'calc(x-2)',
+            y: 'calc(y-2)'
         },
         buttonLabel: {
             pointerEvents: 'none',

--- a/tutorials/js/custom-elements.js
+++ b/tutorials/js/custom-elements.js
@@ -6,7 +6,7 @@
         el: document.getElementById('paper-custom-elements'),
         model: graph,
         width: 600,
-        height: 300
+        height: 400
     });
 
     joint.dia.Element.define('standard.Rectangle', {
@@ -96,23 +96,38 @@
     });
     rect.addTo(graph);
 
-    var rect2 = new joint.shapes.examples.CustomRectangle();
+    var rect2 = new joint.shapes.standard.Rectangle();
     rect2.position(50, 125);
     rect2.resize(500, 50);
     rect2.attr({
+        body: {
+            rx: 10, // add a corner radius
+            ry: 10,
+            fill: '#ADD8E6'
+        },
         label: {
-            text: 'shapes.examples.CustomRectangle()'
+            text: 'shapes.\nstandard.Rectangle()' // add Multiline label with Newline character
         }
     });
     rect2.addTo(graph);
 
-    var rect3 = joint.shapes.examples.CustomRectangle.createRandom();
+    var rect3 = new joint.shapes.examples.CustomRectangle();
     rect3.position(50, 225);
     rect3.resize(500, 50);
     rect3.attr({
         label: {
-            text: 'shapes.examples.CustomRectangle.createRandom()'
+            text: 'shapes.examples.CustomRectangle()'
         }
     });
     rect3.addTo(graph);
+
+    var rect4 = joint.shapes.examples.CustomRectangle.createRandom();
+    rect4.position(50, 325);
+    rect4.resize(500, 50);
+    rect4.attr({
+        label: {
+            text: 'shapes.examples.CustomRectangle.createRandom()'
+        }
+    });
+    rect4.addTo(graph);
 }());

--- a/tutorials/js/custom-elements.js
+++ b/tutorials/js/custom-elements.js
@@ -9,6 +9,34 @@
         height: 300
     });
 
+    joint.dia.Element.define('standard.Rectangle', {
+        attrs: {
+            body: {
+                width: 'calc(w)',
+                height: 'calc(h)',
+                strokeWidth: 2,
+                stroke: '#000000',
+                fill: '#FFFFFF'
+            },
+            label: {
+                textVerticalAnchor: 'middle',
+                textAnchor: 'middle',
+                x: 'calc(0.5*w)',
+                y: 'calc(0.5*h)',
+                fontSize: 14,
+                fill: '#333333'
+            }
+        }
+    }, {
+        markup: [{
+            tagName: 'rect',
+            selector: 'body',
+        }, {
+            tagName: 'text',
+            selector: 'label'
+        }]
+    });
+
     joint.shapes.standard.Rectangle.define('examples.CustomRectangle', {
         attrs: {
             body: {
@@ -19,7 +47,7 @@
             },
             label: {
                 textAnchor: 'left', // align text to left
-                refX: 10, // offset text from right edge of model bbox
+                x: 10, // offset text from right edge of model bbox
                 fill: 'white',
                 fontSize: 18
             }

--- a/tutorials/js/custom-links.js
+++ b/tutorials/js/custom-links.js
@@ -48,8 +48,8 @@
                     strokeWidth: 2,
                     width: 'calc(1.2*w)',
                     height: 'calc(1.2*h)',
-                    x: 'calc(x-7)',
-                    y: 'calc(y-1)'
+                    x: 'calc(x-calc(0.1*w))',
+                    y: 'calc(y-calc(0.1*h))'
                 }
             },
             position: {

--- a/tutorials/js/custom-links.js
+++ b/tutorials/js/custom-links.js
@@ -46,10 +46,10 @@
                     fill: 'white',
                     stroke: 'cornflowerblue',
                     strokeWidth: 2,
-                    refWidth: '120%',
-                    refHeight: '120%',
-                    refX: '-10%',
-                    refY: '-10%'
+                    width: 'calc(w+calc(0.2*w))',
+                    height: 'calc(h+calc(0.2*h))',
+                    x: '-calc(0.6*w)',
+                    y: '-calc(0.6*h)'
                 }
             },
             position: {

--- a/tutorials/js/custom-links.js
+++ b/tutorials/js/custom-links.js
@@ -46,10 +46,10 @@
                     fill: 'white',
                     stroke: 'cornflowerblue',
                     strokeWidth: 2,
-                    width: 'calc(w+calc(0.2*w))',
-                    height: 'calc(h+calc(0.2*h))',
-                    x: '-calc(0.6*w)',
-                    y: '-calc(0.6*h)'
+                    width: 'calc(1.2*w)',
+                    height: 'calc(1.2*h)',
+                    x: 'calc(x-7)',
+                    y: 'calc(y-1)'
                 }
             },
             position: {

--- a/tutorials/js/events-event-attribute.js
+++ b/tutorials/js/events-event-attribute.js
@@ -36,8 +36,8 @@
                 ref: 'buttonLabel',
                 width: 'calc(1.5*w)',
                 height: 'calc(1.5*h)',
-                x: 'calc(x-2)',
-                y: 'calc(y-2)'
+                x: 'calc(x-calc(0.25*w))',
+                y: 'calc(y-calc(0.25*h))'
             },
             buttonLabel: {
                 pointerEvents: 'none',

--- a/tutorials/js/events-event-attribute.js
+++ b/tutorials/js/events-event-attribute.js
@@ -17,8 +17,8 @@
     var CustomElement = joint.dia.Element.define('examples.CustomElement', {
         attrs: {
             body: {
-                refWidth: '100%',
-                refHeight: '100%',
+                width: 'calc(w)',
+                height: 'calc(h)',
                 strokeWidth: 2,
                 stroke: 'black',
                 fill: 'white'
@@ -26,23 +26,22 @@
             label: {
                 textVerticalAnchor: 'middle',
                 textAnchor: 'middle',
-                refX: '50%',
-                refY: '50%',
+                x: 'calc(0.5*w)',
+                y: 'calc(0.5*h)',
                 fontSize: 14,
                 fill: 'black'
             },
             button: {
                 cursor: 'pointer',
-                ref: 'buttonLabel',
-                refWidth: '150%',
-                refHeight: '150%',
-                refX: '-25%',
-                refY: '-25%'
+                width: 'calc(0.14*w)',
+                height: 'calc(0.45*h)',
+                x: 'calc(w-7)',
+                y: '-calc(0.25*h)'
             },
             buttonLabel: {
                 pointerEvents: 'none',
-                refX: '100%',
-                refY: 0,
+                x: 'calc(w)',
+                y: 0,
                 textAnchor: 'middle',
                 textVerticalAnchor: 'middle'
             }

--- a/tutorials/js/events-event-attribute.js
+++ b/tutorials/js/events-event-attribute.js
@@ -33,10 +33,11 @@
             },
             button: {
                 cursor: 'pointer',
-                width: 'calc(0.14*w)',
-                height: 'calc(0.45*h)',
-                x: 'calc(w-7)',
-                y: '-calc(0.25*h)'
+                ref: 'buttonLabel',
+                width: 'calc(1.5*w)',
+                height: 'calc(1.5*h)',
+                x: 'calc(x-2)',
+                y: 'calc(y-2)'
             },
             buttonLabel: {
                 pointerEvents: 'none',

--- a/tutorials/js/hyperlinks.js
+++ b/tutorials/js/hyperlinks.js
@@ -28,8 +28,8 @@
                 stroke: '#000000'
             },
             link: {
-                refWidth: '100%',
-                refHeight: '100%',
+                width: 'calc(w)',
+                height: 'calc(h)',
                 xlinkShow: 'new',
                 cursor: 'pointer'
             },

--- a/tutorials/js/hyperlinks.js
+++ b/tutorials/js/hyperlinks.js
@@ -28,8 +28,6 @@
                 stroke: '#000000'
             },
             link: {
-                width: 'calc(w)',
-                height: 'calc(h)',
                 xlinkShow: 'new',
                 cursor: 'pointer'
             },

--- a/tutorials/js/link-labels-styling.js
+++ b/tutorials/js/link-labels-styling.js
@@ -48,7 +48,7 @@
                 fill: '#ffffff',
                 stroke: '#000000',
                 strokeWidth: 1,
-                r: 'calc(w+1)',
+                r: 'calc(s)',
                 cx: 0,
                 cy: 0
             },
@@ -60,17 +60,17 @@
                 textAnchor: 'middle',
                 textVerticalAnchor: 'middle',
                 pointerEvents: 'none',
-                x: 10,
-                y: -9
+                x: 'calc(x+16.5)',
+                y: 'calc(y-2)'
             },
             asteriskBody: {
                 ref: 'asterisk',
                 fill: '#ffffff',
                 stroke: '#000000',
                 strokeWidth: 1,
-                r: 'calc(w+1)',
-                cx: 'calc(w+2)',
-                cy: '-calc(h+1)'
+                r: 'calc(s)',
+                cx: 'calc(x+4)',
+                cy: 'calc(y+4)'
             }
         }
     });

--- a/tutorials/js/link-labels-styling.js
+++ b/tutorials/js/link-labels-styling.js
@@ -69,8 +69,8 @@
                 stroke: '#000000',
                 strokeWidth: 1,
                 r: 'calc(s)',
-                cx: 'calc(x+4)',
-                cy: 'calc(y+4)'
+                cx: 'calc(x+calc(0.5*w))',
+                cy: 'calc(y+calc(0.5*h))'
             }
         }
     });

--- a/tutorials/js/link-labels-styling.js
+++ b/tutorials/js/link-labels-styling.js
@@ -48,9 +48,9 @@
                 fill: '#ffffff',
                 stroke: '#000000',
                 strokeWidth: 1,
-                refR: 1,
-                refCx: 0,
-                refCy: 0
+                r: 'calc(w+1)',
+                cx: 0,
+                cy: 0
             },
             asterisk: {
                 ref: 'label',
@@ -58,21 +58,19 @@
                 fill: '#ff0000',
                 fontSize: 8,
                 textAnchor: 'middle',
-                yAlignment: 'middle',
+                textVerticalAnchor: 'middle',
                 pointerEvents: 'none',
-                refX: 16.5,
-                refY: -2
+                x: 10,
+                y: -9
             },
             asteriskBody: {
                 ref: 'asterisk',
                 fill: '#ffffff',
                 stroke: '#000000',
                 strokeWidth: 1,
-                refR: 1,
-                refCx: '50%',
-                refCy: '50%',
-                refX: 0,
-                refY: 0
+                r: 'calc(w+1)',
+                cx: 'calc(w+2)',
+                cy: '-calc(h+1)'
             }
         }
     });

--- a/tutorials/js/link-snapping.js
+++ b/tutorials/js/link-snapping.js
@@ -41,7 +41,7 @@
             }
         },
         attrs: {
-            '.label': { text: 'Model', 'ref-x': .5, 'ref-y': .2 },
+            '.label': { text: 'Model', x: 0, y: 'calc(0.2*h)' },
             rect: { fill: '#2ECC71' }
         }
     });

--- a/tutorials/js/mark-available.js
+++ b/tutorials/js/mark-available.js
@@ -45,7 +45,7 @@
             }
         },
         attrs: {
-            '.label': { text: 'Model', 'ref-x': .5, 'ref-y': .2 },
+            '.label': { text: 'Model', x: 0, y: 'calc(0.2*h)' },
             rect: { fill: '#2ECC71' }
         }
     }).addTo(graph);

--- a/tutorials/js/ports-create.js
+++ b/tutorials/js/ports-create.js
@@ -27,7 +27,7 @@
             }
         },
         attrs: {
-            '.label': { text: 'Model', 'ref-x': .5, 'ref-y': .2 },
+            '.label': { text: 'Model', x: 0, y: 'calc(0.2*h)' },
             rect: { fill: '#2ECC71' }
         }
     });

--- a/tutorials/js/ports-link.js
+++ b/tutorials/js/ports-link.js
@@ -27,7 +27,7 @@
             }
         },
         attrs: {
-            '.label': { text: 'Model', 'ref-x': .5, 'ref-y': .2 },
+            '.label': { text: 'Model', x: 0, y: 'calc(0.2*h)' },
             rect: { fill: '#2ECC71' }
         }
     });

--- a/tutorials/js/ports-restrict.js
+++ b/tutorials/js/ports-restrict.js
@@ -48,7 +48,7 @@
             }
         },
         attrs: {
-            '.label': { text: 'Model', 'ref-x': .5, 'ref-y': .2 },
+            '.label': { text: 'Model', x: 0, y: 'calc(0.2*h)' },
             rect: { fill: '#2ECC71' }
         }
     });

--- a/tutorials/link-labels.html
+++ b/tutorials/link-labels.html
@@ -328,7 +328,7 @@ link.appendLabel({
             fill: '#ffffff',
             stroke: '#000000',
             strokeWidth: 1,
-            r: 'calc(w+1)',
+            r: 'calc(s)',
             cx: 0,
             cy: 0
         },
@@ -340,17 +340,17 @@ link.appendLabel({
             textAnchor: 'middle',
             textVerticalAnchor: 'middle',
             pointerEvents: 'none',
-            x: 10,
-            y: -9
+            x: 'calc(x+16.5)',
+            y: 'calc(y-2)'
         },
         asteriskBody: {
             ref: 'asterisk',
             fill: '#ffffff',
             stroke: '#000000',
             strokeWidth: 1,
-            r: 'calc(w+1)',
-            cx: 'calc(w+2)',
-            cy: '-calc(h+1)'
+            r: 'calc(s)',
+            cx: 'calc(x+4)',
+            cy: 'calc(y+4)'
         }
     }
 });</code></pre>

--- a/tutorials/link-labels.html
+++ b/tutorials/link-labels.html
@@ -349,8 +349,8 @@ link.appendLabel({
             stroke: '#000000',
             strokeWidth: 1,
             r: 'calc(s)',
-            cx: 'calc(x+4)',
-            cy: 'calc(y+4)'
+            cx: 'calc(x+calc(0.5*w))',
+            cy: 'calc(y+calc(0.5*h))'
         }
     }
 });</code></pre>

--- a/tutorials/link-labels.html
+++ b/tutorials/link-labels.html
@@ -62,14 +62,14 @@
                     - removes the label at <code>index</code>.</li>
             </ul>
 
-            <h3 id="builtin-default-label">Builtin Default Label</h3>
+            <h3 id="builtin-default-label">Built-in Default Label</h3>
 
             <p>A simple label definition (including markup and attrs) is built into the <code>joint.dia.Link</code>
                 class, from which all subtypes, including <code>joint.shapes.standard.Link</code>, inherit it.
-                The builtin default label has two tags:
+                The built-in default label has two tags:
                 <code>text</code> (the <code>&lt;text&gt;</code> SVGElement of the label), and
-                <code>rect</code> (the <code>&lt;rect&gt;</code> SVGElement for label background).
-                The builtin default attributes specify a simple vertical-centered text on a white rounded rectangle.
+                <code>rect</code> (the <code>&lt;rect&gt;</code> SVGElement for the label background).
+                The built-in default attributes specify a simple vertical-centered text on a white rounded rectangle.
                 Thus, adding a label can be as simple as passing a value for the <code>text/text</code> attribute:</p>
 
             <div class="paper" id="paper-links-label-builtin"></div>
@@ -91,13 +91,13 @@
 
             <p>Labels are positioned at the center point of the link (<code>distance</code> of <code>0.5</code>) by
                 default.
-                Three kinds of <code>label.position.distance</code> values are recognized for setting custom position.
+                Three kinds of <code>label.position.distance</code> values are recognized for setting a custom position.
                 A value between <code>0</code> and <code>1</code> causes the label to be positioned relatively to link length.
-                Positive values signify absolute position in local SVG units away from start point.
+                Positive values signify absolute position in local SVG units away from the start point.
                 Finally, negative values mean absolute position away from end point.
                 An animated example is presented below.
                 (<a href="special-attributes.html#link-subelement-labels">Link labels can also be emulated with link
-                subelements and special attributes; this technique is explained elsewhere in the tutorial.</a>)</p>
+                subelements and special attributes; this technique is explained elsewhere in the tutorial</a>).</p>
 
             <div class="paper" id="paper-link-labels-distance"></div>
 
@@ -190,7 +190,7 @@ link.appendLabel({
 
             <p>JointJS source code: <a href="js/link-labels-offset.js" target="_blank">link-labels-offset.js</a></p>
 
-            <p>By default, labels' anchor point is centered horizontally and vertically, as it was in this example.
+            <p>By default, the labels' anchor point is centered horizontally and vertically, as it was in this example.
                 This can be changed by the <code>textAnchor</code> and
                 <a href="/docs/jointjs#dia.attributes.textVerticalAnchor"><code>textVerticalAnchor</code></a>
                 attributes, respectively.</p>
@@ -200,7 +200,7 @@ link.appendLabel({
             <p>Link labels are horizontal by default, but JointJS allows you to specify label rotation.
                 If you provide a value for the <code>label.position.angle</code> property, the link will rotate clockwise by that amount (with respect to the path of the link).
                 Furthermore, the <code>label.position.args.keepGradient</code> boolean flag has another function, which may be combined with providing a specific rotation angle - when set to <code>true</code>, it rotates the label according to the slope of the connection path at the given position.
-                Additionally, if the <code>label.position.args.ensureLegibility</code> boolean flag is set to <code>true</code>, it ensures that the text never rotates to end up upside-down - if necessary, JointJS adds additional 180-degree rotation to make the text legible.
+                Additionally, if the <code>label.position.args.ensureLegibility</code> boolean flag is set to <code>true</code>, it ensures that the text never rotates to end up upside-down - if necessary, JointJS adds an additional 180-degree rotation to make the text legible.
                 The following example shows rotated links in action.
                 The red asterisk marks the reference point of the two labels that are offset from the connection path.</p>
 
@@ -328,9 +328,9 @@ link.appendLabel({
             fill: '#ffffff',
             stroke: '#000000',
             strokeWidth: 1,
-            refR: 1,
-            refCx: 0,
-            refCy: 0
+            r: 'calc(w+1)',
+            cx: 0,
+            cy: 0
         },
         asterisk: {
             ref: 'label',
@@ -338,21 +338,19 @@ link.appendLabel({
             fill: '#ff0000',
             fontSize: 8,
             textAnchor: 'middle',
-            yAlignment: 'middle',
+            textVerticalAnchor: 'middle',
             pointerEvents: 'none',
-            refX: 16.5,
-            refY: -2
+            x: 10,
+            y: -9
         },
         asteriskBody: {
             ref: 'asterisk',
             fill: '#ffffff',
             stroke: '#000000',
             strokeWidth: 1,
-            refR: 1,
-            refCx: '50%',
-            refCy: '50%',
-            refX: 0,
-            refY: 0
+            r: 'calc(w+1)',
+            cx: 'calc(w+2)',
+            cy: '-calc(h+1)'
         }
     }
 });</code></pre>
@@ -387,7 +385,7 @@ link.appendLabel({
 
             <p>The new position of dragged labels is recorded relatively to the link path.
                 That means that the label will reposition itself when the link changes.
-                (Unfortunately, it also means that the label can never be dragged beyond the endpoints of the link.)</p>
+                (Unfortunately, it also means that the label can never be dragged beyond the endpoints of the link).</p>
 
             <p>If you only want to allow the label to be dragged along the length of the link (and not outside of it), you can do so by specifying the <code>paper.options.snapLabels</code> <a href="/docs/jointjs#dia.Paper.prototype.options.snapLabels">paper option</a>:</p>
 

--- a/tutorials/link-labels.html
+++ b/tutorials/link-labels.html
@@ -35,9 +35,11 @@
 
             <h2>Link Labels</h2>
 
-            <p>This is the sixth article of the intermediate section of the JointJS tutorial.
-                <a href="custom-links.html">Go back to custom links.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the sixth article of the intermediate section of the JointJS tutorial. Return to
+                <a href="custom-links.html">custom links</a>.
+                See <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p><a href="links.html#link-labels">The basic tutorial series offered an introduction into link labels.</a>
                 This section explains everything you need to know to make full use of the powerful label system.</p>

--- a/tutorials/link-tools.html
+++ b/tutorials/link-tools.html
@@ -35,9 +35,11 @@
 
             <h2>Link Tools</h2>
 
-            <p>This is the eighth article of the intermediate section of the JointJS tutorial.
-                <a href="element-tools.html">Go back to element tools.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the eighth article of the intermediate section of the JointJS tutorial. Return to
+                <a href="element-tools.html">element tools</a>.
+                See <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p>JointJS allows creating fully customizable <a href="/docs/jointjs#linkTools" target="_blank">user
                 interaction tools for your links</a>.

--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -54,7 +54,7 @@
                     We now recommend not using <code>devs</code> shapes as they are maintained for backwards compatibility
                     reasons only. They could be used if you are not planning to change an individual port's attributes. 
                     Use any other shape with the 
-                    <a href="https://resources.jointjs.com/docs/jointjs/v3.4/joint.html#dia.Element.ports" target="_blank">
+                    <a href="/docs/jointjs#dia.Element.ports" target="_blank">
                     Element Port API</a> instead.
                 </i>
             </p>

--- a/tutorials/serialization.html
+++ b/tutorials/serialization.html
@@ -35,9 +35,11 @@
 
             <h2>Serialization</h2>
 
-            <p>This is the third article of the intermediate section of the JointJS tutorial.
-                <a href="events.html">Go back to events.</a>
-                Alternatively, you can <a href="intermediate.html">return to index</a> of all articles.</p>
+            <p><i>
+                This is the third article of the intermediate section of the JointJS tutorial. Return to
+                <a href="events.html">events</a>.
+                See <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p>Data serialization is very easy in JointJS.
                 It is done through two import/export functions on the Graph class:</p>

--- a/tutorials/special-attributes.html
+++ b/tutorials/special-attributes.html
@@ -35,8 +35,10 @@
 
             <h2>Special Attributes</h2>
 
-            <p>This is the first article of the intermediate section of the JointJS tutorial.
-                <a href="intermediate.html">Return to index.</a></p>
+            <p><i>
+                This is the first article of the intermediate section of the JointJS tutorial. See
+                <a href="intermediate.html">index</a> of basic and intermediate articles.
+            </i></p>
 
             <p>Special attributes are JointJS-specific attributes that offer functionality beyond that of native SVG
                 attributes.

--- a/tutorials/ts-shape.html
+++ b/tutorials/ts-shape.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-
     <link rel="canonical" href="http://www.jointjs.com/"/>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -16,17 +15,13 @@
     <link rel="stylesheet" href="css/tutorial.css"/>
     <link rel="stylesheet" href="../node_modules/prismjs/themes/prism.css">
 
-    <!-- Dependencies: -->
-    <link rel="stylesheet" type="text/css" href="../build/joint.min.css" />
-
     <title>JointJS - Create a custom shape using TypeScript</title>
-
 </head>
 <body class="language-javascript tutorial-page">
     <div class="tutorial">
 
     <p>
-        At client IO, we often get asked how to incorporate TypeScript with JointJS. As JointJS is a standard JavaScript library, the
+        We often get asked how to incorporate TypeScript with JointJS. As JointJS is a standard JavaScript library, the
         integration process is quite simple and straightforward. In the following tutorial, we are going to create our very own custom
         shape using TypeScript, and also try to provide you with some useful information along the way.
     </p>
@@ -83,10 +78,10 @@ export class MyShape extends dia.Element {
         size: { width: 100, height: 80 },
         attrs: {
             body: {
-                refCx: '50%',
-                refCy: '50%',
-                refRx: '50%',
-                refRy: '50%',
+                cx: 'calc(0.5*w)',
+                cy: 'calc(0.5*h)',
+                rx: 'calc(0.5*w)',
+                ry: 'calc(0.5*h)',
                 strokeWidth: 2,
                 stroke: '#333333',
                 fill: '#FFFFFF'
@@ -94,8 +89,8 @@ export class MyShape extends dia.Element {
             label: {
                 textVerticalAnchor: 'middle',
                 textAnchor: 'middle',
-                refX: '50%',
-                refY: '50%',
+                x: 'calc(0.5*w)',
+                y: 'calc(0.5*h)',
                 fontSize: 14,
                 fill: '#333333'
             }
@@ -112,18 +107,17 @@ export class MyShape extends dia.Element {
 
     <p>
         As we have already set up any parent attributes, we should now add some unique attributes for each instance of our custom 
-        shape. In order to do this, we create an <code>attrs</code> object with keys that correspond to our subelement selectors which are 
-        defined in <code>markup</code>. <code>body</code> and <code>label</code> are the respective keys in our example. The attributes 
-        can consist of standard <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute" target="_blank">SVG attributes</a>, 
-        but also special <a href="https://resources.jointjs.com/docs/jointjs/v3.3/joint.html#dia.attributes" target="_blank">JointJS 
-        attributes</a>.
+        shape. In order to do this, we create an <code>attrs</code> object with keys that correspond to our subelement selectors which are defined in 
+        <code>markup</code>. <code>body</code> and <code>label</code> are the respective keys in our example. The attributes can consist of 
+        standard <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute" target="_blank">SVG attributes</a>, but also special 
+        <a href="/docs/jointjs#dia.attributes" target="_blank">JointJS attributes</a>.
     </p>
 
     <h3>Markup</h3>
 
     <p>
         We already mentioned the next building block of our custom shape, and that is the 
-        <a href="https://resources.jointjs.com/docs/jointjs/v3.3/joint.html#dia.Cell.markup" target="_blank">Markup</a>.
+        <a href="/docs/jointjs#dia.Cell.markup" target="_blank">Markup</a>.
     </p>
 
     <pre><code>defaults() {
@@ -239,10 +233,10 @@ export class MyShape extends dia.Element {
             size: { width: 100, height: 80 },
             attrs: {
                 body: {
-                    refCx: '50%',
-                    refCy: '50%',
-                    refRx: '50%',
-                    refRy: '50%',
+                    cx: 'calc(0.5*w)',
+                    cy: 'calc(0.5*h)',
+                    rx: 'calc(0.5*w)',
+                    ry: 'calc(0.5*h)',
                     strokeWidth: 2,
                     stroke: '#333333',
                     fill: '#FFFFFF'
@@ -250,8 +244,8 @@ export class MyShape extends dia.Element {
                 label: {
                     textVerticalAnchor: 'middle',
                     textAnchor: 'middle',
-                    refX: '50%',
-                    refY: '50%',
+                    x: 'calc(0.5*w)',
+                    y: 'calc(0.5*h)',
                     fontSize: 14,
                     fill: '#333333'
                 }
@@ -323,8 +317,8 @@ class MyShape extends dia.Element {
             position: {x: 10, y: 10 },
             attrs: {
                 body: {
-                    refWidth: '100%',
-                    refHeight: '100%',
+                    width: 'calc(w)',
+                    height: 'calc(h)'
                 }
             } 
         }
@@ -388,10 +382,10 @@ defaults() {
         size: { width: 100, height: 80 },
         attrs: {
             body: {
-                refCx: '50%',
-                refCy: '50%',
-                refRx: '50%',
-                refRy: '50%',
+                cx: 'calc(0.5*w)',
+                cy: 'calc(0.5*h)',
+                rx: 'calc(0.5*w)',
+                ry: 'calc(0.5*h)',
                 strokeWidth: 2,
                 stroke: '#333333',
                 fill: '#FFFFFF'
@@ -399,8 +393,8 @@ defaults() {
             label: {
                 textVerticalAnchor: 'middle',
                 textAnchor: 'middle',
-                refX: '50%',
-                refY: '50%',
+                x: 'calc(0.5*w)',
+                y: 'calc(0.5*h)',
                 fontSize: 14,
                 fill: '#333333'
             }
@@ -419,14 +413,14 @@ defaults() {
     <p>
         Congratulations! You now know how to set up custom shapes in JointJS with TypeScript, and unlock the powerful functionality it 
         gives to the user. Of course, there are many other ways to define shapes in JointJS, and you can see some other methods of doing 
-        this in our <a href="https://resources.jointjs.com/tutorial/custom-elements" target="_blank">documentation</a>. We think this method 
+        this in our <a href="custom-elements.html">custom elements</a> tutorial. We think this method 
         is a nice way to work with TypeScript, and you can see that we use it throughout our Rappid demos.
     </p>
     
     <h3>Custom Views</h3>
     
     <p>
-        <a href="https://resources.jointjs.com/docs/jointjs/v3.3/joint.html#dia.CellView.custom" target="_blank">Custom views</a> provide
+        <a href="/docs/jointjs#dia.CellView.custom" target="_blank">Custom views</a> provide
         some extra flexibility when it comes to working with our models. If we want some additional behaviour, but don't believe that 
         behaviour should live alongside the presentational attributes on our models, custom views can provide this for us. Maybe you want 
         to capture user input, see a minimal version of the same graph, or apply some interesting effect to your elements, those are just 
@@ -443,8 +437,8 @@ defaults() {
             position: {x: 10, y: 10 },
             attrs: {
                 body: {
-                    refWidth: '100%',
-                    refHeight: '100%',
+                    width: 'calc(w)',
+                    height: 'calc(h)'
                 }
             } 
         }
@@ -558,7 +552,7 @@ const paper = new dia.Paper({
     <p>
         That's all we will cover in this tutorial. Thanks for staying with us if you got this far. If you would like 
         to explore any of the features mentioned here in more detail, you can find extra information in our 
-        <a href="https://resources.jointjs.com/docs/jointjs/v3.3/joint.html" target="_blank">JointJS documentation</a>.
+        <a href="/docs/jointjs" target="_blank">JointJS documentation</a>.
     </p>
 
     </div><!--end tutorial-->

--- a/tutorials/ts-shape.html
+++ b/tutorials/ts-shape.html
@@ -15,6 +15,9 @@
     <link rel="stylesheet" href="css/tutorial.css"/>
     <link rel="stylesheet" href="../node_modules/prismjs/themes/prism.css">
 
+    <!-- Dependencies: -->
+    <link rel="stylesheet" type="text/css" href="../build/joint.min.css" />
+
     <title>JointJS - Create a custom shape using TypeScript</title>
 </head>
 <body class="language-javascript tutorial-page">


### PR DESCRIPTION
- add `calc()` to `custom element` and `custom link` tutorials
- add `calc()` to `events`, `link labels` and `Typescript` tutorials
- adapt opening sentence of INT articles so they easier to read at first sight