### PR TITLE
fix(docs): add missing options parameter in addCell

### DIFF
--- a/docs/src/joint/api/dia/Graph/prototype/addCell.html
+++ b/docs/src/joint/api/dia/Graph/prototype/addCell.html
@@ -1,15 +1,25 @@
 <pre class="docs-method-signature"><code>graph.addCell(cell[, opt])</code></pre>
 
-<p>Add a new cell to the graph. If <code>cell</code> is an array, all the cells in the array will be added to the graph.</p>
+<p>
+    Add a new cell to the graph. If <code>cell</code> is an array, all the cells in the array will be added to the graph.
+    Any additional option or custom property provided in the options object will be accessible in the callback function of 
+    the graph add event.
+</p>
 
 <p>
     If <code>opt.dry</code> is set to <code>true</code>, the graph reference is not stored on the <code>cell</code> after it's added.
 </p>
 
-<pre><code>const rect = new joint.shapes.basic.Rect({ 
+<p>
+    If using the default <code>paper</code> <a href="#dia.Paper.prototype.options.sorting"><code>sorting</code></a> option, setting 
+    <code>opt.sort</code> to <code>false</code> means the <code>cell</code> won't change its sorting order based on the 
+    <a href="#dia.Element.intro.z"><code>z</code></a> property, and it will be rendered in the order in which it's added.
+</p>
+
+<pre><code>const rect = new joint.shapes.standard.Rectangle({ 
     position: { x: 100, y: 100 },
-    size: { width: 70, height: 30 },
-    attrs: { text: { text: 'my rectangle' } }
+    size: { width: 90, height: 30 },
+    attrs: { label: { text: 'my rectangle' } }
 });
 const rect2 = rect.clone();
 const link = new joint.dia.Link({ source: { id: rect.id }, target: { id: rect2.id } });

--- a/docs/src/joint/api/dia/Graph/prototype/addCell.html
+++ b/docs/src/joint/api/dia/Graph/prototype/addCell.html
@@ -1,13 +1,17 @@
-<pre class="docs-method-signature"><code>graph.addCell(cell)</code></pre>
+<pre class="docs-method-signature"><code>graph.addCell(cell[, opt])</code></pre>
 
 <p>Add a new cell to the graph. If <code>cell</code> is an array, all the cells in the array will be added to the graph.</p>
 
-<pre><code>var rect = new joint.shapes.basic.Rect({ 
+<p>
+    If <code>opt.dry</code> is set to <code>true</code>, the graph reference is not stored on the <code>cell</code> after it's added.
+</p>
+
+<pre><code>const rect = new joint.shapes.basic.Rect({ 
     position: { x: 100, y: 100 },
     size: { width: 70, height: 30 },
     attrs: { text: { text: 'my rectangle' } }
-})
-var rect2 = rect.clone()
-var link = new joint.dia.Link({ source: { id: rect.id }, target: { id: rect2.id }  });
-var graph = new joint.dia.Graph
-graph.addCell(rect).addCell(rect2).addCell(link)</code></pre>
+});
+const rect2 = rect.clone();
+const link = new joint.dia.Link({ source: { id: rect.id }, target: { id: rect2.id } });
+const graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+graph.addCell(rect).addCell(rect2).addCell(link);</code></pre>

--- a/docs/src/joint/api/dia/Graph/prototype/addCell.html
+++ b/docs/src/joint/api/dia/Graph/prototype/addCell.html
@@ -11,9 +11,11 @@
 </p>
 
 <p>
-    If using the default <code>paper</code> <a href="#dia.Paper.prototype.options.sorting"><code>sorting</code></a> option, setting 
-    <code>opt.sort</code> to <code>false</code> means the <code>cell</code> won't change its sorting order based on the 
-    <a href="#dia.Element.intro.z"><code>z</code></a> property, and it will be rendered in the order in which it's added.
+    If <code>opt.async</code> is set to <code>false</code>, this ensures the <code>cell</code> is rendered synchronously.
+</p>
+
+<p>
+    If <code>opt.sort</code> is set to <code>false</code>, the <code>cell</code> will be added at the end of the collection.
 </p>
 
 <pre><code>const rect = new joint.shapes.standard.Rectangle({ 


### PR DESCRIPTION
## Description

Fixes #1867

- add missing `opt` parameter and descripstions in `addCell`


### Screenshots (if appropriate):
<img width="1134" alt="Screenshot 2022-12-15 at 16 25 26" src="https://user-images.githubusercontent.com/42288565/207901807-32e625b0-b5dd-4734-a968-fe294b263d11.png">

