### PR TITLE
chore(tsconfig): update strict rules

### DIFF
--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -12,11 +12,11 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         /* 
-            Rule is disabled due to design limitation with overloads in TypeScript
+            strictBindCallApply has design limitation with overloads in TypeScript
             https://github.com/microsoft/TypeScript/issues/38353
             https://github.com/microsoft/TypeScript/issues/42196
         */
-        "strictBindCallApply": false,
+        "strictBindCallApply": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,

--- a/test/ts/vectorizer.test.ts
+++ b/test/ts/vectorizer.test.ts
@@ -5,7 +5,7 @@ import { V, Vectorizer } from '../../build/joint';
 // Object
 const rect1 = V('rect');
 rect1.attr('fill', 'red');
-V.prototype.attr.call(rect1, 'fill', 'blue');
+V.prototype.removeAttr.call(rect1, 'fill');
 
 // Static
 if (V.isV(rect1)) {
@@ -25,7 +25,7 @@ V.createSVGMatrix({});
 // Object
 const rect3 = Vectorizer('rect');
 rect3.attr('fill', 'red');
-Vectorizer.prototype.attr.call(rect3, 'fill', 'blue');
+Vectorizer.prototype.removeAttr.call(rect3, 'fill');
 
 // Static
 if (Vectorizer.isV(rect3)) {


### PR DESCRIPTION
## Description
- enable `strictBindCallApply`. Now all `strict` rules are enabled in config.
- adjust tests in `vectorizer.test.ts` due to issue with overloads in TS.
