### PR TITLE
fix(dia.Link): add defaultLabel to TS

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -614,6 +614,7 @@ export namespace dia {
         doubleToolMarkup?: string;
         vertexMarkup: string;
         arrowHeadMarkup: string;
+        defaultLabel?: Link.Label;
         labelMarkup?: string | MarkupJSON; // default label markup
         labelProps?: Link.Label; // default label props
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -614,9 +614,11 @@ export namespace dia {
         doubleToolMarkup?: string;
         vertexMarkup: string;
         arrowHeadMarkup: string;
-        defaultLabel?: Link.Label;
+        defaultLabel?: Link.Label; // default label props
+        /**
+         * @deprecated use `defaultLabel.markup` instead
+         */
         labelMarkup?: string | MarkupJSON; // default label markup
-        labelProps?: Link.Label; // default label props
 
         isElement(): boolean;
 


### PR DESCRIPTION
## Description

Add missing `dia.Link.defaultLabel` property to TS which uses the existing `Link.Label` interface.

## Motivation and Context

Also remove `dia.Link.labelProps` which seems to have been a bug.

Additionally, mark `dia.Link.labelMarkup` as deprecated, in alignment with a comment in our code coming from the same time.
