### PR TITLE
types: fix Paper.Options el type

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1213,6 +1213,7 @@ export namespace dia {
         type FindParentByCallback = ((this: dia.Graph, elementView: ElementView, evt: dia.Event, x: number, y: number) => Cell[]);
 
         interface Options extends mvc.ViewOptions<Graph> {
+            el: HTMLElement;
             // appearance
             width?: Dimension;
             height?: Dimension;


### PR DESCRIPTION
reference: https://resources.jointjs.com/docs/jointjs/v3.5/joint.html#dia.Paper.constructor

```tsx
var graph = new joint.dia.Graph
var paper = new joint.dia.Paper({
    el: $('#paper'),
    width: 600,
    height: 400,
    gridSize: 10,
    model: graph
});
```

previously this example showed an error with typescript about the property `el` not being defined.