### PR TITLE
chore: add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Something doesn't work like it should? Tell us!
+title: "[Bug]: "
+labels: ["bug"]
+assignees: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! If you need to ask a general question, create a github [discussion](https://github.com/clientIO/joint/discussions).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen? If relevant, add code examples, screenshots, steps to reproduce, etc.
+      placeholder: Describe the bug!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our library are you running?
+      placeholder: X.Y.Z
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: dropdown
+    id: os
+    attributes:
+      label: What operating system are you seeing the problem on?
+      multiple: true
+      options:
+        - Windows
+        - Mac
+        - Linux

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Join our GitHub Discussions community
+    url: https://github.com/clientIO/joint/discussions
+    about: Ask and discuss questions with other community members


### PR DESCRIPTION
- Add Issue template for bugs. Template will render as form for the user as shown in the picture below (Tested on personal repo).
- label `bug` will automatically be added to issue
- `title`, `what happened?`, and `version` are required
- `browser` and `os` are optional
- Add link to github discussions at beginning to make sure people create a discussion for general question
<img width="1319" alt="Screenshot 2022-08-05 at 11 16 09" src="https://user-images.githubusercontent.com/42288565/183048758-86be3096-d0ed-403e-8ac4-c489d769cdb0.png">

After clicking on new issue, the following will be displayed:
- `config.yml` contains `blank_issues_enabled` as false. That means users cannot create a blank issue anymore in this section. They have to create a bug report or discussion.
- The `SECURITY.md` policy will be displayed here too to show the user how to report a problem
- Add link to github discussions in this section
<img width="1350" alt="Screenshot 2022-08-05 at 11 14 47" src="https://user-images.githubusercontent.com/42288565/183050257-8cbf4c26-9f8a-4550-bdd6-21a469f0bb08.png">


Blog describing process on github:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

Microsoft examples:
https://github.com/microsoft/vscode/tree/main/.github/ISSUE_TEMPLATE
https://github.com/microsoft/playwright/tree/main/.github/ISSUE_TEMPLATE