### PR TITLE
dia.ElementView: fix getNodeMatrix() and getNodeBBox() for elements wth rotatable group

### DIFF
--- a/src/highlighters/mask.mjs
+++ b/src/highlighters/mask.mjs
@@ -200,11 +200,12 @@ export const mask = HighlighterView.extend({
             vel.remove();
         }
         const highlighterBBox = cellView.getNodeBoundingRect(node).inflate(padding + maskClip);
+        const highlightMatrix = cellView.getNodeRotateMatrix(node).multiply(cellView.getNodeMatrix(node));
         const maskEl = this.getMask(cellView, V(node));
         this.addMask(cellView.paper, maskEl);
         vel.attr(highlighterBBox.toJSON());
         vel.attr({
-            'transform': V.matrixToTransformString(cellView.getNodeMatrix(node)),
+            'transform': V.matrixToTransformString(highlightMatrix),
             'mask': `url(#${maskEl.id})`,
             'fill': color
         });

--- a/src/highlighters/stroke.mjs
+++ b/src/highlighters/stroke.mjs
@@ -52,7 +52,7 @@ export const stroke = HighlighterView.extend({
     highlightNode(cellView, node) {
         const { vel, options } = this;
         const { padding, layer } = options;
-        let highlightMatrix = cellView.getNodeMatrix(node);
+        let highlightMatrix = cellView.getNodeRotateMatrix(node).multiply(cellView.getNodeMatrix(node));
         // Add padding to the highlight element.
         if (padding) {
             if (!layer && node === cellView.el) {

--- a/test/jointjs/elementView.js
+++ b/test/jointjs/elementView.js
@@ -155,6 +155,81 @@ QUnit.module('elementView', function(hooks) {
 
             elementView.model.resize(200, 300, { passed: true });
         });
+
+        QUnit.test('getNodeBBox(), getNodeMatrix()', function(assert) {
+
+            elementView.model.set({
+                markup: [
+                    {
+                        tagName: 'g',
+                        selector: 'rotatable',
+                        children: [
+                            {
+                                tagName: 'rect',
+                                selector: 'rectInside',
+                            },
+                            {
+                                tagName: 'circle',
+                                selector: 'circle',
+                                attributes: {
+                                    transform: 'translate(11,13)',
+                                    r: 5
+                                }
+                            }
+                        ],
+                    }, {
+                        tagName: 'rect',
+                        selector: 'rectOutside',
+                    },
+                ],
+                attrs: {
+                    rectInside: {
+                        x: 21,
+                        y: 13,
+                        width: 20,
+                        height: 10
+                    },
+                    rectOutside: {
+                        x: 21,
+                        y: 13,
+                        width: 20,
+                        height: 10
+                    }
+                }
+            });
+
+            elementView.model.resize(100, 100).translate(100, 100).rotate(90);
+
+            var rectInside = elementView.findBySelector('rectInside')[0];
+            assert.checkBboxApproximately(1, elementView.getNodeBBox(rectInside), {
+                x: 177,
+                y: 121,
+                width: 10,
+                height: 20
+            });
+
+            assert.equal(V.matrixToTransformString(elementView.getNodeMatrix(rectInside)), 'matrix(1,0,0,1,0,0)');
+
+            var rectOutside = elementView.findBySelector('rectOutside')[0];
+            assert.checkBboxApproximately(1, elementView.getNodeBBox(rectOutside), {
+                x: 121,
+                y: 113,
+                width: 20,
+                height: 10
+            });
+
+            assert.equal(V.matrixToTransformString(elementView.getNodeMatrix(rectOutside)), 'matrix(1,0,0,1,0,0)');
+
+            var circle = elementView.findBySelector('circle')[0];
+            assert.checkBboxApproximately(1, elementView.getNodeBBox(circle), {
+                x: 182,
+                y: 106,
+                width: 10,
+                height: 10
+            });
+
+            assert.equal(V.matrixToTransformString(elementView.getNodeMatrix(circle)), 'matrix(1,0,0,1,11,13)');
+        });
     });
 
     QUnit.module('no rotatable group and no scalable group', function(hooks) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -774,6 +774,8 @@ export namespace dia {
 
         getNodeMatrix(node: SVGElement): SVGMatrix;
 
+        getNodeRotateMatrix(node: SVGElement): SVGMatrix;
+
         getNodeBoundingRect(node: SVGElement): g.Rect;
 
         getBBox(opt?: { useModelGeometry?: boolean }): g.Rect;


### PR DESCRIPTION
## Description

The `rotation` matrix is not applied on elements outside the `rotatable` group (if present) when calculating the bounding box.

The `rotation` matrix is applied on the highlighter node when inside the `rotatable` group.

## Motivation and Context

The highlighters (`stroke`, `mask`) does not render properly on elements with `rotatable` group.

### Screenshots (if appropriate):

Before:
<img width="134" alt="before" src="https://user-images.githubusercontent.com/3967880/186675127-404ce11a-5d86-4ef6-bc4b-23dee7e84ef7.png">

After:
<img width="115" alt="after" src="https://user-images.githubusercontent.com/3967880/186674282-782ee567-0772-4c23-9d20-3323c72cf8d5.png">

