### PR TITLE
fix(layouts.PortLabel): center the position of oriented outside/inside labels, remove redundant code from manual layout

### DIFF
--- a/src/layout/ports/portLabel.mjs
+++ b/src/layout/ports/portLabel.mjs
@@ -32,14 +32,15 @@ function outsideLayout(portPosition, elBBox, autoOrient, opt) {
         ty = 0;
         textAnchor = 'start';
     } else if (angle < x[0]) {
-        y = '0';
         tx = 0;
         ty = -offset;
         if (autoOrient) {
             orientAngle = -90;
             textAnchor = 'start';
+            y = '.3em';
         } else {
             textAnchor = 'middle';
+            y = '0';
         }
     } else if (angle < x[3]) {
         y = '.3em';
@@ -47,14 +48,15 @@ function outsideLayout(portPosition, elBBox, autoOrient, opt) {
         ty = 0;
         textAnchor = 'end';
     } else {
-        y = '.6em';
         tx = 0;
         ty = offset;
         if (autoOrient) {
             orientAngle = 90;
             textAnchor = 'start';
+            y = '.3em';
         } else {
             textAnchor = 'middle';
+            y = '.6em';
         }
     }
 
@@ -101,14 +103,15 @@ function insideLayout(portPosition, elBBox, autoOrient, opt) {
         ty = 0;
         textAnchor = 'end';
     } else if (angle < bBoxAngles[0]) {
-        y = '.6em';
         tx = 0;
         ty = offset;
         if (autoOrient) {
             orientAngle = 90;
             textAnchor = 'start';
+            y = '.3em';
         } else {
             textAnchor = 'middle';
+            y = '.6em';
         }
     } else if (angle < bBoxAngles[3]) {
         y = '.3em';
@@ -116,14 +119,15 @@ function insideLayout(portPosition, elBBox, autoOrient, opt) {
         ty = 0;
         textAnchor = 'start';
     } else {
-        y = '0em';
         tx = 0;
         ty = -offset;
         if (autoOrient) {
             orientAngle = -90;
             textAnchor = 'start';
+            y = '.3em';
         } else {
             textAnchor = 'middle';
+            y = '0';
         }
     }
 
@@ -182,8 +186,8 @@ function radialLayout(portCenterOffset, autoOrient, opt) {
     });
 }
 
-export const manual = function(portPosition, elBBox, opt) {
-    return labelAttributes(opt, elBBox);
+export const manual = function(_portPosition, _elBBox, opt) {
+    return labelAttributes(opt);
 };
 
 export const left = function(portPosition, elBBox, opt) {


### PR DESCRIPTION
## Description

Improvements to the Port Label Layout text positioning.

1.  For `outsideOriented` and `insideOriented` layouts, adjust the `y` coordinate of the port label's `<text/>` to align it properly.
2. For `manual` layout, stop copying all `g.Rect` properties and methods to the layout result. None of the properties should actually be copied 
    - `width` and `height` is not used
    - `x` and `y` which is the origin of the element (always 0x0) does not make sense here. the `x` and ` y` is an offset from the port

## Motivation and Context

The **Port Label** layout must always align the center of the label with the port.

### Screenshots:

**Before:**
<img width="756" alt="image" src="https://user-images.githubusercontent.com/3967880/217732127-16409be2-9dc8-444c-97b9-6202a8225feb.png">

**After:**
<img width="766" alt="image" src="https://user-images.githubusercontent.com/3967880/217731952-04b87ee4-71fd-4027-9e1c-d5e959050509.png">

