### PR TITLE
dia.ElementView: findPortNode() search for all port nodes; add portRo…

### DIFF
--- a/docs/src/joint/api/dia/CellView/prototype/findPortNode.html
+++ b/docs/src/joint/api/dia/CellView/prototype/findPortNode.html
@@ -1,5 +1,5 @@
 <pre class="docs-method-signature"><code>cellView.findPortNode(portId)</code></pre>
-<p>Return the port element of this CellView that is identified by <code>portId</code> (i.e. an SVGElement within <code>this.el</code> which has <code>'port': portId</code> / an SVGElement referenced by <code>portRoot</code> selector).</p>
+<p>Return the port element of this CellView that is identified by <code>portId</code> (i.e. an SVGElement within <code>this.el</code> which has <code>'port': portId</code>, an SVGElement referenced by <code>portRoot</code> selector).</p>
 
 <p>If the CellView does not have a port identified by <code>portId</code>, return <code>null</code>.</p>
 

--- a/docs/src/joint/api/dia/CellView/prototype/findPortNode.html
+++ b/docs/src/joint/api/dia/CellView/prototype/findPortNode.html
@@ -1,5 +1,5 @@
 <pre class="docs-method-signature"><code>cellView.findPortNode(portId)</code></pre>
-<p>Return the port element of this CellView that is identified by <code>portId</code> (i.e. the SVGElement within <code>this.el</code> which has <code>'port': portId</code>).</p>
+<p>Return the port element of this CellView that is identified by <code>portId</code> (i.e. an SVGElement within <code>this.el</code> which has <code>'port': portId</code> / an SVGElement referenced by <code>portRoot</code> selector).</p>
 
 <p>If the CellView does not have a port identified by <code>portId</code>, return <code>null</code>.</p>
 

--- a/docs/src/joint/api/dia/Element/ports.md
+++ b/docs/src/joint/api/dia/Element/ports.md
@@ -107,7 +107,7 @@ rect.getGroupPorts('a');
     <td>
         <p>A custom port markup.</p>
         <p>The default port markup is <code>&lt;circle class="joint-port-body" r="10" fill="#FFFFFF" stroke="#000000"/&gt;</code>.</p>
-        <p>The root of the port markup is referenced by <code>portRoot</code> selector.</p>
+        <p>The root of the port markup is referenced by the <code>portRoot</code> selector.</p>
         <p>If the markup contains more than one node, an extra group is created to wrap the nodes. This group becomes the new <code>portRoot</code>.</p>
 <pre><code>// An example of port markup
 markup: [{
@@ -180,7 +180,7 @@ markup: [{
     <td>
         <p>A custom port label markup.</p>
         <p>The default port label markup is <code>&lt;text class="joint-port-label" fill="#000000"/&gt;</code>.</p>
-        <p>The root of the label markup is referenced by <code>labelRoot</code> selector.</p>
+        <p>The root of the label markup is referenced by the <code>labelRoot</code> selector.</p>
         <p>If the markup contains more than one node, an extra group is created to wrap the nodes. This group becomes the new <code>labelRoot</code>.</p>
         <p>Use an empty array <code>[]</code> to prevent the label from being rendered.</p>
     </td>

--- a/docs/src/joint/api/dia/Element/ports.md
+++ b/docs/src/joint/api/dia/Element/ports.md
@@ -33,7 +33,7 @@ const port = {
             selector: 'label'
         }]
     },
-    attrs: { 
+    attrs: {
         body: { magnet: true, width: 16, height: 16, x: -8, y: -4, stroke: 'red', fill: 'gray'},
         label: { text: 'port', fill: 'blue' }
     },
@@ -61,11 +61,11 @@ const rect = new joint.shapes.standard.Rectangle({
 // b.) Or add a single port using API
 rect.addPort(port);
 
-rect.getGroupPorts('a');  
+rect.getGroupPorts('a');
 /*
    [
-       { * Default port settings * }, 
-       { * Follows port definition * }, 
+       { * Default port settings * },
+       { * Follows port definition * },
        { * Follows port definition * }
     ]
 */
@@ -105,32 +105,32 @@ rect.getGroupPorts('a');
     <td><b>markup</b></td>
     <td><i>MarkupJSON&nbsp;|&nbsp;string</i></td>
     <td>
-        <p>Custom port markup. Multiple roots are not allowed. Valid notation would be:</p>
-<pre><code>markup: [{
-    tagName: 'g',
-    children: [{
-        tagName: 'rect',
-        selector: 'bodyInner',
-        className: 'outer',
-        attributes: {
-            'width': 15,
-            'height': 15,
-            'fill': 'red'
-        }
-    }, {
-        tagName: 'rect',
-        selector: 'bodyOuter',
-        className: 'inner',
-        attributes: {
-            'width': 15,
-            'height': 15,
-            'fill': 'blue',
-            'x': 10
-        }
-    }]
+        <p>A custom port markup.</p>
+        <p>The default port markup is <code>&lt;circle class="joint-port-body" r="10" fill="#FFFFFF" stroke="#000000"/&gt;</code>.</p>
+        <p>The root of the port markup is referenced by <code>portRoot</code> selector.</p>
+        <p>If the markup contains more than one node, an extra group is created to wrap the nodes. This group becomes the new <code>portRoot</code>.</p>
+<pre><code>// An example of port markup
+markup: [{
+    tagName: 'rect',
+    selector: 'bodyInner',
+    className: 'outer',
+    attributes: {
+        'width': 15,
+        'height': 15,
+        'fill': 'red'
+    }
+}, {
+    tagName: 'rect',
+    selector: 'bodyOuter',
+    className: 'inner',
+    attributes: {
+        'width': 15,
+        'height': 15,
+        'fill': 'blue',
+        'x': 10
+    }
 }]
 </code></pre>
-        <p>The default port looks like the following: <code>&lt;circle class="joint-port-body" r="10" fill="#FFFFFF" stroke="#000000"/&gt;</code>.</p>
     </td>
 </tr>
 <tr>
@@ -178,7 +178,11 @@ rect.getGroupPorts('a');
     <td><ul><li><b>label.markup</b></li></ul></td>
     <td><i>MarkupJSON&nbsp;|&nbsp;string</i></td>
     <td>
-        Custom port label markup. Multiple roots are not allowed. The default port label looks like the following: <code>&lt;text class="joint-port-label" fill="#000000"/&gt;</code>.
+        <p>A custom port label markup.</p>
+        <p>The default port label markup is <code>&lt;text class="joint-port-label" fill="#000000"/&gt;</code>.</p>
+        <p>The root of the label markup is referenced by <code>labelRoot</code> selector.</p>
+        <p>If the markup contains more than one node, an extra group is created to wrap the nodes. This group becomes the new <code>labelRoot</code>.</p>
+        <p>Use an empty array <code>[]</code> to prevent the label from being rendered.</p>
     </td>
 </tr>
 <tr>
@@ -191,9 +195,9 @@ rect.getGroupPorts('a');
         </p>
         <iframe src="about:blank" data-src="./demo/dia/Element/portZIndex.html" style="height: 224px; width: 803px;"></iframe>
         <p>
-            Shapes most likely consist of 1 or more DOM elements, <code>&lt;rect/&gt;</code>, <code>&lt;rect/&gt;&lt;text/&gt;&lt;circle/&gt;</code> etc. 
-            Ports are placed into the main group element <code>elementView.el</code>, so it will act as the port container. 
-            Ports with <code>z: 'auto'</code> are located right after the last element in the main group. Ports with <code>z</code> 
+            Shapes most likely consist of 1 or more DOM elements, <code>&lt;rect/&gt;</code>, <code>&lt;rect/&gt;&lt;text/&gt;&lt;circle/&gt;</code> etc.
+            Ports are placed into the main group element <code>elementView.el</code>, so it will act as the port container.
+            Ports with <code>z: 'auto'</code> are located right after the last element in the main group. Ports with <code>z</code>
             defined as a number are placed before a DOM element at the position (index within the children of the container, where only
             the original markup elements, and ports with <code>z: 'auto'</code> are taken into account) equal to <code>z</code>.
         </p>
@@ -201,7 +205,7 @@ rect.getGroupPorts('a');
 <pre><code>markup: [{
     tagName: 'rect',
     selector: 'bodyMain',
-    className: 'bodyMain'      
+    className: 'bodyMain'
 }, {
     tagName: 'rect',
     selector: 'bodyInner',
@@ -258,7 +262,7 @@ rect.getGroupPorts('a');
 <pre><code>&lt;g model-id="..."&gt;
     &lt;g class="rotatable"&gt;
         &lt;g class="joint-port"&gt;&lt;/g&gt;         &lt;!-- z: 0 --&gt;
-        &lt;g class="scalable"&gt;&lt;rect class="bodyMain"&gt;&lt;/rect&gt;&lt;/g&gt;         
+        &lt;g class="scalable"&gt;&lt;rect class="bodyMain"&gt;&lt;/rect&gt;&lt;/g&gt;
         &lt;g class="joint-port"&gt;&lt;/g&gt;         &lt;!-- z: 1 --&gt;
         &lt;rect class="bodyInner"&gt;&lt;/rect&gt;
         &lt;text class="label"&gt;&lt;/text&gt;
@@ -278,7 +282,7 @@ All properties described above are optional, and everything has its own default.
 While single port definitions are useful, what if we want more control over our ports? This is where a port group can come into play. A group allows us to define multiple ports with similar properties, and influence the default port alignment. Any individual port can override a property in a port group definition except the type of layout(E.g. `position: 'left'`). The group definition defines the layout, and the individual port `args` are the only way a port can affect it.
 
 ```javascript
-// Port definition for input ports group 
+// Port definition for input ports group
 const portsIn = {
     position: {
         name: 'left', // Layout name
@@ -287,7 +291,7 @@ const portsIn = {
     label: {
         position: {
             name: 'left',
-            args: { y: 6 } 
+            args: { y: 6 }
         },
         markup: [{
             tagName: 'text',
@@ -317,7 +321,7 @@ const rect = new joint.shapes.basic.Rect({
              // Initialize 'rect' with port in group 'group1'
             {
                 group: 'group1',
-                args: { y: 40 } // Overrides `args` from the group level definition for first port 
+                args: { y: 40 } // Overrides `args` from the group level definition for first port
             }
         ]
     }
@@ -451,18 +455,18 @@ var rect = new joint.shapes.basic.Rect({
     // ...
 });
 
-rect.addPort({ 
-    markup: [{ 
+rect.addPort({
+    markup: [{
         tagName: 'rect', selector: 'body', attributes: { 'width': 20, 'height': 20, 'fill': 'blue' }
     }]
 });
 
 rect.addPort({
-    markup: [{ 
+    markup: [{
         tagName: 'rect', selector: 'body', attributes: { 'width': 16, 'height': 16, 'fill': 'red' }
     }],
-    label: { 
-        markup: [{ tagName: 'text', selector: 'label', attributes: { 'fill': '#000000' }}] 
+    label: {
+        markup: [{ tagName: 'text', selector: 'label', attributes: { 'fill': '#000000' }}]
     },
     attrs: { label: { text: 'port' }}
 });

--- a/src/dia/ports.mjs
+++ b/src/dia/ports.mjs
@@ -755,7 +755,7 @@ export const elementViewPortPrototype = {
         }
 
         const portRootSelector = 'portRoot';
-        if (portElement && !(portRootSelector in portContainerSelectors)) {
+        if (!(portRootSelector in portContainerSelectors)) {
             portContainerSelectors[portRootSelector] = portElement.node;
         }
 

--- a/src/dia/ports.mjs
+++ b/src/dia/ports.mjs
@@ -661,8 +661,9 @@ export const elementViewPortPrototype = {
     findPortNode: function(portId, selector) {
         const portCache = this._portElementsCache[portId];
         if (!portCache) return null;
-        const portRoot = portCache.portContentElement.node;
-        const portSelectors = portCache.portContentSelectors;
+        if (!selector) return portCache.portContentElement.node;
+        const portRoot = portCache.portElement.node;
+        const portSelectors = portCache.portSelectors;
         const [node = null] = this.findBySelector(selector, portRoot, portSelectors);
         return node;
     },
@@ -750,7 +751,17 @@ export const elementViewPortPrototype = {
             }
             portContainerSelectors = util.assign({}, portSelectors, labelSelectors);
         } else {
-            portContainerSelectors = portSelectors || labelSelectors;
+            portContainerSelectors = portSelectors || labelSelectors || {};
+        }
+
+        const portRootSelector = 'portRoot';
+        if (portElement && !(portRootSelector in portContainerSelectors)) {
+            portContainerSelectors[portRootSelector] = portElement.node;
+        }
+
+        const labelRootSelector = 'labelRoot';
+        if (labelElement && !(labelRootSelector in portContainerSelectors)) {
+            portContainerSelectors[labelRootSelector] = labelElement.node;
         }
 
         portContainerElement.append(portElement.addClass('joint-port-body'));

--- a/test/jointjs/elementView.js
+++ b/test/jointjs/elementView.js
@@ -65,6 +65,55 @@ QUnit.module('elementView', function(hooks) {
             assert.equal(el2view.findPortNode(2, 'root').lastChild.tagName.toUpperCase(), 'TEXT');
         });
 
+        QUnit.test('implicit selectors', function(assert) {
+            var el1 = new joint.shapes.standard.Rectangle({
+                portMarkup: [{ tagName: 'polygon' }],
+                portLabelMarkup: [{ tagName: 'circle', selector: 'cs' }],
+                ports: {
+                    items: [{
+                        id: 1
+                    }]
+                }
+            });
+            var el2 = new joint.shapes.standard.Rectangle({
+                portMarkup: [{ tagName: 'polygon' }, { tagName: 'polyline' }],
+                portLabelMarkup: [{ tagName: 'circle' }, { tagName: 'ellipse', selector: 'es' }],
+                ports: {
+                    items: [{
+                        id: 1
+                    }]
+                }
+            });
+            paper.model.addCells([el1, el2]);
+
+            var el1view = el1.findView(paper);
+            assert.equal(el1view.findPortNode(1), el1view.findPortNode(1, 'portRoot'));
+            assert.equal(el1view.findPortNode(1, 'root').childNodes.length, 2);
+            assert.equal(el1view.findPortNode(1, 'root').parentNode, el1view.el);
+            assert.equal(el1view.findPortNode(1, 'root').firstChild.tagName.toUpperCase(), 'POLYGON');
+            assert.equal(el1view.findPortNode(1, 'root').lastChild.tagName.toUpperCase(), 'CIRCLE');
+            assert.equal(el1view.findPortNode(1, 'portRoot').tagName.toUpperCase(), 'POLYGON');
+            assert.equal(el1view.findPortNode(1, 'labelRoot').tagName.toUpperCase(), 'CIRCLE');
+            assert.equal(el1view.findPortNode(1, 'portRoot').parentNode, el1view.findPortNode(1, 'root'));
+            assert.equal(el1view.findPortNode(1, 'labelRoot').parentNode, el1view.findPortNode(1, 'root'));
+            assert.equal(el1view.findPortNode(1, 'cs').tagName.toUpperCase(), 'CIRCLE');
+            assert.equal(el1view.findPortNode(1, 'es'), null);
+
+            var el2view = el2.findView(paper);
+            assert.equal(el2view.findPortNode(1), el2view.findPortNode(1, 'portRoot'));
+            assert.equal(el2view.findPortNode(1, 'root').childNodes.length, 2);
+            assert.equal(el2view.findPortNode(1, 'root').parentNode, el2view.el);
+            assert.equal(el2view.findPortNode(1, 'portRoot').tagName.toUpperCase(), 'G');
+            assert.equal(el2view.findPortNode(1, 'portRoot').firstChild.tagName.toUpperCase(), 'POLYGON');
+            assert.equal(el2view.findPortNode(1, 'portRoot').lastChild.tagName.toUpperCase(), 'POLYLINE');
+            assert.equal(el2view.findPortNode(1, 'labelRoot').tagName.toUpperCase(), 'G');
+            assert.equal(el2view.findPortNode(1, 'labelRoot').firstChild.tagName.toUpperCase(), 'CIRCLE');
+            assert.equal(el2view.findPortNode(1, 'labelRoot').lastChild.tagName.toUpperCase(), 'ELLIPSE');
+            assert.equal(el2view.findPortNode(1, 'portRoot').parentNode, el2view.findPortNode(1, 'root'));
+            assert.equal(el2view.findPortNode(1, 'labelRoot').parentNode, el2view.findPortNode(1, 'root'));
+            assert.equal(el2view.findPortNode(1, 'es').tagName.toUpperCase(), 'ELLIPSE');
+            assert.equal(el2view.findPortNode(1, 'cs'), null);
+        });
     });
 
     QUnit.module('custom view ', function() {


### PR DESCRIPTION
…ot and labelRoot selectors

## Description

- `findPortNode(portId, selector)` now returns SVGElements of port labels.
- add `portRoot` selector pointing to the wrapper of the port body.
- add `labelRoot` selector pointing to the wrapper of the port label.
- update port documentation

## Motivation and Context

The API did not allow to get the SVGElement of port labels.
There was no `selector` referring to the implicit `<g>` that wraps ports/port labels with more than one nodes.

### Problem it solves:

https://jsfiddle.net/kumilingus/t7rqx6n5/
The `[port]` CSS selector can be replaced by faster `portRoot` JSON selector.
