### PR TITLE
Fix RegEx queries in code

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1402,11 +1402,11 @@ const V = (function() {
     V.transformSeparatorRegex = /[ ,]+/;
     V.transformationListRegex = /^(\w+)\((.*)\)/;
     // Note: These are more restrictive than the official regex
-    // Note: These cannot be /g because we are using the capturing group
-    // ReDos mitigation: Capturing group used to be `(.*?)` but this is safer
-    V.transformTranslateRegex = /translate\(([^)]+)\)/;
-    V.transformRotateRegex = /rotate\(([^)]+)\)/;
-    V.transformScaleRegex = /scale\(([^)]+)\)/;
+    // ReDos mitigation: Avoids backtracking (uses `[^)]+` instead of `.*?`)
+    // ReDos mitigation: Doesn't use capturing group
+    V.transformTranslateRegex = /translate\([^)]+\)/;
+    V.transformRotateRegex = /rotate\([^)]+\)/;
+    V.transformScaleRegex = /scale\([^)]+\)/;
 
     V.transformStringToMatrix = function(transform) {
 
@@ -1518,18 +1518,23 @@ const V = (function() {
             } else {
 
                 // Note: We only detect the first match of each method (if any)
-                // `match` function returns value of capturing group as `[1]`
-                let translateMatch = transform.match(V.transformTranslateRegex);
+                const translateMatch = transform.match(V.transformTranslateRegex);
                 if (translateMatch) {
-                    translate = translateMatch[1].split(separator);
+                    // get content of parentheses ("translate(" = 10 characters)
+                    const translateMatchContents = translateMatch[0].slice(10, -1);
+                    translate = translateMatchContents.split(separator);
                 }
-                let rotateMatch = transform.match(V.transformRotateRegex);
+                const rotateMatch = transform.match(V.transformRotateRegex);
                 if (rotateMatch) {
-                    rotate = rotateMatch[1].split(separator);
+                    // get content of parentheses ("rotate(" = 7 characters)
+                    const rotateMatchContents = rotateMatch[0].slice(7, -1);
+                    rotate = rotateMatchContents.split(separator);
                 }
-                let scaleMatch = transform.match(V.transformScaleRegex);
+                const scaleMatch = transform.match(V.transformScaleRegex);
                 if (scaleMatch) {
-                    scale = scaleMatch[1].split(separator);
+                    // get contents of parentheses ("scale(" = 6 characters)
+                    const scaleMatchContents = scaleMatch[0].slice(6, -1);
+                    scale = scaleMatchContents.split(separator);
                 }
             }
         }

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1401,6 +1401,12 @@ const V = (function() {
     V.transformRegex = /(\w+)\(([^,)]+),?([^)]+)?\)/gi;
     V.transformSeparatorRegex = /[ ,]+/;
     V.transformationListRegex = /^(\w+)\((.*)\)/;
+    // Note: These are more restrictive than the official regex
+    // Note: These cannot be /g because we are using the capturing group
+    // ReDos mitigation: Capturing group used to be `(.*?)` but this is safer
+    V.transformTranslateRegex = /translate\(([^)]+)\)/;
+    V.transformRotateRegex = /rotate\(([^)]+)\)/;
+    V.transformScaleRegex = /scale\(([^)]+)\)/;
 
     V.transformStringToMatrix = function(transform) {
 
@@ -1511,15 +1517,17 @@ const V = (function() {
 
             } else {
 
-                var translateMatch = transform.match(/translate\((.*?)\)/);
+                // Note: We only detect the first match of each method (if any)
+                // `match` function returns value of capturing group as `[1]`
+                let translateMatch = transform.match(V.transformTranslateRegex);
                 if (translateMatch) {
                     translate = translateMatch[1].split(separator);
                 }
-                var rotateMatch = transform.match(/rotate\((.*?)\)/);
+                let rotateMatch = transform.match(V.transformRotateRegex);
                 if (rotateMatch) {
                     rotate = rotateMatch[1].split(separator);
                 }
-                var scaleMatch = transform.match(/scale\((.*?)\)/);
+                let scaleMatch = transform.match(V.transformScaleRegex);
                 if (scaleMatch) {
                     scale = scaleMatch[1].split(separator);
                 }

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1402,12 +1402,12 @@ const V = (function() {
     V.transformSeparatorRegex = /[ ,]+/;
     V.transformationListRegex = /^(\w+)\((.*)\)/;
     // Note: These are more restrictive than the official regex
+    // Note: These cannot be /g because we are using the capturing group
     // ReDoS mitigation: Avoids backtracking (uses `[^())]+` instead of `.*?`)
-    // ReDoS mitigation: Doesn't use capturing group
     // ReDoS mitigation: Doesn't match initial `(` inside repeated part
-    V.transformTranslateRegex = /translate\([^()]+\)/;
-    V.transformRotateRegex = /rotate\([^()]+\)/;
-    V.transformScaleRegex = /scale\([^()]+\)/;
+    V.transformTranslateRegex = /translate\(([^()]+)\)/;
+    V.transformRotateRegex = /rotate\(([^()]+)\)/;
+    V.transformScaleRegex = /scale\(([^()]+)\)/;
 
     V.transformStringToMatrix = function(transform) {
 
@@ -1519,23 +1519,18 @@ const V = (function() {
             } else {
 
                 // Note: We only detect the first match of each method (if any)
+                // `match` function returns value of capturing group as `[1]`
                 const translateMatch = transform.match(V.transformTranslateRegex);
                 if (translateMatch) {
-                    // get content of parentheses ("translate(" = 10 characters)
-                    const translateMatchContents = translateMatch[0].slice(10, -1);
-                    translate = translateMatchContents.split(separator);
+                    translate = translateMatch[1].split(separator);
                 }
                 const rotateMatch = transform.match(V.transformRotateRegex);
                 if (rotateMatch) {
-                    // get content of parentheses ("rotate(" = 7 characters)
-                    const rotateMatchContents = rotateMatch[0].slice(7, -1);
-                    rotate = rotateMatchContents.split(separator);
+                    rotate = rotateMatch[1].split(separator);
                 }
                 const scaleMatch = transform.match(V.transformScaleRegex);
                 if (scaleMatch) {
-                    // get contents of parentheses ("scale(" = 6 characters)
-                    const scaleMatchContents = scaleMatch[0].slice(6, -1);
-                    scale = scaleMatchContents.split(separator);
+                    scale = scaleMatch[1].split(separator);
                 }
             }
         }

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1398,7 +1398,8 @@ const V = (function() {
         };
     };
 
-    // Note: This allows multiple commas as separator which is incorrect in SVG
+    // Note: This regex allows multiple commas as separator which is incorrect in SVG
+    // This regex is used by `split()`, so it doesn't need to use /g
     V.transformSeparatorRegex = /[ ,]+/;
     // Note: All following regexes are more restrictive than SVG specification
     // ReDoS mitigation: Use an anchor at the beginning of the match

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1494,16 +1494,21 @@ const V = (function() {
 
             var separator = V.transformSeparatorRegex;
 
-            // Allow reading transform string with a single matrix
+            // Special handling for `transform` with one or more matrix functions
             if (transform.trim().indexOf('matrix') >= 0) {
 
+                // Convert EVERYTHING in `transform` string to a matrix
+                // Will combine ALL matrixes * ALL translates * ALL scales * ALL rotates
+                // Note: In non-matrix case, we only take first one of each (if any)
                 var matrix = V.transformStringToMatrix(transform);
                 var decomposedMatrix = V.decomposeMatrix(matrix);
 
+                // Extract `translate`, `scale`, `rotate` from matrix
                 translate = [decomposedMatrix.translateX, decomposedMatrix.translateY];
                 scale = [decomposedMatrix.scaleX, decomposedMatrix.scaleY];
                 rotate = [decomposedMatrix.rotation];
 
+                // Rewrite `transform` string in `translate scale rotate` format
                 var transformations = [];
                 if (translate[0] !== 0 || translate[1] !== 0) {
                     transformations.push('translate(' + translate + ')');
@@ -1518,8 +1523,9 @@ const V = (function() {
 
             } else {
 
-                // Note: We only detect the first match of each method (if any)
-                // `match` function returns value of capturing group as `[1]`
+                // Extract `translate`, `rotate`, `scale` functions from `transform` string
+                // Note: We only detect the first match of each (if any)
+                // `match()` returns value of capturing group as `[1]`
                 const translateMatch = transform.match(V.transformTranslateRegex);
                 if (translateMatch) {
                     translate = translateMatch[1].split(separator);

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1401,15 +1401,16 @@ const V = (function() {
     // Note: This allows multiple commas as separator which is incorrect in SVG
     V.transformSeparatorRegex = /[ ,]+/;
     // Note: All following regexes are more restrictive than SVG specification
+    // ReDoS mitigation: Use an anchor at the beginning of the match
     // ReDoS mitigation: Avoid backtracking (uses `[^()]+` instead of `.*?`)
     // ReDoS mitigation: Don't match initial `(` inside repeated part
     // The following regex needs to use /g (= cannot use capturing groups)
-    V.transformRegex = /\w+\([^()]+\)/g;
+    V.transformRegex = /\b\w+\([^()]+\)/g;
     // The following regexes need to use capturing groups (= cannot use /g)
-    V.transformFunctionRegex = /(\w+)\(([^()]+)\)/;
-    V.transformTranslateRegex = /translate\(([^()]+)\)/;
-    V.transformRotateRegex = /rotate\(([^()]+)\)/;
-    V.transformScaleRegex = /scale\(([^()]+)\)/;
+    V.transformFunctionRegex = /\b(\w+)\(([^()]+)\)/;
+    V.transformTranslateRegex = /\btranslate\(([^()]+)\)/;
+    V.transformRotateRegex = /\brotate\(([^()]+)\)/;
+    V.transformScaleRegex = /\bscale\(([^()]+)\)/;
 
     V.transformStringToMatrix = function(transform) {
 

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1402,11 +1402,12 @@ const V = (function() {
     V.transformSeparatorRegex = /[ ,]+/;
     V.transformationListRegex = /^(\w+)\((.*)\)/;
     // Note: These are more restrictive than the official regex
-    // ReDos mitigation: Avoids backtracking (uses `[^)]+` instead of `.*?`)
-    // ReDos mitigation: Doesn't use capturing group
-    V.transformTranslateRegex = /translate\([^)]+\)/;
-    V.transformRotateRegex = /rotate\([^)]+\)/;
-    V.transformScaleRegex = /scale\([^)]+\)/;
+    // ReDoS mitigation: Avoids backtracking (uses `[^())]+` instead of `.*?`)
+    // ReDoS mitigation: Doesn't use capturing group
+    // ReDoS mitigation: Doesn't match initial `(` inside repeated part
+    V.transformTranslateRegex = /translate\([^()]+\)/;
+    V.transformRotateRegex = /rotate\([^()]+\)/;
+    V.transformScaleRegex = /scale\([^()]+\)/;
 
     V.transformStringToMatrix = function(transform) {
 

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1403,7 +1403,7 @@ const V = (function() {
     V.transformationListRegex = /^(\w+)\((.*)\)/;
     // Note: These are more restrictive than the official regex
     // Note: These cannot be /g because we are using the capturing group
-    // ReDoS mitigation: Avoids backtracking (uses `[^())]+` instead of `.*?`)
+    // ReDoS mitigation: Avoids backtracking (uses `[^()]+` instead of `.*?`)
     // ReDoS mitigation: Doesn't match initial `(` inside repeated part
     V.transformTranslateRegex = /translate\(([^()]+)\)/;
     V.transformRotateRegex = /rotate\(([^()]+)\)/;

--- a/src/g/points.mjs
+++ b/src/g/points.mjs
@@ -9,7 +9,7 @@ export function parsePoints(svgString) {
     // replace sequences of multiple spaces with single spaces
     const simplifiedString = trimmedString.replace(/\s{2,}/, ' ');
     // split at commas (+ their surrounding spaces) or at single spaces
-    const coords = svgString.split(/\s?,\s?|\s/);
+    const coords = simplifiedString.split(/\s?,\s?|\s/);
 
     const numCoords = coords.length;
     for (let i = 0; i < numCoords; i += 2) {

--- a/src/g/points.mjs
+++ b/src/g/points.mjs
@@ -7,7 +7,7 @@ export function parsePoints(svgString) {
     const points = [];
 
     // replace sequences of multiple spaces with single spaces
-    const simplifiedString = trimmedString.replace(/\s{2,}/, ' ');
+    const simplifiedString = trimmedString.replace(/\s{2,}/g, ' ');
     // split at commas (+ their surrounding spaces) or at single spaces
     const coords = simplifiedString.split(/\s?,\s?|\s/);
 

--- a/src/g/points.mjs
+++ b/src/g/points.mjs
@@ -6,17 +6,15 @@ export function parsePoints(svgString) {
 
     const points = [];
 
-    // ReDoS mitigation: First simplify spaces, then split without repetitions
-    // Step 2: Replace sequences of multiple spaces with single spaces
-    // Note: We are using /g to replace all occurrences
-    const simplifiedString = trimmedString.replace(/\s{2,}/g, ' ');
-    // Step 3: Split at commas (+ their surrounding spaces) or at single spaces
+    // Step 2: Split at commas (+ their surrounding spaces) or at multiple spaces
+    // ReDoS mitigation: Have an anchor at the beginning of each alternation
     // Note: This doesn't simplify double (or more) commas - causes empty coords
-    const coords = simplifiedString.split(/\s?,\s?|\s/);
+    // This regex is used by `split()`, so it doesn't need to use /g
+    const coords = trimmedString.split(/\b\s*,\s*|,\s*|\s+/);
 
     const numCoords = coords.length;
     for (let i = 0; i < numCoords; i += 2) {
-        // Step 4: Convert each coord to number
+        // Step 3: Convert each coord to number
         // Note: If the coord cannot be converted to a number, it will be `NaN`
         // Note: If the coord is empty ("", e.g. from ",," input), it will be `0`
         // Note: If we end up with an odd number of coords, the last point's second coord will be `NaN`

--- a/src/g/points.mjs
+++ b/src/g/points.mjs
@@ -1,10 +1,21 @@
 export function parsePoints(svgString) {
-    svgString = svgString.trim();
-    if (svgString === '') return [];
+
+    // discard surrounding spaces
+    const trimmedString = svgString.trim();
+    if (trimmedString === '') return [];
+
     const points = [];
-    const coords = svgString.split(/\s*,\s*|\s+/);
-    const n = coords.length;
-    for (let i = 0; i < n; i += 2) {
+
+    // replace sequences of multiple spaces with single spaces
+    const simplifiedString = trimmedString.replace(/\s{2,}/, ' ');
+    // split at commas (+ their surrounding spaces) or at single spaces
+    const coords = svgString.split(/\s?,\s?|\s/);
+
+    const numCoords = coords.length;
+    for (let i = 0; i < numCoords; i += 2) {
+        // convert each coord to number
+        // note: if the coord cannot be converted to a number, it will be `NaN`
+        // note: if we got an odd number of coords, the last coord will be `NaN`
         points.push({ x: +coords[i], y: +coords[i + 1] });
     }
     return points;

--- a/src/g/points.mjs
+++ b/src/g/points.mjs
@@ -1,21 +1,25 @@
 export function parsePoints(svgString) {
 
-    // discard surrounding spaces
+    // Step 1: Discard surrounding spaces
     const trimmedString = svgString.trim();
     if (trimmedString === '') return [];
 
     const points = [];
 
-    // replace sequences of multiple spaces with single spaces
+    // ReDoS mitigation: First simplify spaces, then split without repetitions
+    // Step 2: Replace sequences of multiple spaces with single spaces
+    // Note: We are using /g to replace all occurrences
     const simplifiedString = trimmedString.replace(/\s{2,}/g, ' ');
-    // split at commas (+ their surrounding spaces) or at single spaces
+    // Step 3: Split at commas (+ their surrounding spaces) or at single spaces
+    // Note: This doesn't simplify double (or more) commas - causes empty coords
     const coords = simplifiedString.split(/\s?,\s?|\s/);
 
     const numCoords = coords.length;
     for (let i = 0; i < numCoords; i += 2) {
-        // convert each coord to number
-        // note: if the coord cannot be converted to a number, it will be `NaN`
-        // note: if we got an odd number of coords, the last coord will be `NaN`
+        // Step 4: Convert each coord to number
+        // Note: If the coord cannot be converted to a number, it will be `NaN`
+        // Note: If the coord is empty ("", e.g. from ",," input), it will be `0`
+        // Note: If we end up with an odd number of coords, the last point's second coord will be `NaN`
         points.push({ x: +coords[i], y: +coords[i + 1] });
     }
     return points;

--- a/test/geometry/polyline.js
+++ b/test/geometry/polyline.js
@@ -98,7 +98,7 @@ QUnit.module('polyline', function() {
         QUnit.test('creates a new Polyline object from svg string with spaces around', function(assert) {
 
             const polyline = new g.Polyline('  10,10 20,20  ');
-            assert.equal(polyline.points.length, 2, 'has expected number of points (svg string with spaces around)');
+            assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
         });
@@ -114,7 +114,7 @@ QUnit.module('polyline', function() {
         QUnit.test('creates a new Polyline object from string with a mixture of commas and spaces', function(assert) {
 
             const polyline = new g.Polyline('10 10,20 , 20');
-            assert.equal(polyline.points.length, 2,);
+            assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
         });

--- a/test/geometry/polyline.js
+++ b/test/geometry/polyline.js
@@ -62,9 +62,9 @@ QUnit.module('polyline', function() {
 
     QUnit.module('parse', function() {
 
-        QUnit.test('creates a new Polyline object from string', function(assert) {
+        QUnit.test('creates a new Polyline object from svg string', function(assert) {
 
-            var polyline;
+            let polyline;
 
             // empty string
             polyline = new g.Polyline('');
@@ -85,30 +85,75 @@ QUnit.module('polyline', function() {
             assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
+        });
 
-            // no commas (single spaces)
-            polyline = new g.Polyline('10 10 20 20');
+        QUnit.test('creates a new Polyline object from string with single spaces', function(assert) {
+
+            const polyline = new g.Polyline('10 10 20 20');
             assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
+        });
 
-            // spaces around
-            polyline = new g.Polyline('  10,10 20,20  ');
+        QUnit.test('creates a new Polyline object from svg string with spaces around', function(assert) {
+
+            const polyline = new g.Polyline('  10,10 20,20  ');
+            assert.equal(polyline.points.length, 2, 'has expected number of points (svg string with spaces around)');
+            assert.equal(polyline.points[0].toString(), '10@10');
+            assert.equal(polyline.points[1].toString(), '20@20');
+        });
+
+        QUnit.test('creates a new Polyline object from string with multi spaces', function(assert) {
+
+            const polyline = new g.Polyline('10  10   20    20');
             assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
+        });
 
-            // multi spaces between
-            polyline = new g.Polyline('10  10  20  20');
+        QUnit.test('creates a new Polyline object from string with a mixture of commas and spaces', function(assert) {
+
+            const polyline = new g.Polyline('10 10,20 , 20');
+            assert.equal(polyline.points.length, 2,);
+            assert.equal(polyline.points[0].toString(), '10@10');
+            assert.equal(polyline.points[1].toString(), '20@20');
+        });
+
+        QUnit.test('creates a new Polyline object from string with commas with spaces around', function(assert) {
+
+            const polyline = new g.Polyline('10, 10 , 20 ,20');
             assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
+        });
 
-            // spaces and commas
-            polyline = new g.Polyline('  10, 10 , 20 , 20  ');
+        QUnit.test('creates a new Polyline object from string with commas and multiple spaces around', function(assert) {
+
+            const polyline = new g.Polyline('  10,  10  ,  20  ,20  ');
             assert.equal(polyline.points.length, 2);
             assert.equal(polyline.points[0].toString(), '10@10');
             assert.equal(polyline.points[1].toString(), '20@20');
+        });
+
+        QUnit.test('creates a new Polyline object from string with multiple commas', function(assert) {
+
+            const polyline = new g.Polyline('10,10,,20,,,20');
+            assert.equal(polyline.points.length, 4);
+            assert.equal(polyline.points[0].toString(), '10@10');
+            assert.equal(polyline.points[1].toString(), '0@20');
+            assert.equal(polyline.points[2].toString(), '0@0');
+            assert.equal(polyline.points[3].toString(), '20@NaN');
+        });
+
+        QUnit.test('creates a new Polyline object from string with multiple commas and multiple spaces', function(assert) {
+
+            const polyline = new g.Polyline('10, ,10 ,  ,  , 20  ,    ,    ,    ,  20');
+            assert.equal(polyline.points.length, 5);
+            assert.equal(polyline.points[0].toString(), '10@0');
+            assert.equal(polyline.points[1].toString(), '10@0');
+            assert.equal(polyline.points[2].toString(), '0@20');
+            assert.equal(polyline.points[3].toString(), '0@0');
+            assert.equal(polyline.points[4].toString(), '0@20');
         });
     });
 


### PR DESCRIPTION
## Description

Fix RegEx in code to avoid potential ReDoS attacks.

## Motivation and Context

JavaScript's RegEx engine uses backtracking which means that its worst-case time complexity can be polynomial or even exponential. This can happen when the regex fails to find any matches in the queried string, when the regex is written in such a way that forces the engine to investigate each character in the queried string multiple times.

### Polynomial Worst-Case Compexity

The polynomial worst-case complexity happens in cases such as `/\w+\(/`. Here, the intention is to find a string of letters terminated with a `(`. If the queried string does end with a `(`, all is good. However, if the queried string doesn't end with a `(`, the engine needs to do a lot of backtracking, which leads to a potential ReDoS vector.

The engine needs to do a pattern that looks like this: start with first letter, collect all following letters, reach end of string without finding `(`, backtrack, start again with second letter, collect all following letters again, reach end of string without finding `(` again, backtrack, start again with third letter... If the string is millions of characters long, the engine can freeze and bring down the whole application.

There are several ways to prevent this problem:
1. Add an anchor (e.g. `/\b\w+\(/`) before each unbounded repetition, if it makes sense. The generic advice is to add a negative lookbehind before the repetition (e.g. `/(?<!\w)\w*\(/` in our example) which acts as a generic anchor, but this is not available in JavaScript.
2. Replace unbounded repetitions - either by restructuring the code and/or the regex to avoid the need for them, or by replacing the repetition with an alternation listing all possible options (e.g. `/(?:scale|translate|rotate|skewx|skewy|matrix)\(/` in our example).
3. Limit backtracking by specifying the end condition (e.g. `/[^)]+\(/` is better than `/.+?\(/` is better than `/.+\(`).
4. Ensure that repetitions inside the regex cannot match the constant parts of the regex that precede them (e.g. `\btranslate\([^()]+\)` where the added `(` in the square bracket group prevents infinite recursion inside the square bracket group).

Note: Repetitions at the very end of a regex (e.g. `/\w+/` or `/\w+|abc/`) are okay because they succeed/fail immediately, without triggering the backtracking which is the problem.

Another case with polynomial worst-case complexity is `/^\w+,?\w+\(/` in absence of the `,` and `(`. In this situation, the second `/w+` subregex becomes unanchored, forcing the regex engine to traverse all letters for each letter, as above. This problem can be prevented by ensuring that there are no overlaps between the two subregexes - that in every possible situation, each subregex is anchored (e.g.`/\w+(,\w+)?\(/`).

### Exponential Worst-Case Complexity

Exponential worst-case complexity happens when the polynomial worst-case complexity items happen inside a repetition and without an anchor. Building on from the previous example, if `(\w+,?\w+)*`, in absence of the `,`. The problem is that not only does the regex engine check every possibility for each letter, it also checks every combination of possible arrangements of the two subregexes, which leads to the exponential factor.

The surest way to prevent these is to avoid repetitions inside repetitions as much as possible - and, if such a construct is necessary, to make sure that the possibilities (e.g. in an alternation) can never overlap.