### PR TITLE
attributes: prevent negative values for dimension attributes

### DIFF
--- a/src/dia/attributes/index.mjs
+++ b/src/dia/attributes/index.mjs
@@ -644,10 +644,7 @@ attributesNS['xlink:href'] = attributesNS.xlinkHref;
     'transform', // g
     'd', // path
     'points', // polyline / polygon
-    'width', 'height', // rect / image
     'cx', 'cy', // circle / ellipse
-    'r', // circle
-    'rx', 'ry', // rect / ellipse
     'x1', 'x2', 'y1', 'y2', // line
     'x', 'y', // rect / text / image
     'dx', 'dy' // text
@@ -659,6 +656,21 @@ attributesNS['xlink:href'] = attributesNS.xlinkHref;
         }
     };
 });
+
+// Prevent "A negative value is not valid" error.
+[
+    'width', 'height', // rect / image
+    'r', // circle
+    'rx', 'ry', // rect / ellipse
+].forEach(attribute => {
+    attributesNS[attribute] = {
+        qualify: isCalcAttribute,
+        set: function setCalcAttribute(value, refBBox) {
+            return { [attribute]: Math.max(0, evalCalcAttribute(value, refBBox)) };
+        }
+    };
+});
+
 
 // Aliases
 attributesNS.refR = attributesNS.refRInscribed;

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -434,6 +434,42 @@ QUnit.module('Attributes', function() {
                 );
             });
         });
+
+        QUnit.test('prevent negative values for dimensions', function(assert) {
+            var ns = joint.dia.attributes;
+            var attributes = [
+                'x',
+                'y',
+                'cx',
+                'cy',
+                'dx',
+                'dy',
+                'x1',
+                'x2',
+                'y1',
+                'y2',
+                'width',
+                'height',
+                'rx',
+                'ry',
+                'r',
+            ];
+            var results = [
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0,
+            ];
+            attributes.forEach(function(attribute, index) {
+                var setter = ns[attribute].set;
+                var result = setter.call(
+                    cellView,
+                    'calc(w-' + (refBBox.width + 1) + ')',
+                    refBBox.clone(),
+                    node,
+                    {}
+                );
+                assert.equal(result[attribute], String(results[index]));
+            });
+        });
+
     });
 
     QUnit.module('Defs Attributes', function(hooks) {


### PR DESCRIPTION
The dimension attributes (`width`, `height`, `r`, `rx`, `ry`) must be always greater than or equal to `0`. The browser throws `"A negative value is not valid"` otherwise.

This PR ensures that the result of the `calc()` expression for the listed attributes is valid.