### PR TITLE
docs(tutorials): fix broken links

### DIFF
--- a/tutorials/elements.html
+++ b/tutorials/elements.html
@@ -125,7 +125,7 @@
                 The <a href="/docs/jointjs#shapes.standard.intro" target="_blank">standard shape library</a>
                 contains many more ready-made element definitions (e.g. Ellipse, Embedded Image, Cylinder...) that can
                 be used in your document.
-                Moreover, <a href="custom-elements">advanced users may supply their own element definitions
+                Moreover, <a href="custom-elements.html">advanced users may supply their own element definitions
                 instead</a>, by extending the basic
                 <a href="/docs/jointjs#dia.Element" target="_blank"><code>joint.dia.Element</code></a> class.</p>
 

--- a/tutorials/hierarchy.html
+++ b/tutorials/hierarchy.html
@@ -58,12 +58,12 @@
             <p>
                 JointJS provides a facility to create hierarchy in your diagrams. The API is simple and
                 contains three methods and two properties dealing with parent-child relationships between elements.
-                The methods are <a href="/docs/jointjs/v1.0/joint.html#dia.Element.prototype.embed" target="_top">embed()</a>,
-                <a href="/docs/jointjs/v1.0/joint.html#dia.Element.prototype.unembed" target="_top">unembed()</a> and
-                <a href="/docs/jointjs/v1.0/joint.html#dia.Element.prototype.getEmbeddedCells" target="_top">getEmbeddedCells()</a>.
+                The methods are <a href="/docs/jointjs#dia.Element.prototype.embed" target="_top">embed()</a>,
+                <a href="/docs/jointjs#dia.Element.prototype.unembed" target="_top">unembed()</a> and
+                <a href="/docs/jointjs#dia.Element.prototype.getEmbeddedCells" target="_top">getEmbeddedCells()</a>.
                 The properties are <code>embeds</code> and <code>parent</code> (Please refer to the <strong>Nesting</strong>
                 section
-                of the <a href="/docs/jointjs/v1.0/joint.html#dia.Element" target="_top">joint.dia.Element</a> model reference).
+                of the <a href="/docs/jointjs#dia.Element" target="_top">joint.dia.Element</a> model reference).
             </p>
 
             <p>This tutorial shows how to take advantage of these methods in order to implement three functionalities

--- a/tutorials/links-patterns.html
+++ b/tutorials/links-patterns.html
@@ -103,7 +103,7 @@
 
             <p>Each time we change a link attribute, source or target, we add a vertex or we move an element that is
                 connected to the link - the link has to be updated.
-                Normally, the <a href="/docs/jointjs/v1.0/joint.html#dia.LinkView" target="_top">joint.dia.LinkView</a> takes care of this.
+                Normally, the <a href="/docs/jointjs#dia.LinkView" target="_top">joint.dia.LinkView</a> takes care of this.
                 It inherits from the <a href="https://backbonejs.org/#View" target="_blank">Backbone.View</a> and extends it
                 by new methods and properties. We're going to introduce some of them.
                 <br>
@@ -117,7 +117,7 @@
                 <br>The <code>linkView.sourcePoint</code> and <code>linkView.targetPoint</code> are cached coordinates of a
                 point where the link connects to an element or point.
                 <br>The <code>linkView.route</code> is a cached array of points calculated from the vertices by a
-                <a href="/docs/jointjs/v1.0/joint.html#dia.Link" target="_blank">router</a>.
+                <a href="/docs/jointjs#dia.Link" target="_blank">router</a>.
                 <br>The <code>linkView.paper</code> is a reference to the paper the view is rendered into.
             </p>
 
@@ -196,7 +196,7 @@
     return this;
 }</code></pre>
 
-            <p>Note that we're using the <a href="/docs/jointjs/v1.0/vectorizer.html" target="_top">built-in Vectorizer library</a> for creating SVG.</p>
+            <p>Note that we're using the <a href="/docs/vectorizer" target="_top">built-in Vectorizer library</a> for creating SVG.</p>
 
             <h3 id="update">Using the pattern</h3>
 
@@ -347,7 +347,7 @@
             <p>Let's combine all this together and create a link which looks like a pipe.
                 The demo below contains all that we described so far, plus it is adding some new features.
                 <br>The LinkView draws into the canvas and updates the pattern asynchronously (using
-                <a href="/docs/jointjs/v1.0/joint.html#util.nextFrame" target="_top">joint.util.nextFrame</a>).
+                <a href="/docs/jointjs#util.nextFrame" target="_top">joint.util.nextFrame</a>).
                 <br>It automatically creates a gradient with a directions perpendicular to the path direction for each link
                 segment. This way you can style your link from the 'border' to 'border' and draw an image like the one
                 below.</p>

--- a/tutorials/multiple-papers.html
+++ b/tutorials/multiple-papers.html
@@ -43,7 +43,7 @@
                 Each of those papers can apply their own transformations to the presented information, which allows us
                 to create diagram minimaps and previews.</p>
 
-            <p>Let's adapt our basic <i>Hello, World!</i> <a href="hello-world">application</a> and overlay it with a smaller,
+            <p>Let's adapt our basic <i>Hello, World!</i> <a href="hello-world.html">application</a> and overlay it with a smaller,
                 non-interactive minimap.
                 Notice that as you interact with the bigger paper, all modifications are reflected in the preview.</p>
 

--- a/tutorials/ports-archive.html
+++ b/tutorials/ports-archive.html
@@ -148,7 +148,7 @@ element.set('outPorts', ['newOut1', 'newOut2']);</code></pre>
                 <code>"passive"</code> in which case JointJS treats these magnets in a way that they can never become a
                 source of a link.
                 For further information, please see the list of options that you can pass to the
-                <code>joint.dia.Paper</code> in the <a href="/docs/jointjs/v1.0/joint.html#dia.Paper" target="_top">API reference page</a>,
+                <code>joint.dia.Paper</code> in the <a href="/docs/jointjs#dia.Paper" target="_top">API reference page</a>,
                 especially the two related functions: <code>validateConnection()</code> and <code>validateMagnet()</code>.
             </p>
 

--- a/tutorials/testing-e2e-playwright.html
+++ b/tutorials/testing-e2e-playwright.html
@@ -259,7 +259,7 @@ Received: "JointJS App"
         <p>
             After visiting your JointJS application, you may want to perform some simple sanity checks in order to check if the state 
             corresponds to your expectations. A tried and tested way of doing this is to determine if the text is displayed correctly. 
-            Playwright provides some nice <a href="https://playwright.dev/docs/selectors" target="_blank"><code>Selectors</code></a> to 
+            Playwright provides some nice <a href="https://playwright.dev/docs/locators#locate-by-css-or-xpath" target="_blank"><code>Selectors</code></a> to 
             target elements which we expect to be present in the normal flow of our app. As we want our testing to be as robust and reliable 
             as possible, we will prioritize user-facing attributes, that means we will use mainly text or CSS selectors.
         </p>
@@ -547,7 +547,7 @@ test('visual regression', async ({ page }) => {
         </p>
 
         <p>
-            The first tool we will look at is the Playwright <a href="https://playwright.dev/docs/inspector" target="_blank">Inspector</a>.
+            The first tool we will look at is the Playwright <a href="https://playwright.dev/docs/debug" target="_blank">Inspector</a>.
             Inspector is a GUI tool that helps authoring and debugging Playwright scripts. To launch the inspector, we need to set the
             <code>PWDEBUG</code> environment variable to run our scripts in debug mode. This configures Playwright for debugging and opens 
             the Inspector.


### PR DESCRIPTION
## Description

- fix links internal that are broken or don't exist anymore (`v1.0` of docs)
- fix external links(playwright) that have changed
