### PR TITLE
docs: update dia.Element.prototype.prop with change event

### DIFF
--- a/docs/src/joint/api/dia/Element/prototype/prop.html
+++ b/docs/src/joint/api/dia/Element/prototype/prop.html
@@ -31,6 +31,25 @@ element.prop('custom/state', { isActive: false }, { rewrite: true });
 }
 </code></pre>
 
+<p>
+    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the change event in JointJS.
+    <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values which can be accessed when 
+    updating the model. This can prove useful if for some reason you need to listen to a specific attribute change.
+</p>
+
+<pre><code>graph.on('change', (cell, opt) => {
+    console.log(opt); 
+    // --> {propertyPath: 'attrs/body/fill', propertyValue: 'cornflowerblue', propertyPathArray: Array(3)}
+
+    if ('attrs' in cell.changed) {
+        console.log(opt.propertyPathArray, 'was changed'); 
+        // --> ['attrs', 'body', 'fill'] 'was changed'
+    }
+});
+
+element.prop('attrs/body/fill', 'cornflowerblue');  
+</code></pre>
+
 
 <p><i>Advanced:</i> Pass <code>{ isolate: true }</code> if the property change does not affect the connected links. Typically, changing the element fill color has zero effect on attached links. By default, the element and all connected links are updated.</p>
 

--- a/docs/src/joint/api/dia/Element/prototype/prop.html
+++ b/docs/src/joint/api/dia/Element/prototype/prop.html
@@ -32,9 +32,10 @@ element.prop('custom/state', { isActive: false }, { rewrite: true });
 </code></pre>
 
 <p>
-    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the change event in JointJS.
-    <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values which can be accessed when 
-    updating the model. This can prove useful if for some reason you need to listen to a specific attribute change.
+    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the
+    change event in JointJS. <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values
+    which can be accessed when updating the model. This can prove useful if for some reason you need to listen to a specific
+    attribute change.
 </p>
 
 <pre><code>graph.on('change', (cell, opt) => {

--- a/docs/src/joint/api/dia/Link/prototype/prop.html
+++ b/docs/src/joint/api/dia/Link/prototype/prop.html
@@ -32,9 +32,10 @@ link.prop('custom/state', { isActive: false }, { rewrite: true });
 </code></pre>
 
 <p>
-    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the change event in JointJS.
-    <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values which can be accessed when 
-    updating the model. This can prove useful if for some reason you need to listen to a specific attribute change.
+    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the
+    change event in JointJS. <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values
+    which can be accessed when updating the model. This can prove useful if for some reason you need to listen to a specific
+    attribute change.
 </p>
 
 <pre><code>graph.on('change', (cell, opt) => {

--- a/docs/src/joint/api/dia/Link/prototype/prop.html
+++ b/docs/src/joint/api/dia/Link/prototype/prop.html
@@ -10,7 +10,7 @@ link.prop({ mylist: [ { data: [ { value: 50 } ] } ] })</code></pre>
 
 <p>As you can see, this is the exact same method as the <a href="#dia.Element.prototype.prop">joint.dia.Element.prop()</a> method.</p>
 
-To overwrite attributes, enable rewrite mode by adding { rewrite: true } as the 3rd argument. This differs from the default behaviour which is to merge our properties.
+To overwrite attributes, enable rewrite mode by adding <code>{ rewrite: true }</code> as the 3rd argument. This differs from the default behaviour which is to merge our properties.
 
 <pre><code>link.prop('custom/state/isVisible', true);
 link.prop('custom/state', { isActive: false }, { rewrite: true });
@@ -30,6 +30,26 @@ link.prop('custom/state', { isActive: false }, { rewrite: true });
     "attrs": {}
 }
 </code></pre>
+
+<p>
+    When changing model attributes via <code>prop()</code> or <code>attr()</code>, some useful information is passed along with the change event in JointJS.
+    <code>propertyPath</code>, <code>propertyValue</code>, and <code>propertyPathArray</code> are all values which can be accessed when 
+    updating the model. This can prove useful if for some reason you need to listen to a specific attribute change.
+</p>
+
+<pre><code>graph.on('change', (cell, opt) => {
+    console.log(opt); 
+    // --> {propertyPath: 'attrs/line/targetMarker/fill', propertyValue: 'cornflowerblue', propertyPathArray: Array(4)}
+
+    if ('attrs' in cell.changed) {
+        console.log(opt.propertyPathArray, 'was changed'); 
+        // --> ['attrs', 'line', 'targetMarker', 'fill'] 'was changed'
+    }
+});
+
+link.prop('attrs/line/targetMarker/fill', 'cornflowerblue');  
+</code></pre>
+
 
 
 <p><i>Advanced:</i> Pass <code>{ isolate: true }</code> if the property change does not affect the connected links. Typically, changing the link color has zero effect on attached links. By default, the link and all connected links are updated.</p>

--- a/tutorials/custom-attributes.html
+++ b/tutorials/custom-attributes.html
@@ -54,72 +54,69 @@
         will merge the properties you want to set with existing ones already present in the <i>Cell</i>.
     </p>
 
-    <pre><code>
-    element.prop('attrs/body/stroke', '#FFF'); // Set presentation attribute
+    <pre><code>element.prop('attrs/body/stroke', '#FFF'); // Set presentation attribute
 
-    element.prop('data', 10); // Set custom attribute with string
-    element.prop({ data: 10 }); // Set custom attribute with object
-    
-    // Output from element.toJSON();
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "19cf14e6-cb78-4c32-b9a1-4256dc53776f",
-        "data": 10, // Our custom attribute
-        "attrs": {
-            "body": {
-                "stroke": "#FFF" // Our presentation attribute
-            }
+element.prop('data', 10); // Set custom attribute with string
+element.prop({ data: 10 }); // Set custom attribute with object
+
+// Output from element.toJSON();
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "19cf14e6-cb78-4c32-b9a1-4256dc53776f",
+    "data": 10, // Our custom attribute
+    "attrs": {
+        "body": {
+            "stroke": "#FFF" // Our presentation attribute
         }
     }
+}
 
 
+element.prop('data/count', 10); // Set nested custom attribute with string
+element.prop({ data: { count: 10 }}); // Set nested custom attribute with object
+element.prop('data': { count: 10 }); // This also creates a nested custom attribute
 
-    element.prop('data/count', 10); // Set nested custom attribute with string
-    element.prop({ data: { count: 10 }}); // Set nested custom attribute with object
-    element.prop('data': { count: 10 }); // This also creates a nested custom attribute
-
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "19cf14e6-cb78-4c32-b9a1-4256dc53776f",
-        "data": {
-            "count": 10  // Our nested custom attribute
-        },
-        "attrs": {}
-    }
-    </code></pre>
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "19cf14e6-cb78-4c32-b9a1-4256dc53776f",
+    "data": {
+        "count": 10  // Our nested custom attribute
+    },
+    "attrs": {}
+}
+</code></pre>
 
     <p>
         <code>prop()</code> not only provides support for nested objects, but for nested arrays too.
     </p>
 
-    <pre><code>
-    element.prop('mylist/0/data/0/value', 50); // Set custom attribute as nested array
+    <pre><code>element.prop('mylist/0/data/0/value', 50); // Set custom attribute as nested array
     
-    // Output from element.toJSON();
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "9adab5e5-cebe-419f-8d62-39cce5486d0d",
-        "mylist": [
-            {
-                "data": [
-                    {
-                        "value": 50 // Our nested custom attribute
-                    }
-                ]
-            }
-        ],
-        "attrs": {}
-    }
-    </code></pre>
+// Output from element.toJSON();
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "9adab5e5-cebe-419f-8d62-39cce5486d0d",
+    "mylist": [
+        {
+            "data": [
+                {
+                    "value": 50 // Our nested custom attribute
+                }
+            ]
+        }
+    ],
+    "attrs": {}
+}
+</code></pre>
 
     <h3>The set() method</h3>
 
@@ -131,36 +128,35 @@
         difference to take note of is that <code>set()</code> will override attributes, while <code>prop()</code> merges them.
     </p>
 
-    <pre><code>
-    element.set('data', 10); // Set custom attribute with string
-    element.set({ data: 10 }); // Set custom attribute with object
+    <pre><code>element.set('data', 10); // Set custom attribute with string
+element.set({ data: 10 }); // Set custom attribute with object
 
-    // Output from element.toJSON();
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "c0a6696d-1857-4fb7-892d-409433f84d29",
-        "data": 10, // Our custom attribute
-        "attrs": {}
-    }
-
+// Output from element.toJSON();
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "c0a6696d-1857-4fb7-892d-409433f84d29",
+    "data": 10, // Our custom attribute
+    "attrs": {}
+}
 
 
-    element.set('data/count', 10); // We try to set a nested custom property using set()
 
-    // The output produced will not be nested as is the case when using prop()
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "afdc42ce-5b10-45e5-832e-afcf2a221314",
-        "data/count": 10, // Note the important difference here
-        "attrs": {}
-    }
-    </code></pre>
+element.set('data/count', 10); // We try to set a nested custom property using set()
+
+// The output produced will not be nested as is the case when using prop()
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "afdc42ce-5b10-45e5-832e-afcf2a221314",
+    "data/count": 10, // Note the important difference here
+    "attrs": {}
+}
+</code></pre>
 
     <h3>Overwriting attributes with prop()</h3>
 
@@ -171,47 +167,46 @@
         merge our properties.
     </p>
 
-    <pre><code>
-    rect.prop('custom/state/isCollapsed', true);
-    rect.prop('custom/state', { isActive: false });
+    <pre><code>rect.prop('custom/state/isCollapsed', true);
+rect.prop('custom/state', { isActive: false });
 
-    // Output from element.toJSON();
+// Output from element.toJSON();
 
-    // We can see our attributes have been merged
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "b1c02090-e46a-4d90-a5dc-5096f1559b9f",
-        "custom": {
-            "state": {
-                "isCollapsed": true,
-                "isActive": false
-            }
-        },
-        "attrs": {}
-    }
+// We can see our attributes have been merged
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "b1c02090-e46a-4d90-a5dc-5096f1559b9f",
+    "custom": {
+        "state": {
+            "isCollapsed": true,
+            "isActive": false
+        }
+    },
+    "attrs": {}
+}
 
 
-    rect.prop('custom/state/isCollapsed', true);
-    rect.prop('custom/state', { isActive: false }, { rewrite: true });
+rect.prop('custom/state/isCollapsed', true);
+rect.prop('custom/state', { isActive: false }, { rewrite: true });
 
-    // We can see our attributes have been overwritten
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "b1c02090-e46a-4d90-a5dc-5096f1559b9f",
-        "custom": {
-            "state": {
-                "isActive": false
-            }
-        },
-        "attrs": {}
-    }
-    </code></pre>
+// We can see our attributes have been overwritten
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "b1c02090-e46a-4d90-a5dc-5096f1559b9f",
+    "custom": {
+        "state": {
+            "isActive": false
+        }
+    },
+    "attrs": {}
+}
+</code></pre>
 
     <h3>Relationship between prop() and attr() methods</h3>
 
@@ -229,25 +224,48 @@
         prepends our path with <i>'attrs'</i>. This means we find our presentation attributes in the <code>attrs</code> object.
     </p>
 
-    <pre><code>
-    element.attr('body/strokeWidth', 2);
-    element.prop('isCollapsed', true);
+    <pre><code>element.attr('body/strokeWidth', 2);
+element.prop('isCollapsed', true);
 
-    // Output from element.toJSON();
-    {
-        "type": "standard.Rectangle",
-        "position": { "x": 0, "y": 0 },
-        "size": { "width": 1, "height": 1 },
-        "angle": 0,
-        "id": "edafa2ac-27e6-4fbc-951a-aa3f9512c741",
-        "isCollapsed": true,
-        "attrs": {
-            "body": {
-                "strokeWidth": 2
-            }
+// Output from element.toJSON();
+{
+    "type": "standard.Rectangle",
+    "position": { "x": 0, "y": 0 },
+    "size": { "width": 1, "height": 1 },
+    "angle": 0,
+    "id": "edafa2ac-27e6-4fbc-951a-aa3f9512c741",
+    "isCollapsed": true,
+    "attrs": {
+        "body": {
+            "strokeWidth": 2
         }
     }
-    </code></pre>
+}
+</code></pre>
+
+    <p>
+        Another important note to mention when talking about <code>prop()</code> and <code>attr()</code> is that when changing the model,
+        some useful information is passed along with the change event in JointJS. <code>propertyPath</code>, <code>propertyValue</code>, 
+        and <code>propertyPathArray</code> are all values which can be accessed when updating the model. This can prove useful if for some 
+        reason you need to listen to a specific attribute change. Note that it is not possible to access these values in this manner 
+        when using <code>set()</code>.
+    </p>
+
+    <pre><code>graph.on('change', (cell, opt) => {
+    if ('attrs' in cell.changed) {
+        console.log(opt.propertyPathArray, 'was changed'); 
+        // --> ['attrs', 'body', 'fill'] 'was changed'
+    }
+
+    if ('isInteractive' in cell.changed) {
+        console.log(opt.propertyPathArray, 'was changed'); 
+        // --> ['isInteractive'] 'was changed'
+    }
+});
+
+element.attr('body/fill', 'cornflowerblue');
+element.prop('isInteractive', true);
+</code></pre>
 
     <p>
         Thanks for reading this far. As you can see, custom attributes open up a new world of functionality within our shapes, and


### PR DESCRIPTION
## Description

- add `change` event to `Link` and `Element` prop methods
- fix code snippet spacing in `custom attributes` tutorial
- update `custom attributes` tutorial with `change` event example line:[246]

### Screenshots (if appropriate):
docs:

<img width="1184" alt="Screenshot 2022-08-23 at 12 24 39" src="https://user-images.githubusercontent.com/42288565/186135200-675df68e-8bcf-4848-bfa5-15fc227bb2bc.png">

custom attributes:

<img width="1197" alt="Screenshot 2022-08-23 at 12 13 00" src="https://user-images.githubusercontent.com/42288565/186135246-28555751-cd66-4c3f-b4cf-b7b053b4bb01.png">

