### PR TITLE
util.breakText: add preserveSpaces options

### DIFF
--- a/docs/src/joint/api/util/breakText.html
+++ b/docs/src/joint/api/util/breakText.html
@@ -34,7 +34,7 @@
     <li><code>opt.svgDocument</code> - an SVG document to which the temporary SVG text element should be added. By default, an SVG document is created automatically for you.</li>
     <li><code>opt.hyphen</code> - a string or regex representing the hyphen symbol. If required, the method tries to break long words at hyphens first.</li>
     <li><code>opt.maxLineCount</code> - a number to limit the maximum number of lines.</li>
-    <li><code>opt.preserveSpaces</code> - preserve the text spaces (avoid all consecutive spaces to be deleted and replaced by one space, and preserve a space at the beginning and the end of the text).</li>
+    <li><code>opt.preserveSpaces</code> - preserve the text spaces (avoid all consecutive spaces being deleted and replaced by one space, and preserve a space at the beginning and the end of the text).</li>
 </ul>
 
 <p>Examples of text with the <code>ellipsis</code> option specified:</p>

--- a/docs/src/joint/api/util/breakText.html
+++ b/docs/src/joint/api/util/breakText.html
@@ -34,6 +34,7 @@
     <li><code>opt.svgDocument</code> - an SVG document to which the temporary SVG text element should be added. By default, an SVG document is created automatically for you.</li>
     <li><code>opt.hyphen</code> - a string or regex representing the hyphen symbol. If required, the method tries to break long words at hyphens first.</li>
     <li><code>opt.maxLineCount</code> - a number to limit the maximum number of lines.</li>
+    <li><code>opt.preserveSpaces</code> - preserve the text spaces (avoid all consecutive spaces to be deleted and replaced by one space, and preserve a space at the beginning and the end of the text).</li>
 </ul>
 
 <p>Examples of text with the <code>ellipsis</code> option specified:</p>

--- a/src/dia/attributes/index.mjs
+++ b/src/dia/attributes/index.mjs
@@ -399,7 +399,8 @@ const attributesNS = {
                     svgDocument: this.paper.svg,
                     ellipsis: value.ellipsis,
                     hyphen: value.hyphen,
-                    maxLineCount: value.maxLineCount
+                    maxLineCount: value.maxLineCount,
+                    preserveSpaces: value.preserveSpaces
                 });
             } else {
                 wrappedText = '';

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -246,6 +246,97 @@ QUnit.module('util', function(hooks) {
             assert.equal(r, '\na\n\nb\n\n');
         });
 
+        QUnit.test('preserveSpaces', function(assert) {
+
+            var WIDTH = 100;
+            var r;
+
+            r = joint.util.breakText(' ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, ' ');
+
+            r = joint.util.breakText('  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '  ');
+
+            r = joint.util.breakText('                       ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r.replace(/\n/g, ' '), '                       ');
+
+            r = joint.util.breakText(' a', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, ' a');
+
+            r = joint.util.breakText('  a', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '  a');
+
+            r = joint.util.breakText('b ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'b ');
+
+            r = joint.util.breakText('b  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'b  ');
+
+            r = joint.util.breakText('a b', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a b');
+
+            r = joint.util.breakText('a  b', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a  b');
+
+            r = joint.util.breakText('  a b  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '  a b  ');
+
+            r = joint.util.breakText('  a  b  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '  a  b  ');
+
+            r = joint.util.breakText('a\nb', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\nb', 'a\\nb');
+
+            r = joint.util.breakText('a\n b', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\n b', 'a\\n_b');
+
+            r = joint.util.breakText('a\n  b', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\n  b', 'a\\n__b');
+
+            r = joint.util.breakText('b\n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'b\n', 'b\\n');
+
+            r = joint.util.breakText('b \n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'b \n', 'b_\\n');
+
+            r = joint.util.breakText('\na', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '\na', '\\na');
+
+            r = joint.util.breakText(' \na', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, ' \na', '_\\na');
+
+            r = joint.util.breakText('\n a', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '\n a', '\\n_a');
+
+            r = joint.util.breakText('\n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '\n', '\\n');
+
+            r = joint.util.breakText('\n\n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '\n\n', '\\n\\n');
+
+            r = joint.util.breakText('\n\n\n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, '\n\n\n', '\\n\\n\n');
+
+            r = joint.util.breakText('a\nb\n', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\nb\n', 'a\\nb\\n');
+
+            r = joint.util.breakText('a\n\nc', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\n\nc', 'a\\n\\nc');
+
+            r = joint.util.breakText('a\nb\nc', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\nb\nc', 'a\\nb\\nc');
+
+            r = joint.util.breakText('a\nb\nca\nb\nc', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r, 'a\nb\nca\nb\nc', 'a\\nb\\nca\\nb\\nc');
+
+            r = joint.util.breakText('   preserve space   test  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r.replace(/\n/g, ' '), '   preserve space   test  ');
+
+            r = joint.util.breakText('   preserve\nspa   a  ', { width: WIDTH }, styles, { preserveSpaces: true });
+            assert.equal(r.replace(/\n/g, ' '), '   preserve spa   a  ');
+
+        });
+
     });
 
     QUnit.test('util.parseCssNumeric', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -2813,6 +2813,7 @@ export namespace util {
             ellipsis?: boolean | string;
             hyphen?: string | RegExp;
             maxLineCount?: number;
+            preserveSpaces?: boolean;
         }
     ) => string;
 
@@ -3771,6 +3772,7 @@ export namespace attributes {
         ellipsis?: boolean | string;
         hyphen?: string;
         maxLineCount?: number;
+        preserveSpaces?: boolean;
         breakText?: util.BreakTextFunction;
         [key: string]: any;
         /**


### PR DESCRIPTION
Add option to preserve the text spaces (avoid all consecutive spaces to be deleted and replaced by one space, and preserve a space at the beginning and the end of the text) while text wrapping.