### PR TITLE
fix(linkTools.Segments): non-orthogonal edge cases

### DIFF
--- a/src/linkTools/Segments.mjs
+++ b/src/linkTools/Segments.mjs
@@ -231,8 +231,8 @@ export const Segments = ToolView.extend({
 
             if (theta % 90 !== 0) {
                 const isSingleVertex = this._originalVertices.length === 1;
-                const origVIndex = isSingleVertex === 1  ? 0 : handleIndex;
-                const additionalOffset = this._firstVertexShifted || isSingleVertex ? 1 : 0;
+                const origVIndex = isSingleVertex ? 0 : handleIndex;
+                const additionalOffset = this._firstVertexShifted && !isSingleVertex ? 1 : 0;
                 let nextVIndex = 1 + indexOffset;
                 vertices.splice(handleIndex + nextVIndex, 0, this._originalVertices[origVIndex - additionalOffset]);
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Make sure all links stay orthogonal while dragging a handle.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

In some cases, links could become non-orthogonal when using linkTools.Segments tool.

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50818204/203062240-c9bdb3ea-9032-4f0b-be6d-e7a8cd993762.png)
![image](https://user-images.githubusercontent.com/50818204/203063144-13406daf-1e59-4a50-ad08-1b1973eb91b0.png)