### PR TITLE
types: allow passing generic attributes to links under shapes.standard

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -2153,7 +2153,7 @@ export namespace shapes {
 
         type LinkAttributes = dia.Link.GenericAttributes<LinkSelectors>;
 
-        class Link extends dia.Link<LinkAttributes> {
+        class Link<A = dia.Link.Attributes> extends dia.Link<A> {
         }
 
         interface DoubleLinkSelectors extends dia.Cell.Selectors {
@@ -2164,7 +2164,7 @@ export namespace shapes {
 
         type DoubleLinkAttributes = dia.Link.GenericAttributes<DoubleLinkSelectors>;
 
-        class DoubleLink extends dia.Link<DoubleLinkAttributes> {
+        class DoubleLink<A = dia.Link.Attributes> extends dia.Link<A> {
         }
 
         interface ShadowLinkSelectors extends dia.Cell.Selectors {
@@ -2175,7 +2175,7 @@ export namespace shapes {
 
         type ShadowLinkAttributes = dia.Link.GenericAttributes<ShadowLinkSelectors>;
 
-        class ShadowLink extends dia.Link<ShadowLinkAttributes> {
+        class ShadowLink<A = dia.Link.Attributes> extends dia.Link<A> {
         }
     }
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -2153,7 +2153,7 @@ export namespace shapes {
 
         type LinkAttributes = dia.Link.GenericAttributes<LinkSelectors>;
 
-        class Link<A = dia.Link.Attributes> extends dia.Link<A> {
+        class Link<A = LinkAttributes> extends dia.Link<A> {
         }
 
         interface DoubleLinkSelectors extends dia.Cell.Selectors {
@@ -2164,7 +2164,7 @@ export namespace shapes {
 
         type DoubleLinkAttributes = dia.Link.GenericAttributes<DoubleLinkSelectors>;
 
-        class DoubleLink<A = dia.Link.Attributes> extends dia.Link<A> {
+        class DoubleLink<A = DoubleLinkAttributes> extends dia.Link<A> {
         }
 
         interface ShadowLinkSelectors extends dia.Cell.Selectors {
@@ -2175,7 +2175,7 @@ export namespace shapes {
 
         type ShadowLinkAttributes = dia.Link.GenericAttributes<ShadowLinkSelectors>;
 
-        class ShadowLink<A = dia.Link.Attributes> extends dia.Link<A> {
+        class ShadowLink<A = ShadowLinkAttributes> extends dia.Link<A> {
         }
     }
 


### PR DESCRIPTION
dia.Link currently allows this but shapes.standard.Link does not:

```ts
interface Attributes {
  foo: string;
}

class CustomLink extends dia.Link<Attributes> {} // dia.Link is generic

class CustomLink2 extends shapes.standard.Link<Attributes> {} // this is not possible with current types

const link = new CustomLink({
  // nice autocomplete here in the editor for `foo` variable
  foo: "foo",
});

const link2 = new CustomLink2({
  // no auto completion and no warnings that a number was passed instead of a string
  foo: 3,
});
```