### PR TITLE
docs(dia.Paper): Replace dead link to getFitToContentArea function

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
+++ b/docs/src/joint/api/dia/Paper/prototype/fitToContent.html
@@ -1,7 +1,7 @@
 <pre class="docs-method-signature"><code>paper.fitToContent([opt])</code></pre>
 <p>Expand or shrink the paper to fit the content inside it. The method returns the area (<code>g.Rect</code>) of the paper after fitting in local coordinates.</p>
 
-<p>The list of all available options can be found <a href="#dia.Paper.prototype.getFitToContentBBox">here</a>. You can try many of these options interactively in the <a href="https://www.jointjs.com/demos/paper-attributes">paper demo</a>.</p>
+<p>The list of all available options can be found in the documentation of the <code>paper.getFitToContentArea</code> <a href="#dia.Paper.prototype.getFitToContentArea">function</a>. You can try many of these options interactively in the <a href="https://www.jointjs.com/demos/paper-attributes">paper demo</a>.</p>
 
 <p>This method might internally trigger the <code>&quot;resize&quot;</code> and <code>&quot;translate&quot;</code> events. These can be handled by listening on the paper object (<code>paper.on('resize', myHandler)</code>).</p>
 


### PR DESCRIPTION
## Description

A link in `dia.Paper.prototype.fitToContent` documentation does not work because it is pointing to a non-existent signature (`dia.Paper.protoype.getFitToContentBBox`).

The correct target is `dia.Paper.prototype.getFitToContentArea`.