### PR TITLE
chore(github): add github discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to create this general Q&A discussion! Review our [technical question guidelines](TODOURL) before proceeding.
+        Thanks for taking the time to create this general Q&A discussion! Review our [technical question guidelines](https://github.com/clientIO/joint/wiki/Asking-Technical-Questions) before proceeding.
 
         Have you searched existing discussions to see if your question was already answered?
         If you create a question that has already been answered, the discussion will be marked as a duplicate and closed.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,43 @@
+title: "[Q&A]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create this general Q&A discussion! Review our [technical question guidelines](TODOURL) before proceeding.
+
+        Have you searched existing discussions to see if your question was already answered?
+  - type: textarea
+    id: introduction
+    attributes:
+      label: Introduce the question.
+      description: Provide more context to your title.
+      placeholder: Description.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce.
+      description: If applicable, provide steps to reproduce the issue. Add code examples or screenshots if relevant. Don't use images of code!
+      placeholder: Step (1)... Step (2)... etc.
+    validations:
+      required: false
+  - type: textarea
+    id: restrictions
+    attributes:
+      label: Restrictions & Constraints.
+      description: If applicable, mention any limitations you have which means you can't use a certain solution.
+      placeholder: Limitations.
+    validations:
+      required: false
+  - type: dropdown
+    id: library
+    attributes:
+      label: Does your question relate to JointJS or JointJS+. Select both if applicable.
+      multiple: true
+      options:
+        - JointJS
+        - JointJS+
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -7,6 +7,7 @@ body:
         Thanks for taking the time to create this general Q&A discussion! Review our [technical question guidelines](TODOURL) before proceeding.
 
         Have you searched existing discussions to see if your question was already answered?
+        If you create a question that has already been answered, the discussion will be marked as a duplicate and closed.
   - type: textarea
     id: introduction
     attributes:
@@ -41,3 +42,7 @@ body:
         - JointJS+
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you are satisfied that your question has been answered, press the `'Mark as answer'` button on the chosen answer. Thanks!


### PR DESCRIPTION
### Description 

Github discussion forms are in public beta as mentioned in the link below, so they should be available soon. They are subject to change, so we will need to review the `.yml` template before merging.
https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms

*"The name must correspond with the slug for one of your discussion categories."*

- File has been named `q-a.yml` as that corresponds to our most popular discussion type
<img width="442" alt="Screenshot 2023-01-18 at 15 19 16" src="https://user-images.githubusercontent.com/42288565/213195141-f02555d2-9770-4ae1-bb65-371fd589af8a.png">
