### PR TITLE
dia.Paper: refactor `fitToContent()`

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
+++ b/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
@@ -1,37 +1,9 @@
 <pre class="docs-method-signature"><code>paper.fitToContent([opt])</code></pre>
 <p>Expand or shrink the paper to fit the content inside it. The method returns the area (<code>g.Rect</code>) of the paper after fitting in local coordinates.</p>
 
-<p>The function accepts an object with additional settings (all optional):</p>
-
-<ul>
-  <li><code>opt.gridWidth</code> and <code>opt.gridHeight</code> – snap the resulting width and height of the paper to a grid defined by these dimensions.</li>
-  <li><code>opt.padding</code> – additional padding around the resulting paper. It may be specified as a number, in which case it represents the padding width on all sides of the paper. It may be an object of the form <code>{ top?: [number], right?: [number], bottom?: [number], left?: [number], vertical?: [number], horizontal?: [number] }</code>.</li>
-  <li><code>opt.allowNewOrigin</code> – should the origin of the resulting paper be adjusted to match the origin of the paper content? In addition to no value being set, three values are recognized by this option: <code>'positive'</code>,&nbsp;<code>'negative'</code>,&nbsp;<code>'any'</code>.
-    <ul>
-      <li>By default, the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the original point (0,0).</li>
-      <li><code>'positive'</code> – the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the origin of the content. (Still, if the content starts at negative coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
-      <li><code>'negative'</code> – the method only recognizes the content at negative coordinates and puts the origin of resulting paper at the origin of the content. (However, if the content starts at positive coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
-      <li><code>'any'</code> – the method recognizes all of paper content. The origin of the resulting paper will be at the origin of the content.</li>
-    </ul>
-  </li>
-  <li><code>opt.allowNegativeBottomRight</code> - can the bottom-right corner of the resulting paper have negative coordinates? By default, the paper area always contains point (0,0). i.e. <code>false</code>.
-<pre><code>// Resize the paper to match the tight bounding box of the content regardless of its position.
-paper.fitToContent({
-  allowNewOrigin: 'any',
-  allowNegativeBottomRight: true
-});</code></pre>
-  </li>
-  <li><code>opt.minWidth</code> and <code>opt.minHeight</code> – define the minimum width and height of the resulting paper after fitting it to content.</li>
-  <li><code>opt.maxWidth</code> and <code>opt.maxHeight</code> – define the maximum width and height of the resulting paper.
-  after fitting it to content.</li>
-  <li><code>opt.useModelGeometry</code> – should paper content area be calculated from cell models instead of views? Default is <code>false</code>. See the documentation of the <code>paper.getContentArea</code> <a href="#dia.Paper.prototype.getContentArea">function</a> for more details.</li>
-  <li><code>opt.contentArea</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area representing the content bounding box in the local coordinate system that paper should be fitted to. By default <code>opt.contentArea</code> is <code>paper.getContentArea(opt)</code>.</li>
-</ul>
-
-<p>You can try many of these options interactively in the <a href="http://jointjs.com/demos/paper">paper demo</a>.</p>
+<p>The list of all available options can be found <a href="#dia.Paper.prototype.getFitToContentBBox">here</a>. You can try many of these options interactively in the <a href="http://jointjs.com/demos/paper">paper demo</a>.</p>
 
 <p>This method might internally trigger the <code>&quot;resize&quot;</code> and <code>&quot;translate&quot;</code> events. These can be handled by listening on the paper object (<code>paper.on('resize', myHandler)</code>).</p>
 
-
 <pre class="docs-method-signature"><code>paper.fitToContent([gridWidth, gridHeight, padding, opt])</code></pre>
-<p><i>Depracated usage. All parameters are expected to be passed inside the <code>opt</code> object.</i></p>
+<p><i>Deprecated usage. All parameters are expected to be passed inside the <code>opt</code> object.</i></p>

--- a/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
+++ b/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
@@ -11,7 +11,7 @@
         <li>By default, the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the original point (0,0).</li>
         <li><code>'positive'</code> – the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the origin of the content. (Still, if the content starts at negative coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
         <li><code>'negative'</code> – the method only recognizes the content at negative coordinates and puts the origin of resulting paper at the origin of the content. (However, if the content starts at positive coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
-        <li><code>'any'</code> – the method recognizes all of paper content. The origin of the resulting paper will be at the origin of the content.</li>
+        <li><code>'any'</code> – the method recognizes all of the paper content. The origin of the resulting paper will be at the origin of the content.</li>
       </ul>
     </li>
     <li><code>opt.allowNegativeBottomRight</code> - can the bottom-right corner of the resulting paper have negative coordinates? By default, the paper area always contains point (0,0). i.e. <code>false</code>.
@@ -22,9 +22,8 @@
   });</code></pre>
     </li>
     <li><code>opt.minWidth</code> and <code>opt.minHeight</code> – define the minimum width and height of the resulting paper after fitting it to content.</li>
-    <li><code>opt.maxWidth</code> and <code>opt.maxHeight</code> – define the maximum width and height of the resulting paper.
-    after fitting it to content.</li>
-    <li><code>opt.useModelGeometry</code> – should paper content area be calculated from cell models instead of views? Default is <code>false</code>. See the documentation of the <code>paper.getContentArea</code> <a href="#dia.Paper.prototype.getContentArea">function</a> for more details.</li>
+    <li><code>opt.maxWidth</code> and <code>opt.maxHeight</code> – define the maximum width and height of the resulting paper after fitting it to content.</li>
+    <li><code>opt.useModelGeometry</code> – should paper content area be calculated from cell models instead of views? The default is <code>false</code>. See the documentation of the <code>paper.getContentArea</code> <a href="#dia.Paper.prototype.getContentArea">function</a> for more details.</li>
     <li><code>opt.contentArea</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area representing the content bounding box in the local coordinate system that paper should be fitted to. By default <code>opt.contentArea</code> is <code>paper.getContentArea(opt)</code>.</li>
   </ul>
 

--- a/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
+++ b/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
@@ -1,5 +1,5 @@
-<pre class="docs-method-signature"><code>paper.getFitToContentBBox([opt])</code></pre>
-<p>Return the bounding box in the paper's coordinate system based on the current content and options provided.</p>
+<pre class="docs-method-signature"><code>paper.getFitToContentArea([opt])</code></pre>
+<p>Return the bounding box in the local coordinate system based on the position and size of the current content and options provided.</p>
 
 <p>The function accepts an object with the following options:</p>
 

--- a/docs/src/joint/api/dia/Paper/prototype/getFitToContentBBox.html
+++ b/docs/src/joint/api/dia/Paper/prototype/getFitToContentBBox.html
@@ -1,0 +1,30 @@
+<pre class="docs-method-signature"><code>paper.getFitToContentBBox([opt])</code></pre>
+<p>Return the bounding box in the paper's coordinate system based on the current content and options provided.</p>
+
+<p>The function accepts an object with the following options:</p>
+
+<ul>
+    <li><code>opt.gridWidth</code> and <code>opt.gridHeight</code> – snap the resulting width and height of the paper to a grid defined by these dimensions.</li>
+    <li><code>opt.padding</code> – additional padding around the resulting paper. It may be specified as a number, in which case it represents the padding width on all sides of the paper. It may be an object of the form <code>{ top?: [number], right?: [number], bottom?: [number], left?: [number], vertical?: [number], horizontal?: [number] }</code>.</li>
+    <li><code>opt.allowNewOrigin</code> – should the origin of the resulting paper be adjusted to match the origin of the paper content? In addition to no value being set, three values are recognized by this option: <code>'positive'</code>,&nbsp;<code>'negative'</code>,&nbsp;<code>'any'</code>.
+      <ul>
+        <li>By default, the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the original point (0,0).</li>
+        <li><code>'positive'</code> – the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the origin of the content. (Still, if the content starts at negative coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
+        <li><code>'negative'</code> – the method only recognizes the content at negative coordinates and puts the origin of resulting paper at the origin of the content. (However, if the content starts at positive coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
+        <li><code>'any'</code> – the method recognizes all of paper content. The origin of the resulting paper will be at the origin of the content.</li>
+      </ul>
+    </li>
+    <li><code>opt.allowNegativeBottomRight</code> - can the bottom-right corner of the resulting paper have negative coordinates? By default, the paper area always contains point (0,0). i.e. <code>false</code>.
+  <pre><code>// Resize the paper to match the tight bounding box of the content regardless of its position.
+  paper.fitToContent({
+    allowNewOrigin: 'any',
+    allowNegativeBottomRight: true
+  });</code></pre>
+    </li>
+    <li><code>opt.minWidth</code> and <code>opt.minHeight</code> – define the minimum width and height of the resulting paper after fitting it to content.</li>
+    <li><code>opt.maxWidth</code> and <code>opt.maxHeight</code> – define the maximum width and height of the resulting paper.
+    after fitting it to content.</li>
+    <li><code>opt.useModelGeometry</code> – should paper content area be calculated from cell models instead of views? Default is <code>false</code>. See the documentation of the <code>paper.getContentArea</code> <a href="#dia.Paper.prototype.getContentArea">function</a> for more details.</li>
+    <li><code>opt.contentArea</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area representing the content bounding box in the local coordinate system that paper should be fitted to. By default <code>opt.contentArea</code> is <code>paper.getContentArea(opt)</code>.</li>
+  </ul>
+

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1145,71 +1145,71 @@ export const Paper = View.extend({
 
     setDimensions: function(width, height) {
 
-        var options = this.options;
-        var w = (width === undefined) ? options.width : width;
-        var h = (height === undefined) ? options.height : height;
-        this.options.width = w;
-        this.options.height = h;
+        const { options } = this;
+        const { width: currentWidth, height: currentHeight } = options;
+        let w = (width === undefined) ? currentWidth : width;
+        let h = (height === undefined) ? currentHeight : height;
+        if (currentWidth === w && currentHeight === h) return;
+        options.width = w;
+        options.height = h;
         if (isNumber(w)) w = Math.round(w);
         if (isNumber(h)) h = Math.round(h);
         this.$el.css({
             width: (w === null) ? '' : w,
             height: (h === null) ? '' : h
         });
-        var computedSize = this.getComputedSize();
+        const computedSize = this.getComputedSize();
         this.trigger('resize', computedSize.width, computedSize.height);
     },
 
     setOrigin: function(ox, oy) {
-
-        return this.translate(ox || 0, oy || 0, { absolute: true });
+        return this.translate(ox || 0, oy || 0);
     },
 
-    // Expand/shrink the paper to fit the content. Snap the width/height to the grid
-    // defined in `gridWidth`, `gridHeight`. `padding` adds to the resulting width/height of the paper.
-    // When options { fitNegative: true } it also translates the viewport in order to make all
-    // the content visible.
-    fitToContent: function(gridWidth, gridHeight, padding, opt) { // alternatively function(opt)
+    // Expand/shrink the paper to fit the content.
+    // Alternatively signature function(opt)
+    fitToContent: function(gridWidth, gridHeight, padding, opt) {
 
         if (isObject(gridWidth)) {
             // first parameter is an option object
             opt = gridWidth;
-            gridWidth = opt.gridWidth || 1;
-            gridHeight = opt.gridHeight || 1;
-            padding = opt.padding || 0;
-
         } else {
-
-            opt || (opt = {});
-            gridWidth = gridWidth || 1;
-            gridHeight = gridHeight || 1;
-            padding = padding || 0;
+            // Support for a deprecated signature
+            opt = assign({ gridWidth, gridHeight, padding }, opt);
         }
+
+        const { x, y, width, height } = this.getFitToContentBBox(opt);
+
+        this.setOrigin(-x, -y);
+        this.setDimensions(width, height);
+
+        const { sx, sy } = this.scale();
+        return new Rect(x / sx, y / sy, width / sx, height / sy);
+    },
+
+    getFitToContentBBox: function(opt = {}) {
 
         // Calculate the paper size to accommodate all the graph's elements.
 
-        var minWidth = Math.max(opt.minWidth || 0, gridWidth);
-        var minHeight = Math.max(opt.minHeight || 0, gridHeight);
-        var maxWidth = opt.maxWidth || Number.MAX_VALUE;
-        var maxHeight = opt.maxHeight || Number.MAX_VALUE;
-        var newOrigin = opt.allowNewOrigin;
+        const gridWidth = opt.gridWidth || 1;
+        const gridHeight = opt.gridHeight || 1;
+        const padding = normalizeSides(opt.padding || 0);
 
-        padding = normalizeSides(padding);
+        const minWidth = Math.max(opt.minWidth || 0, gridWidth);
+        const minHeight = Math.max(opt.minHeight || 0, gridHeight);
+        const maxWidth = opt.maxWidth || Number.MAX_VALUE;
+        const maxHeight = opt.maxHeight || Number.MAX_VALUE;
+        const newOrigin = opt.allowNewOrigin;
 
-        var area = ('contentArea' in opt) ? new Rect(opt.contentArea) : this.getContentArea(opt);
-
-        var currentScale = this.scale();
-        var currentTranslate = this.translate();
-        var sx = currentScale.sx;
-        var sy = currentScale.sy;
-
+        const area = ('contentArea' in opt) ? new Rect(opt.contentArea) : this.getContentArea(opt);
+        const { sx, sy } = this.scale();
         area.x *= sx;
         area.y *= sy;
         area.width *= sx;
         area.height *= sy;
 
-        var calcWidth = Math.ceil((area.width + area.x) / gridWidth);
-        var calcHeight = Math.ceil((area.height + area.y) / gridHeight);
+        let calcWidth = Math.ceil((area.width + area.x) / gridWidth);
+        let calcHeight = Math.ceil((area.height + area.y) / gridHeight);
         if (!opt.allowNegativeBottomRight) {
             calcWidth = Math.max(calcWidth, 1);
             calcHeight = Math.max(calcHeight, 1);
@@ -1217,15 +1217,14 @@ export const Paper = View.extend({
         calcWidth *= gridWidth;
         calcHeight *= gridHeight;
 
-        var tx = 0;
-        var ty = 0;
-
+        let tx = 0;
         if ((newOrigin === 'negative' && area.x < 0) || (newOrigin === 'positive' && area.x >= 0) || newOrigin === 'any') {
             tx = Math.ceil(-area.x / gridWidth) * gridWidth;
             tx += padding.left;
             calcWidth += tx;
         }
 
+        let ty = 0;
         if ((newOrigin === 'negative' && area.y < 0) || (newOrigin === 'positive' && area.y >= 0) || newOrigin === 'any') {
             ty = Math.ceil(-area.y / gridHeight) * gridHeight;
             ty += padding.top;
@@ -1243,19 +1242,7 @@ export const Paper = View.extend({
         calcWidth = Math.min(calcWidth, maxWidth);
         calcHeight = Math.min(calcHeight, maxHeight);
 
-        var computedSize = this.getComputedSize();
-        var dimensionChange = calcWidth != computedSize.width || calcHeight != computedSize.height;
-        var originChange = tx != currentTranslate.tx || ty != currentTranslate.ty;
-
-        // Change the dimensions only if there is a size discrepancy or an origin change
-        if (originChange) {
-            this.translate(tx, ty);
-        }
-        if (dimensionChange) {
-            this.setDimensions(calcWidth, calcHeight);
-        }
-
-        return new Rect(-tx / sx, -ty / sy, calcWidth / sx, calcHeight / sy);
+        return new Rect(-tx, -ty, calcWidth, calcHeight);
     },
 
     scaleContentToFit: function(opt) {
@@ -1651,22 +1638,27 @@ export const Paper = View.extend({
             return V.matrixToTranslate(this.matrix());
         }
 
-        // setter
+        const { options } = this;
+        const { origin, drawGrid } = options;
 
-        var ctm = this.matrix();
-        ctm.e = tx || 0;
-        ctm.f = ty || 0;
+        // setter
+        tx || (tx = 0);
+        ty || (ty = 0);
+
+        const ctm = this.matrix();
+        if (ctm.e === tx && ctm.f === ty) return this;
+        ctm.e = tx;
+        ctm.f = ty;
 
         this.matrix(ctm);
 
-        var newTranslate = this.translate();
-        var origin = this.options.origin;
-        origin.x = newTranslate.tx;
-        origin.y = newTranslate.ty;
+        const { tx: ox, ty: oy } = this.translate();
+        origin.x = ox;
+        origin.y = oy;
 
-        this.trigger('translate', newTranslate.tx, newTranslate.ty);
+        this.trigger('translate', ox, oy);
 
-        if (this.options.drawGrid) {
+        if (drawGrid) {
             this.drawGrid();
         }
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -350,7 +350,7 @@ export const Paper = View.extend({
         this.setGrid(options.drawGrid);
         this.cloneOptions();
         this.render();
-        this.setDimensions();
+        this._setDimensions();
         this.startListening();
 
         // Hash of all cell views.
@@ -1144,7 +1144,6 @@ export const Paper = View.extend({
     },
 
     setDimensions: function(width, height) {
-
         const { options } = this;
         const { width: currentWidth, height: currentHeight } = options;
         let w = (width === undefined) ? currentWidth : width;
@@ -1152,14 +1151,21 @@ export const Paper = View.extend({
         if (currentWidth === w && currentHeight === h) return;
         options.width = w;
         options.height = h;
+        this._setDimensions();
+        const computedSize = this.getComputedSize();
+        this.trigger('resize', computedSize.width, computedSize.height);
+    },
+
+    _setDimensions: function() {
+        const { options } = this;
+        let w = options.width;
+        let h = options.height;
         if (isNumber(w)) w = Math.round(w);
         if (isNumber(h)) h = Math.round(h);
         this.$el.css({
             width: (w === null) ? '' : w,
             height: (h === null) ? '' : h
         });
-        const computedSize = this.getComputedSize();
-        this.trigger('resize', computedSize.width, computedSize.height);
     },
 
     setOrigin: function(ox, oy) {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1184,16 +1184,16 @@ export const Paper = View.extend({
             opt = assign({ gridWidth, gridHeight, padding }, opt);
         }
 
-        const { x, y, width, height } = this.getFitToContentBBox(opt);
-
-        this.setOrigin(-x, -y);
-        this.setDimensions(width, height);
-
+        const { x, y, width, height } = this.getFitToContentArea(opt);
         const { sx, sy } = this.scale();
-        return new Rect(x / sx, y / sy, width / sx, height / sy);
+
+        this.setOrigin(-x * sx, -y * sy);
+        this.setDimensions(width * sx, height * sy);
+
+        return new Rect(x, y, width, height);
     },
 
-    getFitToContentBBox: function(opt = {}) {
+    getFitToContentArea: function(opt = {}) {
 
         // Calculate the paper size to accommodate all the graph's elements.
 
@@ -1248,7 +1248,7 @@ export const Paper = View.extend({
         calcWidth = Math.min(calcWidth, maxWidth);
         calcHeight = Math.min(calcHeight, maxHeight);
 
-        return new Rect(-tx, -ty, calcWidth, calcHeight);
+        return new Rect(-tx / sx, -ty / sy, calcWidth / sx, calcHeight / sy);
     },
 
     scaleContentToFit: function(opt) {

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -77,6 +77,25 @@ QUnit.module('paper', function(hooks) {
             assert.equal(size.height, paper.$el.height());
         });
 
+        QUnit.test('events', function(assert) {
+            var WIDTH = 100;
+            var HEIGHT = 200;
+            var paper = this.paper;
+            var resizeCbSpy = sinon.spy();
+            paper.on('resize', resizeCbSpy);
+            paper.setDimensions(WIDTH, HEIGHT);
+            assert.ok(resizeCbSpy.calledOnce);
+            assert.ok(resizeCbSpy.calledWithExactly(WIDTH, HEIGHT));
+            resizeCbSpy.resetHistory();
+            paper.setDimensions(WIDTH, HEIGHT);
+            assert.ok(resizeCbSpy.notCalled);
+            resizeCbSpy.resetHistory();
+            paper.setDimensions(WIDTH+1, HEIGHT+1);
+            assert.ok(resizeCbSpy.calledOnce);
+            assert.ok(resizeCbSpy.calledWithExactly(WIDTH+1, HEIGHT+1));
+            resizeCbSpy.resetHistory();
+        });
+
     });
 
     QUnit.test('paper.addCell() number of sortViews()', function(assert) {
@@ -1723,6 +1742,25 @@ QUnit.module('paper', function(hooks) {
             var getterTranslate = this.paper.translate();
             assert.equal(getterTranslate.tx, 10);
             assert.equal(getterTranslate.ty, 20);
+        });
+
+        QUnit.test('setOrigin', function(assert) {
+            var X = 100;
+            var Y = 200;
+            var paper = this.paper;
+            var translateCbSpy = sinon.spy();
+            paper.on('translate', translateCbSpy);
+            paper.setOrigin(X, Y);
+            assert.ok(translateCbSpy.calledOnce);
+            assert.ok(translateCbSpy.calledWithExactly(X, Y));
+            translateCbSpy.resetHistory();
+            paper.setOrigin(X, Y);
+            assert.ok(translateCbSpy.notCalled);
+            translateCbSpy.resetHistory();
+            paper.setOrigin(X+1, Y+1);
+            assert.ok(translateCbSpy.calledOnce);
+            assert.ok(translateCbSpy.calledWithExactly(X+1, Y+1));
+            translateCbSpy.resetHistory();
         });
 
         QUnit.test('rotate', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1374,7 +1374,7 @@ export namespace dia {
         fitToContent(opt?: Paper.FitToContentOptions): g.Rect;
         fitToContent(gridWidth?: number, gridHeight?: number, padding?: number, opt?: any): g.Rect;
 
-        getFitToContentBBox(opt?: Paper.FitToContentOptions): g.Rect;
+        getFitToContentArea(opt?: Paper.FitToContentOptions): g.Rect;
 
         scaleContentToFit(opt?: Paper.ScaleContentOptions): void;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1374,6 +1374,8 @@ export namespace dia {
         fitToContent(opt?: Paper.FitToContentOptions): g.Rect;
         fitToContent(gridWidth?: number, gridHeight?: number, padding?: number, opt?: any): g.Rect;
 
+        getFitToContentBBox(opt?: Paper.FitToContentOptions): g.Rect;
+
         scaleContentToFit(opt?: Paper.ScaleContentOptions): void;
 
         drawBackground(opt?: Paper.BackgroundOptions): this;


### PR DESCRIPTION
- split `fitToContent()` into a new `getFitToContentArea()` method (to get the resulting paper bounding box to be used for further calculations).
- prevent `translate` event being triggered after `setOrigin()` without actual change of origin
- prevent `resize` event being triggered after `setDimension()` without actual change of size
