### PR TITLE
fix(css): layout.css remove unprefixed user-drag property

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -58,7 +58,6 @@ the whole group of elements. Each plugin can provide its own stylesheet.
 
 .joint-element * {
    -webkit-user-drag: none;
-   user-drag: none;
 }
 
 .joint-element .scalable * {


### PR DESCRIPTION
## Description

Remove the unprefixed `user-drag` property from `joint/css/layout.css`, since it is not supported by any browsers and some tests are throwing errors.

## Motivation and Context

Note: The prefixed version was recently introduced in #1933.

```diff
.joint-element * {
  -webkit-user-drag: none;
- user-drag: none;
}
```