### PR TITLE
fix(dia.Cell): prevent exception when removeProp() called on non-exis…

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -601,7 +601,9 @@ export const Cell = Backbone.Model.extend({
 
         // A nested property
         var nestedPath = pathArray.slice(1);
-        var propertyValue = cloneDeep(this.get(property));
+        var propertyValue = this.get(property);
+        if (propertyValue === undefined || propertyValue === null) return this;
+        propertyValue = cloneDeep(propertyValue);
 
         unsetByPath(propertyValue, nestedPath, '/');
 

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -250,6 +250,12 @@ QUnit.module('cell', function(hooks) {
                 assert.deepEqual(attributes.a[1], { cc: 'cc' });
             });
 
+            QUnit.test('remove non-existing top-level property', function(assert) {
+
+                el.removeProp('a/b/c');
+                assert.equal(attributes.a, undefined);
+            });
+
             QUnit.module('define path as an array', function(hooks) {
 
                 QUnit.test('remove item from array', function(assert) {


### PR DESCRIPTION
…ting top-level attribute

## Description

Prevent the `removeProp()` method to throw an exception when trying to remove a nested property, when the top-level property does not exist.

e.g.
```js
el.removeProp('a/b');
```
an exception is thrown when 
```js
el.get('a') === undefined
````

![Image](https://user-images.githubusercontent.com/3967880/202271119-7cd3f014-5744-4758-9829-2e5e7f1acc6b.png)