### PR TITLE
chore: update travis nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "lts/*"
+  - 16
 
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
## Description

Temporarily downgrade the nodeJS version in TravisCI.

## Motivation and Context

Node 18 (LTS) is not compatible with the current ubuntu version used in TravisCI
- https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
- https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/4

