### PR TITLE
dia.attributes: add x and y properties to calc() expression

### DIFF
--- a/docs/src/joint/api/dia/attributes/intro.html
+++ b/docs/src/joint/api/dia/attributes/intro.html
@@ -75,6 +75,16 @@ All the standard SVG <a href="https://www.w3.org/TR/SVG/styling.html" target="_b
                     <td>The current height of the model (<code>model.prop('size/height')</code>). The value can be bound to an SVGElement's size instead by using <a href="#dia.attributes.ref">ref</a> attribute.</td>
                 </tr>
                 <tr>
+                    <td><code>x</code></td>
+                    <td>x</td>
+                    <td>The current x coordinate of the SVGElement in the element's coordinate system. If the attribute is not bound to a specific SVGElement with <a href="#dia.attributes.ref">ref</a> attribute, the value of x is always zero.</td>
+                </tr>
+                <tr>
+                    <td><code>y</code></td>
+                    <td>y</td>
+                    <td>The current y coordinate of the SVGElement in the element's coordinate system. If the attribute is not bound to a specific SVGElement with <a href="#dia.attributes.ref">ref</a> attribute, the value of y is always zero.</td>
+                </tr>
+                <tr>
                     <td><code>s</code></td>
                     <td>shortest</td>
                     <td>The shortest side of the rectangle. The minimum of <i>width</i> and <i>height</i>.</td>
@@ -224,6 +234,17 @@ el.attr('myPath/d', 'M 10 calc(0.5*h) calc(w-10) calc(0.5*h)')
 
 // &lt;polygon joint-selector="myPolygon" points="0,0 200,0 200,100 0,100" /&gt;
 el.attr('myPolygon/d', '0,0 calc(w),0 calc(w),calc(h) 0,calc(h)');
+
+// Resize the rectangle to match the text size with extra 5 pixels of padding
+// &lt;rect joint-selector="myTextBackground" /&gt;
+// &lt;text joint-selector="myText" &gtSome text&lt;/text&gt;
+el.attr('myTextBackground', {
+    ref: 'myText',
+    x: 'calc(x - 5)',
+    y: 'calc(y - 5)'
+    width: 'calc(w + 10)',
+    height: 'calc(h + 10)',
+ });
 </code></pre>
 
 

--- a/src/dia/attributes/calc.mjs
+++ b/src/dia/attributes/calc.mjs
@@ -1,4 +1,6 @@
 const props = {
+    x: 'x',
+    y: 'y',
     width: 'w',
     height: 'h',
     minimum: 's',
@@ -19,32 +21,39 @@ export function evalCalcExpression(expression, bbox) {
     if (!match) throwInvalid(expression);
     parseExpressionRegExp.lastIndex = 0; // reset regex results for the next run
     const [,multiply = 1, property, add = 0] = match;
-    // Note: currently, we do not take x and y into account
-    const { width, height } = bbox;
-    let dimension = 0;
+    const { x, y, width, height } = bbox;
+    let value = 0;
     switch (property) {
         case props.width: {
-            dimension = width;
+            value = width;
             break;
         }
         case props.height: {
-            dimension = height;
+            value = height;
+            break;
+        }
+        case props.x: {
+            value = x;
+            break;
+        }
+        case props.y: {
+            value = y;
             break;
         }
         case props.minimum: {
-            dimension = Math.min(height, width);
+            value = Math.min(height, width);
             break;
         }
         case props.maximum: {
-            dimension = Math.max(height, width);
+            value = Math.max(height, width);
             break;
         }
         case props.diagonal: {
-            dimension = Math.sqrt((height * height) + (width * width));
+            value = Math.sqrt((height * height) + (width * width));
             break;
         }
     }
-    return parseFloat(multiply) * dimension + evalAddExpression(add);
+    return parseFloat(multiply) * value + evalAddExpression(add);
 }
 
 function evalAddExpression(addExpression) {

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -302,6 +302,8 @@ QUnit.module('Attributes', function() {
 
     QUnit.module('Calc()', function(hooks) {
 
+        var X = 13;
+        var Y = 17;
         var WIDTH = 85;
         var HEIGHT = 97;
 
@@ -316,7 +318,7 @@ QUnit.module('Attributes', function() {
             cell = new joint.shapes.standard.Rectangle();
             cell.addTo(graph);
             cellView = cell.findView(paper);
-            refBBox = new g.Rect(0, 0, WIDTH, HEIGHT);
+            refBBox = new g.Rect(X, Y, WIDTH, HEIGHT);
             node = cellView.el.querySelector('path');
         });
 
@@ -335,6 +337,8 @@ QUnit.module('Attributes', function() {
                 ['calc(s)', String(Math.min(WIDTH, HEIGHT))],
                 ['calc(l)', String(Math.max(WIDTH, HEIGHT))],
                 ['calc(d)', String(Math.sqrt(WIDTH * WIDTH + HEIGHT * HEIGHT))],
+                ['calc(x)', String(X)],
+                ['calc(y)', String(Y)],
                 // multiply
                 ['calc(2*w)', String(WIDTH * 2)],
                 ['calc(2*h)', String(HEIGHT * 2)],
@@ -363,6 +367,8 @@ QUnit.module('Attributes', function() {
                 ['M 0 0 calc(w+10) calc(h+10)', 'M 0 0 ' + (WIDTH + 10) + ' ' + (HEIGHT + 10)],
                 ['M 0 0 calc(1*w-10) calc(1*h-10)', 'M 0 0 ' + (WIDTH - 10) + ' ' + (HEIGHT - 10)],
                 // nested expression
+                ['calc(w+calc(x))', String(WIDTH + X)],
+                ['calc(h+calc(y))', String(HEIGHT + Y)],
                 ['M 0 0 calc(w + calc(h)) 0', 'M 0 0 ' + (WIDTH + HEIGHT) + ' 0'],
                 ['M 0 0 calc(calc(h) * w + calc(h)) 0', 'M 0 0 ' + (HEIGHT * WIDTH + HEIGHT) + ' 0'],
                 ['M 0 0 calc(w + calc(h + calc(w))) 0', 'M 0 0 ' + (WIDTH + HEIGHT + WIDTH) + ' 0'],


### PR DESCRIPTION
Add `x` and `y` properties to `calc()` in order to support this use case

```js
element.attr('myTextBackground', {
    ref: 'myText',
    refX: -5,
    refY: -5,
    width: 'calc(w + 10)',
    height: 'calc(h + 10)',
 });
```

without a need of using `refX` and `refY` attributes.
```js
element.attr('myTextBackground', {
    ref: 'myText',
    x: 'calc(x - 5)',
    y: 'calc(y - 5)',
    width: 'calc(w + 10)',
    height: 'calc(h + 10)',
 });
 ```

