### PR TITLE
fix(util.svg): support foreignObject

### DIFF
--- a/demo/shapes/foreign-object.html
+++ b/demo/shapes/foreign-object.html
@@ -1,13 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf8"/>
+        <meta charset="utf-8"/>
         <title>Foreign Object</title>
         <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
         <style>
             #paper {
                 display: inline-block;
                 border: 1px solid gray;
+            }
+            span {
+                line-height: 1.5em;
+            }
+            table {
+                border-collapse: collapse;
+                width: 100%;
+            }
+            th,
+            td {
+                padding: 0.25rem;
+                text-align: left;
+                border: 1px solid #ccc;
+            }
+            tbody tr:nth-child(odd) {
+                background: #eee;
             }
         </style>
     </head>

--- a/demo/shapes/src/foreign-object.js
+++ b/demo/shapes/src/foreign-object.js
@@ -1,21 +1,22 @@
-var graph = new joint.dia.Graph;
+const graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
 
-var paper = new joint.dia.Paper({
+const paper = new joint.dia.Paper({
     el: document.getElementById('paper'),
     width: 650,
     height: 400,
     gridSize: 10,
     model: graph,
-    guard: function(evt) {
-        return evt.target instanceof HTMLInputElement;
-    }
+    async: true,
+    cellViewNamespace: joint.shapes,
+    guard: (evt) => ['SELECT', 'INPUT', 'BUTTON'].includes(evt.target.tagName)
 });
 
-paper.on('blank:pointerdown cell:pointerdown', function() {
+// Remove focus from the input when the user clicks on the paper.
+paper.on('blank:pointerdown cell:pointerdown', () => {
     document.activeElement.blur();
 });
 
-var Example = joint.dia.Element.define('example.ForeignObject', {
+const Example = joint.dia.Element.define('example.ForeignObject', {
     attrs: {
         body: {
             width: 'calc(w)',
@@ -99,6 +100,80 @@ var Example = joint.dia.Element.define('example.ForeignObject', {
     }
 });
 
+
+const Example2 = joint.dia.Element.define('example.ForeignObject2', {
+    attrs: {
+        body: {
+            width: 'calc(w)',
+            height: 'calc(h)',
+            stroke: '#333333',
+            fill: '#ffffff',
+            strokeWidth: 2
+        },
+        foreignObject: {
+            width: 'calc(w)',
+            height: 'calc(h)',
+        }
+    }
+}, {
+    // The /* xml */ comment is optional.
+    // It is used to tell the IDE that the markup is XML.
+    markup: joint.util.svg/* xml */`
+        <rect @selector="body"/>
+        <foreignObject @selector="foreignObject" overflow="hidden">
+            <div @selector="content"
+                xmlns="http://www.w3.org/1999/xhtml"
+                style="font-size: 14px; width: 100%; height: 100%; position: static; background-color: transparent; text-align: center; margin: 0px; padding: 0px 10px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; justify-content: center;"
+            >
+                <span>First Name</span>
+                <input @selector="firstname" type="input" style="position: static; width: 100%;"/>
+                <span>Last Name</span>
+                <input @selector="lastname" type="input" style="position: static; width: 100%;"/>
+                <span>Color</span>
+                <select @selector="color" style="position: static; width: 100%;">
+                    <option value="white">White</option>
+                    <option value="black">Black</option>
+                </select>
+                <span>Data</span>
+                <table class="element-table">
+                    <tr>
+                        <td>A</td>
+                        <td>B</td>
+                        <td>C</td>
+                        <td>D</td>
+                        <td>E</td>
+                        <td>F</td>
+                        <td>G</td>
+                        <td>H</td>
+                    </tr>
+                    <tr>
+                        <td>1</td>
+                        <td>2</td>
+                        <td>3</td>
+                        <td>4</td>
+                        <td>5</td>
+                        <td>6</td>
+                        <td>7</td>
+                        <td>8</td>
+                    </tr>
+                </table>
+                <span>Image</span>
+                <img @selector="image" src="https://picsum.photos/180/100" style="position: static; width: 100%; height: 100px;"/>
+                <span>Button</span>
+                <button @selector="button" style="position: static; width: 100%;">Click me</button>
+            </div>
+        </foreignObject>
+    `,
+}, {
+    attributes: {
+        value: {
+            set: function(text, _, node) {
+                if ('value' in node) node.value = text;
+            }
+        }
+    }
+});
+
 joint.shapes.example.ForeignObjectView = joint.dia.ElementView.extend({
 
     events: {
@@ -106,14 +181,56 @@ joint.shapes.example.ForeignObjectView = joint.dia.ElementView.extend({
     },
 
     onInputChange: function(evt) {
-        var input = evt.target;
+        const input = evt.target;
         this.model.attr(input.name + '/value', input.value);
     }
 });
 
-var ex = new Example();
+joint.shapes.example.ForeignObject2View = joint.dia.ElementView.extend({
+
+    events: {
+        'change input,select': 'onInputChange',
+        'click button': 'onButtonClick'
+    },
+
+    onInputChange: function(evt) {
+        const input = evt.target;
+        this.model.attr(input.getAttribute('joint-selector') + '/value', input.value);
+    },
+
+    imageId: 0,
+
+    onButtonClick: function(evt) {
+        const { width } = this.model.size();
+        this.model.attr('image/src', `https://picsum.photos/id/${this.imageId++}/${width-20}/100`);
+    }
+});
+
+const ex = new Example({
+    attrs: {
+        body: {
+            fill: '#fbf5d0',
+            stroke: '#ff9580'
+        }
+    }
+});
 ex.resize(200, 100);
-ex.position(200, 100);
+ex.position(100, 100);
 ex.attr('firstname/value', 'Bobby');
 ex.attr('lastname/value', 'Fisher');
 ex.addTo(graph);
+
+const ex2 = new Example2({
+    attrs: {
+        body: {
+            fill: '#f6f4f4',
+            stroke: '#b2a29f'
+        }
+    }
+});
+ex2.resize(200, 380);
+ex2.position(400, 10);
+ex2.attr('firstname/value', 'Garry');
+ex2.attr('lastname/value', 'Kasparov');
+ex2.attr('color/value', 'white');
+ex2.addTo(graph);

--- a/src/util/svgTagTemplate.mjs
+++ b/src/util/svgTagTemplate.mjs
@@ -73,7 +73,10 @@ function build(root) {
             // multiple text nodes (and other nodes in between) in the JSON markup
             // e.g <text>a<tspan>b</tspan>c</text>
             // The above markup will be converted to <text>ab<tspan>c</tspan></text>
-            markupNode.textContent = textNodes.map(node => node.textContent).join('');
+            const textContent = textNodes.map(node => node.textContent).join('').trim();
+            if (textContent.length > 0) {
+                markupNode.textContent = textContent;
+            }
         }
 
         const nodeAttrs = {};

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -1434,16 +1434,47 @@ QUnit.module('util', function(hooks) {
             assert.equal(markup[2].tagName, 'rect');
         });
 
-        QUnit.test('textContent', function(assert) {
-            const markup = joint.util.svg/*xml*/`
-                <text>a<tspan>b</tspan>c</text>
-            `;
-            assert.equal(markup.length, 1);
-            assert.equal(markup[0].tagName, 'text');
-            assert.equal(markup[0].textContent, 'ac', 'textContent does not contain the tspan element');
-            assert.equal(markup[0].children.length, 1);
-            assert.equal(markup[0].children[0].tagName, 'tspan');
-            assert.equal(markup[0].children[0].textContent, 'b');
+        QUnit.module('textContent', function() {
+
+            QUnit.test('multiple text nodes', function(assert) {
+                const markup = joint.util.svg/*xml*/`
+                    <text>a<tspan>b</tspan>c</text>
+                `;
+                assert.equal(markup.length, 1);
+                assert.equal(markup[0].tagName, 'text');
+                assert.equal(markup[0].textContent, 'ac', 'textContent does not contain the tspan element');
+                assert.equal(markup[0].children.length, 1);
+                assert.equal(markup[0].children[0].tagName, 'tspan');
+                assert.equal(markup[0].children[0].textContent, 'b');
+            });
+
+            QUnit.test('no text nodes', function(assert) {
+                const markup = joint.util.svg/*xml*/`
+                    <!-- 1. no characters -->
+                    <text></text>
+                    <!-- 2. spaces -->
+                    <text> </text>
+                    <!-- 3. and new line character -->
+                    <text>
+</text>
+                    <!-- 4. spaces and new line characters -->
+                    <text>
+
+                    </text>
+                    <!-- 5. spaces and elements -->
+                    <text>  <tspan>a</tspan> </text>
+                    <!-- 6. spaces, new line characters and elements -->
+                    <text>
+                         <tspan>a</tspan>
+                    </text>
+                    <!-- 7. comment -->
+                    <text><!-- the comment --></text>
+                `;
+                assert.equal(markup.length, 7);
+                markup.forEach(node => {
+                    assert.strictEqual(node.textContent, undefined);
+                });
+            });
         });
     });
 

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -358,7 +358,7 @@ QUnit.module('util', function(hooks) {
 
             let r = joint.util.breakText(text, size, { ...styles, lineHeight: `${emVal}em` });
             assert.ok(r.split('\n').length * correctLineHeightPerEm * emVal <= size.height, 'lineHeight in em');
-            
+
             let correctLineHeightInPx = 25;
 
             r = joint.util.breakText(text, size, { ...styles, lineHeight: correctLineHeightInPx });
@@ -1409,6 +1409,41 @@ QUnit.module('util', function(hooks) {
                 <g><rect style="pointer-events:auto"/><circle stroke="${color}"/>textContent</g>
             `;
             testMarkup(assert, markup);
+        });
+
+        QUnit.test('foreignObject', function(assert) {
+            const markup = joint.util.svg/*xml*/`
+                <rect @selector="rect1"/>
+                <foreignObject>
+                    <div xmlns="http://www.w3.org/1999/xhtml">
+                        <p @selector="p1"></p>
+                    </div>
+                </foreignObject>
+                <rect @selector="rect2"/>
+            `;
+            assert.equal(markup.length, 3);
+            assert.equal(markup[0].namespaceURI, 'http://www.w3.org/2000/svg');
+            assert.equal(markup[0].tagName, 'rect');
+            assert.equal(markup[1].namespaceURI, 'http://www.w3.org/2000/svg');
+            assert.equal(markup[1].tagName, 'foreignObject');
+            assert.equal(markup[1].children[0].namespaceURI, 'http://www.w3.org/1999/xhtml');
+            assert.equal(markup[1].children[0].tagName, 'div');
+            assert.equal(markup[1].children[0].children[0].namespaceURI, 'http://www.w3.org/1999/xhtml');
+            assert.equal(markup[1].children[0].children[0].tagName, 'p');
+            assert.equal(markup[2].namespaceURI, 'http://www.w3.org/2000/svg');
+            assert.equal(markup[2].tagName, 'rect');
+        });
+
+        QUnit.test('textContent', function(assert) {
+            const markup = joint.util.svg/*xml*/`
+                <text>a<tspan>b</tspan>c</text>
+            `;
+            assert.equal(markup.length, 1);
+            assert.equal(markup[0].tagName, 'text');
+            assert.equal(markup[0].textContent, 'ac', 'textContent does not contain the tspan element');
+            assert.equal(markup[0].children.length, 1);
+            assert.equal(markup[0].children[0].tagName, 'tspan');
+            assert.equal(markup[0].children[0].textContent, 'b');
         });
     });
 


### PR DESCRIPTION
## Description

Make SVG tag template (`util.svg`) to support foreign objects. Addresses 3 problems in resulting JSON markup:

1. **Wrong `tagName` for HTML elements**

```html
<div namespace="http://www.w3.org/1999/xhtml"></div>
```
was parsed incorrectly as:

```json
{ "tagName": "DIV", "namespaceURI": "http://www.w3.org/1999/xhtml" }
```
*Note: XHTML documents must use lower case for all HTML element and attribute names*

After this change:

```json
{ "tagName": "div", "namespaceURI": "http://www.w3.org/1999/xhtml" }
```

2. **`textContent` property contains text nodes from all descendants**

The following markup:
```html
<p>a<span>b</span>c</p>
```
was parsed incorrectly as:
```json
{ "tagName": "p",  "textContent": "abc", "children": [{ "tagName": "span", "textContent": "b" }] }
```

*Note: it will render the `b` character twice*

After this change:

```json
{ "tagName": "p",  "textContent": "ac", "children": [{ "tagName": "span", "textContent": "b" }] }
```


*Note: This does not solve the problem with the order of text nodes. It should be addressed in another PR by supporting a child array defined as `['a', { tagName: 'span', children: ['b'] }, 'c']`*

3. `textContent` was being set even it contains only whitespaces

```html
<p class="case-1"> </p>
<p class="case-2">
</p>
<p class="case-3"> <span>span</span> </p>
```
All these paragraphs must have no `textContent` *(for other cases see the QUnit test)*.

### Screenshots of updated foreign-object demo

<img width="217" alt="image" src="https://user-images.githubusercontent.com/3967880/221639597-907d6995-a4c3-42a7-a708-c48707ccd9fe.png">
