### PR TITLE
chore(eslint): add mjs extenstion to script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "scripts": {
     "test": "grunt test",
-    "lint": "eslint types/**/*.d.ts src/**/*.mjs",
+    "lint": "eslint types/**/*.d.ts src --ext .mjs,.js",
     "lint:fix": "npm run lint -- --fix"
   },
   "sideEffects": false,


### PR DESCRIPTION
## Description

- Add `--ext mjs` to linting script as `mjs` is not available by default in the eslint version we currently use.
https://github.com/eslint/eslint/issues/14828