### PR TITLE
fix(dia.LinkView): fix incorrect absolute offset label rotation

### DIFF
--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1670,7 +1670,7 @@ export const LinkView = CellView.extend({
         var angle = labelAngle;
         if (tangent) {
             if (isOffsetAbsolute) {
-                translation = tangent.start;
+                translation = tangent.start.clone();
                 translation.offset(labelOffsetCoordinates);
             } else {
                 var normal = tangent.clone();
@@ -1678,15 +1678,17 @@ export const LinkView = CellView.extend({
                 normal.setLength(labelOffset);
                 translation = normal.end;
             }
+
             if (isKeepGradient) {
                 angle = (tangent.angle() + labelAngle);
                 if (isEnsureLegibility) {
                     angle = normalizeAngle(((angle + 90) % 180) - 90);
                 }
             }
+
         } else {
             // fallback - the connection has zero length
-            translation = path.start;
+            translation = path.start.clone();
             if (isOffsetAbsolute) translation.offset(labelOffsetCoordinates);
         }
 

--- a/test/jointjs/links.js
+++ b/test/jointjs/links.js
@@ -1200,6 +1200,67 @@ QUnit.module('links', function(hooks) {
             v1.pointerup(event);
         });
 
+        QUnit.test('label - keepGradient', function(assert) {
+
+            assert.expect(2);
+
+            var r1 = new joint.shapes.basic.Rect({ position: { x: 50, y: 50 }, size: { width: 50, height: 50 }});
+            var r2 = r1.clone().translate(250);
+
+            this.graph.addCell([r1, r2]);
+
+            var l0 = new joint.shapes.standard.Link({
+                source: { id: r1.id }, // left anchor = (100, 75)
+                target: { id: r2.id }, // right anchor = (300, 75)
+                labels: [{
+                    position: {
+                        distance: .5, // midpoint = (200, 75)
+                        args: {
+                            keepGradient: true
+                        }
+                    },
+                    attrs: { text: { text: 'test label' }} // text anchor = center = midpoint
+                }]
+            });
+
+            this.graph.addCell(l0);
+
+            var v0 = this.paper.findViewByModel(l0);
+            v0.options.interactive = { labelMove: true };
+            var event = { currentTarget: v0.$('.label')[0], type: 'mousedown' };
+            v0.dragLabelStart(event, 200, 75);
+            v0.pointermove(event, 200, 25);
+            var l0labelRotation = V.decomposeMatrix(v0.el.getElementsByClassName('labels')[0].getElementsByClassName('label')[0].getCTM()).rotation;
+            assert.equal(l0labelRotation, 0, 'label angle does not change when label is moved around straight-line link (relative offset)');
+            v0.pointerup(event);
+
+            var l1 = new joint.shapes.standard.Link({
+                source: { id: r1.id }, // left anchor = (100, 75)
+                target: { id: r2.id }, // right anchor = (300, 75)
+                labels: [{
+                    position: {
+                        distance: .5, // midpoint = (200, 75)
+                        args: {
+                            keepGradient: true,
+                            absoluteOffset: true,
+                        }
+                    },
+                    attrs: { text: { text: 'test label' }} // text anchor = center = midpoint
+                }]
+            });
+
+            this.graph.addCell(l1);
+
+            var v1 = this.paper.findViewByModel(l1);
+            v1.options.interactive = { labelMove: true };
+            var event = { currentTarget: v1.$('.label')[0], type: 'mousedown' };
+            v1.dragLabelStart(event, 200, 75);
+            v1.pointermove(event, 200, 25);
+            var l1labelRotation = V.decomposeMatrix(v1.el.getElementsByClassName('labels')[0].getElementsByClassName('label')[0].getCTM()).rotation;
+            assert.equal(l1labelRotation, 0, 'label angle does not change when label is moved around straight-line link (absolute offset)');
+            v1.pointerup(event);
+        });
+
         QUnit.test('change:labels', function(assert) {
 
             var l = new joint.dia.Link({

--- a/test/jointjs/links.js
+++ b/test/jointjs/links.js
@@ -1227,12 +1227,12 @@ QUnit.module('links', function(hooks) {
 
             var v0 = this.paper.findViewByModel(l0);
             v0.options.interactive = { labelMove: true };
-            var event = { currentTarget: v0.$('.label')[0], type: 'mousedown' };
-            v0.dragLabelStart(event, 200, 75);
-            v0.pointermove(event, 200, 25);
-            var l0labelRotation = V.decomposeMatrix(v0.el.getElementsByClassName('labels')[0].getElementsByClassName('label')[0].getCTM()).rotation;
+            var evt0 = { currentTarget: v0.$('.label')[0], type: 'mousedown' };
+            v0.dragLabelStart(evt0, 200, 75);
+            v0.pointermove(evt0, 200, 25);
+            var l0labelRotation = V.decomposeMatrix(v0.el.querySelector('.labels .label').getCTM()).rotation;
             assert.equal(l0labelRotation, 0, 'label angle does not change when label is moved around straight-line link (relative offset)');
-            v0.pointerup(event);
+            v0.pointerup(evt0);
 
             var l1 = new joint.shapes.standard.Link({
                 source: { id: r1.id }, // left anchor = (100, 75)
@@ -1253,12 +1253,12 @@ QUnit.module('links', function(hooks) {
 
             var v1 = this.paper.findViewByModel(l1);
             v1.options.interactive = { labelMove: true };
-            var event = { currentTarget: v1.$('.label')[0], type: 'mousedown' };
-            v1.dragLabelStart(event, 200, 75);
-            v1.pointermove(event, 200, 25);
-            var l1labelRotation = V.decomposeMatrix(v1.el.getElementsByClassName('labels')[0].getElementsByClassName('label')[0].getCTM()).rotation;
+            var evt1 = { currentTarget: v1.$('.label')[0], type: 'mousedown' };
+            v1.dragLabelStart(evt1, 200, 75);
+            v1.pointermove(evt1, 200, 25);
+            var l1labelRotation = V.decomposeMatrix(v1.el.querySelector('.labels .label').getCTM()).rotation;
             assert.equal(l1labelRotation, 0, 'label angle does not change when label is moved around straight-line link (absolute offset)');
-            v1.pointerup(event);
+            v1.pointerup(evt1);
         });
 
         QUnit.test('change:labels', function(assert) {


### PR DESCRIPTION
## Description

Labels using `keepGradient` and `absoluteOffset` have unexpected rotation applied to them.

## Motivation and Context

The issue was caused by the `g.Point.offset()` method being applied on `start` point of `tangent` line. The method modifies the point in-place.

This caused the `tangent.start` point stay in this modified state beyond the intended scope (i.e. out-of-sync with `tangent.end`) - during the time of the `angle` calculation, which happens afterward. On top of the `tangent` angle, the `angle` was thus then also incorrectly adding the angle between the modified `tangent.start` position and the original `tangent.end` position.

This PR fixes the issue by cloning the `tangent.start` point and applying the offset method to the clone. This also applies to the fallback algorithm, which uses `path.start` in absence of a tangent line.

### Screenshots:

Correct rotation while on line:

![Screenshot 2023-02-07 at 17 45 37](https://user-images.githubusercontent.com/6071519/217506444-c9705a9e-7d3d-42ee-8013-e3d3e6f0bb25.png)

Incorrect rotation when dragged away from line:

![Screenshot 2023-02-07 at 17 45 52](https://user-images.githubusercontent.com/6071519/217506471-5ac4249e-916b-4a16-aa23-10c7aee9ca67.png) | ![Screenshot 2023-02-07 at 17 46 01](https://user-images.githubusercontent.com/6071519/217506498-9e8f4571-7ed8-4679-b7ff-576ef9c8cef1.png)

Correct rotation when dragged away from the line thanks to this PR:

![Screenshot 2023-02-10 at 11 14 58](https://user-images.githubusercontent.com/6071519/218065949-309cdd16-82fc-4e23-a039-45e3274348e1.png)
