### PR TITLE
svgTagTemplate: correct textNode parsing

### DIFF
--- a/docs/src/joint/api/dia/Cell/markup.html
+++ b/docs/src/joint/api/dia/Cell/markup.html
@@ -23,7 +23,7 @@ markup: '&lt;rect&gt;&lt;g&gt;&lt;circle/&gt;&lt;circle/&gt;&lt;/g&gt;'</code></
 <h4 id="dia.Cell.markup.json">JSON Markup</h4>
 
 <p>
-    JSON markup is defined recursively as an array of <code>JSONElement</code>, where <code>JSONElement</code> is a plain object with the following properties:
+    JSON markup is defined recursively as an array of <code>JSONElement</code> or strings representing text nodes, where <code>JSONElement</code> is a plain object with the following properties:
 </p>
 
 <ul>
@@ -60,7 +60,9 @@ markup: [{
         tagName: 'circle',
         selector: 'circle1',
         groupSelector: 'circles'
-    }, {
+    },
+    'text content',
+    {
         tagName: 'circle',
         selector: 'circle2',
         groupSelector: 'circles'
@@ -95,6 +97,7 @@ markup: svg`
             @selector="circle1"
             @group-selector="circles"
         /&gt
+        text content
         &ltcircle
             @selector="circle2"
             @group-selector="circles"

--- a/docs/src/joint/api/util/svg.html
+++ b/docs/src/joint/api/util/svg.html
@@ -42,6 +42,6 @@
         </tr>
     </table>
     <br/>
-    Text nodes are placed into the children array as strings. For example markup <code data-lang="html">&lt;span&gt;a&lt;span&gt;b&lt;/span&gt;&lt;/span&gt;</code> is converted to <code>{ tagName: 'span', children: ['a', { tagName: 'span', children: ['b']}]}</code>.
+    Text nodes are placed into the children array as strings. For example, the markup <code data-lang="html">&lt;span&gt;a&lt;span&gt;b&lt;/span&gt;&lt;/span&gt;</code> is converted to <code>{ tagName: 'span', children: ['a', { tagName: 'span', children: ['b']}]}</code>.
 </p>
 

--- a/docs/src/joint/api/util/svg.html
+++ b/docs/src/joint/api/util/svg.html
@@ -40,10 +40,8 @@
             <td>children</td>
             <td>The children of the element.</td>
         </tr>
-        <tr>
-            <td>textContent</td>
-            <td>The text content of the element.</td>
-        </tr>
     </table>
+    <br/>
+    Text nodes are placed into the children array as strings. For example markup <code data-lang="html">&lt;span&gt;a&lt;span&gt;b&lt;/span&gt;&lt;/span&gt;</code> is converted to <code>{ tagName: 'span', children: ['a', { tagName: 'span', children: ['b']}]}</code>.
 </p>
 

--- a/src/util/svgTagTemplate.mjs
+++ b/src/util/svgTagTemplate.mjs
@@ -65,32 +65,23 @@ function buildNode(node) {
         markupNode.className = className.value;
     }
 
-    const children = Array.from(childNodes);
-    if (children.some(n => n.nodeType !== Node.TEXT_NODE)) {
-        childNodes.forEach(node => {
-            switch (node.nodeType) {
-                case Node.TEXT_NODE: {
-                    const trimmedText = node.data.replace(/\s\s+/g, ' ');
-                    if (trimmedText.trim()) {
-                        markupNode.children.push({ tagName: '#text' , textContent: trimmedText });
-                    }
-                    break;
+    childNodes.forEach(node => {
+        switch (node.nodeType) {
+            case Node.TEXT_NODE: {
+                const trimmedText = node.data.replace(/\s\s+/g, ' ');
+                if (trimmedText.trim()) {
+                    markupNode.children.push(trimmedText);
                 }
-                case Node.ELEMENT_NODE: {
-                    markupNode.children.push(buildNode(node));
-                    break;
-                }
-                default:
-                    break;
+                break;
             }
-        });
-    } else {
-        const textContent = children.map(node => node.textContent).join('').replace(/\s\s+/g, ' ');
-        if (textContent.trim()) {
-            markupNode.textContent = textContent;
+            case Node.ELEMENT_NODE: {
+                markupNode.children.push(buildNode(node));
+                break;
+            }
+            default:
+                break;
         }
-    }
-
+    });
 
     const nodeAttrs = {};
 

--- a/src/util/svgTagTemplate.mjs
+++ b/src/util/svgTagTemplate.mjs
@@ -24,77 +24,93 @@ function parseFromSVGString(str) {
     return build(svg);
 }
 
+function buildNode(node) {
+    const markupNode = {
+        children: []
+    };
+    const { tagName, attributes, namespaceURI, style, childNodes } = node;
+
+    markupNode.namespaceURI = namespaceURI;
+    markupNode.tagName = (namespaceURI === V.namespace.xhtml)
+        // XHTML documents must use lower case for all HTML element and attribute names.
+        // The tagName property returns upper case value for HTML elements.
+        // e.g. <DIV> vs.<div/>
+        ? tagName.toLowerCase()
+        : tagName;
+
+    const stylesObject = {};
+    for (var i = style.length; i--;) {
+        var nameString = style[i];
+        stylesObject[nameString] = style.getPropertyValue(nameString);
+    }
+    markupNode.style = stylesObject;
+
+    // selector fallbacks to tagName
+    const selectorAttribute = attributes.getNamedItem('@selector');
+    if (selectorAttribute) {
+        markupNode.selector = selectorAttribute.value;
+        attributes.removeNamedItem('@selector');
+    }
+
+    const groupSelectorAttribute = attributes.getNamedItem('@group-selector');
+    if (groupSelectorAttribute) {
+        const groupSelectors = groupSelectorAttribute.value.split(',');
+        markupNode.groupSelector = groupSelectors.map(s => s.trim());
+
+        attributes.removeNamedItem('@group-selector');
+    }
+
+    const className = attributes.getNamedItem('class');
+    if (className) {
+        markupNode.className = className.value;
+    }
+
+    const children = Array.from(childNodes);
+    if (children.some(n => n.nodeType !== Node.TEXT_NODE)) {
+        childNodes.forEach(node => {
+            switch (node.nodeType) {
+                case Node.TEXT_NODE: {
+                    const trimmedText = node.data.replace(/\s\s+/g, ' ');
+                    if (trimmedText.trim()) {
+                        markupNode.children.push({ tagName: '#text' , textContent: trimmedText });
+                    }
+                    break;
+                }
+                case Node.ELEMENT_NODE: {
+                    markupNode.children.push(buildNode(node));
+                    break;
+                }
+                default:
+                    break;
+            }
+        });
+    } else {
+        const textContent = children.map(node => node.textContent).join('').replace(/\s\s+/g, ' ');
+        if (textContent.trim()) {
+            markupNode.textContent = textContent;
+        }
+    }
+
+
+    const nodeAttrs = {};
+
+    Array.from(attributes).forEach(nodeAttribute => {
+        const { name, value } = nodeAttribute;
+        nodeAttrs[name] = value;
+    });
+
+    if (Object.keys(nodeAttrs).length > 0) {
+        markupNode.attributes = nodeAttrs;
+    }
+
+    return markupNode;
+}
+
 function build(root) {
     const markup = [];
 
     Array.from(root.children).forEach(node => {
-        const markupNode = {};
-        const { tagName, attributes, namespaceURI, style, childNodes } = node;
-
-        markupNode.namespaceURI = namespaceURI;
-        markupNode.tagName = (namespaceURI === V.namespace.xhtml)
-            // XHTML documents must use lower case for all HTML element and attribute names.
-            // The tagName property returns upper case value for HTML elements.
-            // e.g. <DIV> vs.<div/>
-            ? tagName.toLowerCase()
-            : tagName;
-
-        const stylesObject = {};
-        for (var i = style.length; i--;) {
-            var nameString = style[i];
-            stylesObject[nameString] = style.getPropertyValue(nameString);
-        }
-        markupNode.style = stylesObject;
-
-        // selector fallbacks to tagName
-        const selectorAttribute = attributes.getNamedItem('@selector');
-        if (selectorAttribute) {
-            markupNode.selector = selectorAttribute.value;
-            attributes.removeNamedItem('@selector');
-        }
-
-        const groupSelectorAttribute = attributes.getNamedItem('@group-selector');
-        if (groupSelectorAttribute) {
-            const groupSelectors = groupSelectorAttribute.value.split(',');
-            markupNode.groupSelector = groupSelectors.map(s => s.trim());
-
-            attributes.removeNamedItem('@group-selector');
-        }
-
-        const className = attributes.getNamedItem('class');
-        if (className) {
-            markupNode.className = className.value;
-        }
-
-        const textNodes = Array.from(childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-        if (textNodes.length > 0) {
-            // TODO: handle multiple text nodes
-            // Currently, there is no way to describe
-            // multiple text nodes (and other nodes in between) in the JSON markup
-            // e.g <text>a<tspan>b</tspan>c</text>
-            // The above markup will be converted to <text>ab<tspan>c</tspan></text>
-            const textContent = textNodes.map(node => node.textContent).join('').trim();
-            if (textContent.length > 0) {
-                markupNode.textContent = textContent;
-            }
-        }
-
-        const nodeAttrs = {};
-
-        Array.from(attributes).forEach(nodeAttribute => {
-            const { name, value } = nodeAttribute;
-            nodeAttrs[name] = value;
-        });
-
-        if (Object.keys(nodeAttrs).length > 0) {
-            markupNode.attributes = nodeAttrs;
-        }
-
-        if (node.childElementCount > 0) {
-            markupNode.children = build(node);
-        }
-
-        markup.push(markupNode);
+        markup.push(buildNode(node));
     });
 
     return markup;

--- a/src/util/svgTagTemplate.mjs
+++ b/src/util/svgTagTemplate.mjs
@@ -25,9 +25,7 @@ function parseFromSVGString(str) {
 }
 
 function buildNode(node) {
-    const markupNode = {
-        children: []
-    };
+    const markupNode = {};
     const { tagName, attributes, namespaceURI, style, childNodes } = node;
 
     markupNode.namespaceURI = namespaceURI;
@@ -65,23 +63,27 @@ function buildNode(node) {
         markupNode.className = className.value;
     }
 
+    const children = [];
     childNodes.forEach(node => {
         switch (node.nodeType) {
             case Node.TEXT_NODE: {
                 const trimmedText = node.data.replace(/\s\s+/g, ' ');
                 if (trimmedText.trim()) {
-                    markupNode.children.push(trimmedText);
+                    children.push(trimmedText);
                 }
                 break;
             }
             case Node.ELEMENT_NODE: {
-                markupNode.children.push(buildNode(node));
+                children.push(buildNode(node));
                 break;
             }
             default:
                 break;
         }
     });
+    if (children.length) {
+        markupNode.children = children;
+    }
 
     const nodeAttrs = {};
 

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -43,62 +43,66 @@ export const parseDOMJSON = function(json, namespace) {
     const fragment = document.createDocumentFragment();
 
     const parseNode = function(siblingsDef, parentNode, ns) {
-        for (let i = 0, n = siblingsDef.length; i < n; i++) {
+        for (let i = 0; i < siblingsDef.length; i++) {
             const nodeDef = siblingsDef[i];
+
+            // Text node
+            if (typeof nodeDef === 'string') {
+                const textNode = document.createTextNode(nodeDef);
+                parentNode.appendChild(textNode);
+                continue;
+            }
+
             // TagName
             if (!nodeDef.hasOwnProperty('tagName')) throw new Error('json-dom-parser: missing tagName');
             const tagName = nodeDef.tagName;
 
             let node;
 
-            // Process text nodes
-            if (tagName === '#text') {
-                node = document.createTextNode(nodeDef.textContent);
-            } else {
-                // Namespace URI
-                if (nodeDef.hasOwnProperty('namespaceURI')) ns = nodeDef.namespaceURI;
-                node = document.createElementNS(ns, tagName);
-                const svg = (ns === svgNamespace);
+            // Namespace URI
+            if (nodeDef.hasOwnProperty('namespaceURI')) ns = nodeDef.namespaceURI;
+            node = document.createElementNS(ns, tagName);
+            const svg = (ns === svgNamespace);
 
-                const wrapper = (svg) ? V : $;
-                // Attributes
-                const attributes = nodeDef.attributes;
-                if (attributes) wrapper(node).attr(attributes);
-                // Style
-                const style = nodeDef.style;
-                if (style) $(node).css(style);
-                // ClassName
-                if (nodeDef.hasOwnProperty('className')) {
-                    const className = nodeDef.className;
-                    if (svg) {
-                        node.className.baseVal = className;
-                    } else {
-                        node.className = className;
-                    }
-                }
-                // TextContent
-                if (nodeDef.hasOwnProperty('textContent')) {
-                    node.textContent = nodeDef.textContent;
-                }
-                // Selector
-                if (nodeDef.hasOwnProperty('selector')) {
-                    const nodeSelector = nodeDef.selector;
-                    if (selectors[nodeSelector]) throw new Error('json-dom-parser: selector must be unique');
-                    selectors[nodeSelector] = node;
-                    wrapper(node).attr('joint-selector', nodeSelector);
-                }
-                // Groups
-                if (nodeDef.hasOwnProperty('groupSelector')) {
-                    var nodeGroups = nodeDef.groupSelector;
-                    if (!Array.isArray(nodeGroups)) nodeGroups = [nodeGroups];
-                    for (var j = 0, m = nodeGroups.length; j < m; j++) {
-                        var nodeGroup = nodeGroups[j];
-                        var group = groupSelectors[nodeGroup];
-                        if (!group) group = groupSelectors[nodeGroup] = [];
-                        group.push(node);
-                    }
+            const wrapper = (svg) ? V : $;
+            // Attributes
+            const attributes = nodeDef.attributes;
+            if (attributes) wrapper(node).attr(attributes);
+            // Style
+            const style = nodeDef.style;
+            if (style) $(node).css(style);
+            // ClassName
+            if (nodeDef.hasOwnProperty('className')) {
+                const className = nodeDef.className;
+                if (svg) {
+                    node.className.baseVal = className;
+                } else {
+                    node.className = className;
                 }
             }
+            // TextContent
+            if (nodeDef.hasOwnProperty('textContent')) {
+                node.textContent = nodeDef.textContent;
+            }
+            // Selector
+            if (nodeDef.hasOwnProperty('selector')) {
+                const nodeSelector = nodeDef.selector;
+                if (selectors[nodeSelector]) throw new Error('json-dom-parser: selector must be unique');
+                selectors[nodeSelector] = node;
+                wrapper(node).attr('joint-selector', nodeSelector);
+            }
+            // Groups
+            if (nodeDef.hasOwnProperty('groupSelector')) {
+                var nodeGroups = nodeDef.groupSelector;
+                if (!Array.isArray(nodeGroups)) nodeGroups = [nodeGroups];
+                for (var j = 0; j < nodeGroups.length; j++) {
+                    var nodeGroup = nodeGroups[j];
+                    var group = groupSelectors[nodeGroup];
+                    if (!group) group = groupSelectors[nodeGroup] = [];
+                    group.push(node);
+                }
+            }
+
             parentNode.appendChild(node);
 
             // Children

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -93,11 +93,11 @@ export const parseDOMJSON = function(json, namespace) {
             }
             // Groups
             if (nodeDef.hasOwnProperty('groupSelector')) {
-                var nodeGroups = nodeDef.groupSelector;
+                let nodeGroups = nodeDef.groupSelector;
                 if (!Array.isArray(nodeGroups)) nodeGroups = [nodeGroups];
-                for (var j = 0; j < nodeGroups.length; j++) {
-                    var nodeGroup = nodeGroups[j];
-                    var group = groupSelectors[nodeGroup];
+                for (let j = 0; j < nodeGroups.length; j++) {
+                    const nodeGroup = nodeGroups[j];
+                    let group = groupSelectors[nodeGroup];
                     if (!group) group = groupSelectors[nodeGroup] = [];
                     group.push(node);
                 }

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -35,71 +35,80 @@ export const removeClassNamePrefix = function(className) {
 
 export const parseDOMJSON = function(json, namespace) {
 
-    var selectors = {};
-    var groupSelectors = {};
-    var svgNamespace = V.namespace.svg;
+    const selectors = {};
+    const groupSelectors = {};
+    const svgNamespace = V.namespace.svg;
 
-    var ns = namespace || svgNamespace;
-    var fragment = document.createDocumentFragment();
-    var queue = [json, fragment, ns];
-    while (queue.length > 0) {
-        ns = queue.pop();
-        var parentNode = queue.pop();
-        var siblingsDef = queue.pop();
-        for (var i = 0, n = siblingsDef.length; i < n; i++) {
-            var nodeDef = siblingsDef[i];
+    const ns = namespace || svgNamespace;
+    const fragment = document.createDocumentFragment();
+
+    const parseNode = function(siblingsDef, parentNode, ns) {
+        for (let i = 0, n = siblingsDef.length; i < n; i++) {
+            const nodeDef = siblingsDef[i];
             // TagName
             if (!nodeDef.hasOwnProperty('tagName')) throw new Error('json-dom-parser: missing tagName');
-            var tagName = nodeDef.tagName;
-            // Namespace URI
-            if (nodeDef.hasOwnProperty('namespaceURI')) ns = nodeDef.namespaceURI;
-            var node = document.createElementNS(ns, tagName);
-            var svg = (ns === svgNamespace);
+            const tagName = nodeDef.tagName;
 
-            var wrapper = (svg) ? V : $;
-            // Attributes
-            var attributes = nodeDef.attributes;
-            if (attributes) wrapper(node).attr(attributes);
-            // Style
-            var style = nodeDef.style;
-            if (style) $(node).css(style);
-            // ClassName
-            if (nodeDef.hasOwnProperty('className')) {
-                var className = nodeDef.className;
-                if (svg) {
-                    node.className.baseVal = className;
-                } else {
-                    node.className = className;
+            let node;
+
+            // Process text nodes
+            if (tagName === '#text') {
+                node = document.createTextNode(nodeDef.textContent);
+            } else {
+                // Namespace URI
+                if (nodeDef.hasOwnProperty('namespaceURI')) ns = nodeDef.namespaceURI;
+                node = document.createElementNS(ns, tagName);
+                const svg = (ns === svgNamespace);
+
+                const wrapper = (svg) ? V : $;
+                // Attributes
+                const attributes = nodeDef.attributes;
+                if (attributes) wrapper(node).attr(attributes);
+                // Style
+                const style = nodeDef.style;
+                if (style) $(node).css(style);
+                // ClassName
+                if (nodeDef.hasOwnProperty('className')) {
+                    const className = nodeDef.className;
+                    if (svg) {
+                        node.className.baseVal = className;
+                    } else {
+                        node.className = className;
+                    }
                 }
-            }
-            // TextContent
-            if (nodeDef.hasOwnProperty('textContent')) {
-                node.textContent = nodeDef.textContent;
-            }
-            // Selector
-            if (nodeDef.hasOwnProperty('selector')) {
-                var nodeSelector = nodeDef.selector;
-                if (selectors[nodeSelector]) throw new Error('json-dom-parser: selector must be unique');
-                selectors[nodeSelector] = node;
-                wrapper(node).attr('joint-selector', nodeSelector);
-            }
-            // Groups
-            if (nodeDef.hasOwnProperty('groupSelector')) {
-                var nodeGroups = nodeDef.groupSelector;
-                if (!Array.isArray(nodeGroups)) nodeGroups = [nodeGroups];
-                for (var j = 0, m = nodeGroups.length; j < m; j++) {
-                    var nodeGroup = nodeGroups[j];
-                    var group = groupSelectors[nodeGroup];
-                    if (!group) group = groupSelectors[nodeGroup] = [];
-                    group.push(node);
+                // TextContent
+                if (nodeDef.hasOwnProperty('textContent')) {
+                    node.textContent = nodeDef.textContent;
+                }
+                // Selector
+                if (nodeDef.hasOwnProperty('selector')) {
+                    const nodeSelector = nodeDef.selector;
+                    if (selectors[nodeSelector]) throw new Error('json-dom-parser: selector must be unique');
+                    selectors[nodeSelector] = node;
+                    wrapper(node).attr('joint-selector', nodeSelector);
+                }
+                // Groups
+                if (nodeDef.hasOwnProperty('groupSelector')) {
+                    var nodeGroups = nodeDef.groupSelector;
+                    if (!Array.isArray(nodeGroups)) nodeGroups = [nodeGroups];
+                    for (var j = 0, m = nodeGroups.length; j < m; j++) {
+                        var nodeGroup = nodeGroups[j];
+                        var group = groupSelectors[nodeGroup];
+                        if (!group) group = groupSelectors[nodeGroup] = [];
+                        group.push(node);
+                    }
                 }
             }
             parentNode.appendChild(node);
+
             // Children
-            var childrenDef = nodeDef.children;
-            if (Array.isArray(childrenDef)) queue.push(childrenDef, node, ns);
+            const childrenDef = nodeDef.children;
+            if (Array.isArray(childrenDef)) {
+                parseNode(childrenDef, node, ns);
+            }
         }
-    }
+    };
+    parseNode(json, fragment, ns);
     return {
         fragment: fragment,
         selectors: selectors,
@@ -529,7 +538,7 @@ function getLineHeight(heightValue, textElement) {
     if (heightValue === null) {
         // Default 1em lineHeight
         return textElement.getBBox().height;
-    } 
+    }
 
     switch (heightValue.unit) {
         case 'em':

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -1389,10 +1389,10 @@ QUnit.module('util', function(hooks) {
             assert.equal(markup[1].groupSelector[0], 'group-selector1');
             assert.equal(markup[1].groupSelector[1], 'group-selector2');
             assert.equal(markup[1].className, 'circle');
-            assert.equal(markup[2].children.length, 2);
-            assert.equal(markup[2].textContent, 'textContent');
+            assert.equal(markup[2].children.length, 3);
             assert.equal(markup[2].children[0].style['pointer-events'], 'auto');
             assert.equal(markup[2].children[1].attributes['stroke'], 'red');
+            assert.equal(markup[2].children[2].textContent, 'textContent');
         }
 
         QUnit.test('function', function(assert) {
@@ -1442,10 +1442,14 @@ QUnit.module('util', function(hooks) {
                 `;
                 assert.equal(markup.length, 1);
                 assert.equal(markup[0].tagName, 'text');
-                assert.equal(markup[0].textContent, 'ac', 'textContent does not contain the tspan element');
-                assert.equal(markup[0].children.length, 1);
-                assert.equal(markup[0].children[0].tagName, 'tspan');
-                assert.equal(markup[0].children[0].textContent, 'b');
+                assert.equal(markup[0].textContent, undefined, 'textContent does not textContent property because it has non-text children');
+                assert.equal(markup[0].children.length, 3);
+                assert.equal(markup[0].children[0].tagName, '#text');
+                assert.equal(markup[0].children[0].textContent, 'a');
+                assert.equal(markup[0].children[1].tagName, 'tspan');
+                assert.equal(markup[0].children[1].textContent, 'b');
+                assert.equal(markup[0].children[2].tagName, '#text');
+                assert.equal(markup[0].children[2].textContent, 'c');
             });
 
             QUnit.test('no text nodes', function(assert) {

--- a/test/jointjs/core/util.js
+++ b/test/jointjs/core/util.js
@@ -1392,7 +1392,7 @@ QUnit.module('util', function(hooks) {
             assert.equal(markup[2].children.length, 3);
             assert.equal(markup[2].children[0].style['pointer-events'], 'auto');
             assert.equal(markup[2].children[1].attributes['stroke'], 'red');
-            assert.equal(markup[2].children[2].textContent, 'textContent');
+            assert.equal(markup[2].children[2], 'textContent');
         }
 
         QUnit.test('function', function(assert) {
@@ -1442,14 +1442,35 @@ QUnit.module('util', function(hooks) {
                 `;
                 assert.equal(markup.length, 1);
                 assert.equal(markup[0].tagName, 'text');
-                assert.equal(markup[0].textContent, undefined, 'textContent does not textContent property because it has non-text children');
+                assert.equal(markup[0].textContent, undefined, 'text element does not have textContent property because it has non-text children');
                 assert.equal(markup[0].children.length, 3);
-                assert.equal(markup[0].children[0].tagName, '#text');
-                assert.equal(markup[0].children[0].textContent, 'a');
+                assert.equal(markup[0].children[0], 'a');
                 assert.equal(markup[0].children[1].tagName, 'tspan');
-                assert.equal(markup[0].children[1].textContent, 'b');
-                assert.equal(markup[0].children[2].tagName, '#text');
-                assert.equal(markup[0].children[2].textContent, 'c');
+                assert.equal(markup[0].children[1].children[0], 'b');
+                assert.equal(markup[0].children[2], 'c');
+            });
+
+            QUnit.test('spaces handling', function(assert) {
+                const markup1 = joint.util.svg/*xml*/`
+                    <text>  a <tspan>b</tspan>
+                    c</text>
+                `;
+                assert.equal(markup1.length, 1);
+                assert.equal(markup1[0].children[0], ' a ');
+                assert.equal(markup1[0].children[1].children[0], 'b');
+                assert.equal(markup1[0].children[2], ' c');
+
+                const markup2 = joint.util.svg/*xml*/`
+                <text>a
+
+                <tspan>b           </tspan>c
+                </text>
+                `;
+
+                assert.equal(markup2.length, 1);
+                assert.equal(markup2[0].children[0], 'a ');
+                assert.equal(markup2[0].children[1].children[0], 'b ');
+                assert.equal(markup2[0].children[2], 'c ');
             });
 
             QUnit.test('no text nodes', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -70,7 +70,7 @@ export namespace dia {
         textContent?: string;
     };
 
-    type MarkupJSON = MarkupNodeJSON[];
+    type MarkupJSON = Array<MarkupNodeJSON | string>;
 
     type Path = string | Array<string | number>;
 


### PR DESCRIPTION
This PR adds new functionality to the `svgTagTemplate` util function. Now it is correctly parse several chunks of text nodes, preserving the order and rendering them back as text nodes. For example `<span>a<span>b</span>c</span>` will be rendered exactly the same in the final DOM. Also it uses HTML style space removing, so it will preserve only one space instead of several spaces and/or other special symbol (like a new line).

Also this PR adds a new logic for processing text nodes into the `parseDOMJSON` function in the `util` module. Now this function will parse json with string `children` entries as HTML text nodes.
For example 
```
{
    tagName: 'div'
    children: [
        'a',
        {
            tagName: 'span',
            children: ['b']
        },    
        'c',
    ]
}
```
will be parsed as `<div>a<span>b</span>c</div>`.