### PR TITLE
dia.LinkView, g.Line: update types

### DIFF
--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -291,7 +291,7 @@ export namespace g {
 
         clone(): Line;
 
-        parallel(): Line;
+        parallel(distance?: number): Line;
 
         closestPoint(p: PlainPoint | string): Point;
 

--- a/types/geometry.d.ts
+++ b/types/geometry.d.ts
@@ -291,7 +291,7 @@ export namespace g {
 
         clone(): Line;
 
-        parallel(distance?: number): Line;
+        parallel(distance: number): Line;
 
         closestPoint(p: PlainPoint | string): Point;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1,3 +1,4 @@
+import { g } from './geometry';
 
 export const version: string;
 
@@ -1107,6 +1108,8 @@ export namespace dia {
         protected dragArrowheadEnd(evt: dia.Event, x: number, y: number): void;
 
         protected dragEnd(evt: dia.Event, x: number, y: number): void;
+
+        protected findPath(route: Point[], sourcePoint: Point, targetPoint: Point): g.Path;
 
         protected notifyPointerdown(evt: dia.Event, x: number, y: number): void;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1,4 +1,3 @@
-import { g } from './geometry';
 
 export const version: string;
 


### PR DESCRIPTION
## Description

- Add missing protected method type for `findPath` in `dia.LinkView`
- Add missing parameter for `parallel` method in `g.Line`

Both of these errors were encountered in `VSMElectronicInformationFlowView`.

### Screenshots (if appropriate):

<img width="486" alt="Screenshot 2022-09-22 at 15 36 35" src="https://user-images.githubusercontent.com/42288565/191766807-e066d4f2-8742-4303-afe7-9cbff2e40e62.png">
<img width="578" alt="Screenshot 2022-09-22 at 15 37 30" src="https://user-images.githubusercontent.com/42288565/191766834-38210669-d1c8-44e5-ab56-b9ba926de2c5.png">
