### PR TITLE
connectors.Curve: rotate option

### DIFF
--- a/docs/src/joint/api/connectors/curve/intro.html
+++ b/docs/src/joint/api/connectors/curve/intro.html
@@ -10,14 +10,14 @@
     <tr>
         <th>sourceDirection</th>
         <td><a href="#connectors.curve.TangentDirections">curve.TangentDirections</a>|object|number</td>
-        <td>The unit vector direction of the tangent at the source point. If the option is an object it must have x and y properties. 
+        <td>The unit vector direction of the tangent at the source point. If the option is an object it must have x and y properties.
             If the option is a number, it represents an angle relative to the x-axis in the positive direction (counterclockwise).
         </td>
     </tr>
     <tr>
         <th>targetDirection</th>
         <td><a href="#connectors.curve.TangentDirections">curve.TangentDirections</a>|object|number</td>
-        <td>The unit vector direction of the tangent at the target point. If the option is an object it must have x and y properties. 
+        <td>The unit vector direction of the tangent at the target point. If the option is an object it must have x and y properties.
             If the option is a number, it represents an angle relative to the x-axis in the positive direction (counterclockwise).
         </td>
     </tr>
@@ -35,6 +35,11 @@
         <th>distanceCoefficient</th>
         <td>number</td>
         <td>Coefficient of the tangent vector length relative to the distance between points. The default is <code>0.6</code>.</td>
+    </tr>
+    <tr>
+        <th>rotate</th>
+        <td>boolean</td>
+        <td>Whether the rotation of the source or target element should be taken into account. Only works for AUTO, HORIZONTAL and VERTICAL directions. The default is <code>false</code>.</td>
     </tr>
 </table>
 

--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -102,7 +102,7 @@ function getHorizontalSourceDirection(linkView, route, options) {
 
     let sourceSide;
     let rotation;
-    if (!sourceBBox.width || !sourceBBox.height) {
+    if (!linkView.sourceView) {
         if (sourceBBox.x > route[1].x)
             sourceSide = 'right';
         else
@@ -142,7 +142,7 @@ function getHorizontalTargetDirection(linkView, route, options) {
 
     let targetSide;
     let rotation;
-    if (!targetBBox.width || !targetBBox.height) {
+    if (!linkView.targetView) {
         if (targetBBox.x > route[route.length - 2].x)
             targetSide = 'left';
         else
@@ -182,7 +182,7 @@ function getVerticalSourceDirection(linkView, route, options) {
 
     let sourceSide;
     let rotation;
-    if (!sourceBBox.width || !sourceBBox.height) {
+    if (!linkView.sourceView) {
         if (sourceBBox.y > route[1].y)
             sourceSide = 'bottom';
         else
@@ -222,7 +222,7 @@ function getVerticalTargetDirection(linkView, route, options) {
 
     let targetSide;
     let rotation;
-    if (!targetBBox.width || !targetBBox.height) {
+    if (!linkView.targetView) {
         if (targetBBox.y > route[route.length - 2].y)
             targetSide = 'top';
         else
@@ -263,7 +263,7 @@ function getAutoSourceDirection(linkView, route, options) {
 
     let sourceSide;
     let rotation;
-    if (!sourceBBox.width || !sourceBBox.height) {
+    if (!linkView.sourceView) {
         sourceSide = sourceBBox.sideNearestToPoint(route[1]);
     } else {
         rotation = linkView.sourceView.model.angle();
@@ -305,7 +305,7 @@ function getAutoTargetDirection(linkView, route, options) {
 
     let targetSide;
     let rotation;
-    if (!targetBBox.width || !targetBBox.height) {
+    if (!linkView.targetView) {
         targetSide = targetBBox.sideNearestToPoint(route[route.length - 2]);
     } else {
         rotation = linkView.targetView.model.angle();

--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -108,14 +108,12 @@ function getHorizontalSourceDirection(linkView, route, options) {
         else
             sourceSide = 'left';
     } else {
-        if (options.rotate) {
-            rotation = linkView.sourceView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
-                const sourcePoint = route[0].clone();
-                sourcePoint.rotate(sourceBBox.center(), rotation);
-                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
-            }
+        rotation = linkView.sourceView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+            const sourcePoint = route[0].clone();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -150,14 +148,12 @@ function getHorizontalTargetDirection(linkView, route, options) {
         else
             targetSide = 'right';
     } else {
-        if (options.rotate) {
-            rotation = linkView.targetView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
-                const targetPoint = route[route.length - 1].clone();
-                targetPoint.rotate(targetBBox.center(), rotation);
-                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
-            }
+        rotation = linkView.targetView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+            const targetPoint = route[route.length - 1].clone();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }
@@ -192,14 +188,12 @@ function getVerticalSourceDirection(linkView, route, options) {
         else
             sourceSide = 'top';
     } else {
-        if (options.rotate) {
-            rotation = linkView.sourceView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
-                const sourcePoint = route[0].clone();
-                sourcePoint.rotate(sourceBBox.center(), rotation);
-                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
-            }
+        rotation = linkView.sourceView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+            const sourcePoint = route[0].clone();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -234,14 +228,12 @@ function getVerticalTargetDirection(linkView, route, options) {
         else
             targetSide = 'bottom';
     } else {
-        if (options.rotate) {
-            rotation = linkView.targetView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
-                const targetPoint = route[route.length - 1].clone();
-                targetPoint.rotate(targetBBox.center(), rotation);
-                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
-            }
+        rotation = linkView.targetView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+            const targetPoint = route[route.length - 1].clone();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }
@@ -274,14 +266,12 @@ function getAutoSourceDirection(linkView, route, options) {
     if (!sourceBBox.width || !sourceBBox.height) {
         sourceSide = sourceBBox.sideNearestToPoint(route[1]);
     } else {
-        if (options.rotate) {
-            rotation = linkView.sourceView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
-                const sourcePoint = route[0].clone();
-                sourcePoint.rotate(sourceBBox.center(), rotation);
-                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
-            }
+        rotation = linkView.sourceView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+            const sourcePoint = route[0].clone();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -318,14 +308,12 @@ function getAutoTargetDirection(linkView, route, options) {
     if (!targetBBox.width || !targetBBox.height) {
         targetSide = targetBBox.sideNearestToPoint(route[route.length - 2]);
     } else {
-        if (options.rotate) {
-            rotation = linkView.targetView.model.angle();
-            if (rotation) {
-                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
-                const targetPoint = route[route.length - 1].clone();
-                targetPoint.rotate(targetBBox.center(), rotation);
-                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
-            }
+        rotation = linkView.targetView.model.angle();
+        if (options.rotate && rotation) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+            const targetPoint = route[route.length - 1].clone();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }

--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -34,7 +34,8 @@ export const curve = function(sourcePoint, targetPoint, route = [], opt = {}, li
         angleTangentCoefficient: opt.angleTangentCoefficient || 80,
         tau: opt.tension || 0.5,
         sourceTangent: opt.sourceTangent ? new Point(opt.sourceTangent) : null,
-        targetTangent: opt.targetTangent ? new Point(opt.targetTangent) : null
+        targetTangent: opt.targetTangent ? new Point(opt.targetTangent) : null,
+        rotate: Boolean(opt.rotate)
     };
     if (typeof opt.sourceDirection === 'string')
         options.sourceDirection = opt.sourceDirection;
@@ -100,132 +101,245 @@ function getHorizontalSourceDirection(linkView, route, options) {
     const { sourceBBox } = linkView;
 
     let sourceSide;
+    let rotation;
     if (!sourceBBox.width || !sourceBBox.height) {
         if (sourceBBox.x > route[1].x)
             sourceSide = 'right';
         else
             sourceSide = 'left';
     } else {
-        sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
+            const sourcePoint = route[0].clone();
+            rotation = linkView.sourceView.model.angle();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+        } else {
+            sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        }
     }
 
+    let direction;
     switch (sourceSide) {
         case 'left':
-            return new Point(-1, 0);
+            direction = new Point(-1, 0);
+            break;
         case 'right':
         default:
-            return new Point(1, 0);
+            direction = new Point(1, 0);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getHorizontalTargetDirection(linkView, route, options) {
     const { targetBBox } = linkView;
 
     let targetSide;
+    let rotation;
     if (!targetBBox.width || !targetBBox.height) {
         if (targetBBox.x > route[route.length - 2].x)
             targetSide = 'left';
         else
             targetSide = 'right';
     } else {
-        targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
+            const targetPoint = route[route.length - 1].clone();
+            rotation = linkView.targetView.model.angle();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+        } else {
+            targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        }
     }
 
+    let direction;
     switch (targetSide) {
         case 'left':
-            return new Point(-1, 0);
+            direction = new Point(-1, 0);
+            break;
         case 'right':
         default:
-            return new Point(1, 0);
+            direction = new Point(1, 0);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getVerticalSourceDirection(linkView, route, options) {
     const { sourceBBox } = linkView;
 
     let sourceSide;
+    let rotation;
     if (!sourceBBox.width || !sourceBBox.height) {
         if (sourceBBox.y > route[1].y)
             sourceSide = 'bottom';
         else
             sourceSide = 'top';
     } else {
-        sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
+            const sourcePoint = route[0].clone();
+            rotation = linkView.sourceView.model.angle();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+        } else {
+            sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        }
     }
 
+    let direction;
     switch (sourceSide) {
         case 'top':
-            return new Point(0, -1);
+            direction = new Point(0, -1);
+            break;
         case 'bottom':
         default:
-            return new Point(0, 1);
+            direction = new Point(0, 1);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getVerticalTargetDirection(linkView, route, options) {
     const { targetBBox } = linkView;
 
     let targetSide;
+    let rotation;
     if (!targetBBox.width || !targetBBox.height) {
         if (targetBBox.y > route[route.length - 2].y)
             targetSide = 'top';
         else
             targetSide = 'bottom';
     } else {
-        targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
+            const targetPoint = route[route.length - 1].clone();
+            rotation = linkView.targetView.model.angle();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+        } else {
+            targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        }
     }
 
+
+    let direction;
     switch (targetSide) {
         case 'top':
-            return new Point(0, -1);
+            direction = new Point(0, -1);
+            break;
         case 'bottom':
         default:
-            return new Point(0, 1);
+            direction = new Point(0, 1);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getAutoSourceDirection(linkView, route, options) {
     const { sourceBBox } = linkView;
 
     let sourceSide;
+    let rotation;
     if (!sourceBBox.width || !sourceBBox.height) {
         sourceSide = sourceBBox.sideNearestToPoint(route[1]);
     } else {
-        sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
+            const sourcePoint = route[0].clone();
+            rotation = linkView.sourceView.model.angle();
+            sourcePoint.rotate(sourceBBox.center(), rotation);
+            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+        } else {
+            sourceSide = sourceBBox.sideNearestToPoint(route[0]);
+        }
     }
 
+    let direction;
     switch (sourceSide) {
         case 'top':
-            return new Point(0, -1);
+            direction = new Point(0, -1);
+            break;
         case 'bottom':
-            return new Point(0, 1);
+            direction = new Point(0, 1);
+            break;
         case 'right':
-            return new Point(1, 0);
+            direction = new Point(1, 0);
+            break;
         case 'left':
-            return new Point(-1, 0);
+            direction = new Point(-1, 0);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getAutoTargetDirection(linkView, route, options) {
     const { targetBBox } = linkView;
 
     let targetSide;
+    let rotation;
     if (!targetBBox.width || !targetBBox.height) {
         targetSide = targetBBox.sideNearestToPoint(route[route.length - 2]);
     } else {
-        targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        if (options.rotate) {
+            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
+            const targetPoint = route[route.length - 1].clone();
+            rotation = linkView.targetView.model.angle();
+            targetPoint.rotate(targetBBox.center(), rotation);
+            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+        } else {
+            targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
+        }
     }
 
+    let direction;
     switch (targetSide) {
         case 'top':
-            return new Point(0, -1);
+            direction = new Point(0, -1);
+            break;
         case 'bottom':
-            return new Point(0, 1);
+            direction = new Point(0, 1);
+            break;
         case 'right':
-            return new Point(1, 0);
+            direction = new Point(1, 0);
+            break;
         case 'left':
-            return new Point(-1, 0);
+            direction = new Point(-1, 0);
+            break;
     }
+
+    if (options.rotate) {
+        direction.rotate(null, -rotation);
+    }
+
+    return direction;
 }
 
 function getClosestPointSourceDirection(linkView, route, options) {

--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -109,11 +109,13 @@ function getHorizontalSourceDirection(linkView, route, options) {
             sourceSide = 'left';
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
-            const sourcePoint = route[0].clone();
             rotation = linkView.sourceView.model.angle();
-            sourcePoint.rotate(sourceBBox.center(), rotation);
-            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+                const sourcePoint = route[0].clone();
+                sourcePoint.rotate(sourceBBox.center(), rotation);
+                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            }
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -130,7 +132,7 @@ function getHorizontalSourceDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 
@@ -149,11 +151,13 @@ function getHorizontalTargetDirection(linkView, route, options) {
             targetSide = 'right';
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
-            const targetPoint = route[route.length - 1].clone();
             rotation = linkView.targetView.model.angle();
-            targetPoint.rotate(targetBBox.center(), rotation);
-            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+                const targetPoint = route[route.length - 1].clone();
+                targetPoint.rotate(targetBBox.center(), rotation);
+                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            }
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }
@@ -170,7 +174,7 @@ function getHorizontalTargetDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 
@@ -189,11 +193,13 @@ function getVerticalSourceDirection(linkView, route, options) {
             sourceSide = 'top';
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
-            const sourcePoint = route[0].clone();
             rotation = linkView.sourceView.model.angle();
-            sourcePoint.rotate(sourceBBox.center(), rotation);
-            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+                const sourcePoint = route[0].clone();
+                sourcePoint.rotate(sourceBBox.center(), rotation);
+                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            }
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -210,7 +216,7 @@ function getVerticalSourceDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 
@@ -229,11 +235,13 @@ function getVerticalTargetDirection(linkView, route, options) {
             targetSide = 'bottom';
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
-            const targetPoint = route[route.length - 1].clone();
             rotation = linkView.targetView.model.angle();
-            targetPoint.rotate(targetBBox.center(), rotation);
-            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+                const targetPoint = route[route.length - 1].clone();
+                targetPoint.rotate(targetBBox.center(), rotation);
+                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            }
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }
@@ -251,7 +259,7 @@ function getVerticalTargetDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 
@@ -267,11 +275,13 @@ function getAutoSourceDirection(linkView, route, options) {
         sourceSide = sourceBBox.sideNearestToPoint(route[1]);
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el)
-            const sourcePoint = route[0].clone();
             rotation = linkView.sourceView.model.angle();
-            sourcePoint.rotate(sourceBBox.center(), rotation);
-            sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.sourceView.getNodeUnrotatedBBox(linkView.sourceView.el);
+                const sourcePoint = route[0].clone();
+                sourcePoint.rotate(sourceBBox.center(), rotation);
+                sourceSide = unrotatedBBox.sideNearestToPoint(sourcePoint);
+            }
         } else {
             sourceSide = sourceBBox.sideNearestToPoint(route[0]);
         }
@@ -293,7 +303,7 @@ function getAutoSourceDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 
@@ -309,11 +319,13 @@ function getAutoTargetDirection(linkView, route, options) {
         targetSide = targetBBox.sideNearestToPoint(route[route.length - 2]);
     } else {
         if (options.rotate) {
-            const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el)
-            const targetPoint = route[route.length - 1].clone();
             rotation = linkView.targetView.model.angle();
-            targetPoint.rotate(targetBBox.center(), rotation);
-            targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            if (rotation) {
+                const unrotatedBBox = linkView.targetView.getNodeUnrotatedBBox(linkView.targetView.el);
+                const targetPoint = route[route.length - 1].clone();
+                targetPoint.rotate(targetBBox.center(), rotation);
+                targetSide = unrotatedBBox.sideNearestToPoint(targetPoint);
+            }
         } else {
             targetSide = targetBBox.sideNearestToPoint(route[route.length - 1]);
         }
@@ -335,7 +347,7 @@ function getAutoTargetDirection(linkView, route, options) {
             break;
     }
 
-    if (options.rotate) {
+    if (options.rotate && rotation) {
         direction.rotate(null, -rotation);
     }
 

--- a/test/jointjs/connectors.js
+++ b/test/jointjs/connectors.js
@@ -24,7 +24,7 @@ QUnit.module('connectors', function(hooks) {
 
     QUnit.test('construction', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300);
 
         this.graph.addCell([r1, r2]);
@@ -77,8 +77,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector direction auto', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -95,8 +95,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector direction auto with vertex', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -172,8 +172,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector with enum directions (left/right)', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -196,8 +196,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector with horizontal direction', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -219,8 +219,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector with vertical direction', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -242,8 +242,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector with closest point direction', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -265,8 +265,8 @@ QUnit.module('connectors', function(hooks) {
     });
 
     QUnit.test('curve connector with outwards direction', function(assert) {
-        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 } });
-        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 } });
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
 
         var link = new joint.shapes.standard.Link({
             source: { id: r1.id },
@@ -310,5 +310,28 @@ QUnit.module('connectors', function(hooks) {
         var pathData = linkView.metrics.data;
 
         assert.checkDataPath(pathData, 'M 335.31 300.31 C 369.299 319.934 385.066 335.701 404.69 369.69', 'curve link with rotate was correctly rendered');
+    });
+
+    QUnit.test('curve connector rotate (target is nonrotated)', function(assert) {
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }, angle: 30 });
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }});
+
+        var link = new joint.shapes.standard.Link({
+            source: { id: r1.id },
+            target: { id: r2.id },
+            connector: {
+                name: 'curve',
+                args: {
+                    rotate: true
+                }
+            }
+        });
+
+        this.graph.addCells([r1, r2, link]);
+
+        var linkView = this.paper.findViewByModel(link);
+        var pathData = linkView.metrics.data;
+
+        assert.checkDataPath(pathData, 'M 335.31 300.31 C 384.148 328.507 435 343.607 435 400', 'curve link with rotate was correctly rendered');
     });
 });

--- a/test/jointjs/connectors.js
+++ b/test/jointjs/connectors.js
@@ -288,4 +288,27 @@ QUnit.module('connectors', function(hooks) {
 
         assert.checkDataPath(pathData, 'M 340 216.15 C 364 209.69 378.299 187.884 400 200 C 472.884 240.691 435.742 320 459.57 400');
     });
+
+    QUnit.test('curve connector rotate', function(assert) {
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 200, y: 200 }, size: { width: 140, height: 70 }, angle: 30 });
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 400, y: 400 }, size: { width: 140, height: 70 }, angle: 60 });
+
+        var link = new joint.shapes.standard.Link({
+            source: { id: r1.id },
+            target: { id: r2.id },
+            connector: {
+                name: 'curve',
+                args: {
+                    rotate: true
+                }
+            }
+        });
+
+        this.graph.addCells([r1, r2, link]);
+
+        var linkView = this.paper.findViewByModel(link);
+        var pathData = linkView.metrics.data;
+
+        assert.checkDataPath(pathData, 'M 335.31 300.31 C 369.299 319.934 385.066 335.701 404.69 369.69', 'curve link with rotate was correctly rendered');
+    });
 });


### PR DESCRIPTION
Add `rotate` option to `connector.Curve`.
```js
el.set('angle', 45);
el.set('connector', {
    name: 'curve',
    args: {
        rotate: true // take the element's angle into account
    }
});
```