### PR TITLE
types: enable use of strict in tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 coverage/
 *.log
 demo/**/dist/**
-/test/ts/*.js*
+/test/ts/*.js
+/test/ts/*.js.map
 .tscache/
 .DS_Store

--- a/grunt/config/ts.js
+++ b/grunt/config/ts.js
@@ -2,13 +2,23 @@ module.exports = {
     test: {
         src: ['test/ts/*.ts'],
         options: {
-            noImplicitAny: true,
+            strict: true,
+            pretty: true,
             forceConsistentCasingInFileNames: true,
             noImplicitReturns: true,
-            noImplicitThis: true,
-            strictNullChecks: false,
             suppressImplicitAnyIndexErrors: true,
-            noUnusedLocals: false
+            noUnusedLocals: false,
+            /* 
+                'strict' is shorthand for the following options:
+                    noImplicitAny: true,
+                    noImplicitThis: true,
+                    alwaysStrict: true,
+                    strictBindCallApply: true,
+                    strictNullChecks: true,
+                    strictFunctionTypes: true,
+                    strictPropertyInitialization: true,
+                    useUnknownInCatchVariables: true,
+            */    
         }
     }
 };

--- a/grunt/config/ts.js
+++ b/grunt/config/ts.js
@@ -1,24 +1,8 @@
 module.exports = {
     test: {
-        src: ['test/ts/*.ts'],
-        options: {
-            strict: true,
-            pretty: true,
-            forceConsistentCasingInFileNames: true,
-            noImplicitReturns: true,
-            suppressImplicitAnyIndexErrors: true,
-            noUnusedLocals: false,
-            /* 
-                'strict' is shorthand for the following options:
-                    noImplicitAny: true,
-                    noImplicitThis: true,
-                    alwaysStrict: true,
-                    strictBindCallApply: true,
-                    strictNullChecks: true,
-                    strictFunctionTypes: true,
-                    strictPropertyInitialization: true,
-                    useUnknownInCatchVariables: true,
-            */    
+        tsconfig: {
+            tsconfig: 'test/ts/tsconfig.json',
+            passThrough: true
         }
     }
 };

--- a/test/ts/index.test.ts
+++ b/test/ts/index.test.ts
@@ -84,7 +84,7 @@ graph.addCell({
 });
 
 // `cells` attribute is a collection of cells
-const cell = graph.get('cells').at(0);
+const cell = graph.getCells()[0];
 (<joint.dia.Element>cell).getBBox({ rotate: true }).inflate(5);
 
 // ModelSetOptions
@@ -94,7 +94,7 @@ rectangle.set('test', true, { silent: true, customOption: true });
 // a child inherits attributes from `dia.Element`
 const cylinder = new joint.shapes.standard.Cylinder({ z: 0 });
 cylinder.set({ position: { x: 4, y: 5 }});
-cylinder.set('z', cylinder.attributes.z + 1);
+cylinder.set('z', cylinder.attr('z') + 1);
 
 const paper = new joint.dia.Paper({
     model: graph,

--- a/test/ts/index.test.ts
+++ b/test/ts/index.test.ts
@@ -84,7 +84,7 @@ graph.addCell({
 });
 
 // `cells` attribute is a collection of cells
-const cell = graph.getCells()[0];
+const cell = graph.get('cells')?.at(0);
 (<joint.dia.Element>cell).getBBox({ rotate: true }).inflate(5);
 
 // ModelSetOptions
@@ -94,7 +94,7 @@ rectangle.set('test', true, { silent: true, customOption: true });
 // a child inherits attributes from `dia.Element`
 const cylinder = new joint.shapes.standard.Cylinder({ z: 0 });
 cylinder.set({ position: { x: 4, y: 5 }});
-cylinder.set('z', cylinder.attr('z') + 1);
+cylinder.set('z', (cylinder.attributes.z || 0) + 1);
 
 const paper = new joint.dia.Paper({
     model: graph,
@@ -102,7 +102,7 @@ const paper = new joint.dia.Paper({
     findParentBy: (_elementView, _evt, x, y) => graph.findModelsFromPoint({ x, y })
 });
 
-const cellView = cell.findView(paper);
+const cellView = graph.getCells[0].findView(paper);
 cellView.vel.addClass('test-class');
 
 let isHTMLView: AssertExtends<typeof paper.vel, null> = true;

--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "include": [
+        "**/*.ts",
+    ],
+    "compilerOptions": {
+        "target": "es6",
+        "moduleResolution": "node",
+        "pretty": true,
+        "sourceMap": true,
+        // The following options are enabled when using 'strict: true'
+        "alwaysStrict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        /* 
+            Rule is disabled due to design limitation with overloads in TypeScript
+            https://github.com/microsoft/TypeScript/issues/38353
+            https://github.com/microsoft/TypeScript/issues/42196
+        */
+        "strictBindCallApply": false,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "strictPropertyInitialization": true,
+        "useUnknownInCatchVariables": true,
+        // 'strict' options **End**
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitReturns": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "noUnusedLocals": false,
+        "skipLibCheck": false,
+        "types": [],
+    }
+}

--- a/test/ts/vectorizer.test.ts
+++ b/test/ts/vectorizer.test.ts
@@ -5,7 +5,7 @@ import { V, Vectorizer } from '../../build/joint';
 // Object
 const rect1 = V('rect');
 rect1.attr('fill', 'red');
-V.prototype.attr.call(rect1, ['fill', 'blue']);
+V.prototype.attr.call(rect1, 'fill', 'blue');
 
 // Static
 if (V.isV(rect1)) {
@@ -25,7 +25,7 @@ V.createSVGMatrix({});
 // Object
 const rect3 = Vectorizer('rect');
 rect3.attr('fill', 'red');
-Vectorizer.prototype.attr.call(rect3, ['fill', 'blue']);
+Vectorizer.prototype.attr.call(rect3, 'fill', 'blue');
 
 // Static
 if (Vectorizer.isV(rect3)) {

--- a/test/ts/vectorizer.test.ts
+++ b/test/ts/vectorizer.test.ts
@@ -5,7 +5,7 @@ import { V, Vectorizer } from '../../build/joint';
 // Object
 const rect1 = V('rect');
 rect1.attr('fill', 'red');
-V.prototype.attr.call(rect1, 'fill', 'blue');
+V.prototype.attr.call(rect1, ['fill', 'blue']);
 
 // Static
 if (V.isV(rect1)) {
@@ -25,7 +25,7 @@ V.createSVGMatrix({});
 // Object
 const rect3 = Vectorizer('rect');
 rect3.attr('fill', 'red');
-Vectorizer.prototype.attr.call(rect3, 'fill', 'blue');
+Vectorizer.prototype.attr.call(rect3, ['fill', 'blue']);
 
 // Static
 if (Vectorizer.isV(rect3)) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -157,7 +157,7 @@ export namespace dia {
         }
     }
 
-    class Graph<A = Graph.Attributes, S = dia.ModelSetOptions> extends Backbone.Model<A, S> {
+    class Graph<A extends Backbone.ObjectHash = Graph.Attributes, S = dia.ModelSetOptions> extends Backbone.Model<A, S> {
 
         constructor(attributes?: Graph.Attributes, opt?: { cellNamespace?: any, cellModel?: typeof Cell });
 
@@ -314,7 +314,7 @@ export namespace dia {
         }
     }
 
-    class Cell<A = Cell.Attributes, S = dia.ModelSetOptions> extends Backbone.Model<A, S> {
+    class Cell<A extends Backbone.ObjectHash = Cell.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Backbone.Model<A, S> {
 
         constructor(attributes?: A, opt?: Graph.Options);
 
@@ -485,7 +485,7 @@ export namespace dia {
         }
     }
 
-    class Element<A = Element.Attributes, S = dia.ModelSetOptions> extends Cell<A, S> {
+    class Element<A extends Backbone.ObjectHash = Element.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
 
         isElement(): boolean;
 
@@ -608,7 +608,7 @@ export namespace dia {
         }
     }
 
-    class Link<A = Link.Attributes, S = dia.ModelSetOptions> extends Cell<A, S> {
+    class Link<A extends Backbone.ObjectHash = Link.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
 
         toolMarkup: string;
         doubleToolMarkup?: string;
@@ -1816,7 +1816,7 @@ export namespace dia {
         }
     }
 
-    class HighlighterView<Options = HighlighterView.Options> extends mvc.View<undefined, SVGElement> {
+    class HighlighterView<Options extends mvc.ViewOptions<undefined, SVGElement> = HighlighterView.Options> extends mvc.View<undefined, SVGElement> {
 
         constructor(options?: Options);
 
@@ -2015,7 +2015,7 @@ export namespace highlighters {
         }
     }
 
-    class list<Item = any, Options = list.Options> extends dia.HighlighterView<Options> {
+    class list<Item = any, Options extends mvc.ViewOptions<undefined, SVGElement> = list.Options> extends dia.HighlighterView<Options> {
 
         options: Options;
 
@@ -2189,7 +2189,7 @@ export namespace shapes {
 
         type CylinderAttributes = dia.Element.GenericAttributes<CylinderSelectors>;
 
-        class Cylinder<S = dia.ModelSetOptions> extends dia.Element<CylinderAttributes, S> {
+        class Cylinder<S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends dia.Element<CylinderAttributes, S> {
             topRy(): string | number;
             topRy(t: string | number, opt?: S): this;
         }
@@ -3300,6 +3300,7 @@ export namespace mvc {
 
     interface ViewOptions<T extends (Backbone.Model | undefined), E extends Element = HTMLElement> extends Backbone.ViewOptions<T, E> {
         theme?: string;
+        [key: string]: any;
     }
 
     interface viewEventData {
@@ -4136,7 +4137,7 @@ export namespace elementTools {
         }
     }
 
-    abstract class Control<T = Control.Options> extends dia.ToolView {
+    abstract class Control<T extends mvc.ViewOptions<undefined, SVGElement> = Control.Options> extends dia.ToolView {
         options: T;
         constructor(opt?: T);
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -12,6 +12,8 @@ export namespace dia {
 
     type Event = JQuery.TriggeredEvent;
 
+    type ObjectHash = { [key: string]: any };
+
     type Point = g.PlainPoint;
 
     type BBox = g.PlainRect;
@@ -157,7 +159,7 @@ export namespace dia {
         }
     }
 
-    class Graph<A extends Backbone.ObjectHash = Graph.Attributes, S = dia.ModelSetOptions> extends Backbone.Model<A, S> {
+    class Graph<A extends ObjectHash = Graph.Attributes, S = dia.ModelSetOptions> extends Backbone.Model<A, S> {
 
         constructor(attributes?: Graph.Attributes, opt?: { cellNamespace?: any, cellModel?: typeof Cell });
 
@@ -314,7 +316,7 @@ export namespace dia {
         }
     }
 
-    class Cell<A extends Backbone.ObjectHash = Cell.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Backbone.Model<A, S> {
+    class Cell<A extends ObjectHash = Cell.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Backbone.Model<A, S> {
 
         constructor(attributes?: A, opt?: Graph.Options);
 
@@ -485,7 +487,7 @@ export namespace dia {
         }
     }
 
-    class Element<A extends Backbone.ObjectHash = Element.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
+    class Element<A extends ObjectHash = Element.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
 
         isElement(): boolean;
 
@@ -608,7 +610,7 @@ export namespace dia {
         }
     }
 
-    class Link<A extends Backbone.ObjectHash = Link.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
+    class Link<A extends ObjectHash = Link.Attributes, S extends Backbone.ModelSetOptions = dia.ModelSetOptions> extends Cell<A, S> {
 
         toolMarkup: string;
         doubleToolMarkup?: string;


### PR DESCRIPTION
## Description

Fixes #2018 
-  Add separate `tsconfig` for `tests`. Now `grunt` just runs `tsc`. All of the TS options are not available in `grunt-ts`.
https://github.com/TypeStrong/grunt-ts/issues/442
-  Add `pretty: true` to `tsconfig` in order to format output nicely
-  Add `extends` to various parameters - needed in order to add a constraint in all instances
-  Fix the following errors with `clone()` via extending parameters 
<img width="1165" alt="Screenshot 2023-02-15 at 9 56 47" src="https://user-images.githubusercontent.com/42288565/218986486-017365c5-ed29-49ef-ba95-d1f040b544a8.png">

- add type of `[key: string]: any;` to `mvc.ViewOptions`. This allows the following test to pass in `index.test.ts`. Otherwise `{ attribute: string }` doesn't have properties in common with `ViewOptions`.
```js
class AttributeHighlighterView extends joint.dia.HighlighterView<{ attribute: string; }> {
    preinitialize() {
        this.UPDATE_ATTRIBUTES = function() { return [this.options.attribute]; };
    }
}
```
- Fix object is possibly `undefined` errors in `index.test.ts`
- Due to a design limitation with overloads in TypeScript, `strictBindCallApply` is disabled.
https://github.com/microsoft/TypeScript/issues/38353
https://github.com/microsoft/TypeScript/issues/38353

## Motivation

Allow users to enable `strict` in their `tsconfig`