### PR TITLE
docs: file path fixes

### DIFF
--- a/docs/css/api.css
+++ b/docs/css/api.css
@@ -51,7 +51,7 @@
     font-family: 'PPFraktionMono';
     font-style: italic;
     font-weight: 600;
-    src: url('../fonts/fonts/PPFraktionMono/PPFraktionMono-BoldItalic.woff') format('woff');
+    src: url('../fonts/PPFraktionMono/PPFraktionMono-BoldItalic.woff') format('woff');
 }
 
 :root {

--- a/docs/demo/shapes/shapes.standard.html
+++ b/docs/demo/shapes/shapes.standard.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8"/>
         <title>Standard Shapes</title>
-        <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="../../css/lib/joint.min.css" />
         <style>
             body {
                 margin: 0;


### PR DESCRIPTION
## Description

While checking all documentation files for task #1948, I discovered some file paths in the `docs` folder which appear to be wrong.

## Motivation and Context

- `docs/css/api.css`: font path of bold italic PP Fraktion Mono has duplicated `/fonts` string
  - changed to `../fonts/PPFraktionMono/PPFraktionMono-BoldItalic.woff` which is in line with other font paths in the file 

- `docs/demo/shapes/shapes.standard.html`: stylesheet path doesn't point to anything (note that we care about what happens inside `build/docs`)
  - changed to `../../css/lib/joint.min.css` (like it is in `docs/demo/shapes/shapes.devs.html`)