### PR TITLE
elementTools.Button: enable calc() expression for x and y

### DIFF
--- a/docs/src/joint/api/elementTools/Button.html
+++ b/docs/src/joint/api/elementTools/Button.html
@@ -4,7 +4,7 @@
     <tr>
         <th>x</th>
         <td rowspan="2"><i>string | number</i></td>
-        <td rowspan="2">Use percentage strings (e.g. <code>'40%'</code>) to position the button relatively to the element width/height. A number means distance from the top-left corner of the element. Default is <code>0</code>.</td>
+        <td rowspan="2">Use percentage strings (e.g. <code>'40%'</code>) or <a href="#dia.attributes.calc">calc()</a> expression (e.g. <code>'calc(0.4 * w)'</code>) to position the button relatively to the element width/height. A number means distance from the top-left corner of the element. Default is <code>0</code>.</td>
     </tr>
     <tr>
         <th>y</th>

--- a/src/linkTools/index.mjs
+++ b/src/linkTools/index.mjs
@@ -4,6 +4,7 @@ import * as util from '../util/index.mjs';
 import * as connectionStrategies from '../connectionStrategies/index.mjs';
 import * as mvc from '../mvc/index.mjs';
 import { ToolView } from '../dia/ToolView.mjs';
+import { evalCalcAttribute, isCalcAttribute } from '../dia/attributes/calc.mjs';
 
 function getAnchor(coords, view, magnet) {
     // take advantage of an existing logic inside of the
@@ -743,9 +744,13 @@ var Button = ToolView.extend({
         const { x: offsetX = 0, y: offsetY = 0 } = offset;
         if (util.isPercentage(x)) {
             x = parseFloat(x) / 100 * bbox.width;
+        } else if (isCalcAttribute(x)) {
+            x = Number(evalCalcAttribute(x, bbox));
         }
         if (util.isPercentage(y)) {
             y = parseFloat(y) / 100 * bbox.height;
+        } else if (isCalcAttribute(y)) {
+            y = Number(evalCalcAttribute(y, bbox));
         }
         let matrix = V.createSVGMatrix().translate(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
         if (rotate) matrix = matrix.rotate(angle);

--- a/test/jointjs/dia/elementTools.js
+++ b/test/jointjs/dia/elementTools.js
@@ -51,6 +51,9 @@ QUnit.module('elementTools', function(hooks) {
             options: { x: '100%', y: '100%', useModelGeometry: true },
             position: { x: 200, y: 200 }
         }, {
+            options: { x: 'calc(w+11)', y: 'calc(h+13)', useModelGeometry: true },
+            position: { x: 211, y: 213 }
+        }, {
             options: { x: '100%', y: '100%', offset: { x: 2, y: 3 }},
             position: { x: 211 + 2, y: 213 + 3 }
         }, {


### PR DESCRIPTION
A convenient way to place buttons on the elements.
```js
new elementTools.Remove({
  // the button will be at the bottom-right corner
  // and 10 pixels towards the center of the element
  x: 'calc(w - 10)',
  y: 'calc(h - 10)'
});
```