### PR TITLE
fix(dia.ElementView): apply port layout transformations before ref nodes b…

### DIFF
--- a/src/dia/ports.mjs
+++ b/src/dia/ports.mjs
@@ -795,20 +795,19 @@ export const elementViewPortPrototype = {
             var portId = metrics.portId;
             var cached = this._portElementsCache[portId] || {};
             var portTransformation = metrics.portTransformation;
-            this.applyPortTransform(cached.portElement, portTransformation);
-            this.updateDOMSubtreeAttributes(cached.portElement.node, metrics.portAttrs, {
-                rootBBox: new Rect(metrics.portSize),
-                selectors: cached.portSelectors
-            });
-
             var labelTransformation = metrics.labelTransformation;
             if (labelTransformation && cached.portLabelElement) {
-                this.applyPortTransform(cached.portLabelElement, labelTransformation, (-portTransformation.angle || 0));
                 this.updateDOMSubtreeAttributes(cached.portLabelElement.node, labelTransformation.attrs, {
                     rootBBox: new Rect(metrics.labelSize),
                     selectors: cached.portLabelSelectors
                 });
+                this.applyPortTransform(cached.portLabelElement, labelTransformation, (-portTransformation.angle || 0));
             }
+            this.updateDOMSubtreeAttributes(cached.portElement.node, metrics.portAttrs, {
+                rootBBox: new Rect(metrics.portSize),
+                selectors: cached.portSelectors
+            });
+            this.applyPortTransform(cached.portElement, portTransformation);
         }
     },
 

--- a/test/jointjs/elementPorts.js
+++ b/test/jointjs/elementPorts.js
@@ -970,4 +970,95 @@ QUnit.module('element ports', function() {
             shape.addPorts([{ id: 'x' }, { id: 'y' }]);
         });
     });
+
+    QUnit.module('rendering', function(hooks) {
+
+        let graph, paper;
+
+        hooks.beforeEach(function() {
+            graph = new joint.dia.Graph;
+            var fixtures = document.getElementById('qunit-fixture');
+            var paperEl = document.createElement('div');
+            fixtures.appendChild(paperEl);
+            paper = new joint.dia.Paper({ el: paperEl, model: graph });
+        });
+
+        hooks.afterEach(function() {
+            paper.remove();
+        });
+
+        QUnit.test('referencing port label node', function(assert) {
+            const model = new joint.shapes.standard.Rectangle({
+                size: { width: 200, height: 200 },
+                portLabelMarkup: [
+                    {
+                        tagName: 'rect',
+                        selector: 'rectCopy'
+                    },
+                    {
+                        tagName: 'rect',
+                        selector: 'rectRef'
+                    }
+                ],
+                ports: {
+                    groups: {
+                        left: {
+                            position: 'left',
+                            label: {
+                                position: {
+                                    name: 'manual',
+                                    args: {
+                                        attrs: {
+                                            'rectRef': {
+                                                x: -11,
+                                                y: -13
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            attrs: {
+                                rectCopy: {
+                                    ref: 'rectRef',
+                                    fill: 'red',
+                                    x: 'calc(x)',
+                                    y: 'calc(y)',
+                                    width: 'calc(w)',
+                                    height: 'calc(h)'
+                                },
+                                rectRef: {
+                                    width: 100,
+                                    height: 20,
+                                },
+                            }
+                        },
+                    },
+                    items: [{
+                        id: 'p1',
+                        group: 'left'
+                    }]
+                }
+            });
+            model.addTo(graph, { async: false });
+            const shapeView = model.findView(paper);
+            const rectRefNode = shapeView.findPortNode('p1', 'rectRef');
+            const rectCopyNode = shapeView.findPortNode('p1', 'rectCopy');
+            const x = Number(rectRefNode.getAttribute('x'));
+            const y = Number(rectRefNode.getAttribute('y'));
+            const width = Number(rectRefNode.getAttribute('width'));
+            const height = Number(rectRefNode.getAttribute('height'));
+            // Reference rectangle should have a position and size set.
+            assert.notEqual(x, 0);
+            assert.notEqual(y, 0);
+            assert.notEqual(width, 0);
+            assert.notEqual(height, 0);
+            // Rectangle copy should have the same position and size
+            // as the reference rectangle.
+            assert.equal(Number(rectCopyNode.getAttribute('x')), x);
+            assert.equal(Number(rectCopyNode.getAttribute('y')), y);
+            assert.equal(Number(rectCopyNode.getAttribute('width')), width);
+            assert.equal(Number(rectCopyNode.getAttribute('height')), height);
+        });
+    });
+
 });


### PR DESCRIPTION
Addresses issue no. 2 from https://github.com/clientIO/joint/issues/2026#issuecomment-1422185153

---

After this change, the `ref` attributes used with ports positioned to the **left** of elements (having `text-anchor: 'end'`) are defined as expected:

```js
label: {
  text: 'Port'
},
background: {
  ref: 'label'
  x: 'calc(x)',
  y: 'calc(y)',
  width: 'calc(w)'
  height: 'calc(h)'
}
```

The `x: calc(x - calc(w))` is no longer required (and it was never meant to be required). See [example](https://codepen.io/jointjs/pen/rNdzYZj).

The `calc(x)` must be referring to `x` coordinate of the `ref` node no matter what `text-anchor` it has set.

