### PR TITLE
types(mvc): Fix TS error in ModifiedCallback signature

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3372,7 +3372,7 @@ export namespace mvc {
         protected onRemove(): void;
     }
 
-    type ModifiedCallback<CallbackArgs extends any[], EventCallback extends Callback> = (...args: [...CallbackArgs, ...Parameters<EventCallback>]) => any;
+    type ModifiedCallback<CallbackArgs extends any[], EventCallback extends Callback> = (...args: any[]) => any;
 
     type EventHashMap<CallbackArgs extends any[], T extends Record<keyof T, Callback>> = {
         [Property in keyof T]?: ModifiedCallback<CallbackArgs, T[Property]>;


### PR DESCRIPTION
## Description

The changed line causes the following error "TS1256: A rest element must be last in a tuple type." This is caused by the two rest operators for `...args`. I see what the intention was (a variable number of CallbackArgs followed by a variable number of arguments from EventCallback) but I don't see a way to communicate that in valid typescript.