### PR TITLE
chore(github): fix github discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,4 +1,4 @@
-title: ""
+title: "Your Q&A Title"
 labels: []
 body:
   - type: markdown


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

- fix discussion template. Title cannot be an empty string.
<img width="1292" alt="Screenshot 2023-03-06 at 16 24 07" src="https://user-images.githubusercontent.com/42288565/223154970-cbf66576-3cf5-4026-9260-e31015e82c1d.png">

