### PR TITLE
fix(Vectorizer): fix removing & toggling multiple classes at once

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1037,7 +1037,8 @@ const V = (function() {
     }
 
     VPrototype.hasClass = function(className) {
-        return this.node.classList.contains(className);
+        if (!V.isString(className)) return false;
+        return this.node.classList.contains(className.trim());
     };
 
     VPrototype.addClass = function(className) {
@@ -1051,7 +1052,10 @@ const V = (function() {
     };
 
     VPrototype.toggleClass = function(className, toAdd) {
-        this.node.classList.toggle(...getTokenList(className), toAdd);
+        const tokens = getTokenList(className);
+        for (let i = 0; i < tokens.length; i++) {
+            this.node.classList.toggle(tokens[i], toAdd);
+        }
         return this;
     };
 

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1027,41 +1027,31 @@ const V = (function() {
         return this;
     };
 
-    VPrototype.hasClass = function(className) {
 
-        return new RegExp('(\\s|^)' + className + '(\\s|$)').test(this.node.getAttribute('class'));
+    // Split a string into an array of tokens.
+    // https://infra.spec.whatwg.org/#ascii-whitespace
+    const noHTMLWhitespaceRegex = /[^\x20\t\r\n\f]+/g;
+    function getTokenList(str) {
+        if (!V.isString(str)) return [];
+        return str.trim().match(noHTMLWhitespaceRegex) || [];
+    }
+
+    VPrototype.hasClass = function(className) {
+        return this.node.classList.contains(className);
     };
 
     VPrototype.addClass = function(className) {
-
-        if (className && !this.hasClass(className)) {
-            var prevClasses = this.node.getAttribute('class') || '';
-            this.node.setAttribute('class', (prevClasses + ' ' + className).trim());
-        }
-
+        this.node.classList.add(...getTokenList(className));
         return this;
     };
 
     VPrototype.removeClass = function(className) {
-
-        if (className && this.hasClass(className)) {
-            var newClasses = this.node.getAttribute('class').replace(new RegExp('(\\s|^)' + className + '(\\s|$)', 'g'), '$2');
-            this.node.setAttribute('class', newClasses);
-        }
-
+        this.node.classList.remove(...getTokenList(className));
         return this;
     };
 
     VPrototype.toggleClass = function(className, toAdd) {
-
-        var toRemove = V.isUndefined(toAdd) ? this.hasClass(className) : !toAdd;
-
-        if (toRemove) {
-            this.removeClass(className);
-        } else {
-            this.addClass(className);
-        }
-
+        this.node.classList.toggle(...getTokenList(className), toAdd);
         return this;
     };
 

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -1557,6 +1557,8 @@ QUnit.module('vectorizer', function(hooks) {
             rect.addClass('test2');
             assert.equal(rect.hasClass('test1'), true);
             assert.equal(rect.hasClass('test2'), true);
+            assert.equal(rect.hasClass(' test1 '), true);
+            assert.equal(rect.hasClass(' test3 '), false);
         });
 
     });

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -1501,6 +1501,63 @@ QUnit.module('vectorizer', function(hooks) {
             assert.equal(rect.node.className.baseVal, 'test1');
             rect.addClass('test2');
             assert.equal(rect.node.className.baseVal, 'test1 test2');
+            rect.addClass('test3 test4');
+            assert.equal(rect.node.className.baseVal, 'test1 test2 test3 test4');
+            rect.addClass(' test5 ');
+            assert.equal(rect.node.className.baseVal, 'test1 test2 test3 test4 test5');
         });
+
+        QUnit.test('removeClass()', function(assert) {
+            var res;
+            var rect = V('rect');
+            res = rect.removeClass();
+            assert.ok(res === rect);
+            assert.equal(rect.node.className.baseVal, '');
+            res = rect.removeClass('test1');
+            assert.ok(res === rect);
+            assert.equal(rect.node.className.baseVal, '');
+            rect.addClass('test1 test2 test3 test4 test5');
+            rect.removeClass('test2');
+            assert.equal(rect.node.className.baseVal, 'test1 test3 test4 test5');
+            rect.removeClass('test3 test4');
+            assert.equal(rect.node.className.baseVal, 'test1 test5');
+            rect.removeClass(' test5 ');
+            assert.equal(rect.node.className.baseVal, 'test1');
+        });
+
+        QUnit.test('toggleClass()', function(assert) {
+            var res;
+            var rect = V('rect');
+            res = rect.toggleClass();
+            assert.ok(res === rect);
+            assert.equal(rect.node.className.baseVal, '');
+            res = rect.toggleClass('test1');
+            assert.ok(res === rect);
+            assert.equal(rect.node.className.baseVal, 'test1');
+            rect.toggleClass('test1');
+            assert.equal(rect.node.className.baseVal, '');
+            rect.toggleClass('test1 test2');
+            assert.equal(rect.node.className.baseVal, 'test1 test2');
+            rect.toggleClass('test1 test2');
+            assert.equal(rect.node.className.baseVal, '');
+            rect.addClass('test1');
+            rect.toggleClass('test1 test2');
+            assert.equal(rect.node.className.baseVal, 'test2');
+            rect.toggleClass('test1 test2');
+            assert.equal(rect.node.className.baseVal, 'test1');
+        });
+
+        QUnit.test('hasClass()', function(assert) {
+            var rect = V('rect');
+            assert.equal(rect.hasClass(), false);
+            assert.equal(rect.hasClass('test1'), false);
+            rect.addClass('test1');
+            assert.equal(rect.hasClass('test1'), true);
+            assert.equal(rect.hasClass('test2'), false);
+            rect.addClass('test2');
+            assert.equal(rect.hasClass('test1'), true);
+            assert.equal(rect.hasClass('test2'), true);
+        });
+
     });
 });


### PR DESCRIPTION
## Description


Properly handle multiple tokens in `removeClass()` and `toggleClass()` prototype methods.

```js
const g = V('g');
g.addClass('token1 token2'); // worked already
g.removeClass('token1 token2'); // fixed
g.toggleClass('token1 token2'); // fixed
```

## Motivation and Context

See issue: https://github.com/clientIO/joint/issues/1900
