### PR TITLE
dia.Paper: fix `graph.clear()` causing an infinite loop

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -254,7 +254,8 @@ export const Paper = View.extend({
             // 1. the view was just inserted (added to the graph and rendered)
             // 2. the view was just mounted (added back to the paper by viewport function)
             // 3. the change was marked as `isolate`.
-            if ((flag & view.FLAG_INSERT) || opt.mounting || opt.isolate) return;
+            // 4. the view model was just removed from the graph
+            if ((flag & (view.FLAG_INSERT | view.FLAG_REMOVE)) || opt.mounting || opt.isolate) return;
             paper.requestConnectedLinksUpdate(view, priority, opt);
         },
 

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -942,6 +942,22 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                             onViewUpdateSpy.restore();
                             confirmUpdateSpy.restore();
                         });
+
+                        QUnit.test('graph.clear() on link to link', function(assert) {
+                            var link1 = new joint.shapes.standard.Link();
+                            var link2 = new joint.shapes.standard.Link();
+                            link1.addTo(graph);
+                            link2.addTo(graph);
+                            link2.source(link1);
+                            var linkView1 = link1.findView(paper);
+                            var linkView2 = link2.findView(paper);
+                            var onViewUpdateSpy = sinon.spy(paper.options, 'onViewUpdate');
+                            graph.clear({ test: true });
+                            assert.equal(onViewUpdateSpy.callCount, 2);
+                            assert.ok(onViewUpdateSpy.calledWithExactly(linkView1, sinon.match.number, sinon.match.number, sinon.match({ test: true }), paper));
+                            assert.ok(onViewUpdateSpy.calledWithExactly(linkView2, sinon.match.number, sinon.match.number, sinon.match({ test: true }), paper));
+                            onViewUpdateSpy.restore();
+                        });
                     });
 
                     QUnit.module('onViewPostponed', function() {


### PR DESCRIPTION
when the graph contains link to link connection and is in the sync mode