### PR TITLE
fix(dia.Cell): inconsistent merging behavior in prop()

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -542,11 +542,6 @@ export const Cell = Backbone.Model.extend({
                     options.rewrite = false;
                 }
 
-                if (pathArrayLength === 1) {
-                    // Property is not nested. We can simply use `set()`.
-                    return this.set(property, value, options);
-                }
-
                 var update = {};
                 // Initialize the nested object. Sub-objects are either arrays or objects.
                 // An empty array is created if the sub-key is an integer. Otherwise, an empty object is created.

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -408,8 +408,11 @@ QUnit.module('cell', function(hooks) {
                 el.prop('name/first', 'john');
                 assert.ok(attrs.hasOwnProperty('name'));
                 assert.equal(attrs.name.first, 'john');
-
                 assert.equal(el.prop('name/first'), 'john');
+
+                el.prop('name/second', 'doe');
+                assert.equal(el.prop('name/first'), 'john');
+                assert.equal(el.prop('name/second'), 'doe');
             });
 
             QUnit.test('path and value as object', function(assert) {
@@ -417,8 +420,36 @@ QUnit.module('cell', function(hooks) {
                 el.prop({ name: { first: 'john' }});
                 assert.ok(attrs.hasOwnProperty('name'));
                 assert.equal(attrs.name.first, 'john');
-
                 assert.equal(el.prop('name/first'), 'john');
+
+                el.prop({ name: { second: 'doe' }});
+                assert.equal(el.prop('name/first'), 'john');
+                assert.equal(el.prop('name/second'), 'doe');
+            });
+
+
+            QUnit.test('path as top-level attribute name and value as object', function(assert) {
+
+                el.prop('name', { first: 'john' });
+                assert.ok(attrs.hasOwnProperty('name'));
+                assert.equal(attrs.name.first, 'john');
+                assert.equal(el.prop('name/first'), 'john');
+
+                el.prop('name', { second: 'doe' });
+                assert.equal(el.prop('name/first'), 'john');
+                assert.equal(el.prop('name/second'), 'doe');
+            });
+
+            QUnit.test('path as top-level attribute name and value as object (rewrite)', function(assert) {
+
+                el.prop('name', { first: 'john' }, { rewrite: true });
+                assert.ok(attrs.hasOwnProperty('name'));
+                assert.equal(attrs.name.first, 'john');
+                assert.equal(el.prop('name/first'), 'john');
+
+                el.prop('name', { second: 'doe' }, { rewrite: true });
+                assert.equal(el.prop('name/first'), undefined);
+                assert.equal(el.prop('name/second'), 'doe');
             });
 
             QUnit.test('path as array - root level', function(assert) {


### PR DESCRIPTION
## Description

Unify the `prop()` method mergin behavior. Do not **rewrite** the current values unless the the `{ rewrite: true }` option was passed.

## Motivation and Context

`dia.Cell` `prop()` method does not merge existing properties with the new ones in case when the path is a top level attribute and the value is an object. It preserves the current values in all other cases.

#### Current behavior:

```js
// Removes `b`
cell.prop('a', { b: 1 });
cell.prop('a', { c: 2 });
cell.prop('a') ~== {  c: 2 } // INCORRECT
```

```js
// Preserves `b`
cell.prop('a/b', '1');
cell.prop('a/c', '2');
cell.prop('a') ~== { b: 1, c: 2 }
```

```js
// Preserves `b`
cell.prop({ a: { b: 1 }});
cell.prop({ a: { c: 2 }});
cell.prop('a') ~== { b: 1, c: 2 }
```

#### New behavior:
```js
// Preserves`b`
cell.prop('a', { b: 1 });
cell.prop('a', { c: 2 });
cell.prop('a') ~== { b: 1, c: 2 }
```

```js
// Removes `b`
cell.prop('a', { b: 1 });
cell.prop('a', { c: 2 }, { rewrite: true });
cell.prop('a') ~== { c: 2 }
```



