### PR TITLE
chore(seo): add missing lang attr to docs template

### DIFF
--- a/docs/templates/api.html
+++ b/docs/templates/api.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html lang="en" class="no-js">
 <head>
     <meta http-equiv="x-ua-compatible" content="IE=Edge">
     <meta charset="utf-8">


### PR DESCRIPTION
## Description

- add missing lang attribute to `docs` template in order to improve SEO performance 

Error was listed by SERanking service.

