### PR TITLE
docs: fix search on delete query

### DIFF
--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -38,6 +38,7 @@
 
         var prototypeSection = document.querySelector('[href="#prototype"]');
         var gSection = document.querySelector('[href="#g"]');
+        var vSection = document.querySelector('[href="#V"]');
 
         if (prototypeSection) {
             addClassToEl(prototypeSection.parentNode, 'open');
@@ -45,6 +46,10 @@
 
         if (gSection) {
             addClassToEl(gSection.parentNode, 'open');
+        }
+
+        if (vSection) {
+            addClassToEl(vSection.parentNode, 'open');
         }
     }
 

--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -166,8 +166,11 @@
         function search() {
 
             if (input.value === '') {
-                return ;
+                closeAll();
+                showAllItems();
+                return;
             }
+
             hideAllItems();
             closeAll();
             showItemsThatMatch(input.value);


### PR DESCRIPTION
- JointJS docs should show all items again after deleting query with keyboard
- open V items when you visit page, just to make behaviour consistent with geometry items behaviour 