### PR TITLE
linkTools, elementTools: add scale option

### DIFF
--- a/docs/src/joint/api/elementTools/Button.html
+++ b/docs/src/joint/api/elementTools/Button.html
@@ -31,6 +31,11 @@
         <td><i><a href="#dia.Cell.markup.json">JSONMarkup</a></i></td>
         <td>The markup of the button, provided in the <a href="#dia.Cell.markup.json">JointJS JSON format</a>. Default is <code>undefined</code> (no content).</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example of a useful custom info button:</p>

--- a/docs/src/joint/api/elementTools/Button.html
+++ b/docs/src/joint/api/elementTools/Button.html
@@ -34,7 +34,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the button up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/elementTools/Control.html
+++ b/docs/src/joint/api/elementTools/Control.html
@@ -16,6 +16,11 @@
         <td><i>function</i></td>
         <td>An object with SVG attributes to be applied to the tool's handle.</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <pre><code>namespace Control {

--- a/docs/src/joint/api/elementTools/Control.html
+++ b/docs/src/joint/api/elementTools/Control.html
@@ -19,7 +19,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the button up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/elementTools/Remove.html
+++ b/docs/src/joint/api/elementTools/Remove.html
@@ -34,6 +34,11 @@
         <td><i><a href="#dia.Cell.markup.json">JSONMarkup</a></i></td>
         <td>The markup of the button, provided in the <a href="#dia.Cell.markup.json">JointJS JSON format</a>. Default is <code>undefined</code> (no content).</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example:</p>

--- a/docs/src/joint/api/elementTools/Remove.html
+++ b/docs/src/joint/api/elementTools/Remove.html
@@ -37,7 +37,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the button up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/Button.html
+++ b/docs/src/joint/api/linkTools/Button.html
@@ -36,7 +36,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the button up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/Button.html
+++ b/docs/src/joint/api/linkTools/Button.html
@@ -33,6 +33,11 @@
         <td><i><a href="#dia.Cell.markup.json">JSONMarkup</a></i></td>
         <td>The markup of the button, provided in the <a href="#dia.Cell.markup.json">JointJS JSON format</a>. Default is <code>undefined</code> (no content).</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example of a useful custom info button:</p>

--- a/docs/src/joint/api/linkTools/Remove.html
+++ b/docs/src/joint/api/linkTools/Remove.html
@@ -62,7 +62,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the button up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/Remove.html
+++ b/docs/src/joint/api/linkTools/Remove.html
@@ -59,6 +59,11 @@
 }]</code></pre>
         </td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the button up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example:</p>

--- a/docs/src/joint/api/linkTools/Segments.html
+++ b/docs/src/joint/api/linkTools/Segments.html
@@ -34,7 +34,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the segment handles up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the segment handles up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/Segments.html
+++ b/docs/src/joint/api/linkTools/Segments.html
@@ -31,6 +31,11 @@
         <td><i>mvc.View</i></td>
         <td>The view for the segment handle. By default it uses <code>linkTools.Segments.SegmentHandle</code> class.</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the segment handles up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example:</p>

--- a/docs/src/joint/api/linkTools/SourceAnchor.html
+++ b/docs/src/joint/api/linkTools/SourceAnchor.html
@@ -76,7 +76,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the anchor element up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the anchor element up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/SourceAnchor.html
+++ b/docs/src/joint/api/linkTools/SourceAnchor.html
@@ -1,4 +1,4 @@
-<p>The <code>SourceAnchor</code> link tool renders a handle above the source anchor of the link (as determined by the <a href="#dia.Link.geometry.anchor">anchor function</a> applied on <a href="#dia.Link.geometry.source">link source</a>). It accepts five additional arguments, which can be passed as an object to the link tool constructor:</p>
+<p>The <code>SourceAnchor</code> link tool renders a handle above the source anchor of the link (as determined by the <a href="#dia.Link.geometry.anchor">anchor function</a> applied on <a href="#dia.Link.geometry.source">link source</a>). It accepts several additional arguments, which can be passed as an object to the link tool constructor:</p>
 
 <table>
     <tr>
@@ -72,6 +72,11 @@
                 </tr>
             </table>
         </td>
+    </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the anchor element up or down on the 2D plane. Default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/SourceArrowhead.html
+++ b/docs/src/joint/api/linkTools/SourceArrowhead.html
@@ -4,7 +4,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the arrowhead element up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the arrowhead element up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/SourceArrowhead.html
+++ b/docs/src/joint/api/linkTools/SourceArrowhead.html
@@ -1,4 +1,12 @@
-<p>The <code>SourceArrowhead</code> link tool renders an arrow-like handle above the source connection point of the link (as determined by the <a href="#dia.Link.geometry.connectionPoint">connectionPoint function</a> applied on <a href="#dia.Link.geometry.source">link source</a>).</p>
+<p>The <code>SourceArrowhead</code> link tool renders an arrow-like handle above the source connection point of the link (as determined by the <a href="#dia.Link.geometry.connectionPoint">connectionPoint function</a> applied on <a href="#dia.Link.geometry.source">link source</a>). It accepts a few additional arguments, which can be passed as an object to the link tool constructor:</p>
+
+<table>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the arrowhead element up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
+</table>
 
 <p>Example:</p>
 

--- a/docs/src/joint/api/linkTools/TargetAnchor.html
+++ b/docs/src/joint/api/linkTools/TargetAnchor.html
@@ -76,7 +76,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the anchor element up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the anchor element up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/TargetAnchor.html
+++ b/docs/src/joint/api/linkTools/TargetAnchor.html
@@ -1,4 +1,4 @@
-<p>The <code>TargetAnchor</code> link tool renders a handle above the target anchor of the link (as determined by the <a href="#dia.Link.geometry.anchor">anchor function</a> applied on <a href="#dia.Link.geometry.target">link target</a>). It accepts five additional arguments, which can be passed as an object to the link tool constructor:</p>
+<p>The <code>TargetAnchor</code> link tool renders a handle above the target anchor of the link (as determined by the <a href="#dia.Link.geometry.anchor">anchor function</a> applied on <a href="#dia.Link.geometry.target">link target</a>). It accepts several additional arguments, which can be passed as an object to the link tool constructor:</p>
 
 <table>
     <tr>
@@ -72,6 +72,11 @@
                 </tr>
             </table>
         </td>
+    </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the anchor element up or down on the 2D plane. Default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/TargetArrowhead.html
+++ b/docs/src/joint/api/linkTools/TargetArrowhead.html
@@ -4,7 +4,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the arrowhead element up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the arrowhead element up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/docs/src/joint/api/linkTools/TargetArrowhead.html
+++ b/docs/src/joint/api/linkTools/TargetArrowhead.html
@@ -1,4 +1,12 @@
-<p>The <code>TargetArrowhead</code> link tool renders an arrow-like handle above the target connection point of the link (as determined by the <a href="#dia.Link.geometry.connectionPoint">connectionPoint function</a> applied on <a href="#dia.Link.geometry.target">link target</a>).</p>
+<>The <code>TargetArrowhead</code> link tool renders an arrow-like handle above the target connection point of the link (as determined by the <a href="#dia.Link.geometry.connectionPoint">connectionPoint function</a> applied on <a href="#dia.Link.geometry.target">link target</a>). It accepts a few additional arguments, which can be passed as an object to the link tool constructor:</p>
+
+<table>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the arrowhead element up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
+</table>
 
 <p>Example:</p>
 

--- a/docs/src/joint/api/linkTools/Vertices.html
+++ b/docs/src/joint/api/linkTools/Vertices.html
@@ -26,6 +26,11 @@
         <td><i>mvc.View</i></td>
         <td>The view for the vertex handle. By default it uses <code>linkTools.Vertices.VertexHandle</code> class.</td>
     </tr>
+    <tr>
+        <th>scale</th>
+        <td><i>number</i></td>
+        <td>Scale the vertices handles up or down on the 2D plane. Default is <code>1</code>.</td>
+    </tr>
 </table>
 
 <p>Example:</p>

--- a/docs/src/joint/api/linkTools/Vertices.html
+++ b/docs/src/joint/api/linkTools/Vertices.html
@@ -29,7 +29,7 @@
     <tr>
         <th>scale</th>
         <td><i>number</i></td>
-        <td>Scale the vertices handles up or down on the 2D plane. Default is <code>1</code>.</td>
+        <td>Scale the vertices handles up or down on a 2D plane. The default is <code>1</code>.</td>
     </tr>
 </table>
 

--- a/src/elementTools/Control.mjs
+++ b/src/elementTools/Control.mjs
@@ -42,6 +42,7 @@ export const Control = ToolView.extend({
         handleAttributes: null,
         selector: 'root',
         padding: 6,
+        scale: null
     },
 
     getPosition: function() {
@@ -75,8 +76,12 @@ export const Control = ToolView.extend({
         const { model } = relatedView;
         const relativePos = this.getPosition(relatedView, this);
         const absolutePos = model.getAbsolutePointFromRelative(relativePos);
-        handleNode.setAttribute('transform', `translate(${absolutePos.x},${absolutePos.y})`);
-        const { handleAttributes } = options;
+        const { handleAttributes, scale } = options;
+        let transformString =  `translate(${absolutePos.x},${absolutePos.y})`;
+        if (scale) {
+            transformString += ` scale(${scale})`;
+        }
+        handleNode.setAttribute('transform', transformString);
         if (handleAttributes) {
             for (let attrName in handleAttributes) {
                 handleNode.setAttribute(attrName, handleAttributes[attrName]);

--- a/src/linkTools/Anchor.mjs
+++ b/src/linkTools/Anchor.mjs
@@ -40,6 +40,7 @@ const Anchor = ToolView.extend({
     options: {
         snap: snapAnchor,
         anchor: getAnchor,
+        scale: null,
         resetAnchor: true,
         customAnchorAttributes: {
             'stroke-width': 4,
@@ -86,7 +87,11 @@ const Anchor = ToolView.extend({
         var position = relatedView.getEndAnchor(type);
         var options = this.options;
         var customAnchor = relatedView.model.prop([type, 'anchor']);
-        anchorNode.setAttribute('transform', 'translate(' + position.x + ',' + position.y + ')');
+        let transformString =  `translate(${position.x},${position.y})`;
+        if (options.scale) {
+            transformString += ` scale(${options.scale})`;
+        }
+        anchorNode.setAttribute('transform', transformString);
         var anchorAttributes = (customAnchor) ? options.customAnchorAttributes : options.defaultAnchorAttributes;
         for (var attrName in anchorAttributes) {
             anchorNode.setAttribute(attrName, anchorAttributes[attrName]);

--- a/src/linkTools/Arrowhead.mjs
+++ b/src/linkTools/Arrowhead.mjs
@@ -18,6 +18,9 @@ const Arrowhead = ToolView.extend({
         touchend: 'onPointerUp',
         touchcancel: 'onPointerUp'
     },
+    options: {
+        scale: null
+    },
     onRender: function() {
         this.update();
     },
@@ -35,6 +38,8 @@ const Arrowhead = ToolView.extend({
         }
         if (!position) return this;
         var matrix = V.createSVGMatrix().translate(position.x, position.y).rotate(angle);
+        const { scale } = this.options;
+        if (scale) matrix = matrix.scale(scale);
         this.vel.transform(matrix, { absolute: true });
         return this;
     },

--- a/src/linkTools/Button.mjs
+++ b/src/linkTools/Button.mjs
@@ -14,6 +14,7 @@ export const Button = ToolView.extend({
     options: {
         distance: 0,
         offset: 0,
+        scale: null,
         rotate: false
     },
     onRender: function() {
@@ -31,7 +32,7 @@ export const Button = ToolView.extend({
     },
     getElementMatrix() {
         const { relatedView: view, options } = this;
-        let { x = 0, y = 0, offset = {}, useModelGeometry, rotate } = options;
+        let { x = 0, y = 0, offset = {}, useModelGeometry, rotate, scale } = options;
         let bbox = getViewBBox(view, useModelGeometry);
         const angle = view.model.angle();
         if (!rotate) bbox = bbox.bbox(angle);
@@ -49,11 +50,12 @@ export const Button = ToolView.extend({
         let matrix = V.createSVGMatrix().translate(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
         if (rotate) matrix = matrix.rotate(angle);
         matrix = matrix.translate(x + offsetX - bbox.width / 2, y + offsetY - bbox.height / 2);
+        if (scale) matrix = matrix.scale(scale);
         return matrix;
     },
     getLinkMatrix() {
         const { relatedView: view, options } = this;
-        const { offset = 0, distance = 0, rotate } = options;
+        const { offset = 0, distance = 0, rotate, scale } = options;
         let tangent, position, angle;
         if (util.isPercentage(distance)) {
             tangent = view.getTangentAtRatio(parseFloat(distance) / 100);
@@ -72,6 +74,7 @@ export const Button = ToolView.extend({
             .rotate(angle)
             .translate(0, offset);
         if (!rotate) matrix = matrix.rotate(-angle);
+        if (scale) matrix = matrix.scale(scale);
         return matrix;
     },
     onPointerDown: function(evt) {

--- a/src/linkTools/Segments.mjs
+++ b/src/linkTools/Segments.mjs
@@ -48,8 +48,10 @@ var SegmentHandle = mvc.View.extend({
         this.renderChildren();
     },
     position: function(x, y, angle, view) {
+        const { scale } = this.options;
+        let matrix = V.createSVGMatrix().translate(x, y).rotate(angle);
+        if (scale) matrix = matrix.scale(scale);
 
-        var matrix = V.createSVGMatrix().translate(x, y).rotate(angle);
         var handle = this.childNodes.handle;
         handle.setAttribute('transform', V.matrixToTransformString(matrix));
         handle.setAttribute('cursor', (angle % 180 === 0) ? 'row-resize' : 'col-resize');
@@ -117,6 +119,7 @@ export const Segments = ToolView.extend({
     renderHandle: function(vertex, nextVertex) {
         var handle = new (this.options.handleClass)({
             paper: this.paper,
+            scale: this.options.scale,
             guard: evt => this.guard(evt)
         });
         handle.render();

--- a/src/linkTools/Vertices.mjs
+++ b/src/linkTools/Vertices.mjs
@@ -2,6 +2,7 @@ import * as g from '../g/index.mjs';
 import * as util from '../util/index.mjs';
 import * as mvc from '../mvc/index.mjs';
 import { ToolView } from '../dia/ToolView.mjs';
+import V from '../V/index.mjs';
 
 
 // Vertex Handles
@@ -30,7 +31,11 @@ var VertexHandle = mvc.View.extend({
         'cursor': 'move'
     },
     position: function(x, y) {
-        this.vel.attr({ cx: x, cy: y });
+        const { vel, options } = this;
+        const { scale } = options;
+        let matrix = V.createSVGMatrix().translate(x, y);
+        if (scale) matrix = matrix.scale(scale);
+        vel.transform(matrix, { absolute: true });
     },
     onPointerDown: function(evt) {
         if (this.options.guard(evt)) return;
@@ -60,7 +65,8 @@ export const Vertices = ToolView.extend({
         snapRadius: 20,
         redundancyRemoval: true,
         vertexAdding: true,
-        stopPropagation: true
+        stopPropagation: true,
+        scale: null
     },
     children: [{
         tagName: 'path',
@@ -118,6 +124,7 @@ export const Vertices = ToolView.extend({
             var handle = new (this.options.handleClass)({
                 index: i,
                 paper: this.paper,
+                scale: this.options.scale,
                 guard: evt => this.guard(evt)
             });
             handle.render();

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3990,6 +3990,7 @@ export namespace elementTools {
             action?: ActionCallback;
             markup?: dia.MarkupJSON;
             useModelGeometry?: boolean;
+            scale?: number;
         }
     }
 
@@ -4044,6 +4045,7 @@ export namespace elementTools {
             selector?: string | null;
             padding?: number;
             handleAttributes?: Partial<attributes.NativeSVGAttributes>;
+            scale?: number;
         }
     }
 
@@ -4093,6 +4095,7 @@ export namespace linkTools {
             redundancyRemoval?: boolean;
             vertexAdding?: boolean;
             stopPropagation?: boolean;
+            scale?: number;
         }
     }
 
@@ -4120,6 +4123,7 @@ export namespace linkTools {
             segmentLengthThreshold?: number;
             anchor?: AnchorCallback<anchors.AnchorJSON>;
             stopPropagation?: boolean;
+            scale?: number;
         }
     }
 
@@ -4128,10 +4132,19 @@ export namespace linkTools {
         constructor(opt?: Segments.Options);
     }
 
+    namespace Arrowhead {
+
+        interface Options extends dia.ToolView.Options {
+            scale?: number;
+        }
+    }
+
     abstract class Arrowhead extends dia.ToolView {
 
         ratio: number;
         arrowheadType: string;
+
+        constructor(opt?: Arrowhead.Options);
 
         protected onPointerDown(evt: dia.Event): void;
 
@@ -4161,6 +4174,7 @@ export namespace linkTools {
             snapRadius?: number;
             restrictArea?: boolean;
             redundancyRemoval?: boolean;
+            scale?: number;
         }
     }
 
@@ -4191,6 +4205,7 @@ export namespace linkTools {
             rotate?: boolean;
             action?: ActionCallback;
             markup?: dia.MarkupJSON;
+            scale?: number;
         }
     }
 


### PR DESCRIPTION
Add an option to easily change the size of the tools.

```js
// enlarge the tools 2x
const tools1 = new dia.ToolsView({
    tools: [
        new linkTools.TargetArrowhead({ scale: 2 }),
        new linkTools.SourceArrowhead({ scale: 2 }),
        new linkTools.Vertices({ scale: 2 }),
        new linkTools.Segments({ scale: 2 }),
        new linkTools.SourceAnchor({ scale: 2 }),
        new linkTools.TargetAnchor({ scale: 2 })
    ]
});

// shrink the tools to half their original size
const tools2 = new dia.ToolsView({
    tools: [
        new elementTools.Control({ scale: 0.5 }),
        new elementTools.Button({ scale: 0.5 }),
        new elementTools.Connect({ scale: 0.5 })
    ]
});
```