### PR TITLE
types: fix on event handler types when passed an events object

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1583,7 +1583,7 @@ export namespace dia {
 
         on<T extends keyof Paper.EventMap = keyof Paper.EventMap>(eventName: T, callback: Paper.EventMap[T], context?: any): this;
 
-        on<T extends keyof Paper.EventMap = keyof Paper.EventMap>(events: { [eventName in T]: Paper.EventMap[T]; }, context?: any): this;
+        on<T extends keyof Paper.EventMap = keyof Paper.EventMap>(events: { [eventName in T]: Paper.EventMap[eventName]; }, context?: any): this;
 
         // protected
 


### PR DESCRIPTION
Before these changes this didn't had the correct types, it just had `any`:

```ts
paper.on({
	'link:mouseenter': (linkView) => {
	},
})
```

With this changes `linkView` correctly has the `joint.dia.LinkView`