### PR TITLE
chore: remove unused css lint config

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,6 +1,0 @@
-{
-	"adjoining-classes": false,
-	"box-sizing": false,
-	"fallback-colors": false,
-	"known-properties": false
-}


### PR DESCRIPTION
## Description

The CSS lint config was used with `grunt-contrib-css`. 
https://www.npmjs.com/package/grunt-contrib-csslint

We don't use this dependency anymore, so the config is redundant. The dependency was removed in this old PR:
https://github.com/clientIO/joint/pull/1012