### PR TITLE
dia.attributes: prevent redundant network requests when href in use

### DIFF
--- a/src/dia/attributes/index.mjs
+++ b/src/dia/attributes/index.mjs
@@ -152,6 +152,14 @@ function atConnectionWrapper(method, opt) {
     };
 }
 
+function setIfChangedWrapper(attribute) {
+    return function setIfChanged(value, _, node) {
+        const vel = V(node);
+        if (vel.attr(attribute) === value) return;
+        vel.attr(attribute, value);
+    };
+}
+
 function isTextInUse(_value, _node, attrs) {
     return (attrs.text !== undefined);
 }
@@ -191,10 +199,6 @@ function setPaintURL(def) {
 }
 
 const attributesNS = {
-
-    xlinkHref: {
-        set: 'xlink:href'
-    },
 
     xlinkShow: {
         set: 'xlink:show'
@@ -250,6 +254,14 @@ const attributesNS = {
 
     externalResourcesRequired: {
         set: 'externalResourceRequired'
+    },
+
+    href: {
+        set: setIfChangedWrapper('href')
+    },
+
+    xlinkHref: {
+        set: setIfChangedWrapper('xlink:href')
     },
 
     filter: {
@@ -624,6 +636,8 @@ const attributesNS = {
         set: atConnectionWrapper('getTangentAtRatio', { rotate: false })
     }
 };
+
+attributesNS['xlink:href'] = attributesNS.xlinkHref;
 
 // Support `calc()` with the following SVG attributes
 [


### PR DESCRIPTION
When `href` or `xlink:href` in use:
```js
const image = new standard.BorderedImage({ attrs: { image: { href: 'my-image.png' }}});
// Should this trigger a new network request?
image.addTo(graph); // YES
image.attr('image/href', 'my-other-image.png'); // YES
image.attr('image/href', 'my-other-image.png'); // NO
image.attr('border/stroke', 'red'); // NO
image.resize(100, 100); // NO
```