### PR TITLE
chore(seo): update headings and meta descriptions

### DIFF
--- a/demo/bandwidth/index.html
+++ b/demo/bandwidth/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Carrier Frequency Bandwidth demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Carrier Frequency Bandwidth demo serves as a template to help bring your idea to life in no time.">
 
         <title>Carrier Frequency Bandwidth | JointJS</title>
 

--- a/demo/bus/index.html
+++ b/demo/bus/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Audio Mix Bus demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Audio Mix Bus demo serves as a template to help bring your idea to life in no time.">
 
         <title>Audio Mix Bus | JointJS</title>
 

--- a/demo/chess/index.html
+++ b/demo/chess/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Chess Board demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Chess Board demo serves as a template to help bring your idea to life in no time.">
 
         <title>Chess Board | JointJS</title>
 

--- a/demo/container/index.html
+++ b/demo/container/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Container and Embedding demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Container and Embedding demo serves as a template to help bring your idea to life in no time.">
 
         <title>Container and Embedding | JointJS</title>
 

--- a/demo/curves/index.html
+++ b/demo/curves/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS SVG Curves demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS SVG Curves demo serves as a template to help bring your idea to life in no time.">
         <title>SVG Curves | JointJS</title>
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
         <link rel="stylesheet" type="text/css" href="css/curves.css" />

--- a/demo/devs/index.html
+++ b/demo/devs/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"/>
-        <meta name="description" content="The JointJS Discrete Event System Specification demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Discrete Event System Specification demo serves as a template to help bring your idea to life in no time.">
 
         <title>Discrete Event System Specification | JointJS</title>
 

--- a/demo/dgl/index.html
+++ b/demo/dgl/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Directed Graph Layout demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Directed Graph Layout demo serves as a template to help bring your idea to life in no time.">
         <title>Directed Graph Layout | JointJS</title>
         <link rel="stylesheet" type="text/css" href="./css/styles.css" />
     </head>

--- a/demo/elk/index.html
+++ b/demo/elk/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS ELK Layered Layout demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+    <meta name="description" content="The JointJS ELK Layered Layout demo serves as a template to help bring your idea to life in no time.">
     <title>ELK Layered Layout | JointJS</title>
     <link rel="stylesheet" type="text/css" href="css/styles.css">
 </head>

--- a/demo/erd/index.html
+++ b/demo/erd/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS ER diagrams demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS ER diagrams demo serves as a template to help bring your idea to life in no time.">
 
         <title>ER Diagrams | JointJS</title>
 

--- a/demo/fsa/index.html
+++ b/demo/fsa/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Finite State Machines demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Finite State Machines demo serves as a template to help bring your idea to life in no time.">
 
         <title>Finite State Machines | JointJS</title>
 

--- a/demo/fta/index.html
+++ b/demo/fta/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Fault Tree Analysis demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Fault Tree Analysis demo serves as a template to help bring your idea to life in no time.">
 
         <title>Fault Tree Analysis | JointJS</title>
 

--- a/demo/html/index.html
+++ b/demo/html/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS HTML Tasks demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS HTML Tasks demo serves as a template to help bring your idea to life in no time.">
 
         <title>HTML Tasks | JointJS</title>
 

--- a/demo/hull/index.html
+++ b/demo/hull/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Convex Hull Algorithm demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Convex Hull Algorithm demo serves as a template to help bring your idea to life in no time.">
 
         <title>Convex Hull Algorithm | JointJS</title>
 

--- a/demo/icons/index.html
+++ b/demo/icons/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Icons Element List demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Icons Element List demo serves as a template to help bring your idea to life in no time.">
 
         <title>Icons Element List | JointJS</title>
 

--- a/demo/links/index.html
+++ b/demo/links/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Links and Labels demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Links and Labels demo serves as a template to help bring your idea to life in no time.">
 
         <title>Links and Labels | JointJS</title>
 

--- a/demo/list/index.html
+++ b/demo/list/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS List Items demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+    <meta name="description" content="The JointJS List Items demo serves as a template to help bring your idea to life in no time.">
     <title>List Items | JointJS</title>
     <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
   </head>

--- a/demo/logic/index.html
+++ b/demo/logic/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Logic Circuits demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Logic Circuits demo serves as a template to help bring your idea to life in no time.">
 
         <title>Logic Circuits | JointJS</title>
 

--- a/demo/marey/index.html
+++ b/demo/marey/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Marey Chart demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Marey Chart demo serves as a template to help bring your idea to life in no time.">
         <title>Marey Chart | JointJS</title>
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
         <link rel="stylesheet" type="text/css" href="css/marey.css" />

--- a/demo/org/index.html
+++ b/demo/org/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Organizational Charts demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Organizational Charts demo serves as a template to help bring your idea to life in no time.">
 
         <title>Organizational Charts | JointJS</title>
 

--- a/demo/paper/index.html
+++ b/demo/paper/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS Paper attributes demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+    <meta name="description" content="The JointJS Paper attributes demo serves as a template to help bring your idea to life in no time.">
 
     <title>Paper attributes | JointJS</title>
 

--- a/demo/petri nets/index.html
+++ b/demo/petri nets/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Petri Nets demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Petri Nets demo serves as a template to help bring your idea to life in no time.">
 
         <title>Petri Nets | JointJS</title>
 

--- a/demo/puzzle/index.html
+++ b/demo/puzzle/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Jigsaw Puzzle demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Jigsaw Puzzle demo serves as a template to help bring your idea to life in no time.">
         <title>Jigsaw Puzzle | JointJS</title>
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
         <style>

--- a/demo/rough/index.html
+++ b/demo/rough/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"/>
-        <meta name="description" content="The JointJS RoughJS Sketch demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS RoughJS Sketch demo serves as a template to help bring your idea to life in no time.">
 
         <title>RoughJS Sketch | JointJS</title>
 

--- a/demo/routing/index.html
+++ b/demo/routing/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Smart Routing demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Smart Routing demo serves as a template to help bring your idea to life in no time.">
 
         <title>Smart Routing | JointJS</title>
 

--- a/demo/sequence/index.html
+++ b/demo/sequence/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Sequence Diagram demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Sequence Diagram demo serves as a template to help bring your idea to life in no time.">
 
         <title>Sequence Diagram | JointJS</title>
 

--- a/demo/shapes/fills.html
+++ b/demo/shapes/fills.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS Fills and Gradients demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS Fills and Gradients demo serves as a template to help bring your idea to life in no time.">
         <title>Fills and Gradients | JointJS</title>
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
         <style>

--- a/demo/umlcd/index.html
+++ b/demo/umlcd/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS UML Class Diagrams demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS UML Class Diagrams demo serves as a template to help bring your idea to life in no time.">
 
         <title>UML Class Diagrams | JointJS</title>
 

--- a/demo/umlsc/index.html
+++ b/demo/umlsc/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="The JointJS UML StateChart Diagrams demo showcases a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+        <meta name="description" content="The JointJS UML StateChart Diagrams demo serves as a template to help bring your idea to life in no time.">
 
         <title>UML StateChart Diagrams | JointJS</title>
 

--- a/docs/templates/api.html
+++ b/docs/templates/api.html
@@ -4,7 +4,7 @@
     <meta http-equiv="x-ua-compatible" content="IE=Edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta name="description" content="Documentation for JointJS, a proven JavaScript/TypeScript diagramming library that helps developers and companies of any size build visual and No-Code/Low-Code applications faster.">
+    <meta name="description" content="JointJS {{description}} documentation for a proven SVG JavaScript/TypeScript diagramming library that helps build visual applications faster.">
     <link rel="stylesheet" type="text/css" href="css/prism.css">
     <link rel="stylesheet" type="text/css" href="css/api.css">
     <title>{{title}}</title>

--- a/grunt/config/compileDocs.js
+++ b/grunt/config/compileDocs.js
@@ -52,6 +52,16 @@ module.exports = function(grunt) {
         return `${this.heading} (v${pkg.version.split('.').slice(0, -1).join('.')}) - JointJS Docs`;
     });
 
+    /* 
+        Create unique content to insert into documentation meta description using the page heading and version number.
+        `Joint API v(3.6)`
+        For SEO performance, each documentation page meta description should be unique, and also unique across
+        different versions of the documentation.
+    */
+    Handlebars.registerHelper('description', function() {
+        return `${this.heading} (v${pkg.version.split('.').slice(0, -1).join('.')})`;
+    });
+
     return {
         all: {
             options: {

--- a/tutorials/advanced.html
+++ b/tutorials/advanced.html
@@ -28,7 +28,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Advanced Tutorial</h2>
+            <h1>Advanced Tutorial</h1>
 
             <p>By now, you should be familiar with the <a href="hello-world.html">basics of JointJS</a>, as well as with
                 some <a href="intermediate.html">intermediate-difficulty topics</a>.</p>

--- a/tutorials/archive.html
+++ b/tutorials/archive.html
@@ -28,7 +28,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Archive</h2>
+            <h1>Archive</h1>
 
             <p>This is the final section of the JointJS tutorial.
                 We presume that you are already familiar with the <a href="hello-world.html">basic</a>,

--- a/tutorials/connecting-by-dropping.html
+++ b/tutorials/connecting-by-dropping.html
@@ -30,7 +30,7 @@
 
         <div id="connecting-by-dropping" class="tutorial">
 
-            <h2>Connecting an element by dropping it over another element</h2>
+            <h1>Connecting an element by dropping it over another element</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/constraint-move-to-circle.html
+++ b/tutorials/constraint-move-to-circle.html
@@ -30,7 +30,7 @@
 
         <div id="constraint-move-to-circle" class="tutorial">
 
-            <h2>Constraint movement to circle/ellipse/rectangle</h2>
+            <h1>Constraint movement to circle/ellipse/rectangle</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/content-driven-element.html
+++ b/tutorials/content-driven-element.html
@@ -28,7 +28,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Content Driven Elements</h2>
+            <h1>Content Driven Elements</h1>
 
             <p>
                 JointJS provides its users with a lot of flexibility when it comes to creating custom shapes. You may have already taken

--- a/tutorials/css/tutorial.css
+++ b/tutorials/css/tutorial.css
@@ -100,22 +100,23 @@ img {
 }
 
 h1 {
+    border-bottom: 1px solid #eee;
     color: var(--primary-blue);
     font-size: 35px;
     font-weight: var(--text-font-weight-bold);
     word-spacing: 3.5px;
+    letter-spacing: var(--text-letter-spacing);
+    padding-bottom: 30px;
     letter-spacing: 1px;
     text-align: center;
     text-transform: capitalize;
-    margin: 49px 0 46px;
+    margin: 40px 0 46px;
 }
 
 h2 {
     font-size: 24px;
     text-align: center;
     text-transform: uppercase;
-    border-bottom: 1px solid #d1d2d8;
-    padding-bottom: 30px;
     margin: 32px 0 0;
 }
 

--- a/tutorials/custom-attributes.html
+++ b/tutorials/custom-attributes.html
@@ -21,7 +21,7 @@
 <body class="language-javascript tutorial-page">
     <div class="tutorial">
 
-    <h2>Custom Attributes</h2>
+    <h1>Custom Attributes</h1>
 
     <p>
         If you have been working with JointJS for any amount of time, you are probably familiar with presentation attributes.

--- a/tutorials/custom-elements.html
+++ b/tutorials/custom-elements.html
@@ -30,7 +30,7 @@
 
         <div id="custom-elements" class="tutorial">
 
-            <h2>Custom Elements</h2>
+            <h1>Custom Elements</h1>
 
             <p><i>
                 This is the fourth article of the intermediate section of the JointJS tutorial. Return to 

--- a/tutorials/custom-links.html
+++ b/tutorials/custom-links.html
@@ -30,7 +30,7 @@
 
         <div id="custom-elements" class="tutorial">
 
-            <h2>Custom Links</h2>
+            <h1>Custom Links</h1>
 
             <p><i>
                 This is the fifth article of the intermediate section of the JointJS tutorial. Return to 

--- a/tutorials/element-tools.html
+++ b/tutorials/element-tools.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Element Tools</h2>
+            <h1>Element Tools</h1>
 
             <p><i>
                 This is the seventh article of the intermediate section of the JointJS tutorial. Return to

--- a/tutorials/elements.html
+++ b/tutorials/elements.html
@@ -31,7 +31,7 @@
 
         <div class="tutorial">
 
-            <h2>Elements</h2>
+            <h1>Elements</h1>
 
             <p>In the <a href="hello-world.html">first part</a> of the tutorial, we saw a working example of a
                 simple JointJS application:</a></p>

--- a/tutorials/events.html
+++ b/tutorials/events.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Events</h2>
+            <h1>Events</h1>
 
             <p><i>
                 This is the second article of the intermediate section of the JointJS tutorial. Return to

--- a/tutorials/filters-gradients.html
+++ b/tutorials/filters-gradients.html
@@ -30,7 +30,7 @@
 
         <div id="filters-gradients" class="tutorial">
 
-            <h2>Filters and gradients in elements and links</h2>
+            <h1>Filters and gradients in elements and links</h1>
 
             <p>This is an introduction to <a href="#filters" target="_self">filters</a> and
                 <a href="#gradients" target="_self">gradients</a> to style your JointJS

--- a/tutorials/graph-and-paper.html
+++ b/tutorials/graph-and-paper.html
@@ -30,7 +30,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Graph &amp; Paper</h2>
+            <h1>Graph &amp; Paper</h1>
 
             <p>In the <a href="hello-world.html">first part</a> of the tutorial, we saw a working example of a
                 simple JointJS application:</p>

--- a/tutorials/hello-world.html
+++ b/tutorials/hello-world.html
@@ -29,7 +29,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Hello world!</h2>
+            <h1>Hello world!</h1>
 
             <p>In the following few pages of the tutorial, we will understand how to create a basic
                 <a href="introduction.html">JointJS diagram</a>:</p>

--- a/tutorials/hierarchy.html
+++ b/tutorials/hierarchy.html
@@ -30,7 +30,7 @@
 
         <div id="hierarchy" class="tutorial">
 
-            <h2>Tips on hierarchical diagrams</h2>
+            <h1>Tips on hierarchical diagrams</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/html-elements.html
+++ b/tutorials/html-elements.html
@@ -30,7 +30,7 @@
 
         <div id="html-elements" class="tutorial">
 
-            <h2>Using HTML in JointJS elements</h2>
+            <h1>Using HTML in JointJS elements</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/hyperlinks.html
+++ b/tutorials/hyperlinks.html
@@ -30,7 +30,7 @@
 
         <div id="hyperlinks" class="tutorial">
 
-            <h2>Custom elements with hyperlinks</h2>
+            <h1>Custom elements with hyperlinks</h1>
 
             <p>It is possible to define <a href="custom-elements.html">custom JointJS elements</a> with hyperlinks
                 pointing to external sites - by including the <code>&lt;a&gt;</code>

--- a/tutorials/installation.html
+++ b/tutorials/installation.html
@@ -30,7 +30,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Installation</h2>
+            <h1>Installation</h1>
 
             <p>In the <a href="hello-world.html">first part</a> of the tutorial, we saw a working example of a
                 simple JointJS application:</p>

--- a/tutorials/intermediate.html
+++ b/tutorials/intermediate.html
@@ -28,7 +28,7 @@
         </script>
         <div class="tutorial">
 
-            <h2>Intermediate Tutorial</h2>
+            <h1>Intermediate Tutorial</h1>
 
             <p>In the <a href="hello-world.html">basic section of the tutorial</a>, we learned how to create a simple
                 JointJS application.

--- a/tutorials/introduction.html
+++ b/tutorials/introduction.html
@@ -31,8 +31,6 @@
 
         <div class="tutorial">
 
-            <h2>About JointJS</h2>
-
             <p><strong>The JointJS diagramming library</strong> lets you create fully interactive diagramming tools for all
                 modern browsers, relying only on JavaScript and
                 <a href="https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html" target="_blank">SVG</a>.

--- a/tutorials/link-labels.html
+++ b/tutorials/link-labels.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Link Labels</h2>
+            <h1>Link Labels</h1>
 
             <p><i>
                 This is the sixth article of the intermediate section of the JointJS tutorial. Return to

--- a/tutorials/link-tools.html
+++ b/tutorials/link-tools.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Link Tools</h2>
+            <h1>Link Tools</h1>
 
             <p><i>
                 This is the eighth article of the intermediate section of the JointJS tutorial. Return to

--- a/tutorials/links-patterns.html
+++ b/tutorials/links-patterns.html
@@ -30,7 +30,7 @@
 
         <div id="links-patterns" class="tutorial">
 
-            <h2>Links and patterns</h2>
+            <h1>Links and patterns</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/links.html
+++ b/tutorials/links.html
@@ -31,7 +31,7 @@
 
         <div class="tutorial">
 
-            <h2>Links</h2>
+            <h1>Links</h1>
 
             <p>In the <a href="hello-world.html">first part</a> of the tutorial, we saw a working example of a
                 simple JointJS application:</p>

--- a/tutorials/multiple-links-between-elements.html
+++ b/tutorials/multiple-links-between-elements.html
@@ -30,7 +30,7 @@
 
         <div id="multiple-links-between-elements" class="tutorial">
 
-            <h2>Multiple links between elements</h2>
+            <h1>Multiple links between elements</h1>
 
             <p>We have been asked how to accommodate two or more links connecting to the same two elements.
                 By default, multiple links that connect the same two elements simply overlap one another, which makes

--- a/tutorials/multiple-papers.html
+++ b/tutorials/multiple-papers.html
@@ -30,7 +30,7 @@
 
         <div class="tutorial">
 
-            <h2>Multiple papers for the same graph</h2>
+            <h1>Multiple papers for the same graph</h1>
 
             <p>We mentioned in the <a href="introduction.html">tutorial introduction</a> that JointJS has an MVC
                 structure.

--- a/tutorials/ports-archive.html
+++ b/tutorials/ports-archive.html
@@ -30,7 +30,7 @@
 
         <div id="ports" class="tutorial">
 
-            <h2>Working with Ports</h2>
+            <h1>Working with Ports (Archive)</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/ports.html
+++ b/tutorials/ports.html
@@ -31,7 +31,7 @@
 
         <div id="ports" class="tutorial">
 
-            <h2>Working with Ports</h2>
+            <h1>Working with Ports</h1>
 
             <p>
                 Many diagramming applications deal with the idea of elements with ports. Ports are often displayed

--- a/tutorials/requirejs.html
+++ b/tutorials/requirejs.html
@@ -30,7 +30,7 @@
 
         <div id="requirejs" class="tutorial">
 
-            <h2>Integrating JointJS with RequireJS</h2>
+            <h1>Integrating JointJS with RequireJS</h1>
 
             <p>
                 <strong>Disclaimer</strong> 

--- a/tutorials/serialization.html
+++ b/tutorials/serialization.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Serialization</h2>
+            <h1>Serialization</h1>
 
             <p><i>
                 This is the third article of the intermediate section of the JointJS tutorial. Return to

--- a/tutorials/special-attributes.html
+++ b/tutorials/special-attributes.html
@@ -29,7 +29,7 @@
 
         <div class="tutorial">
 
-            <h2>Special Attributes</h2>
+            <h1>Special Attributes</h1>
 
             <p><i>
                 This is the first article of the intermediate section of the JointJS tutorial. See

--- a/tutorials/testing-e2e-playwright.html
+++ b/tutorials/testing-e2e-playwright.html
@@ -25,7 +25,7 @@
 
         <div id="e2e-testing-playwright" class="tutorial">
 
-            <h2>E2E Testing with Playwright</h2>
+            <h1>E2E Testing with Playwright</h1>
 
             <p>
                 E2E testing is an integral part of ensuring your application behaves as expected. In the following tutorial, we will cover 

--- a/tutorials/ts-shape.html
+++ b/tutorials/ts-shape.html
@@ -20,6 +20,8 @@
 <body class="language-javascript tutorial-page">
     <div class="tutorial">
 
+    <h1>Custom shape with TypeScript</h1>
+
     <p>
         We often get asked how to incorporate TypeScript with JointJS. As JointJS is a standard JavaScript library, the
         integration process is quite simple and straightforward. In the following tutorial, we are going to create our very own custom


### PR DESCRIPTION
## Description

- create `meta` description upto 158 characters for `docs` and `demos`
- create unique `meta`description for each documentation page, and across documentation versions
- update tutorials to have `h1` instead of `h2` for main headings
