### PR TITLE
Vectorizer: text() reads empty line heights from annotations

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -581,7 +581,27 @@ const V = (function() {
                 var lineNodeStyle = lineNode.style;
                 lineNodeStyle.fillOpacity = 0;
                 lineNodeStyle.strokeOpacity = 0;
-                if (annotations) lineMetrics = {};
+                if (annotations) {
+                    // Empty line with annotations.
+                    lineMetrics = {};
+                    lineAnnotations = V.findAnnotationsBetweenIndexes(annotations, offset, offset);
+                    var lineFontSize = lineAnnotations.reduce((maxFs, annotation) => {
+                        // Check for max font size
+                        var fs = parseFloat(annotation.attrs['font-size']);
+                        return (!isFinite(fs)) ? maxFs : Math.max(maxFs, fs);
+                    }, -1);
+                    if (lineFontSize < 0) lineFontSize = fontSize;
+                    if (autoLineHeight) {
+                        if (i > 0) {
+                            dy = lineFontSize * 1.2;
+                        } else {
+                            annotatedY = lineFontSize * 0.8;
+                        }
+                    }
+                    // The font size is important for the native selection box height.
+                    lineNode.setAttribute('font-size', lineFontSize);
+                    lineMetrics.maxFontSize = lineFontSize;
+                }
             }
             if (lineMetrics) linesMetrics.push(lineMetrics);
             if (i > 0) lineNode.setAttribute('dy', dy);

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -584,7 +584,7 @@ const V = (function() {
                 if (annotations) {
                     // Empty line with annotations.
                     lineMetrics = {};
-                    lineAnnotations = V.findAnnotationsBetweenIndexes(annotations, offset, offset);
+                    lineAnnotations = V.findAnnotationsAtIndex(annotations, offset);
                     let lineFontSize = fontSize;
                     // Check if any of the annotations overrides the font size.
                     for (let j = lineAnnotations.length; j > 0; j--) {

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -585,12 +585,17 @@ const V = (function() {
                     // Empty line with annotations.
                     lineMetrics = {};
                     lineAnnotations = V.findAnnotationsBetweenIndexes(annotations, offset, offset);
-                    var lineFontSize = lineAnnotations.reduce((maxFs, annotation) => {
-                        // Check for max font size
-                        var fs = parseFloat(annotation.attrs['font-size']);
-                        return (!isFinite(fs)) ? maxFs : Math.max(maxFs, fs);
-                    }, -1);
-                    if (lineFontSize < 0) lineFontSize = fontSize;
+                    let lineFontSize = fontSize;
+                    // Check if any of the annotations overrides the font size.
+                    for (let j = lineAnnotations.length; j > 0; j--) {
+                        const attrs = lineAnnotations[j - 1].attrs;
+                        if (!attrs || !('font-size' in attrs)) continue;
+                        const fs = parseFloat(attrs['font-size']);
+                        if (isFinite(fs)) {
+                            lineFontSize = fs;
+                            break;
+                        }
+                    }
                     if (autoLineHeight) {
                         if (i > 0) {
                             dy = lineFontSize * 1.2;

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -300,6 +300,86 @@ QUnit.module('vectorizer', function(hooks) {
             assert.deepEqual(linesDy, ['0', '36']); // max font-size * 1.2
         });
 
+        QUnit.test('empty line height', function(assert) {
+
+            var fontSize = 20;
+            var annotationFontSize = 30;
+
+            var t = V('text', { 'font-size': fontSize });
+            var linesDy;
+            var linesFontSize;
+            var text = '\na\n\nb\n\n';
+            var annotations = [
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }}
+            ];
+
+            // Line Height 'Auto'
+
+            t.text(text, {
+                lineHeight: 'auto',
+                annotations: annotations
+            });
+
+            linesDy = t.children().map(function(vTSpan) {
+                return vTSpan.attr('dy');
+            });
+
+            assert.deepEqual(linesDy,  [
+                '0',
+                String(annotationFontSize * 1.2),
+                String(annotationFontSize * 1.2),
+                String(annotationFontSize * 1.2),
+                String(annotationFontSize * 1.2),
+                String(fontSize * 1.2),
+            ]);
+
+            linesFontSize = t.children().map(function(vTSpan) {
+                return vTSpan.attr('font-size');
+            });
+
+            assert.deepEqual(linesFontSize,  [
+                String(annotationFontSize),
+                null,
+                String(annotationFontSize),
+                null,
+                String(annotationFontSize),
+                String(fontSize),
+            ]);
+
+            // Line Height '2em'
+
+            t.text(text, {
+                lineHeight: '2em',
+                annotations: annotations
+            });
+
+            linesDy = t.children().map(function(vTSpan) {
+                return vTSpan.attr('dy');
+            });
+
+            assert.deepEqual(linesDy,  [
+                '0',
+                '2em',
+                '2em',
+                '2em',
+                '2em',
+                '2em',
+            ]);
+
+            linesFontSize = t.children().map(function(vTSpan) {
+                return vTSpan.attr('font-size');
+            });
+
+            assert.deepEqual(linesFontSize,  [
+                String(annotationFontSize),
+                null,
+                String(annotationFontSize),
+                null,
+                String(annotationFontSize),
+                String(fontSize),
+            ]);
+        });
+
         QUnit.test('custom EOL', function(assert) {
 
             var svg = getSvg();

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -344,22 +344,22 @@ QUnit.module('vectorizer', function(hooks) {
             }
 
             testLineHeightAuto([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start:-1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeightAuto([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeightAuto([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeightAuto([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
-                { start: 0, end: 6, attrs: { 'no-font-size': true }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'no-font-size': true }},
             ]);
 
             // Line Height '2em'
@@ -398,22 +398,22 @@ QUnit.module('vectorizer', function(hooks) {
             }
 
             testLineHeight2em([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeight2em([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeight2em([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
             testLineHeight2em,([
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
-                { start: 0, end: 6, attrs: { 'no-font-size': true }},
+                { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: -1, end: 6, attrs: { 'no-font-size': true }},
             ]);
         });
 

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -411,7 +411,7 @@ QUnit.module('vectorizer', function(hooks) {
                 { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
-            testLineHeight2em,([
+            testLineHeight2em([
                 { start: -1, end: 6, attrs: { 'font-size': annotationFontSize }},
                 { start: -1, end: 6, attrs: { 'no-font-size': true }},
             ]);

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -306,77 +306,114 @@ QUnit.module('vectorizer', function(hooks) {
             var annotationFontSize = 30;
 
             var t = V('text', { 'font-size': fontSize });
-            var linesDy;
-            var linesFontSize;
             var text = '\na\n\nb\n\n';
-            var annotations = [
-                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }}
-            ];
 
             // Line Height 'Auto'
+            function testLineHeightAuto(annotations) {
 
-            t.text(text, {
-                lineHeight: 'auto',
-                annotations: annotations
-            });
+                t.text(text, {
+                    lineHeight: 'auto',
+                    annotations: annotations
+                });
 
-            linesDy = t.children().map(function(vTSpan) {
-                return vTSpan.attr('dy');
-            });
+                var linesDy = t.children().map(function(vTSpan) {
+                    return vTSpan.attr('dy');
+                });
 
-            assert.deepEqual(linesDy,  [
-                '0',
-                String(annotationFontSize * 1.2),
-                String(annotationFontSize * 1.2),
-                String(annotationFontSize * 1.2),
-                String(annotationFontSize * 1.2),
-                String(fontSize * 1.2),
+                assert.deepEqual(linesDy,  [
+                    '0',
+                    String(annotationFontSize * 1.2),
+                    String(annotationFontSize * 1.2),
+                    String(annotationFontSize * 1.2),
+                    String(annotationFontSize * 1.2),
+                    String(fontSize * 1.2),
+                ]);
+
+                var linesFontSize = t.children().map(function(vTSpan) {
+                    return vTSpan.attr('font-size');
+                });
+
+                assert.deepEqual(linesFontSize,  [
+                    String(annotationFontSize),
+                    null,
+                    String(annotationFontSize),
+                    null,
+                    String(annotationFontSize),
+                    String(fontSize),
+                ]);
+            }
+
+            testLineHeightAuto([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
-            linesFontSize = t.children().map(function(vTSpan) {
-                return vTSpan.attr('font-size');
-            });
+            testLineHeightAuto([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+            ]);
 
-            assert.deepEqual(linesFontSize,  [
-                String(annotationFontSize),
-                null,
-                String(annotationFontSize),
-                null,
-                String(annotationFontSize),
-                String(fontSize),
+            testLineHeightAuto([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+            ]);
+
+            testLineHeightAuto([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: 0, end: 6, attrs: { 'no-font-size': true }},
             ]);
 
             // Line Height '2em'
+            function testLineHeight2em(annotations) {
 
-            t.text(text, {
-                lineHeight: '2em',
-                annotations: annotations
-            });
+                t.text(text, {
+                    lineHeight: '2em',
+                    annotations: annotations
+                });
 
-            linesDy = t.children().map(function(vTSpan) {
-                return vTSpan.attr('dy');
-            });
+                var linesDy = t.children().map(function(vTSpan) {
+                    return vTSpan.attr('dy');
+                });
 
-            assert.deepEqual(linesDy,  [
-                '0',
-                '2em',
-                '2em',
-                '2em',
-                '2em',
-                '2em',
+                assert.deepEqual(linesDy,  [
+                    '0',
+                    '2em',
+                    '2em',
+                    '2em',
+                    '2em',
+                    '2em',
+                ]);
+
+                var linesFontSize = t.children().map(function(vTSpan) {
+                    return vTSpan.attr('font-size');
+                });
+
+                assert.deepEqual(linesFontSize,  [
+                    String(annotationFontSize),
+                    null,
+                    String(annotationFontSize),
+                    null,
+                    String(annotationFontSize),
+                    String(fontSize),
+                ]);
+            }
+
+            testLineHeight2em([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
             ]);
 
-            linesFontSize = t.children().map(function(vTSpan) {
-                return vTSpan.attr('font-size');
-            });
+            testLineHeight2em([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize - 1 }},
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+            ]);
 
-            assert.deepEqual(linesFontSize,  [
-                String(annotationFontSize),
-                null,
-                String(annotationFontSize),
-                null,
-                String(annotationFontSize),
-                String(fontSize),
+            testLineHeight2em([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize + 1 }},
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+            ]);
+
+            testLineHeight2em,([
+                { start: 0, end: 6, attrs: { 'font-size': annotationFontSize }},
+                { start: 0, end: 6, attrs: { 'no-font-size': true }},
             ]);
         });
 


### PR DESCRIPTION
The PR allows empty lines to be annotated.
The actual `line-height` of an empty line is calculated based on the annotations now.

Note that the empty line at the beginning of the text is annotated at `(-1,0>`.