### PR TITLE
fix(highligters.mask): prevent class attribute from being copied over to mask element

### DIFF
--- a/src/highlighters/mask.mjs
+++ b/src/highlighters/mask.mjs
@@ -41,7 +41,8 @@ export const mask = HighlighterView.extend({
         'marker-end',
         'marker-mid',
         'transform',
-        'stroke-dasharray'
+        'stroke-dasharray',
+        'class',
     ],
 
     MASK_CHILD_ATTRIBUTE_BLACKLIST: [
@@ -53,7 +54,8 @@ export const mask = HighlighterView.extend({
         'fill-opacity',
         'marker-start',
         'marker-end',
-        'marker-mid'
+        'marker-mid',
+        'class',
     ],
 
     // TODO: change the list to a function callback

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -769,7 +769,7 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.notOk(paper.isDefined(highlighter.getMaskId()));
         });
 
-        QUnit.test('Purifying the mask element', function(assert) {
+        QUnit.test('Purging the mask nodes', function(assert) {
             // class names
             const HighlighterView = joint.highlighters.mask;
             const id = 'highlighter-id';

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -769,6 +769,19 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.notOk(paper.isDefined(highlighter.getMaskId()));
         });
 
+        QUnit.test('Purifying the mask element', function(assert) {
+            // class names
+            const HighlighterView = joint.highlighters.mask;
+            const id = 'highlighter-id';
+            elementView.el.classList.add('root');
+            elementView.el.querySelector('rect').classList.add('body');
+            elementView.el.querySelector('text').classList.add('label');
+            const highlighter = HighlighterView.add(elementView, 'root', id, { deep: true });
+            const maskEl = paper.svg.getElementById(highlighter.getMaskId());
+            assert.notOk(maskEl.querySelector('.root'));
+            assert.notOk(maskEl.querySelector('.body'));
+            assert.notOk(maskEl.querySelector('.label'));
+        });
     });
 
     QUnit.module('stroke', function() {


### PR DESCRIPTION
## Description

The `<mask/>` element inside paper's `<defs/>` should not copy `class` attributes from the source cell nodes.

## Motivation and Context

If external CSS is used to style elements, this should prevent `mask` nodes inside `defs` from unintentionally becoming the target of CSS rules (in the context of `<mask/>` children nodes, it makes no sense to change their presentation attributes).
