### PR TITLE
fix(css): layout.css prefixed user-drag property

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -57,6 +57,7 @@ the whole group of elements. Each plugin can provide its own stylesheet.
 }
 
 .joint-element * {
+   -webkit-user-drag: none;
    user-drag: none;
 }
 


### PR DESCRIPTION
## Description

Fixes Issue #1926

## Motivation and Context

There is a CSS rule in `rappid.css` (actual source: `joint/css/layout.css`) which is missing a vendor prefix:

```diff
.joint-element * {
+  -webkit-user-drag: none;
   user-drag: none;
}
```

This is the only rule that is missing it; all other places where `user-drag` is used have the vendor prefix.
