### PR TITLE
feat(util.breakText): support lineHeight in px

### DIFF
--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -524,6 +524,23 @@ function splitWordWithEOL(word, eol) {
     return eolWords.filter(word => word !== '');
 }
 
+function getLineHeight(heightValue, textElementHeight) {
+    if (heightValue === null) {
+        // Default 1em lineHeight
+        return textElementHeight;
+    } 
+
+    switch (heightValue.unit) {
+        case 'em':
+            return textElementHeight * heightValue.value;
+        case 'px':
+        case '':
+            return heightValue.value;
+        default:
+            return textElementHeight;
+    }
+}
+
 export const breakText = function(text, size, styles = {}, opt = {}) {
 
     var width = size.width;
@@ -718,23 +735,17 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
             if (lineHeight === undefined && textNode.data !== '') {
 
-                var heightValue;
-
                 // use the same defaults as in V.prototype.text
                 if (styles.lineHeight === 'auto') {
-                    heightValue = { value: 1.5, unit: 'em' };
+                    lineHeight = getLineHeight({ value: 1.5, unit: 'em' }, textElement.getBBox().height);
                 } else {
-                    heightValue = parseCssNumeric(styles.lineHeight, ['em']) || { value: 1, unit: 'em' };
-                }
+                    const parsed = parseCssNumeric(styles.lineHeight, ['em', 'px', '']);
 
-                lineHeight = heightValue.value;
-                if (heightValue.unit === 'em') {
-                    lineHeight *= textElement.getBBox().height;
+                    lineHeight = getLineHeight(parsed, textElement.getBBox().height);
                 }
             }
 
             if (lineHeight * lines.length > height) {
-
                 // remove overflowing lines
                 lastL = Math.floor(height / lineHeight) - 1;
             }

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -524,20 +524,19 @@ function splitWordWithEOL(word, eol) {
     return eolWords.filter(word => word !== '');
 }
 
-function getLineHeight(heightValue, textElementHeight) {
+
+function getLineHeight(heightValue, textElement) {
     if (heightValue === null) {
         // Default 1em lineHeight
-        return textElementHeight;
+        return textElement.getBBox().height;
     } 
 
     switch (heightValue.unit) {
         case 'em':
-            return textElementHeight * heightValue.value;
+            return textElement.getBBox().height * heightValue.value;
         case 'px':
         case '':
             return heightValue.value;
-        default:
-            return textElementHeight;
     }
 }
 
@@ -737,11 +736,11 @@ export const breakText = function(text, size, styles = {}, opt = {}) {
 
                 // use the same defaults as in V.prototype.text
                 if (styles.lineHeight === 'auto') {
-                    lineHeight = getLineHeight({ value: 1.5, unit: 'em' }, textElement.getBBox().height);
+                    lineHeight = getLineHeight({ value: 1.5, unit: 'em' }, textElement);
                 } else {
                     const parsed = parseCssNumeric(styles.lineHeight, ['em', 'px', '']);
 
-                    lineHeight = getLineHeight(parsed, textElement.getBBox().height);
+                    lineHeight = getLineHeight(parsed, textElement);
                 }
             }
 

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -347,6 +347,26 @@ QUnit.module('util', function(hooks) {
             r = joint.util.breakText(' a\nb\nc\nd\ne', { width: 20, height: 20 }, styles, { preserveSpaces: true });
             assert.equal(r, ' a');
         });
+
+        QUnit.test('lineHeight measuring', function(assert) {
+
+            const size = { width: 50, height: 50 };
+            const text = 'This is very very very very very very very very very very very very very very very very very very very very very very long text';
+
+            let emVal = 2;
+            let correctLineHeightPerEm = 14;
+
+            let r = joint.util.breakText(text, size, { ...styles, lineHeight: `${emVal}em` });
+            assert.ok(r.split('\n').length * correctLineHeightPerEm * emVal <= size.height, 'lineHeight in em');
+            
+            let correctLineHeightInPx = 25;
+
+            r = joint.util.breakText(text, size, { ...styles, lineHeight: correctLineHeightInPx });
+            assert.ok(r.split('\n').length * correctLineHeightInPx <= size.height, 'lineHeight in px without unit');
+
+            r = joint.util.breakText(text, size, { ...styles, lineHeight: `${correctLineHeightInPx}px` });
+            assert.ok(r.split('\n').length * correctLineHeightInPx <= size.height, 'lineHeight in px');
+        });
     });
 
     QUnit.test('util.parseCssNumeric', function(assert) {


### PR DESCRIPTION
feat: return test

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Allow usage of pixel units when breaking text with `util.breakText` function. Pixels are a default unit when no unit is provided.
```js
const styles = {
    fontSize: 14,
    fontFamily: 'Arial, helvetica, sans-serif'
};
const t = 'This is very very very very very very very very very very very very very very very very very very very very very very long text';
// valid
const lineHeight = 20;
// valid as well
// const lineHeight = '20px';
const cell = new joint.shapes.standard.Rectangle({
    size: { width: 50, height: 250 },
    attrs: {
        text: {
            text: t,
            textWrap: {},
            ...styles,
            lineHeight
        }
    }
});
graph.addCell(cell);
```
fixes: *util.breakText - incorrect result when custom `lineHeight` provided*

## Motivation and Context

Easier and cleaner usage of `util.breakText` function. Allow usage of pixels.
