### PR TITLE
[WIP] 2-axis-scroll / pinch-to-zoom support

### DIFF
--- a/docs/src/joint/api/dia/Paper/events.html
+++ b/docs/src/joint/api/dia/Paper/events.html
@@ -309,6 +309,38 @@
     </td>
   </tr>
   <tr>
+    <th>pan</th>
+    <td>
+      <p>Triggered when a pan event is emitted while pointer is on top the target. Pan events are simillar to mousewheel events, but while mousewheel events cover only on the Y axis, pan events cover both X and Y axis. This is usually possible with touchpads / trackpad devices.</p>
+      <p>The callback function is passed <code>evt</code>, <code>deltaX</code> and <code>deltaY</code> as arguments.</p>
+      <table>
+        <tr>
+          <th>paper:pan</th>
+          <td>
+            <p>Triggered when a pan event is emitted while the pointer is on the paper or any cell.</p>
+            <p>The callback function is passed <code>evt</code>, <code>deltaX</code> and <code>deltaY</code> as arguments.</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <th>pinch</th>
+    <td>
+      <p>Triggered when a pinch event is emitted while pointer is on top the target. This is usually possible with touchpads / trackpad devices.</p>
+      <p>The callback function is passed <code>evt</code>, <code>x</code>, <code>y</code> and <code>scale</code> as arguments.</p>
+      <table>
+        <tr>
+          <th>paper:pinch</th>
+          <td>
+            <p>Triggered when a pinch event is emitted while the pointer is on the paper or any cell.</p>
+            <p>The callback function is passed <code>evt</code>, <code>x</code> <code>y</code> and <code>scale</code> as arguments.</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
     <th>magnet</th>
       <td>
         <p>Triggered when interacting with a magnet target.</p>

--- a/docs/src/joint/api/dia/Paper/events.html
+++ b/docs/src/joint/api/dia/Paper/events.html
@@ -311,7 +311,7 @@
   <tr>
     <th>pan</th>
     <td>
-      <p>Triggered when a pan event is emitted while the pointer is on top of the target. Pan events are simillar to mousewheel events, but while mousewheel events cover only the Y axis, pan events cover both X and Y axis. This is usually possible with touchpads / trackpad devices.</p>
+      <p>Triggered when a pan event is emitted while the pointer is on top of the target. Pan events are similar to mousewheel events, but while mousewheel events cover only the Y axis, pan events cover both X and Y axis. This is usually possible with touchpads / trackpad devices.</p>
       <p>The callback function is passed <code>evt</code>, <code>deltaX</code> and <code>deltaY</code> as arguments.</p>
       <table>
         <tr>

--- a/docs/src/joint/api/dia/Paper/events.html
+++ b/docs/src/joint/api/dia/Paper/events.html
@@ -311,7 +311,7 @@
   <tr>
     <th>pan</th>
     <td>
-      <p>Triggered when a pan event is emitted while pointer is on top the target. Pan events are simillar to mousewheel events, but while mousewheel events cover only on the Y axis, pan events cover both X and Y axis. This is usually possible with touchpads / trackpad devices.</p>
+      <p>Triggered when a pan event is emitted while the pointer is on top of the target. Pan events are simillar to mousewheel events, but while mousewheel events cover only the Y axis, pan events cover both X and Y axis. This is usually possible with touchpads / trackpad devices.</p>
       <p>The callback function is passed <code>evt</code>, <code>deltaX</code> and <code>deltaY</code> as arguments.</p>
       <table>
         <tr>
@@ -327,7 +327,7 @@
   <tr>
     <th>pinch</th>
     <td>
-      <p>Triggered when a pinch event is emitted while pointer is on top the target. This is usually possible with touchpads / trackpad devices.</p>
+      <p>Triggered when a pinch event is emitted while the pointer is on top of the target. This is usually possible with touchpads / trackpad devices.</p>
       <p>The callback function is passed <code>evt</code>, <code>x</code>, <code>y</code> and <code>scale</code> as arguments.</p>
       <table>
         <tr>

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2272,15 +2272,13 @@ export const Paper = View.extend({
                 this._mw_evt_buffer.deltas.push(deltaY);
                 this._processMouseWheelEvtBuf();
             }
-        } else if(Math.abs(deltaX) != 0 && Math.abs(deltaY) != 0) {
-            // This is a 2-axis-scroll gesture, we must not debounce the event
-            this.trigger('paper:pan', evt, deltaX, deltaY);
         } else {
             const delta = Math.max(-1, Math.min(1, originalEvent.wheelDelta));
             if (view) {
                 view.mousewheel(evt, localPoint.x, localPoint.y, delta);
 
             } else {
+                this.trigger('paper:pan', evt, deltaX, deltaY);
                 this.trigger('blank:mousewheel', evt, localPoint.x, localPoint.y, delta);
             }
         }

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2252,12 +2252,12 @@ export const Paper = View.extend({
 
         evt = normalizeEvent(evt);
 
-        var view = this.findView(evt.target);
+        const view = this.findView(evt.target);
         if (this.guard(evt, view)) return;
 
-        var originalEvent = evt.originalEvent;
-        var localPoint = this.snapToGrid(originalEvent.clientX, originalEvent.clientY);
-        var { deltaX, deltaY } = normalizeWheel(originalEvent);
+        const originalEvent = evt.originalEvent;
+        const localPoint = this.snapToGrid(originalEvent.clientX, originalEvent.clientY);
+        const { deltaX, deltaY } = normalizeWheel(originalEvent);
 
         // Touchpad devices will send a fake CTRL press when a pinch is performed
         if(evt.ctrlKey) {
@@ -2270,11 +2270,12 @@ export const Paper = View.extend({
             // This is a 2-axis-scroll gesture, we must not debounce the event
             this.trigger('paper:pan', evt, deltaX, deltaY);
         } else {
+            const delta = Math.max(-1, Math.min(1, originalEvent.wheelDelta));
             if (view) {
-                view.mousewheel(evt, localPoint.x, localPoint.y, deltaY);
+                view.mousewheel(evt, localPoint.x, localPoint.y, delta);
 
             } else {
-                this.trigger('blank:mousewheel', evt, localPoint.x, localPoint.y, deltaY);
+                this.trigger('blank:mousewheel', evt, localPoint.x, localPoint.y, delta);
             }
         }
     },

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2278,9 +2278,10 @@ export const Paper = View.extend({
                 view.mousewheel(evt, localPoint.x, localPoint.y, delta);
 
             } else {
-                this.trigger('paper:pan', evt, deltaX, deltaY);
                 this.trigger('blank:mousewheel', evt, localPoint.x, localPoint.y, delta);
             }
+
+            this.trigger('paper:pan', evt, deltaX, deltaY);
         }
     },
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2261,11 +2261,17 @@ export const Paper = View.extend({
 
         // Touchpad devices will send a fake CTRL press when a pinch is performed
         if(evt.ctrlKey) {
-            // This is a pinch gesture, it's safe to assume that we must call .preventDefault()
-            originalEvent.preventDefault();
-            this._mw_evt_buffer.event = originalEvent;
-            this._mw_evt_buffer.deltas.push(deltaY);
-            this._processMouseWheelEvtBuf();
+            // Check if there are any subscribers to this event. If there are none,
+            // just skip the entire block of code (we don't want to blindly call
+            // .preventDefault() if we really don't have to).
+            const handlers = this._events['paper:pinch'];
+            if(handlers && handlers.length > 0) {
+                // This is a pinch gesture, it's safe to assume that we must call .preventDefault()
+                originalEvent.preventDefault();
+                this._mw_evt_buffer.event = originalEvent;
+                this._mw_evt_buffer.deltas.push(deltaY);
+                this._processMouseWheelEvtBuf();
+            }
         } else if(Math.abs(deltaX) != 0 && Math.abs(deltaY) != 0) {
             // This is a 2-axis-scroll gesture, we must not debounce the event
             this.trigger('paper:pan', evt, deltaX, deltaY);

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2240,7 +2240,7 @@ export const Paper = View.extend({
 
         const scale = Math.pow(0.995, deltaY); // 1.005 for inverted pinch/zoom
         const { x, y } = this.clientToLocalPoint(event.clientX, event.clientY);
-        this.trigger('TBD_system:scale', event, x, y, scale);
+        this.trigger('paper:pinch', event, x, y, scale);
 
         this._mw_evt_buffer = {
             event: null,
@@ -2268,7 +2268,7 @@ export const Paper = View.extend({
             this._processMouseWheelEvtBuf();
         } else if(Math.abs(deltaX) != 0 && Math.abs(deltaY) != 0) {
             // This is a 2-axis-scroll gesture, we must not debounce the event
-            this.trigger('TBD_system:scroll', evt, deltaX, deltaY);
+            this.trigger('paper:pan', evt, deltaX, deltaY);
         } else {
             if (view) {
                 view.mousewheel(evt, localPoint.x, localPoint.y, deltaY);

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -279,6 +279,55 @@ export const normalizeEvent = function(evt) {
     return normalizedEvent;
 };
 
+export const normalizeWheel = function(evt) {
+    // Sane values derived empirically
+    const PIXEL_STEP  = 10;
+    const LINE_HEIGHT = 40;
+    const PAGE_HEIGHT = 800;
+
+    let sX = 0, sY = 0, pX = 0, pY = 0;
+
+    // Legacy
+    if ("detail"      in evt) { sY = evt.detail; }
+    if ("wheelDelta"  in evt) { sY = -evt.wheelDelta / 120; }
+    if ("wheelDeltaY" in evt) { sY = -evt.wheelDeltaY / 120; }
+    if ("wheelDeltaX" in evt) { sX = -evt.wheelDeltaX / 120; }
+
+    // side scrolling on FF with DOMMouseScroll
+    if ( "axis" in evt && evt.axis === evt.HORIZONTAL_AXIS ) {
+        sX = sY;
+        sY = 0;
+    }
+
+    pX = "deltaX" in evt ? evt.deltaX : sX * PIXEL_STEP;
+    pY = "deltaY" in evt ? evt.deltaY : sY * PIXEL_STEP;
+
+    if ((pX || pY) && evt.deltaMode) {
+        if (evt.deltaMode == 1) {
+            pX *= LINE_HEIGHT;
+            pY *= LINE_HEIGHT;
+        } else {
+            pX *= PAGE_HEIGHT;
+            pY *= PAGE_HEIGHT;
+        }
+    }
+
+    // Fall-back if spin cannot be determined
+    if (pX && !sX) { sX = (pX < 1) ? -1 : 1; }
+    if (pY && !sY) { sY = (pY < 1) ? -1 : 1; }
+
+    return {
+        spinX  : sX,
+        spinY  : sY,
+        pixelX : pX,
+        pixelY : pY,
+    };
+};
+
+export const cap = function(val, max) {
+    return val > max ? max : val < -max ? -max : val;
+};
+
 export const nextFrame = (function() {
 
     var raf;

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -288,19 +288,19 @@ export const normalizeWheel = function(evt) {
     let sX = 0, sY = 0, pX = 0, pY = 0;
 
     // Legacy
-    if ("detail"      in evt) { sY = evt.detail; }
-    if ("wheelDelta"  in evt) { sY = -evt.wheelDelta / 120; }
-    if ("wheelDeltaY" in evt) { sY = -evt.wheelDeltaY / 120; }
-    if ("wheelDeltaX" in evt) { sX = -evt.wheelDeltaX / 120; }
+    if ('detail'      in evt) { sY = evt.detail; }
+    if ('wheelDelta'  in evt) { sY = -evt.wheelDelta / 120; }
+    if ('wheelDeltaY' in evt) { sY = -evt.wheelDeltaY / 120; }
+    if ('wheelDeltaX' in evt) { sX = -evt.wheelDeltaX / 120; }
 
     // side scrolling on FF with DOMMouseScroll
-    if ( "axis" in evt && evt.axis === evt.HORIZONTAL_AXIS ) {
+    if ( 'axis' in evt && evt.axis === evt.HORIZONTAL_AXIS ) {
         sX = sY;
         sY = 0;
     }
 
-    pX = "deltaX" in evt ? evt.deltaX : sX * PIXEL_STEP;
-    pY = "deltaY" in evt ? evt.deltaY : sY * PIXEL_STEP;
+    pX = 'deltaX' in evt ? evt.deltaX : sX * PIXEL_STEP;
+    pY = 'deltaY' in evt ? evt.deltaY : sY * PIXEL_STEP;
 
     if ((pX || pY) && evt.deltaMode) {
         if (evt.deltaMode == 1) {
@@ -319,8 +319,8 @@ export const normalizeWheel = function(evt) {
     return {
         spinX  : sX,
         spinY  : sY,
-        pixelX : pX,
-        pixelY : pY,
+        deltaX : pX,
+        deltaY : pY,
     };
 };
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1367,6 +1367,9 @@ export namespace dia {
             'element:mousewheel': (elementView: dia.ElementView, evt: dia.Event, x: number, y: number, delta: number) => void;
             'link:mousewheel': (linkView: dia.LinkView, evt: dia.Event, x: number, y: number, delta: number) => void;
             'blank:mousewheel': (evt: dia.Event, x: number, y: number, delta: number) => void;
+            // touchpad
+            'paper:pan': (evt: dia.Event, deltaX: number, deltaY: number) => void;
+            'paper:pinch': (evt: dia.Event, x: number, y: number, scale: number) => void;
             // magnet
             'element:magnet:pointerclick': (elementView: dia.ElementView, evt: dia.Event, magnetNode: SVGElement, x: number, y: number) => void;
             'element:magnet:pointerdblclick': (elementView: dia.ElementView, evt: dia.Event, magnetNode: SVGElement, x: number, y: number) => void;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

As discussed previously via email, this is an initial draft for the support of 2-axis-scroll and pinch-to-zoom (touchpad devices). There are some things that we must clear out before merging this!

## Motivation and Context

The patch implements 2-axis-scroll, which is something very common when using touchpad devices (and greatly improves the UX!). It also implements pìnch-to-zoom gestures.

Initially, we discussed to start only with the 2-axis-scroll patch, but since the pinch-to-zoom is a +2 lines net addition on top of the 2-axis-scroll patch and since it would actually cost more to split it rather than keep it, I decided to just push them both in the same PR. If you still feel that we should drop the pinch-to-zoom patch, removing it should be easy.

## Usage

This patch could be used like this:

```
      "TBD_system:scale": (_evt, x, y, scale) => {
        const zoom = this.paperScroller.zoom();
        this.paperScroller.zoom(zoom * scale, { min: 0.2, max: 5, ox: x, oy: y, absolute: true });
      },

      "TBD_system:scroll": (_evt, x, y) => {
        this.paperScroller.el.scrollLeft += x;
        this.paperScroller.el.scrollTop += y;
      },
```
