### PR TITLE
dia.attributes: calc() expression supports division

### DIFF
--- a/docs/src/joint/api/dia/attributes/intro.html
+++ b/docs/src/joint/api/dia/attributes/intro.html
@@ -44,11 +44,30 @@ All the standard SVG <a href="https://www.w3.org/TR/SVG/styling.html" target="_b
 'calc(0.5 * h)'</code></pre>
     </li>
     <li>
+        <span class="calc-part">Variable</span>
+        <span class="calc-part">Division</span>
+        <pre><code>'calc(w / 2)'
+'calc(h / 3)'</code></pre>
+    </li>
+    <li>
+        <span class="calc-part">Variable</span>
+        <span class="calc-part">Division</span>
+        <pre><code>'calc(w / 2)'
+'calc(h / 3)'</code></pre>
+    </li>
+    <li>
         <span class="calc-part">Multiplication</span>
         <span class="calc-part">Variable</span>
         <span class="calc-part">Addition or Subtraction</span>
         <pre><code>'calc(2 * w + 5)'
 'calc(0.5 * h - 10)'</code></pre>
+    </li>
+    <li>
+        <span class="calc-part">Variable</span>
+        <span class="calc-part">Division</span>
+        <span class="calc-part">Addition or Subtraction</span>
+        <pre><code>'calc(w / 2 + 5)'
+'calc(h / 3 - 10)'</code></pre>
     </li>
 </ul>
 
@@ -105,6 +124,10 @@ All the standard SVG <a href="https://www.w3.org/TR/SVG/styling.html" target="_b
     <li>
         <span class="calc-part">Multiplication</span> is an optional floating number factor of the variable. It's a number followed by the <code>*</code> symbol.
         <pre><code>1.5 *</code></pre>
+    </li>
+    <li>
+        <span class="calc-part">Division</span> is an optional floating number divisor of the variable. It's the <code>/</code> symbol followed by a number.
+        <pre><code>/ 2</code></pre>
     </li>
     <li>
         <span class="calc-part">Addition or Subtraction</span> is an optional floating number added or subtracted from the variable. It's a <code>+</code> or <code>-</code> symbol followed by a number.

--- a/src/dia/attributes/calc.mjs
+++ b/src/dia/attributes/calc.mjs
@@ -10,7 +10,7 @@ const props = {
 const propsList = Object.keys(props).map(key => props[key]).join('');
 const numberPattern = '[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?';
 const findSpacesRegex = /\s/g;
-const parseExpressionRegExp = new RegExp(`^(${numberPattern}\\*)?([${propsList}])([-+]{1,2}${numberPattern})?$`, 'g');
+const parseExpressionRegExp = new RegExp(`^(${numberPattern}\\*)?([${propsList}])(/${numberPattern})?([-+]{1,2}${numberPattern})?$`, 'g');
 
 function throwInvalid(expression) {
     throw new Error(`Invalid calc() expression: ${expression}`);
@@ -20,7 +20,7 @@ export function evalCalcExpression(expression, bbox) {
     const match = parseExpressionRegExp.exec(expression.replace(findSpacesRegex, ''));
     if (!match) throwInvalid(expression);
     parseExpressionRegExp.lastIndex = 0; // reset regex results for the next run
-    const [,multiply = 1, property, add = 0] = match;
+    const [,multiply, property, divide, add = 0] = match;
     const { x, y, width, height } = bbox;
     let value = 0;
     switch (property) {
@@ -53,7 +53,18 @@ export function evalCalcExpression(expression, bbox) {
             break;
         }
     }
-    return parseFloat(multiply) * value + evalAddExpression(add);
+    if (multiply) {
+        // e.g "2*"
+        value *= parseFloat(multiply);
+    }
+    if (divide) {
+        // e.g "/2"
+        value /= parseFloat(divide.slice(1));
+    }
+    if (add) {
+        value += evalAddExpression(add);
+    }
+    return value;
 }
 
 function evalAddExpression(addExpression) {

--- a/src/dia/attributes/calc.mjs
+++ b/src/dia/attributes/calc.mjs
@@ -20,7 +20,7 @@ export function evalCalcExpression(expression, bbox) {
     const match = parseExpressionRegExp.exec(expression.replace(findSpacesRegex, ''));
     if (!match) throwInvalid(expression);
     parseExpressionRegExp.lastIndex = 0; // reset regex results for the next run
-    const [,multiply, property, divide, add = 0] = match;
+    const [,multiply, property, divide, add] = match;
     const { x, y, width, height } = bbox;
     let value = 0;
     switch (property) {

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -411,9 +411,18 @@ QUnit.module('Attributes', function() {
                 ['calc(2*h+10)', String(HEIGHT * 2 + 10)],
                 ['calc(w+-10)', String(WIDTH - 10)],
                 ['calc(h--10)', String(HEIGHT + 10)],
+                // division
+                ['calc(w/2)', String(WIDTH / 2)],
+                ['calc(h/3)', String(HEIGHT / 3)],
+                ['calc(w/2.5)', String(WIDTH / 2.5)],
+                ['calc(w/1e-1)', String(WIDTH / 1e-1)],
+                ['calc(3*w/2)', String(3 * WIDTH / 2)],
+                ['calc(4*w/2+1)', String(4 * WIDTH / 2 + 1)],
+                ['calc(4*w/2-1)', String(4 * WIDTH / 2 - 1)],
                 // spaces
                 ['calc( 2 * w + 10 )', String(WIDTH * 2 + 10)],
                 ['calc( 2 * h + 10 )', String(HEIGHT * 2 + 10)],
+                ['calc( 3 * w / 2 + 10 )', String(WIDTH * 3 / 2 + 10)],
                 // multiple expressions
                 ['M 0 0 calc(w) calc(h) 200 200', 'M 0 0 ' + WIDTH + ' ' + HEIGHT + ' 200 200'],
                 ['M 0 0 calc(w+10) calc(h+10)', 'M 0 0 ' + (WIDTH + 10) + ' ' + (HEIGHT + 10)],


### PR DESCRIPTION
Make `calc()` expression understand division to increase the comfort and precision.
```js
// precision
calc(0.3333 * w)
// vs.
calc(w / 3)

// comfort
calc(0.5 * w)
// vs.
calc(w / 2)
```