### PR TITLE
dia.Paper: fix magnet contextmenu handling

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2058,8 +2058,8 @@ export const Paper = View.extend({
 
         if (evt.button === 2) {
             this.contextMenuFired = true;
-            const event = $.Event(evt, { type: 'contextmenu', data: evt.data });
-            this.contextMenuTrigger(event);
+            const contextmenuEvt = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            this.contextMenuTrigger(contextmenuEvt);
         } else {
             var view = this.findView(evt.target);
 
@@ -2323,9 +2323,9 @@ export const Paper = View.extend({
         if (evt.button === 2) {
             this.contextMenuFired = true;
             this.magnetContextMenuFired = true;
-            const event = $.Event(evt, { type: 'contextmenu', data: evt.data });
-            this.magnetContextMenuTrigger(event);
-            if (event.isPropagationStopped()) {
+            const contextmenuEvt = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            this.magnetContextMenuTrigger(contextmenuEvt);
+            if (contextmenuEvt.isPropagationStopped()) {
                 evt.stopPropagation();
             }
         } else {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2059,14 +2059,7 @@ export const Paper = View.extend({
         if (evt.button === 2) {
             this.contextMenuFired = true;
             const event = $.Event(evt, { type: 'contextmenu', data: evt.data });
-            if (evt.target.closest('.joint-cell') && evt.target.getAttribute('magnet')) {
-                event.currentTarget = evt.target;
-                this.magnetContextMenuFired = true;
-                this.magnetContextMenuTrigger(event);
-            }
-            if (!event.isPropagationStopped()) {
-                this.contextMenuTrigger(event);
-            }
+            this.contextMenuTrigger(event);
         } else {
             var view = this.findView(evt.target);
 
@@ -2327,11 +2320,20 @@ export const Paper = View.extend({
 
     onmagnet: function(evt) {
 
-        this.magnetEvent(evt, function(view, evt, _, x, y) {
-            view.onmagnet(evt, x, y);
-        });
+        if (evt.button === 2) {
+            this.contextMenuFired = true;
+            this.magnetContextMenuFired = true;
+            const event = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            this.magnetContextMenuTrigger(event);
+            if (event.isPropagationStopped()) {
+                evt.stopPropagation();
+            }
+        } else {
+            this.magnetEvent(evt, function(view, evt, _, x, y) {
+                view.onmagnet(evt, x, y);
+            });
+        }
     },
-
 
     magnetpointerdblclick: function(evt) {
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2058,7 +2058,15 @@ export const Paper = View.extend({
 
         if (evt.button === 2) {
             this.contextMenuFired = true;
-            this.contextMenuTrigger($.Event(evt, { type: 'contextmenu', data: evt.data }));
+            const event = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            if (evt.target.closest('.joint-cell') && evt.target.getAttribute('magnet')) {
+                event.currentTarget = evt.target;
+                this.magnetContextMenuFired = true;
+                this.magnetContextMenuTrigger(event);
+            }
+            if (!event.isPropagationStopped()) {
+                this.contextMenuTrigger(event);
+            }
         } else {
             var view = this.findView(evt.target);
 
@@ -2333,8 +2341,17 @@ export const Paper = View.extend({
     },
 
     magnetcontextmenu: function(evt) {
-
         if (this.options.preventContextMenu) evt.preventDefault();
+
+        if (this.magnetContextMenuFired) {
+            this.magnetContextMenuFired = false;
+            return;
+        }
+
+        this.magnetContextMenuTrigger(evt);
+    },
+
+    magnetContextMenuTrigger: function(evt) {
         this.magnetEvent(evt, function(view, evt, magnet, x, y) {
             view.magnetcontextmenu(evt, magnet, x, y);
         });

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2437,6 +2437,59 @@ QUnit.module('paper', function(hooks) {
             assert.deepEqual(getEventNames(spy), eventOrder.slice(0, eventOrder.indexOf('cell:pointerclick')));
         });
 
+        QUnit.test('right button click contextmenu interactions', function(assert) {
+
+            const paper = this.paper;
+            const spy = sinon.spy();
+
+            paper.on('all', spy);
+
+            const magnet = document.createElement('div');
+            magnet.setAttribute('magnet', 'true');
+            elRect.appendChild(magnet);
+
+            simulate.click({
+                el: elRect,
+                button: 2,
+                clientX: 1200,
+                clientY: 1300
+            });
+
+            let events = getEventNames(spy);
+            assert.equal(events.length, 2);
+            assert.equal(events[0], 'cell:contextmenu');
+            assert.equal(events[1], 'element:contextmenu');
+            spy.resetHistory();
+
+            simulate.click({
+                el: magnet,
+                button: 2,
+                clientX: 1200,
+                clientY: 1300
+            });
+
+            events = getEventNames(spy);
+            assert.equal(events.length, 3);
+            assert.equal(events[0], 'element:magnet:contextmenu');
+            assert.equal(events[1], 'cell:contextmenu');
+            assert.equal(events[2], 'element:contextmenu');
+            spy.resetHistory();
+
+            paper.on('element:magnet:contextmenu', function(_, evt) {
+                evt.stopPropagation();
+            });
+            simulate.click({
+                el: magnet,
+                button: 2,
+                clientX: 1200,
+                clientY: 1300
+            });
+            events = getEventNames(spy);
+            assert.equal(events.length, 1);
+            assert.equal(events[0], 'element:magnet:contextmenu');
+            spy.resetHistory();
+        });
+
         QUnit.test('blank:pointerclick', function(assert) {
 
             var eventName = 'blank:pointerclick';


### PR DESCRIPTION
## Description

Fix of the `element:magnet:contextmenu` event handling in dia.Paper. Preserve events hierarchy so it is possible to use `stopPropagation()` in `element:magnet:contextmenu` handler to prevent triggering of the `element:contextmenu` and `cell:contextmenu` events.
