### PR TITLE
fix(Vectorizer): remove deprecated hasFeature check

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -8,11 +8,7 @@ import * as g from '../g/index.mjs';
 
 const V = (function() {
 
-    var hasSvg = typeof window === 'object' &&
-        !!(
-            window.SVGAngle ||
-            document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1')
-        );
+    var hasSvg = typeof window === 'object' && !!window.SVGAngle;
 
     // SVG support is required.
     if (!hasSvg) {


### PR DESCRIPTION
## Description

Remove usage of `document.implementation.hasFeature`.

## Motivation and Context

⚠️ The feature is deprecated: https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature

It is safe to remove it because it always returns `true`. See [StackOverflow](https://stackoverflow.com/a/50232660/2921495) answer:

> hasFeature was deprecated some time ago. To ease the migration of people not to use it it still exists (for a while) but is supposed to [always return true](https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature) regardless of input arguments
