### PR TITLE
refactor: update demo layouts for new site theme

### DIFF
--- a/demo/bandwidth/css/bandwidth.css
+++ b/demo/bandwidth/css/bandwidth.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/bandwidth/index.html
+++ b/demo/bandwidth/index.html
@@ -6,6 +6,7 @@
         <title>Carrier Frequency Bandwidth</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/bandwidth.css"/>
     </head>
     <body>
         <div id="paper"></div>

--- a/demo/bus/css/bus.css
+++ b/demo/bus/css/bus.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 .active.joint-element [joint-selector="body"],
 .active.joint-type-mix-connector [joint-selector="line"] {
     stroke: #D8A47F;

--- a/demo/bus/src/bus.js
+++ b/demo/bus/src/bus.js
@@ -5,7 +5,7 @@ var graph = new joint.dia.Graph;
 var paper = new joint.dia.Paper({
     el: document.getElementById('paper'),
     width: 1000,
-    height: 800,
+    height: 725,
     model: graph,
     async: true,
     frozen: true,

--- a/demo/chess/css/chess.css
+++ b/demo/chess/css/chess.css
@@ -1,6 +1,18 @@
+html,
 body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
     text-align: center;
 }
+
 #board {
     margin: 0 auto;
     border-style: none;

--- a/demo/container/css/container.css
+++ b/demo/container/css/container.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/container/index.html
+++ b/demo/container/index.html
@@ -6,6 +6,7 @@
         <title>Container</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/container.css" />
     </head>
     <body>
 

--- a/demo/curves/css/curves.css
+++ b/demo/curves/css/curves.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 #paper {
     margin: 0 auto;
 }

--- a/demo/devs/css/shapes.devs.css
+++ b/demo/devs/css/shapes.devs.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 .joint-type-devs text {
     text-transform: uppercase;
     font-weight: 800;

--- a/demo/erd/css/erd.css
+++ b/demo/erd/css/erd.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 #paper {
     width: inherit;
     display: block;

--- a/demo/fta/css/fta.css
+++ b/demo/fta/css/fta.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/fta/index.html
+++ b/demo/fta/index.html
@@ -6,6 +6,7 @@
         <title>Fault Tree Analysis</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/fta.css" />
     </head>
     <body>
 

--- a/demo/fta/src/index.js
+++ b/demo/fta/src/index.js
@@ -7,7 +7,7 @@
     var paper = new joint.dia.Paper({
         el: document.getElementById('paper'),
         width: 900,
-        height: 800,
+        height: 725,
         model: graph,
         defaultConnectionPoint: { name: 'boundary', args: { extrapolate: true }},
         defaultConnector: { name: 'rounded' },

--- a/demo/html/css/html.css
+++ b/demo/html/css/html.css
@@ -1,6 +1,13 @@
 html, body {
     margin: 0;
-    padding: 0
+    padding: 0;
+    height: 100%;
+}
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow-y: hidden;
 }
 #paper {
     border: 1px solid #E2E2E2;

--- a/demo/hull/css/hull.css
+++ b/demo/hull/css/hull.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/hull/index.html
+++ b/demo/hull/index.html
@@ -6,6 +6,7 @@
         <title>Convex Hull Algorithm</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/hull.css" />
     </head>
     <body>
         <div id="paper"></div>

--- a/demo/icons/css/icons.css
+++ b/demo/icons/css/icons.css
@@ -1,16 +1,11 @@
-html,
-body {
+html {
     height: 100%;
 }
 
 body {
+    min-height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     margin: 0;
-    overflow-y: hidden;
-}
-
-#paper {
-    display: inline-block;
 }

--- a/demo/icons/index.html
+++ b/demo/icons/index.html
@@ -6,6 +6,7 @@
         <title>Icons</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/icons.css" />
     </head>
     <body>
         <div id="paper"></div>

--- a/demo/icons/src/icons.js
+++ b/demo/icons/src/icons.js
@@ -48,7 +48,7 @@ const graph = new dia.Graph({}, { cellNamespace: shapes });
 const paper = new dia.Paper({
     model: graph,
     cellViewNamespace: shapes,
-    width: '100%',
+    width: 800,
     height: '100%',
     gridSize: 20,
     async: true,

--- a/demo/links/css/links.css
+++ b/demo/links/css/links.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/links/index.html
+++ b/demo/links/index.html
@@ -6,6 +6,7 @@
         <title>Links</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/links.css" />
     </head>
     <body>
         <div id="paper"></div>

--- a/demo/list/index.html
+++ b/demo/list/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html style="height:100%;">
   <head>
     <meta charset="utf-8"/>
     <title>JointJS List Element</title>
     <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
   </head>
-  <body>
+  <body style="height:100%;display:flex;justify-content:center;align-items:center;margin:0;overflow-y:hidden;">
     <div id="paper"></div>
     <script src="dist/bundle.js"></script>
   </body>

--- a/demo/logic/css/logic.css
+++ b/demo/logic/css/logic.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 .connection {
     stroke: #999;
 }

--- a/demo/marey/css/marey.css
+++ b/demo/marey/css/marey.css
@@ -2,6 +2,11 @@
     user-select: none;  
 }
 
+body {
+    display: flex;
+    justify-content: center;
+}
+
 #paper {
     position: absolute;  
 }

--- a/demo/paper/css/paper.css
+++ b/demo/paper/css/paper.css
@@ -1,4 +1,13 @@
+html,
 body {
+    height:100%;
+}
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
     text-align: center;
 }
 .content-container {

--- a/demo/petri nets/css/petri.css
+++ b/demo/petri nets/css/petri.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/petri nets/index.html
+++ b/demo/petri nets/index.html
@@ -6,6 +6,7 @@
         <title>Petri Nets</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/petri.css" />
     </head>
     <body>
         <div id="paper"></div>

--- a/demo/rough/css/rough.css
+++ b/demo/rough/css/rough.css
@@ -1,7 +1,18 @@
 [data-tool-name="button"] > circle { fill: #333; }
 
+html,
 body {
-    background-color: #FAFAFA
+    height: 100%;
+}
+
+body {
+    background-color: #FAFAFA;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
 }
 
 #paper {

--- a/demo/rough/src/rough.js
+++ b/demo/rough/src/rough.js
@@ -1,7 +1,7 @@
 (function(joint, Rough, g, V) {
 
     var WIDTH = 800;
-    var HEIGHT = 800;
+    var HEIGHT = 600;
 
     var graph = new joint.dia.Graph;
 

--- a/demo/routing/css/routing.css
+++ b/demo/routing/css/routing.css
@@ -1,3 +1,17 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 .router-switch {
     width: 100px;
     margin: 4px;

--- a/demo/sequence/css/sequence.css
+++ b/demo/sequence/css/sequence.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/sequence/index.html
+++ b/demo/sequence/index.html
@@ -6,6 +6,7 @@
         <title>Sequence Diagram</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/sequence.css" />
         <style>
             .available-cell.joint-type-sd-message [joint-selector="wrapper"] {
                 stroke-width: 26;

--- a/demo/umlcd/css/umlcd.css
+++ b/demo/umlcd/css/umlcd.css
@@ -1,3 +1,16 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    overflow-y: hidden;
+}
+
 .joint-type-uml-composition .marker-target {
     fill: #4a4e69;
     stroke: #4a4e69;

--- a/demo/umlsc/css/umlsc.css
+++ b/demo/umlsc/css/umlsc.css
@@ -10,7 +10,3 @@ body {
     margin: 0;
     overflow-y: hidden;
 }
-
-#paper {
-    display: inline-block;
-}

--- a/demo/umlsc/index.html
+++ b/demo/umlsc/index.html
@@ -6,6 +6,7 @@
         <title>Unified Modeling Language</title>
 
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="css/umlsc.css" />
     </head>
     <body>
         <div id="paper"></div>


### PR DESCRIPTION
## Description

- apply more or less the following CSS to joint demos. This provides little or no change on the JointJS_Site, but centers content on the iframe in webflow, and centers the content when opened locally.

```css
html,
body {
    height: 100%;
}

body {
    display: flex;
    justify-content: center;
    align-items: center;
    margin: 0;
    overflow-y: hidden;
}
```
Other changes 
- reduce `height` of paper a little in a few demos, so it looks better in webflow (`rough`, `fta`, `mix bus` )


