### PR TITLE
chore(github): remove automatic addition of bug label from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Something doesn't work like it should? Tell us!
-title: "[Bug]: "
-labels: ["bug"]
+title: ""
+labels: []
 assignees: 
   - ""
 body:


### PR DESCRIPTION
## Description

- Remove automatic addition of `bug` label from github issue template `bug.yml`
