### PR TITLE
fix(connectionPoints.Boundary): disabling automatic magnet lookup via selector option

### DIFF
--- a/docs/src/joint/api/connectionPoints/boundary.html
+++ b/docs/src/joint/api/connectionPoints/boundary.html
@@ -39,7 +39,7 @@
     <tr>
         <th>selector</th>
         <td><i>string</i></td>
-        <td>A selector to identify subelement/magnet of the end element at whose boundary we want the connection point to be found. Default is <code>undefined</code>, meaning that the first non-group descendant of the end element's node will be considered. (An example of another setting that may be useful is <code>'root'</code>, which forces the usage of the root group bbox instead.)</td>
+        <td>A selector to identify subelement/magnet of the end element at whose boundary we want the connection point to be found. Default is <code>undefined</code>, meaning that the first non-group descendant of the end element's node will be considered. (An example of another setting that may be useful is <code>'root'</code>, which forces the usage of the root group bbox instead.). If set to <code>false</code>, the magnet is used as is, even if it is an SVGGroup (it's the most suitable for use in conjunction with <a href="#dia.attributes.magnetSelector">magnetSelector</a>).</td>
     </tr>
     <tr>
         <th>stroke</th>

--- a/src/connectionPoints/index.mjs
+++ b/src/connectionPoints/index.mjs
@@ -132,6 +132,8 @@ function boundaryIntersection(line, view, magnet, opt) {
 
     if (typeof selector === 'string') {
         node = view.findBySelector(selector)[0];
+    } else if (selector === false) {
+        node = magnet;
     } else if (Array.isArray(selector)) {
         node = util.getByPath(magnet, selector);
     } else {

--- a/test/jointjs/connectionPoints.js
+++ b/test/jointjs/connectionPoints.js
@@ -266,6 +266,28 @@ QUnit.module('connectionPoints', function(hooks) {
                 line = new g.Line(tp.clone(), sp.clone());
                 cp = connectionPointFn.call(lv1, line, rv1, rv1.el, { selector: null });
                 assert.ok(cp.round().equals(r1.getBBox().rightMiddle()));
+
+                // Disabling the magnet lookup should use the magnet
+                // passed to the connector even if it is a group node.
+                r1.set('markup', [{
+                    tagName: 'g',
+                    selector: 'wrapper',
+                    children: [{
+                        tagName: 'rect',
+                        selector: 'quarter'
+                    }, {
+                        tagName: 'rect',
+                        selector: 'full',
+                    }]
+                }]);
+                // lookup off
+                line = new g.Line(tp.clone(), sp.clone());
+                cp = connectionPointFn.call(lv1, line, rv1, rv1.findBySelector('wrapper')[0], { selector: false });
+                assert.ok(cp.round().equals(r1.getBBox().rightMiddle()));
+                // lookup on
+                line = new g.Line(tp.clone(), sp.clone());
+                cp = connectionPointFn.call(lv1, line, rv1, rv1.findBySelector('wrapper')[0], { selector: undefined });
+                assert.ok(cp.round().equals(r1.getBBox().center().offset(25, 0)));
             });
 
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3691,7 +3691,7 @@ export namespace connectionPoints {
     }
 
     interface BoundaryConnectionPointArguments extends StrokeConnectionPointArguments {
-        selector?: Array<string | number> | string;
+        selector?: Array<string | number> | string | false;
         precision?: number;
         extrapolate?: boolean;
         sticky?: boolean;


### PR DESCRIPTION
## Description

If the `selector` option of the `boundary` link connection point is set to `false`, the connection point is found on the boundary of the `magnet` regardless of what type of SVGElement it is. Previously, it would try to find the first non-group node descendant of the `magnet` if it the `magnet` was an `SVGGroup`, and this behavior could not be stopped.

## Motivation and Context

See comment: https://github.com/clientIO/joint/discussions/2028#discussioncomment-4901097

Fixes #2030.
