### PR TITLE
feat(dia.Element): add fitParent() to fit embedding parent to specified child

### DIFF
--- a/demo/container/src/index.js
+++ b/demo/container/src/index.js
@@ -116,18 +116,12 @@
     paper.on('element:button:pointerdown', function(elementView) {
         var element = elementView.model;
         element.toggle();
-        fitAncestors(element);
+        element.fitAncestorElements();
     });
 
     paper.on('element:pointermove', function(elementView) {
         var element = elementView.model;
-        fitAncestors(element);
+        element.fitAncestorElements();
     });
-
-    function fitAncestors(element) {
-        element.getAncestors().forEach(function(container) {
-            container.fitChildren();
-        });
-    }
 
 })(joint);

--- a/demo/container/src/joint.shapes.container.js
+++ b/demo/container/src/joint.shapes.container.js
@@ -161,7 +161,7 @@
                 this.resize(140, 30);
             } else {
                 buttonD = 'M 2 7 12 7';
-                this.fitChildren();
+                this.fitToChildElements();
             }
             this.attr(['buttonIcon','d'], buttonD);
             this.set('collapsed', collapsed);
@@ -171,9 +171,22 @@
             return Boolean(this.get('collapsed'));
         },
 
-        fitChildren: function() {
+        fitToChildElements: function() {
             var padding = 10;
-            this.fitEmbeds({
+            this.fitToChildren({
+                padding: {
+                    top: headerHeight + padding,
+                    left: padding,
+                    right: padding,
+                    bottom: padding
+                }
+            })
+        },
+
+        fitAncestorElements: function() {
+            var padding = 10;
+            this.fitParent({
+                deep: true,
                 padding: {
                     top: headerHeight + padding,
                     left: padding,

--- a/demo/sequence/src/joint.shapes.sd.js
+++ b/demo/sequence/src/joint.shapes.sd.js
@@ -29,7 +29,7 @@
         placeholder: 'What\'s the group\'s name?',
 
         fitRoles: function() {
-            this.fitEmbeds({ padding: 10 });
+            this.fitToChildren({ padding: 10 });
         }
     });
 

--- a/docs/css/api.css
+++ b/docs/css/api.css
@@ -353,6 +353,15 @@ pre {
     padding: 16px;
 }
 
+.docs-content td p:first-child {
+    margin-top: 0;
+}
+
+.docs-content td p:last-child,
+.docs-content td ul:last-child {
+    margin-bottom: 0;
+}
+
 .docs-content th {
     font-weight: var(--text-font-weight-bold);
 }

--- a/docs/src/joint/api/dia/Element/prototype/fitEmbeds.html
+++ b/docs/src/joint/api/dia/Element/prototype/fitEmbeds.html
@@ -1,4 +1,0 @@
-<pre class="docs-method-signature"><code>element.fitEmbeds([opt])</code></pre><p>Resize the element so that it fits all the embedded elements inside it. If <code>opt.deep</code> is <code>true</code>,
-          the resizing will be done recursively for any embedded elements that contain embedded elements themselves.
-          Set <code>opt.padding</code> if you want certain padding on all the parent elements.
-        </p>

--- a/docs/src/joint/api/dia/Element/prototype/fitEmbeds.md
+++ b/docs/src/joint/api/dia/Element/prototype/fitEmbeds.md
@@ -1,0 +1,3 @@
+<pre class="docs-method-signature"><code>element.fitEmbeds([opt])</code></pre>
+
+An alias for the `element.fitToChildren` [function](#dia.Element.prototype.fitToChildren).

--- a/docs/src/joint/api/dia/Element/prototype/fitParent.md
+++ b/docs/src/joint/api/dia/Element/prototype/fitParent.md
@@ -1,0 +1,49 @@
+<pre class="docs-method-signature"><code>element.fitParent([opt])</code></pre>
+
+Resize and reposition this element's embedding parent element such that all of its children (including this element) end up within the parent's new bounding box.
+
+Starting from a given element, this function proceeds <q>upwards</q> to that element's parent (and further ancestors, if `opt.deep` is used). In that sense, this function is the opposite of the `element.fitToChildren` [function](#dia.Element.prototype.fitToChildren).
+
+Available options:
+
+<table>
+    <tr>
+        <th>padding</th>
+        <td><i>number</i></td>
+        <td>Inflate the embedding parent element's calculated bounding box by this much additional padding.</td>
+    </tr>
+    <tr>
+        <th>expandOnly</th>
+        <td><i>boolean</i></td>
+        <td>If <code>true</code>, the algorithm is only ever allowed to expand the bounding box of the embedding parent element, never to shrink it. You can visualize this setting as the algorithm dragging the top-left and bottom-right corners of the parent's bounding box <strong>outward</strong> until its children (including this element) are within the bounding box.</td>
+    </tr>
+    <tr>
+        <th>shrinkOnly</th>
+        <td><i>boolean</i></td>
+        <td>
+            <p>If <code>true</code>, the algorithm is only ever allowed to shrink the bounding box of the embedding parent element, never to expand it. You can visualize this setting as the algorithm dragging the top-left and bottom-right corners of the parent's bounding box <strong>inward</strong> until only its children (including this element) are within the bounding box.</p>
+            <p>If only a portion of this element (or this element's sibling element) initially overlaps the embedding parent element, the parent's calculated bounding box will only include that portion. If there is no overlap between this element and its parent (i.e. this element is <q>outside</q> the parent), then this function does nothing (since satisfying the shrink-only restriction is impossible).</p>
+        </td>
+    </tr>
+    <tr>
+        <th>deep</th>
+        <td><i>boolean</i></td>
+        <td>
+            <p>If <code>true</code>, this algorithm is applied recursively on the embedding parent element of this element's embedding parent element, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from this element, then going up (to the topmost embedding ancestor element), to make sure that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
+            <p>Note that if this option is used in conjunction with <code>opt.shrinkOnly</code>, the algorithm is still applied strictly recursively (i.e. one level at a time). Therefore, even if this element lies completely within the current bounding box of its grandfather element, the grandfather element's calculated bounding box will shrink only based on this element's parent - which may mean that this element will end up outside of the calculated bounding box of the grandfather element.</p>
+        </td>
+    </tr>
+    <tr>
+        <th>terminator</th>
+        <td><i>elementID</i></td>
+        <td>
+            <p>If <code>opt.deep</code> is <code>true</code> and an element ID is provided as a value of this option, then this element is the last one for which the bounding box algorithm is applied during recursion - it is the last element whose bounding box is resized and repositioned based on the bounding boxes of its children.</p>
+            <p>Handling of edge cases:</p>
+            <ul>
+                <li>If the provided value is the ID of this element, then nothing happens.</li>
+                <li>If the provided value is the ID of this element's embedding parent element, then the result is the same as calling the <code>element.fitParent</code> function without <code>opt.deep</code>.</li>
+                <li>If the provided value is not an ID of an ancestor of this element, then the result is the same as calling the <code>element.fitParent</code> function without <code>opt.terminator</code>.</li>
+            </ul>
+        </td>
+    </tr>
+</table>

--- a/docs/src/joint/api/dia/Element/prototype/fitParent.md
+++ b/docs/src/joint/api/dia/Element/prototype/fitParent.md
@@ -29,20 +29,21 @@ Available options:
         <th>deep</th>
         <td><i>boolean</i></td>
         <td>
-            <p>If <code>true</code>, this algorithm is applied recursively on the embedding parent element of this element's embedding parent element, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from this element, then going up (to the topmost embedding ancestor element), to make sure that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
+            <p>If <code>true</code>, this algorithm is applied recursively on the embedding parent element of this element's embedding parent element, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from this element, then going up (i.e. to the topmost embedding ancestor element - or <code>opt.terminator</code>), to make sure that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
             <p>Note that if this option is used in conjunction with <code>opt.shrinkOnly</code>, the algorithm is still applied strictly recursively (i.e. one level at a time). Therefore, even if this element lies completely within the current bounding box of its grandfather element, the grandfather element's calculated bounding box will shrink only based on this element's parent - which may mean that this element will end up outside of the calculated bounding box of the grandfather element.</p>
         </td>
     </tr>
     <tr>
         <th>terminator</th>
-        <td><i>elementID</i></td>
+        <td><i>Cell&nbsp;|&nbsp;Cell.ID</i></td>
         <td>
-            <p>If <code>opt.deep</code> is <code>true</code> and an element ID is provided as a value of this option, then this element is the last one for which the bounding box algorithm is applied during recursion - it is the last element whose bounding box is resized and repositioned based on the bounding boxes of its children.</p>
+            <p>If <code>opt.deep</code> is <code>true</code> and a Cell reference or a Cell ID is provided as a value of this option, then the specified element is the last one for which the bounding box algorithm is applied during recursion - it is the last element whose bounding box is resized and repositioned based on the bounding boxes of its children.</p>
             <p>Handling of edge cases:</p>
             <ul>
-                <li>If the provided value is the ID of this element, then nothing happens.</li>
-                <li>If the provided value is the ID of this element's embedding parent element, then the result is the same as calling the <code>element.fitParent</code> function without <code>opt.deep</code>.</li>
-                <li>If the provided value is not an ID of an ancestor of this element, then the result is the same as calling the <code>element.fitParent</code> function without <code>opt.terminator</code>.</li>
+                <li>If the provided value refers to this element, then nothing happens.</li>
+                <li>If the provided value refers to this element's embedding parent element, then the result is the same as calling the function without <code>opt.deep</code> and <code>opt.terminator</code>.</li>
+                <li>If the provided value does not refer to an ancestor of this element, then the result is the same as calling the function without <code>opt.terminator</code>.</li>
+                <li>If the provided value does not refer to a Cell of the Element type, then the result is the same as calling the function without <code>opt.terminator</code>.</li>
             </ul>
         </td>
     </tr>

--- a/docs/src/joint/api/dia/Element/prototype/fitToChildren.md
+++ b/docs/src/joint/api/dia/Element/prototype/fitToChildren.md
@@ -29,7 +29,7 @@ Available options:
         <th>deep</th>
         <td><i>boolean</i></td>
         <td>
-            <p>If <code>true</code>, this algorithm is applied recursively on all embedded children of this element which have embedded children of their own, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from the deepest descendant, then going up (to this element). This ensures that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
+            <p>If <code>true</code>, this algorithm is applied recursively on all embedded children of this element which have embedded children of their own, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from the deepest descendant, then going up (i.e. to this element). This ensures that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
             <p>Note that if this option is used in conjunction with <code>opt.shrinkOnly</code>, the algorithm is still applied strictly recursively - one level at a time. Therefore, even if this element's current bounding box completely overlaps one of its grandchild elements, this element's calculated bounding box will shrink only based on the grandchild's parent (this element's child), which may mean that the grandchild element will end up outside of the calculated bounding box of this element.</p>
         </td>
     </tr>

--- a/docs/src/joint/api/dia/Element/prototype/fitToChildren.md
+++ b/docs/src/joint/api/dia/Element/prototype/fitToChildren.md
@@ -1,0 +1,36 @@
+<pre class="docs-method-signature"><code>element.fitToChildren([opt])</code></pre>
+
+Resize and reposition this element such that all of its embedded child elements end up within this element's new bounding box.
+
+Starting from a given element, this function proceeds <q>downwards</q> through that element's children (and further descendants, if `opt.deep` is used). In that sense, this function is the opposite of the `element.fitParent` [function](#dia.Element.prototype.fitParent).
+
+Available options:
+
+<table>
+    <tr>
+        <th>padding</th>
+        <td><i>number</i></td>
+        <td>Inflate this element's calculated bounding box by this much additional padding.</td>
+    </tr>
+    <tr>
+        <th>expandOnly</th>
+        <td><i>boolean</i></td>
+        <td>If <code>true</code>, the algorithm is only ever allowed to expand the bounding box of this element, never to shrink it. You can visualize this setting as the algorithm dragging the top-left and bottom-right corners of this element's bounding box <strong>outward</strong> until all its embedded child elements are within the bounding box.</td>
+    </tr>
+    <tr>
+        <th>shrinkOnly</th>
+        <td><i>boolean</i></td>
+        <td>
+            <p>If <code>true</code>, the algorithm is only ever allowed to shrink the bounding box of this element, never to expand it. You can visualize this setting as the algorithm dragging the top-left and bottom-right corners of this element's bounding box <strong>inward</strong> until only its embedded child elements are within the bounding box.</p>
+            <p>If only a portion of an embedded child element initially overlaps this element, the calculated bounding box will only include that portion. If there is no overlap between this element and its children (i.e. all children are currently placed <q>outside</q> of this element), then this function does nothing (since satisfying the shrink-only restriction is impossible).</p>
+        </td>
+    </tr>
+    <tr>
+        <th>deep</th>
+        <td><i>boolean</i></td>
+        <td>
+            <p>If <code>true</code>, this algorithm is applied recursively on all embedded children of this element which have embedded children of their own, and so on. The bounding box algorithm is evaluated in reverse-depth order - starting from the deepest descendant, then going up (to this element). This ensures that any paddings applied on lower-level elements are taken into account by higher-level elements.</p>
+            <p>Note that if this option is used in conjunction with <code>opt.shrinkOnly</code>, the algorithm is still applied strictly recursively - one level at a time. Therefore, even if this element's current bounding box completely overlaps one of its grandchild elements, this element's calculated bounding box will shrink only based on the grandchild's parent (this element's child), which may mean that the grandchild element will end up outside of the calculated bounding box of this element.</p>
+        </td>
+    </tr>
+</table>

--- a/docs/src/joint/api/shapes/devs.html
+++ b/docs/src/joint/api/shapes/devs.html
@@ -89,7 +89,7 @@ For instance a <code>devs.Coupled</code> can embed <code>devs.Atomic</code>'s bu
 
 <p><a href="#dia.Element.prototype.embed"><code>coupled.embed(atomic)</code></a> that can put the `atomic` shape into the `coupled`.</p>
 
-<p><a href="#dia.Element.prototype.fitEmbeds"><code>coupled.fitEmbeds()</code></a> that resizes the `coupled` shape, so it visually contains all shapes embedded in.</p>
+<p><a href="#dia.Element.prototype.fitToChildren"><code>coupled.fitToChildren()</code></a> that resizes the `coupled` shape such that all embedded elements are visually contained within it.</p>
 
 <p><a href="#dia.Link.prototype.reparent"><code>link.reparent()</code></a> that finds the best parent for the `link` based on the source and target element.</p>
 

--- a/src/dia/Element.mjs
+++ b/src/dia/Element.mjs
@@ -359,7 +359,7 @@ export const Element = Cell.extend({
         // Set new size and position of this element, based on:
         // - union of bboxes of all children
         // - inflated by given `opt.padding`
-        this._fitToElements({ elements: childElements, ...opt });
+        this._fitToElements(Object.assign({ elements: childElements }, opt));
 
         this.stopBatch('fit-to-children');
 
@@ -387,7 +387,7 @@ export const Element = Cell.extend({
         // Set new size and position of parent element, based on:
         // - union of bboxes of all children of parent element (i.e. this element + any sibling elements)
         // - inflated by given `opt.padding`
-        parentElement._fitToElements({ elements: siblingElements, ...opt });
+        parentElement._fitToElements(Object.assign({ elements: siblingElements }, opt));
 
         if (opt.deep) {
             // `opt.deep = true` means "fit all ancestors to their respective children".
@@ -438,8 +438,8 @@ export const Element = Cell.extend({
 
         // Set the new size and position of this element.
         this.set({
-            position: { resultBBox.x, resultBBox.y },
-            size: { resultBBox.width, resultBBox.height }
+            position: { x: resultBBox.x, y: resultBBox.y },
+            size: { width: resultBBox.width, height: resultBBox.height }
         }, opt);
     },
 

--- a/src/dia/Element.mjs
+++ b/src/dia/Element.mjs
@@ -332,42 +332,115 @@ export const Element = Cell.extend({
         return this;
     },
 
-    fitEmbeds: function(opt = {}) {
+    fitEmbeds: function(opt) {
+
+        return this.fitToChildren(opt);
+    },
+
+    fitToChildren: function(opt = {}) {
 
         // Getting the children's size and position requires the collection.
-        // Cell.get('embeds') helds an array of cell ids only.
+        // Cell.get('embeds') holds an array of cell ids only.
         const { graph } = this;
         if (!graph) throw new Error('Element must be part of a graph.');
 
-        const embeddedCells = this.getEmbeddedCells().filter(cell => cell.isElement());
-        if (embeddedCells.length === 0) return this;
+        const childElements = this.getEmbeddedCells().filter(cell => cell.isElement());
+        if (childElements.length === 0) return this;
 
-        this.startBatch('fit-embeds', opt);
+        this.startBatch('fit-to-children', opt);
 
         if (opt.deep) {
-            // Recursively apply fitEmbeds on all embeds first.
-            invoke(embeddedCells, 'fitEmbeds', opt);
+            // `opt.deep = true` means "fit to all descendants".
+            // As the first action of the fitting algorithm, recursively apply `fitToChildren()` on all descendants.
+            // - i.e. the algorithm is applied in reverse-depth order - start from deepest descendant, then go up (= this element).
+            invoke(childElements, 'fitToChildren', opt);
         }
 
-        // Compute cell's size and position based on the children bbox
-        // and given padding.
+        // Set new size and position of this element, based on:
+        // - union of bboxes of all children
+        // - inflated by given `opt.padding`
+        this._fitToElements({ elements: childElements, ...opt });
+
+        this.stopBatch('fit-to-children');
+
+        return this;
+    },
+
+    fitParent: function(opt = {}) {
+
+        const { graph } = this;
+        if (!graph) throw new Error('Element must be part of a graph.');
+
+        // When `opt.deep = true`, we want `opt.terminator` to be the last ancestor processed.
+        // If the current element is `opt.terminator`, it means that this element has already been processed as parent so we can exit now.
+        if (opt.deep && opt.terminator && (opt.terminator === this.getIdAttribute())) return this;
+
+        const parentElement = this.getParentCell();
+        if (!parentElement || !parentElement.isElement()) return this;
+
+        // Get all children of parent element (i.e. this element + any sibling elements).
+        const siblingElements = parentElement.getEmbeddedCells().filter(cell => cell.isElement());
+        if (siblingElements.length === 0) return this;
+
+        this.startBatch('fit-parent', opt);
+
+        // Set new size and position of parent element, based on:
+        // - union of bboxes of all children of parent element (i.e. this element + any sibling elements)
+        // - inflated by given `opt.padding`
+        parentElement._fitToElements({ elements: siblingElements, ...opt });
+
+        if (opt.deep) {
+            // `opt.deep = true` means "fit all ancestors to their respective children".
+            // As the last action of the fitting algorithm, recursively apply `fitParent()` on all ancestors.
+            // - i.e. the algorithm is applied in reverse-depth order - start from deepest descendant (= this element), then go up.
+            parentElement.fitParent(opt);
+        }
+
+        this.stopBatch('fit-parent');
+
+        return this;
+    },
+
+    // Assumption: This element is part of a graph.
+    _fitToElements: function(opt = {}) {
+
+        const elementsBBox = this.graph.getCellsBBox(opt.elements);
+        // If no `opt.elements` were provided, do nothing.
+        if (!elementsBBox) return;
+
+        const { expandOnly, shrinkOnly } = opt;
+        // This combination is meaningless, do nothing.
+        if (expandOnly && shrinkOnly) return;
+
+        // Calculate new size and position of this element based on:
+        // - union of bboxes of `opt.elements`
+        // - inflated by `opt.padding` (if not provided, all four properties = 0)
+        let { x, y, width, height } = elementsBBox;
         const { left, right, top, bottom } = normalizeSides(opt.padding);
-        let { x, y, width, height } = graph.getCellsBBox(embeddedCells);
-        // Apply padding computed above to the bbox.
         x -= left;
         y -= top;
         width += left + right;
         height += bottom + top;
+        let resultBBox = new Rect(x, y, width, height);
 
-        // Set new element dimensions finally.
+        if (expandOnly) {
+            // Non-shrinking is enforced by taking union of this element's current bbox with bbox calculated from `opt.elements`.
+            resultBBox = this.getBBox().union(resultBBox);
+
+        } else if (shrinkOnly) {
+            // Non-expansion is enforced by taking intersection of this element's current bbox with bbox calculated from `opt.elements`.
+            const intersectionBBox = this.getBBox().intersect(resultBBox);
+            // If all children are outside this element's current bbox, then `intersectionBBox` is `null` - does not make sense, do nothing.
+            if (!intersectionBBox) return;
+
+            resultBBox =  intersectionBBox;
+        }
+
+        // Set the new size and position of this element.
         this.set({
-            position: { x, y },
-            size: { width, height }
+            position: { resultBBox.x, resultBBox.y },
+            size: { resultBBox.width, resultBBox.height }
         }, opt);
-
-        this.stopBatch('fit-embeds');
-
-        return this;
     },
 
     // Rotate element by `angle` degrees, optionally around `origin` point.

--- a/src/dia/Element.mjs
+++ b/src/dia/Element.mjs
@@ -347,7 +347,7 @@ export const Element = Cell.extend({
         const childElements = this.getEmbeddedCells().filter(cell => cell.isElement());
         if (childElements.length === 0) return this;
 
-        this.startBatch('fit-to-children', opt);
+        this.startBatch('fit-embeds', opt);
 
         if (opt.deep) {
             // `opt.deep = true` means "fit to all descendants".
@@ -361,7 +361,7 @@ export const Element = Cell.extend({
         // - inflated by given `opt.padding`
         this._fitToElements(Object.assign({ elements: childElements }, opt));
 
-        this.stopBatch('fit-to-children');
+        this.stopBatch('fit-embeds');
 
         return this;
     },

--- a/src/dia/Element.mjs
+++ b/src/dia/Element.mjs
@@ -373,7 +373,7 @@ export const Element = Cell.extend({
 
         // When `opt.deep = true`, we want `opt.terminator` to be the last ancestor processed.
         // If the current element is `opt.terminator`, it means that this element has already been processed as parent so we can exit now.
-        if (opt.deep && opt.terminator && (opt.terminator === this.getIdAttribute())) return this;
+        if (opt.deep && opt.terminator && ((opt.terminator === this) || (opt.terminator === this.id))) return this;
 
         const parentElement = this.getParentCell();
         if (!parentElement || !parentElement.isElement()) return this;

--- a/src/layout/DirectedGraph/DirectedGraph.mjs
+++ b/src/layout/DirectedGraph/DirectedGraph.mjs
@@ -197,7 +197,7 @@ export const DirectedGraph = {
                     return bCluster.getAncestors().length - aCluster.getAncestors().length;
                 });
 
-            util.invoke(clusters, 'fitEmbeds', { padding: opt.clusterPadding });
+            util.invoke(clusters, 'fitToChildren', { padding: opt.clusterPadding });
         }
 
         graph.stopBatch('layout');

--- a/test/jointjs/elements.js
+++ b/test/jointjs/elements.js
@@ -1,5 +1,27 @@
 QUnit.module('elements', function(hooks) {
 
+    hooks.beforeEach(function() {
+
+        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
+        var $paper = $('<div/>');
+        $fixture.append($paper);
+
+        this.graph = new joint.dia.Graph;
+        this.paper = new joint.dia.Paper({
+
+            el: $paper,
+            gridSize: 10,
+            model: this.graph
+        });
+    });
+
+    hooks.afterEach(function() {
+
+        this.paper.remove();
+        this.graph = null;
+        this.paper = null;
+    });
+
     QUnit.module('isElement()', function(hooks) {
 
         QUnit.test('should be a function', function(assert) {
@@ -57,5 +79,383 @@ QUnit.module('elements', function(hooks) {
         });
     });
 
+    QUnit.module('fitParent()', function(hooks) {
 
+        hooks.beforeEach(function() {
+            // structure of objects:
+            // `mainGroup` has the following children:
+            // - `group1` has the following children:
+            //   - `a`
+            //   - `b`
+            // - `group2` has the following children:
+            //   - `c`
+
+            this.mainGroup = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 150 }, size: { width: 500, height: 400 }}); // (x: 50-550, y: 150-550)
+            this.group1 = new joint.shapes.standard.Rectangle({ position: { x: 101, y: 101 }, size: { width: 100, height: 100 }}); // (x: 101-201, y: 101-201) = reaches over `mainGroup` at top
+            this.group2 = new joint.shapes.standard.Rectangle({ position: { x: 502, y: 202 }, size: { width: 100, height: 100 }}); // (x: 502-602, y: 202-302) = reaches over `mainGroup` at right
+            this.a = new joint.shapes.standard.Rectangle({ position: { x: 153, y: 153 }, size: { width: 100, height: 100 }}); // (x: 153-253, y: 153-253) = within `mainGroup`, reaches over `group1` at bottom and right
+            this.b = new joint.shapes.standard.Rectangle({ position: { x: 154, y: 604 }, size: { width: 100, height: 100 }}); // (x: 154-254, y: 604-704) = outside `mainGroup`, outside `group1`
+            this.c = new joint.shapes.standard.Rectangle({ position: { x: 505, y: 355 }, size: { width: 100, height: 100 }}); // (x: 505-605, y: 355-455) = within `mainGroup`, outside `group2`
+
+            this.mainGroup.embed(this.group2.embed(this.c)).embed(this.group1.embed(this.a).embed(this.b));
+
+            this.graph.addCells([this.mainGroup, this.group1, this.group2, this.a, this.b, this.c]);
+        });
+
+        QUnit.test('sanity', function(assert) {
+
+            const r = new joint.shapes.basic.Rect({ position: { x: 0, y: 0 }, size: { width: 10, height: 10 }});
+            // not added to graph
+
+            assert.throws(function() {
+                r.fitParent();
+            }, /graph/, 'Shallow: Calling method on element that is not part of a graph throws an error.');
+
+            assert.throws(function() {
+                r.fitParent({ deep: true });
+            }, /graph/, 'Deep: Calling method on element that is not part of a graph throws an error.');
+        });
+
+        QUnit.test('expandOnly + shrinkOnly', function(assert) {
+
+            this.a.fitParent({ expandOnly: true, shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Using shrinkOnly and expandOnly together does nothing.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Using shrinkOnly and expandOnly together does nothing.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Using shrinkOnly and expandOnly together does nothing.');
+        });
+
+        QUnit.test('shallow', function(assert) {
+
+            // element with no embedding parent:
+            this.mainGroup.fitParent();
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Calling method on element that has no embedding parent has no effect.');
+
+            this.a.fitParent();
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Shallow: Call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes ancestors only one level above into account.');
+
+            this.a.fitParent({ deep: false });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Shallow: Call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes ancestors only one level above into account.');
+
+            // padding:
+            this.a.fitParent({ padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Using padding options is expanding the ancestors only one level above.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Shallow: Using padding options is expanding the ancestors only one level above.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the ancestors only one level above.');
+        });
+
+        QUnit.test('shallow + expandOnly', function(assert) {
+
+            this.a.fitParent({ expandOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: ExpandOnly call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 153, 603), 'Shallow: ExpandOnly call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ExpandOnly call takes ancestors only one level above into account.');
+        });
+
+        QUnit.test('shallow + expandOnly + padding', function(assert) {
+
+            this.a.fitParent({ expandOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 163, 613), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+        });
+
+        QUnit.test('shallow + shrinkOnly', function(assert) {
+
+            this.a.fitParent({ shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: ShrinkOnly call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 48, 48), 'Shallow: ShrinkOnly call takes ancestors only one level above into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ShrinkOnly call takes ancestors only one level above into account.');
+        });
+
+        QUnit.test('shallow + shrinkOnly + padding', function(assert) {
+
+            this.a.fitParent({ shrinkOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 58, 58), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+        });
+
+        QUnit.test('deep', function(assert) {
+
+            // element with no embedding parent:
+            this.mainGroup.fitParent({ deep: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Deep: Calling method on element that has no embedding parent has no effect.');
+
+            this.a.fitParent({ deep: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Call takes all embedding ancestors into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: After the call the first group fits its embeds.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: After the call the second group is unchanged.');
+
+            // padding:
+            this.a.fitParent({ deep: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 133, 479, 591), 'Deep: Using padding options is expanding the groups.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Deep: Using padding is expanding first group.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Using padding does not expand second group.');
+        });
+
+        QUnit.test('deep + terminator', function(assert) {
+
+            // - terminator element is the same as this element
+            this.a.fitParent({ deep: true, terminator: this.a });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Deep: Terminator (ref) same as this element does nothing.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Deep: Terminator (ref) same as this element does nothing.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) same as this element does nothing.');
+
+            this.a.fitParent({ deep: true, terminator: this.a.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Deep: Terminator (id) same as this element does nothing.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Deep: Terminator (id) same as this element does nothing.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) same as this element does nothing.');
+
+            // - terminator element is this element's embedding parent
+            this.a.fitParent({ deep: true, terminator: this.group1 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Deep: Terminator (ref) being embedding parent has same result as shallow.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (ref) being embedding parent has same result as shallow.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) being embedding parent has same result as shallow.');
+
+            this.a.fitParent({ deep: true, terminator: this.group1.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Deep: Terminator (id) being embedding parent has same result as shallow.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (id) being embedding parent has same result as shallow.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) being embedding parent has same result as shallow.');
+
+            // - terminator element is this element's topmost embedding ancestor
+            this.a.fitParent({ deep: true, terminator: this.mainGroup });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (ref) being topmost embedding ancestor has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (ref) being topmost embedding ancestor has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) being topmost embedding ancestor has same result as not providing terminator.');
+
+            this.a.fitParent({ deep: true, terminator: this.mainGroup.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (id) being topmost embedding ancestor has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (id) being topmost embedding ancestor has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) being topmost embedding ancestor has same result as not providing terminator.');
+
+            // - terminator element is not an ancestor of this element
+            this.a.fitParent({ deep: true, terminator: this.c });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (ref) not being ancestor of this element has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (ref) not being ancestor of this element has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) not being ancestor of this element has same result as not providing terminator.');
+
+            this.a.fitParent({ deep: true, terminator: this.c.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (id) not being ancestor of this element has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (id) not being ancestor of this element has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) not being ancestor of this element has same result as not providing terminator.');
+
+            // - terminator is not an Element
+            const l = new joint.shapes.standard.Link();
+            l.source(this.a);
+            l.target(this.b);
+            this.graph.addCells([l]);
+
+            this.a.fitParent({ deep: true, terminator: l });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (ref) not of type Element has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (ref) not of type Element has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) not of type Element has same result as not providing terminator.');
+
+            this.a.fitParent({ deep: true, terminator: l.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (id) not of type Element has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (id) not of type Element has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) not of type Element has same result as not providing terminator.');
+
+            // - terminator element is not in a graph
+            const r = new joint.shapes.basic.Rect({ position: { x: 0, y: 0 }, size: { width: 10, height: 10 }});
+            // not added to graph
+
+            this.a.fitParent({ deep: true, terminator: r });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (ref) not in a graph has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (ref) not in a graph has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (ref) not in a graph has same result as not providing terminator.');
+
+            this.a.fitParent({ deep: true, terminator: r.id });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Terminator (id) not in a graph has same result as not providing terminator.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: Terminator (id) not in a graph has same result as not providing terminator.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Terminator (id) not in a graph has same result as not providing terminator.');
+        });
+
+        QUnit.test('deep + expandOnly', function(assert) {
+
+            this.a.fitParent({ deep: true, expandOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 101, 552, 603), 'Deep: ExpandOnly call takes all embedding ancestors into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 153, 603), 'Deep: After expandOnly call the first group fits its embeds and keeps extra from original.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: After expandOnly call the second group is unchanged.');
+        });
+
+        QUnit.test('deep + expandOnly + padding', function(assert) {
+
+            this.a.fitParent({ deep: true, expandOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 91, 562, 633), 'Deep: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 163, 613), 'Deep: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: ExpandOnly using padding options does not expand second group.');
+        });
+
+        QUnit.test('deep + shrinkOnly', function(assert) {
+
+            this.a.fitParent({ deep: true, shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 397, 149), 'Deep: ShrinkOnly call takes all embedding ancestors into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 48, 48), 'Deep: After shrinkOnly call the first group shrinks to only contain originally overlapped part of embeds.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: After shrinkOnly call the second group is unchanged.');
+        });
+
+        QUnit.test('deep + shrinkOnly + padding', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, shrinkOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 150, 417, 162), 'Deep: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 58, 58), 'Deep: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: ShrinkOnly using padding options does not expand second group.');
+        });
+    });
+
+    // older tests for `dia.Element.fitEmbeds()` using `joint.shapes.basic.Rect` can be found in `/test/jointjs/basic.js`
+    QUnit.module('fitToChildren()', function(hooks) {
+
+        hooks.beforeEach(function() {
+            // structure of objects:
+            // `mainGroup` has the following children:
+            // - `group1` has the following children:
+            //   - `a`
+            //   - `b`
+            // - `group2` has the following children:
+            //   - `c`
+
+            this.mainGroup = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 150 }, size: { width: 500, height: 400 }}); // (x: 50-550, y: 150-550)
+            this.group1 = new joint.shapes.standard.Rectangle({ position: { x: 101, y: 101 }, size: { width: 100, height: 100 }}); // (x: 101-201, y: 101-201) = reaches over `mainGroup` at top
+            this.group2 = new joint.shapes.standard.Rectangle({ position: { x: 502, y: 202 }, size: { width: 100, height: 100 }}); // (x: 502-602, y: 202-302) = reaches over `mainGroup` at right
+            this.a = new joint.shapes.standard.Rectangle({ position: { x: 153, y: 153 }, size: { width: 100, height: 100 }}); // (x: 153-253, y: 153-253) = within `mainGroup`, reaches over `group1` at bottom and right
+            this.b = new joint.shapes.standard.Rectangle({ position: { x: 154, y: 604 }, size: { width: 100, height: 100 }}); // (x: 154-254, y: 604-704) = outside `mainGroup`, outside `group1`
+            this.c = new joint.shapes.standard.Rectangle({ position: { x: 505, y: 355 }, size: { width: 100, height: 100 }}); // (x: 505-605, y: 355-455) = within `mainGroup`, outside `group2`
+
+            this.mainGroup.embed(this.group2.embed(this.c)).embed(this.group1.embed(this.a).embed(this.b));
+
+            this.graph.addCells([this.mainGroup, this.group1, this.group2, this.a, this.b, this.c]);
+        });
+
+        QUnit.test('sanity', function(assert) {
+
+            const r = new joint.shapes.basic.Rect({ position: { x: 0, y: 0 }, size: { width: 10, height: 10 }});
+            // not added to graph
+
+            assert.throws(function() {
+                r.fitToChildren();
+            }, /graph/, 'Shallow: Calling method on element that is not part of a graph throws an error.');
+
+            assert.throws(function() {
+                r.fitToChildren({ deep: true });
+            }, /graph/, 'Deep: Calling method on element that is not part of a graph throws an error.');
+        });
+
+        QUnit.test('expandOnly + shrinkOnly', function(assert) {
+
+            this.mainGroup.fitToChildren({ expandOnly: true, shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Using shrinkOnly and expandOnly together does nothing.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Using shrinkOnly and expandOnly together does nothing.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Using shrinkOnly and expandOnly together does nothing.');
+        });
+
+        QUnit.test('shallow', function(assert) {
+
+            // element with no embedded children:
+            this.a.fitToChildren();
+            assert.deepEqual(this.a.getBBox(), g.rect(153, 153, 100, 100), 'Shallow: Calling method on element that has no embeds has no effect.');
+
+            this.mainGroup.fitToChildren();
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(101, 101, 501, 201), 'Shallow: Call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
+
+            this.mainGroup.fitToChildren({ deep: false });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(101, 101, 501, 201), 'Shallow: Call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
+
+            // padding:
+            this.mainGroup.fitToChildren({ padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(91, 91, 521, 221), 'Shallow: Using padding options is expanding the groups only one level deep.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
+        });
+
+        QUnit.test('shallow + expandOnly', function(assert) {
+
+            this.mainGroup.fitToChildren({ expandOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 101, 552, 449), 'Shallow: ExpandOnly call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: ExpandOnly call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ExpandOnly call takes embeds only one level deep into account.');
+        });
+
+        QUnit.test('shallow + expandOnly + padding', function(assert) {
+
+            this.mainGroup.fitToChildren({ expandOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 91, 562, 459), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ExpandOnly using padding options expands at child edges only.');
+        });
+
+        QUnit.test('shallow + shrinkOnly', function(assert) {
+
+            this.mainGroup.fitToChildren({ shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(101, 150, 449, 152), 'Shallow: ShrinkOnly call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: ShrinkOnly call takes embeds only one level deep into account.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ShrinkOnly call takes embeds only one level deep into account.');
+        });
+
+        QUnit.test('shallow + shrinkOnly + padding', function(assert) {
+
+            this.mainGroup.fitToChildren({ shrinkOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(91, 150, 459, 162), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: ShrinkOnly using padding options expands at child edges only.');
+        });
+
+        QUnit.test('deep', function(assert) {
+
+            // element with no embedded children:
+            this.a.fitToChildren({ deep: true });
+            assert.deepEqual(this.a.getBBox(), g.rect(153, 153, 100, 100), 'Deep: Calling method on element that has no embeds has no effect.');
+
+            this.mainGroup.fitToChildren({ deep: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 452, 551), 'Deep: Call takes all descendant embeds into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: After the call the first group fits its embeds.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(505, 355, 100, 100), 'Deep: After the call the second group fits its embeds.');
+
+            // padding:
+            this.mainGroup.fitToChildren({ deep: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 133, 492, 591), 'Deep: Using padding options is expanding the groups.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Deep: Using padding is expanding first group.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(495, 345, 120, 120), 'Deep: Using padding is expanding second group.');
+        });
+
+        QUnit.test('deep + expandOnly', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, expandOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 101, 555, 603), 'Deep: ExpandOnly call takes all descendant embeds into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 153, 603), 'Deep: After expandOnly call the first group fits its embeds and keeps extra from original.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 103, 253), 'Deep: After expandOnly call the second group fits its embeds and keeps extra from original.');
+        });
+
+        QUnit.test('deep + expandOnly + padding', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, expandOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 91, 575, 633), 'Deep: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 163, 613), 'Deep: ExpandOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(495, 202, 120, 263), 'Deep: ExpandOnly using padding options expands at child edges only.');
+        });
+
+        QUnit.test('deep + shrinkOnly', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, shrinkOnly: true });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 397, 149), 'Deep: ShrinkOnly call takes all descendant embeds into account.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 48, 48), 'Deep: After shrinkOnly call the first group shrinks to only contain originally overlapped part of embeds.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: After shrinkOnly call the second group does not shrink because no overlap.');
+        });
+
+        QUnit.test('deep + shrinkOnly + padding', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, shrinkOnly: true, padding: 10 });
+            assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 150, 417, 162), 'Deep: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 58, 58), 'Deep: ShrinkOnly using padding options expands at child edges only.');
+            assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: ShrinkOnly using padding options does not expand anywhere because no overlap.');
+        });
+    });
 });

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -510,7 +510,7 @@ export namespace dia {
         scale(scaleX: number, scaleY: number, origin?: Point, opt?: { [key: string]: any }): this;
 
         fitEmbeds(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean }): this;
-        fitToChildren(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean}): this;
+        fitToChildren(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean }): this;
 
         fitParent(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean, terminator?: Cell | Cell.ID }): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -509,7 +509,10 @@ export namespace dia {
 
         scale(scaleX: number, scaleY: number, origin?: Point, opt?: { [key: string]: any }): this;
 
-        fitEmbeds(opt?: { deep?: boolean, padding?: Padding }): this;
+        fitEmbeds(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean }): this;
+        fitToChildren(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean}): this;
+
+        fitParent(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean, terminator?: Cell | Cell.ID }): this;
 
         getBBox(opt?: Element.BBoxOptions): g.Rect;
 


### PR DESCRIPTION
## Description

- Added `dia.Element.fitParent()` method - to adjust bbox of parent/ancestors of this element to envelop element's bbox (including padding, if any).
- Added `dia.Element.fitToChildren()` method as an alias for `dia.Element.fitEmbeds()` - to adjust bbox of this element to envelop bbox of element's children/descendants (including padding, if any).
- Kept `padding` and `deep` options of both methods. 
- Added `expandOnly` and `shrinkOnly` options to both methods - to limit which types of adjustments are allowed.
  - If `shrinkOnly` is used and there is no overlap between the parent element and its children, nothing happens.
  - Note that when `shrinkOnly` is used together with the `deep` option, each step of the algorithm is independent - always only the bbox of the currently evaluated element is used to inform parent bbox adjustments (i.e. bboxes of children are never used when calculating parent bbox adjustments).
- Added `terminator` option to `dia.Element.fitParent()` (relevant when `deep` option is used).
  - If `terminator` is the element itself, nothing happens.
  - If `terminator` is the element's parent, the result is the same as calling `dia.Element.fitParent()` without `deep` option.
  - If `terminator` is not an ancestor of element, the result is the same as calling `dia.Element.fitParent()` without a `terminator` option.

## Motivation and Context

This feature is based on a client request, to have a broader API for working with embedded cells. Specifically, the request was to adjust all parent elements when an element is resized and/or repositioned, without affecting siblings of the element.

### Screenshots (if appropriate):

In the following examples, in the "before" images, the structure is as follows: The orange element (`r1`) has two children (`r11` at top-left, and `r12` at top-right), and `r11` has a child (`r111` at bottom-left).

|function call|before|after|after (`expandOnly: true`)|after (`shrinkOnly: true`)|
|-|-|-|-|-|
|`r1.fitToChildren({ padding: 10 })`|<img width="812" alt="Screenshot 2023-03-16 at 19 35 37" src="https://user-images.githubusercontent.com/6071519/225720252-915ab5c3-7dd7-4099-a873-db91f4153068.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 37 07" src="https://user-images.githubusercontent.com/6071519/225720535-8f55e863-96aa-4e75-bf97-dd560c06d43e.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 44 24" src="https://user-images.githubusercontent.com/6071519/225723125-00491398-a5a2-4cbc-a223-ff190cc04501.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 51 15" src="https://user-images.githubusercontent.com/6071519/225724059-9515254c-828f-4ba5-a10c-3031d9a44bd3.png">|
|`r1.fitToChildren({ padding: 10, deep: true })`|<img width="812" alt="Screenshot 2023-03-16 at 19 35 37" src="https://user-images.githubusercontent.com/6071519/225720252-915ab5c3-7dd7-4099-a873-db91f4153068.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 37 21" src="https://user-images.githubusercontent.com/6071519/225720575-c5f565d4-3b15-495f-8def-42385d23e968.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 44 45" src="https://user-images.githubusercontent.com/6071519/225723185-78808b50-6390-4cea-b61f-9bcd41e605b8.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 51 27" src="https://user-images.githubusercontent.com/6071519/225724114-d2cbd3a2-3cd8-42c8-94d9-8ac638dbb9e9.png">|
|`r111.fitParent({ padding: 10 })`|<img width="812" alt="Screenshot 2023-03-16 at 19 35 37" src="https://user-images.githubusercontent.com/6071519/225720252-915ab5c3-7dd7-4099-a873-db91f4153068.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 37 38" src="https://user-images.githubusercontent.com/6071519/225720637-9b306611-ef88-44c1-b37b-172e40610d52.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 45 12" src="https://user-images.githubusercontent.com/6071519/225723227-5d23c2b8-f4b9-4ba4-8ccc-3d1396eabf77.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 51 55" src="https://user-images.githubusercontent.com/6071519/225724141-3f6d6d48-9e42-459d-8766-647faabe4d61.png">|
|`r111.fitParent({ padding: 10, deep: true })`|<img width="812" alt="Screenshot 2023-03-16 at 19 35 37" src="https://user-images.githubusercontent.com/6071519/225720252-915ab5c3-7dd7-4099-a873-db91f4153068.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 38 59" src="https://user-images.githubusercontent.com/6071519/225720895-061f3107-3238-4ba4-9af8-081faecb331b.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 45 30" src="https://user-images.githubusercontent.com/6071519/225723282-70a2edb7-d6b4-4f8b-8807-561e2bace6b7.png">|<img width="812" alt="Screenshot 2023-03-16 at 19 52 21" src="https://user-images.githubusercontent.com/6071519/225724185-41c8a580-e177-4dce-b6f3-1e6f4014cdcd.png">|

Note that when `shrinkOnly` is used together with the `deep` option, the results are evaluated iteratively (i.e. one step at a time). In the example below, this means that the orange element (`r1`) adjusts according to its two children (`r11` at top-left and `r12` at top-right), but not according to its grandchild `r111` (at bottom-left). The behavior is exactly the same for both functions, `dia.Element.fitToChildren()` and `dia.Element.fitParent()`:

|function call|before|after|
|-|-|-|
|`r1.fitToChildren({ padding: 10, deep: true, shrinkOnly: true })`|<img width="812" alt="Screenshot 2023-03-16 at 20 21 47" src="https://user-images.githubusercontent.com/6071519/225732126-f3590720-78f7-4317-8cb6-8320ffa6af98.png">|<img width="812" alt="Screenshot 2023-03-16 at 20 23 31" src="https://user-images.githubusercontent.com/6071519/225732178-ed94a8d3-5839-4d98-8f9c-9407d465050b.png">|
|`r111.fitParent({ padding: 10, deep: true, shrinkOnly: true })`|<img width="812" alt="Screenshot 2023-03-16 at 20 21 47" src="https://user-images.githubusercontent.com/6071519/225732126-f3590720-78f7-4317-8cb6-8320ffa6af98.png">|<img width="812" alt="Screenshot 2023-03-16 at 20 23 31" src="https://user-images.githubusercontent.com/6071519/225732178-ed94a8d3-5839-4d98-8f9c-9407d465050b.png">|
