### PR TITLE
docs(tutorials): add portProp example to ports tutorial

### DIFF
--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -255,7 +255,7 @@ model.addPorts([
             <h3 id="port-prop">Setting port properties</h3>
 
             <p>
-                If you are already familiar with the <a href="/docs/jointjs#dia.Element.prototype.attr" target="_blank"><code>attr()</code></a>
+                If you are already familiar with the <a href="/docs/jointjs#dia.Element.prototype.prop" target="_blank"><code>prop()</code></a>
                 method for Elements and Links, JointJS also provides a similar method for working with ports. 
                 <a href="/docs/jointjs#dia.Element.prototype.portProp" target="_blank"><code>portProp()</code></a> allows users to set 
                 presentation attributes or custom data properties on an element port.

--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -255,7 +255,7 @@ model.addPorts([
             <h3 id="port-prop">Setting port properties</h3>
 
             <p>
-                If you are already familiar with the <a href="/docs/jointjs#dia.Element.prototype.attr" target="_blank"><code><code>attr()</code></code></a> 
+                If you are already familiar with the <a href="/docs/jointjs#dia.Element.prototype.attr" target="_blank"><code>attr()</code></a>
                 method for Elements and Links, JointJS also provides a similar method for working with ports. 
                 <a href="/docs/jointjs#dia.Element.prototype.portProp" target="_blank"><code>portProp()</code></a> allows users to set 
                 presentation attributes or custom data properties on an element port.

--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -252,6 +252,42 @@ model.addPorts([
 ]);
 </code></pre>
 
+            <h3 id="port-prop">Setting port properties</h3>
+
+            <p>
+                If you are already familiar with the <a href="/docs/jointjs#dia.Element.prototype.attr" target="_blank"><code><code>attr()</code></code></a> 
+                method for Elements and Links, JointJS also provides a similar method for working with ports. 
+                <a href="/docs/jointjs#dia.Element.prototype.portProp" target="_blank"><code>portProp()</code></a> allows users to set 
+                presentation attributes or custom data properties on an element port.
+            </p>
+
+            <pre><code>const port = {
+    id: 'custom-port-id'
+};
+
+const element = new joint.shapes.standard.Rectangle({
+    position: { x: 275, y: 50 },
+    size: { width: 90, height: 90 },
+    attrs: {
+        body: {
+            fill: '#8ECAE6'
+        }
+    },
+    ports: {
+        items: [ port ] 
+    }
+});
+
+element.portProp('custom-port-id', 'attrs/circle', { r: 8, fill: 'darkslateblue' });
+
+const portId = element.getPorts()[0].id;
+
+element.portProp(portId, 'custom', { testAttribute: true });
+console.log(element.portProp(portId, 'custom'));  // {testAttribute: true}
+
+element.portProp(portId, 'attrs/circle/fill', 'tomato');
+</code></pre>
+
             <h3 id="link">Linking elements with ports</h3>
 
             <p>

--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -261,10 +261,33 @@ model.addPorts([
                 presentation attributes or custom data properties on an element port.
             </p>
 
-            <pre><code>const port = {
-    id: 'custom-port-id'
+            <pre><code> const port = {
+    id: 'custom-port-id', // set a custom ID
+    label: {
+        markup: [{
+            tagName: 'text',
+            selector: 'label'
+        }]
+    },
+    attrs: { 
+        portBody: { 
+            magnet: true,
+            width: 16,
+            height: 16,
+            x: -8,
+            y: -8,
+            fill:  '#03071E'
+        }, 
+        label: { 
+            text: 'port' 
+        }
+    },
+    markup: [{
+        tagName: 'rect',
+        selector: 'portBody'
+    }]
 };
-
+                        
 const element = new joint.shapes.standard.Rectangle({
     position: { x: 275, y: 50 },
     size: { width: 90, height: 90 },
@@ -278,15 +301,15 @@ const element = new joint.shapes.standard.Rectangle({
     }
 });
 
-element.portProp('custom-port-id', 'attrs/circle', { r: 8, fill: 'darkslateblue' });
+element.portProp('custom-port-id', 'attrs/portBody', { r: 8, fill: 'darkslateblue' });
 
 const portId = element.getPorts()[0].id;
 
 element.portProp(portId, 'custom', { testAttribute: true });
 console.log(element.portProp(portId, 'custom'));  // {testAttribute: true}
 
-element.portProp(portId, 'attrs/circle/fill', 'tomato');
-</code></pre>
+element.portProp(portId, 'attrs/portBody/fill', 'tomato');
+</code></pre> 
 
             <h3 id="link">Linking elements with ports</h3>
 


### PR DESCRIPTION
- update `Working with ports` tutorial with `portProp` example
<img width="895" alt="Screenshot 2023-01-31 at 8 35 15" src="https://user-images.githubusercontent.com/42288565/215697023-c54fc8de-ab72-44c3-9518-ad96493f0346.png">
