### PR TITLE
types: fix cell.prop object types

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -349,7 +349,7 @@ export namespace dia {
         isEmbedded(): boolean;
 
         prop(key: Path): any;
-        prop(object: A, opt?: Cell.Options): this;
+        prop(object: Partial<A>, opt?: Cell.Options): this;
         prop(key: Path, value: any, opt?: Cell.Options): this;
 
         removeProp(path: Path, opt?: Cell.Options): this;


### PR DESCRIPTION
Fixes

```ts
const cell = new dia.Cell<{foo: string, bar: string}>({foo: 'foo', bar: 'bar'})

cell.prop({foo: 'foo2'}) // this would fail because it was asking for the bar property
```