### PR TITLE
fix(demo.curves): use tools from elementTools namespace instead of li…

### DIFF
--- a/demo/curves/src/curves.js
+++ b/demo/curves/src/curves.js
@@ -1,4 +1,4 @@
-const { dia, shapes, linkTools, connectors } = joint;
+const { dia, shapes, elementTools, linkTools, connectors } = joint;
 const { Polygon, Ellipse, Rect, toDeg } = g;
 const { TangentDirections } = connectors.curve;
 
@@ -162,7 +162,7 @@ const BaseShape = dia.Element.define(ShapeTypes.BASE, {
 
     getTools() {
         return [
-            new linkTools.Connect({
+            new elementTools.Connect({
                 focusOpacity: 0,
                 markup: this.getConnectToolMarkup()
             })


### PR DESCRIPTION
…nkTools in element context

## Description

When connecting a tool to an element, use `elementTools.Connect` instead of `linkTools.Connect` (they refer to the same class, but the implementation of the element and link `Connect` tool may change in the future).



