### PR TITLE
fix(linkTools.Anchor): make sure mouseleave event is triggered after drag&drop interaction

### DIFF
--- a/src/linkTools/Anchor.mjs
+++ b/src/linkTools/Anchor.mjs
@@ -211,8 +211,8 @@ const Anchor = ToolView.extend({
         this.toggleArea(false);
         var linkView = this.relatedView;
         if (this.options.redundancyRemoval) linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
-        linkView.model.stopBatch('anchor-move', { ui: true, tool: this.cid });
         linkView.checkMouseleave(normalizedEvent);
+        linkView.model.stopBatch('anchor-move', { ui: true, tool: this.cid });
     },
 
     onPointerDblClick: function() {

--- a/src/linkTools/Anchor.mjs
+++ b/src/linkTools/Anchor.mjs
@@ -204,6 +204,7 @@ const Anchor = ToolView.extend({
     },
 
     onPointerUp: function(evt) {
+        const normalizedEvent = util.normalizeEvent(evt);
         this.paper.delegateEvents();
         this.undelegateDocumentEvents();
         this.blur();
@@ -211,6 +212,7 @@ const Anchor = ToolView.extend({
         var linkView = this.relatedView;
         if (this.options.redundancyRemoval) linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
         linkView.model.stopBatch('anchor-move', { ui: true, tool: this.cid });
+        linkView.checkMouseleave(normalizedEvent);
     },
 
     onPointerDblClick: function() {


### PR DESCRIPTION
## Description

Make sure the `cell:mouseleave` event is triggered after drag & drop interaction when the pointer is outside the linkView on `mouseup`.

## Motivation and Context

The problem is that on `mousedown` we undelegate all paper events to prevent other events like `mouseover` and `mouseout` events from triggering during drag & drop interaction, and delegate them back on `mouseup`.

The ideal solution could be not to undelegate the events and use `setPointerCapure` API instead. This PR is just a simple fix of existing problem and it is not addressing this technical debt.

