### PR TITLE
dia.HighlighterView: fix stroke and mask highlighter size and position

### DIFF
--- a/src/dia/HighlighterView.mjs
+++ b/src/dia/HighlighterView.mjs
@@ -70,6 +70,26 @@ export const HighlighterView = mvc.View.extend({
         return el ? el : null;
     },
 
+    getNodeMatrix(cellView, node) {
+        const { options } = this;
+        const { layer } = options;
+        const { rotatableNode } = cellView;
+        const nodeMatrix = cellView.getNodeMatrix(node);
+        if (rotatableNode) {
+            if (layer) {
+                if (rotatableNode.contains(node)) {
+                    return nodeMatrix;
+                }
+                // The node is outside of the rotatable group.
+                // Compensate the rotation set by transformGroup.
+                return cellView.getRootRotateMatrix().inverse().multiply(nodeMatrix);
+            } else {
+                return cellView.getNodeRotateMatrix(node).multiply(nodeMatrix);
+            }
+        }
+        return nodeMatrix;
+    },
+
     mount() {
         const { MOUNTABLE, cellView, el, options, transformGroup } = this;
         if (!MOUNTABLE || transformGroup) return;

--- a/src/highlighters/mask.mjs
+++ b/src/highlighters/mask.mjs
@@ -200,7 +200,7 @@ export const mask = HighlighterView.extend({
             vel.remove();
         }
         const highlighterBBox = cellView.getNodeBoundingRect(node).inflate(padding + maskClip);
-        const highlightMatrix = cellView.getNodeRotateMatrix(node).multiply(cellView.getNodeMatrix(node));
+        const highlightMatrix = this.getNodeMatrix(cellView, node);
         const maskEl = this.getMask(cellView, V(node));
         this.addMask(cellView.paper, maskEl);
         vel.attr(highlighterBBox.toJSON());

--- a/src/highlighters/stroke.mjs
+++ b/src/highlighters/stroke.mjs
@@ -52,7 +52,7 @@ export const stroke = HighlighterView.extend({
     highlightNode(cellView, node) {
         const { vel, options } = this;
         const { padding, layer } = options;
-        let highlightMatrix = cellView.getNodeRotateMatrix(node).multiply(cellView.getNodeMatrix(node));
+        let highlightMatrix = this.getNodeMatrix(cellView, node);
         // Add padding to the highlight element.
         if (padding) {
             if (!layer && node === cellView.el) {

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -735,6 +735,144 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.notEqual(elementView.el, highlighter.el.parentNode);
         });
 
+
+        QUnit.module('Rendering', function() {
+
+            QUnit.test('no rotatable group', function(assert) {
+                element.set({
+                    position: { x: 0, y: 0 },
+                    size: { width: 100, height: 100 },
+                    angle: 90,
+                    markup: [
+                        {
+                            tagName: 'rect',
+                            selector: 'rect',
+                        },
+                    ],
+                    attrs: {
+                        rect: {
+                            x: 21,
+                            y: 13,
+                            width: 20,
+                            height: 10
+                        }
+                    }
+                });
+
+                const h1 = joint.highlighters.stroke.add(elementView, 'rect', 'l1', {
+                    layer: 'front',
+                    padding: 0
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h1.vel.getBBox({ target: paper.svg }), {
+                    x: 100 - 13 - 10,
+                    y: 21,
+                    width: 10,
+                    height: 20
+                });
+
+                const h2 = joint.highlighters.stroke.add(elementView, 'rect', 'l0', {
+                    layer: null,
+                    padding: 0
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h2.vel.getBBox({ target: paper.svg }), {
+                    x: 100 - 13 - 10,
+                    y: 21,
+                    width: 10,
+                    height: 20
+                });
+            });
+
+            QUnit.test('rotatable group', function(assert) {
+                element.set({
+                    position: { x: 0, y: 0 },
+                    size: { width: 100, height: 100 },
+                    angle: 90,
+                    markup: [
+                        {
+                            tagName: 'g',
+                            selector: 'rotatable',
+                            children: [
+                                {
+                                    tagName: 'rect',
+                                    selector: 'rectInside',
+                                }
+                            ],
+                        }, {
+                            tagName: 'rect',
+                            selector: 'rectOutside',
+                        },
+                    ],
+                    attrs: {
+                        rectInside: {
+                            x: 21,
+                            y: 13,
+                            width: 20,
+                            height: 10
+                        },
+                        rectOutside: {
+                            x: 7,
+                            y: 5,
+                            width: 20,
+                            height: 10,
+                            fill: 'red'
+                        }
+                    }
+                });
+
+                const h1 = joint.highlighters.stroke.add(elementView, 'rectInside', 'in1', {
+                    layer: 'front',
+                    padding: 0,
+                    attrs: { stroke: 'green' }
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h1.vel.getBBox({ target: paper.svg }), {
+                    x: 100 - 13 - 10,
+                    y: 21,
+                    width: 10,
+                    height: 20
+                });
+
+                const h2 = joint.highlighters.stroke.add(elementView, 'rectOutside', 'out1', {
+                    layer: 'front',
+                    padding: 0,
+                    attrs: { stroke: 'gray' }
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h2.vel.getBBox({ target: paper.svg }), {
+                    x: 7,
+                    y: 5,
+                    width: 20,
+                    height: 10
+                });
+
+                const h3 = joint.highlighters.stroke.add(elementView, 'rectInside', 'in2', {
+                    layer: null,
+                    padding: 0,
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h3.vel.getBBox({ target: paper.svg }), {
+                    x: 100 - 13 - 10,
+                    y: 21,
+                    width: 10,
+                    height: 20
+                });
+
+                const h4 = joint.highlighters.stroke.add(elementView, 'rectOutside', 'out2', {
+                    layer: null,
+                    padding: 0
+                });
+
+                assert.checkBboxApproximately(1/* +- */, h4.vel.getBBox({ target: paper.svg }), {
+                    x: 7,
+                    y: 5,
+                    width: 20,
+                    height: 10
+                });
+
+            });
+        });
     });
 
     QUnit.module('list', function() {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1843,6 +1843,8 @@ export namespace dia {
 
         protected onCellAttributeChange(): void;
 
+        protected getNodeMatrix(cellView: dia.CellView, node: SVGElement): SVGMatrix;
+
         static uniqueId(node: SVGElement, options?: any): string;
 
         static add<T extends HighlighterView>(


### PR DESCRIPTION
## Description

Fix `stroke` and `mask` highlighter angle and position for rotated elements. Add test cases for many element configurations (angle, rotatable group, highlighter layer).

## Motivation and Context

This [PR](https://github.com/clientIO/joint/pull/1791) made highlighters not to work properly for rotated elements without rotatable group.