### PR TITLE
fix(dia.Paper): requireView() must trigger before & after render

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/requireView.html
+++ b/docs/src/joint/api/dia/Paper/prototype/requireView.html
@@ -1,6 +1,10 @@
-<pre class="docs-method-signature"><code>paper.requireView(cell)</code></pre>
+<pre class="docs-method-signature"><code>paper.requireView(cell[, opt])</code></pre>
 <p>Ensure that the view associated with the <code>cell</code> model is attached to the DOM and that it is updated.</p>
 
 <p>This function <a href="#dia.Paper.prototype.findViewByModel">finds the view by the cell model</a>. If the view is not part of the paper's DOM (e.g. because it was outside the <a href="#dia.Paper.prototype.options.viewport">paper viewport</a>), this function attaches it. Additionally, the view is updated to reflect any changes that may have been done on the cell model in the meantime.</p>
 
 <p>Certain CellView methods require the view to be updated and present in the DOM to function properly (e.g. <a href="#dia.ElementView.prototype.getBBox">elementView.getBBox</a>/<a href="#dia.LinkView.prototype.getBBox">linkView.getBBox</a>). In <a href="#dia.Paper.prototype.options.async"><code>async</code></a> papers, you should precede calls to these methods with this function to guard against inconsistencies.</p>
+
+<p>
+    If <code>opt.silent</code> is set to <code>true</code>, the paper <a href="#dia.Paper.prototype.options.beforeRender">beforeRender</a> and <a href="#dia.Paper.prototype.options.afterRender">afterRender</a> callbacks are not fired (and <code>'render:done'</code> event is not triggered).
+</p>

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -700,23 +700,24 @@ export const Paper = View.extend({
         var model = view.model;
         if (model.isElement()) return false;
         if ((flag & view.getFlag(['SOURCE', 'TARGET'])) === 0) {
+            var dumpOptions = { silent: true };
             // LinkView is waiting for the target or the source cellView to be rendered
             // This can happen when the cells are not in the viewport.
             var sourceFlag = 0;
             var sourceView = this.findViewByModel(model.getSourceCell());
             if (sourceView && !this.isViewMounted(sourceView)) {
-                sourceFlag = this.dumpView(sourceView);
+                sourceFlag = this.dumpView(sourceView, dumpOptions);
                 view.updateEndMagnet('source');
             }
             var targetFlag = 0;
             var targetView = this.findViewByModel(model.getTargetCell());
             if (targetView && !this.isViewMounted(targetView)) {
-                targetFlag = this.dumpView(targetView);
+                targetFlag = this.dumpView(targetView, dumpOptions);
                 view.updateEndMagnet('target');
             }
             if (sourceFlag === 0 && targetFlag === 0) {
                 // If leftover flag is 0, all view updates were done.
-                return !this.dumpView(view);
+                return !this.dumpView(view, dumpOptions);
             }
         }
         return false;
@@ -777,10 +778,17 @@ export const Paper = View.extend({
         return flag;
     },
 
-    dumpView: function(view, opt) {
-        var flag = this.dumpViewUpdate(view);
+    dumpView: function(view, opt = {}) {
+        const flag = this.dumpViewUpdate(view);
         if (!flag) return 0;
-        return this.updateView(view, flag, opt);
+        const shouldNotify = !opt.silent;
+        if (shouldNotify) this.notifyBeforeRender(opt);
+        const leftover = this.updateView(view, flag, opt);
+        if (shouldNotify) {
+            const stats = { updated: 1, batches: 1, priority: view.UPDATE_PRIORITY };
+            this.notifyAfterRender(stats, opt);
+        }
+        return leftover;
     },
 
     updateView: function(view, flag, opt) {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -785,7 +785,7 @@ export const Paper = View.extend({
         if (shouldNotify) this.notifyBeforeRender(opt);
         const leftover = this.updateView(view, flag, opt);
         if (shouldNotify) {
-            const stats = { updated: 1, batches: 1, priority: view.UPDATE_PRIORITY };
+            const stats = { updated: 1, priority: view.UPDATE_PRIORITY };
             this.notifyAfterRender(stats, opt);
         }
         return leftover;

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -1197,7 +1197,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                                 ));
                                 assert.equal(afterRenderSpy.callCount, 1);
                                 assert.ok(afterRenderSpy.calledWithExactly(
-                                    sinon.match({ updated: 1, batches: 1, priority: linkView.UPDATE_PRIORITY }),
+                                    sinon.match({ updated: 1, priority: linkView.UPDATE_PRIORITY }),
                                     sinon.match({ test: true }),
                                     paper
                                 ));


### PR DESCRIPTION
## Description

If a view is updated manually (by calling `requireView`), the `beforeRender` and `afterRender` callbacks, and `render:done` event must be triggered.

## Motivation and Context

It is important to always let the outside world know that the CellView has been changed. Right now, the updates can happen without any notification, when there is a scheduled update for the view and `requireView` is called.

An example where this can cause a problem is when the `linkPinnings` parameter is set to `false` and the link is rolled back (removed) at the end of the interaction if it is not connected to another cell. In this case, the link is deleted, the `checkMouseleave` function is called, and the udpates to the view are [executed synchronously](https://github.com/clientIO/joint/blob/master/src/dia/CellView.mjs#L1169) without any notification. 