### PR TITLE
fix(dia.Cell): preserve stacking of nested cells when toFront/toBack is called

### DIFF
--- a/demo/embedding/front-and-back.html
+++ b/demo/embedding/front-and-back.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JointJS</title>
+
+    <link rel="stylesheet" type="text/css" href="../../build/joint.css"/>
+    <style>
+		body {
+			background: #f7f7f7;
+		}
+		#demo {
+			width: 400px;
+			margin: 40px auto;
+			text-align: center;
+		}
+		#paper {
+			-webkit-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+			-moz-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+			box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+			border-radius: 10px;
+			margin-bottom: 30px;
+			background: white;
+		}
+		button {
+			padding: 10px 15px;
+			margin: 0 8px 8px 0;
+			font-family: monospace;
+		}
+    </style>
+</head>
+<body>
+    <div id="demo">
+        <div id="paper"></div>
+
+        <p>
+            <button id="toFrontButton">red.toFront()</button>
+            <button id="toBackButton">red.toBack()</button>
+        </p>
+    </div>
+
+    <!-- Dependencies: -->
+    <script src="../../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../../node_modules/lodash/lodash.js"></script>
+    <script src="../../node_modules/backbone/backbone.js"></script>
+
+    <script src="../../build/joint.js"></script>
+    <script src="./front-and-back.js"></script>
+</body>
+</html>

--- a/demo/embedding/front-and-back.js
+++ b/demo/embedding/front-and-back.js
@@ -1,0 +1,68 @@
+var namespace = joint.shapes;
+
+var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
+
+new joint.dia.Paper({
+    el: document.getElementById('paper'),
+    model: graph,
+    width: 400,
+    height: 400,
+    gridSize: 1,
+    cellViewNamespace: namespace
+});
+
+
+var r1 = new joint.shapes.standard.Rectangle({
+    position: { x: 40, y: 40 },
+    size: { width: 250, height: 300 },
+    attrs: {
+        body: { fill: '#E74C3C' }
+    }
+});
+var r2 = new joint.shapes.standard.Rectangle({
+    position: { x: 60, y: 50 },
+    size: { width: 100, height: 100 },
+    z: 10,
+    attrs: {
+        body: { fill: '#F1C40F' }
+    }
+});
+var r3 = new joint.shapes.standard.Rectangle({
+    position: { x: 140, y: 80 },
+    size: { width: 100, height: 90 },
+    z: 5,
+    attrs: {
+        body: { fill: '#46acd9' }
+    }
+});
+var r4 = new joint.shapes.standard.Rectangle({
+    position: { x: 260, y: 210 },
+    size: { width: 100, height: 100 },
+    z: 5,
+    attrs: {
+        body: { fill: '#7ac949' },
+    }
+});
+
+const updateLabels = () => {
+    [r1, r2, r3, r4].forEach((element) => {
+        element.attr('label/text', 'Z = ' + element.get('z'));
+    });
+};
+
+r1.embed(r2);
+r1.embed(r3);
+graph.addCells([r1, r2, r3, r4]);
+
+updateLabels();
+
+document.getElementById('toFrontButton').addEventListener('click', () => {
+    r1.toFront({ deep: true });
+    updateLabels();
+});
+
+
+document.getElementById('toBackButton').addEventListener('click', () => {
+    r1.toBack({ deep: true });
+    updateLabels();
+});

--- a/docs/src/joint/api/dia/Cell/prototype/z.html
+++ b/docs/src/joint/api/dia/Cell/prototype/z.html
@@ -1,0 +1,3 @@
+<pre class="docs-method-signature"><code>cell.z()</code></pre>
+<p>Return z – the stacking order (an equivalent to HTML <code>z-index</code>).</p>
+<p>When z is <code>undefined</code> or <code>null</code>, function returns <code>0</code>.</p>

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -291,6 +291,24 @@ QUnit.module('basic', function(hooks) {
         assert.ok(raSpy.calledWithExactly(17, 19, raOpt));
     });
 
+    QUnit.test('z()', function(assert) {
+        const r1 = new joint.shapes.standard.Rectangle;
+
+        assert.equal(r1.z(), 0);
+
+        r1.set('z', 10);
+        assert.equal(r1.z(), 10);
+
+        r1.set('z', -10);
+        assert.equal(r1.z(), -10);
+
+        r1.set('z', undefined);
+        assert.equal(r1.z(), 0);
+
+        r1.set('z', null);
+        assert.equal(r1.z(), 0);
+    });
+
     QUnit.test('translate()', function(assert) {
 
         var myrect = new joint.shapes.basic.Rect({
@@ -944,6 +962,70 @@ QUnit.module('basic', function(hooks) {
                 });
             });
         });
+    });
+
+    QUnit.test('toFront() preserve stacking of nested elements (z-indexes)', function(assert) {
+        const Rect = joint.shapes.standard.Rectangle;
+
+        const r1 = new Rect({ z: 1 });
+        const r2 = new Rect({ z: 6 });
+        const r3 = new Rect({ z: 4 });
+        const r4 = new Rect({ z: 2 });
+
+        const r5 = new Rect({ z: 3 }); // this rectangle forces r1 to go front
+
+        r1.embed(r2);
+        r1.embed(r3);
+        r1.embed(r4);
+
+        this.graph.addCells([r1, r2, r3, r4, r5]);
+
+        r1.toFront({ deep: true });
+
+        assert.equal(r1.get('z'), 7);
+        assert.equal(r2.get('z'), 10);
+        assert.equal(r3.get('z'), 9);
+        assert.equal(r4.get('z'), 8);
+
+        r1.toFront({ deep: true });
+        r1.toFront({ deep: true }); // calling toFront again doesn't change anything
+
+        assert.equal(r1.get('z'), 7);
+        assert.equal(r2.get('z'), 10);
+        assert.equal(r3.get('z'), 9);
+        assert.equal(r4.get('z'), 8);
+    });
+
+    QUnit.test('toBack() preserve stacking of nested elements (z-indexes)', function(assert) {
+        const Rect = joint.shapes.standard.Rectangle;
+
+        const r1 = new Rect({ z: 2 });
+        const r2 = new Rect({ z: 7 });
+        const r3 = new Rect({ z: 5 });
+        const r4 = new Rect({ z: 3 });
+
+        const r5 = new Rect({ z: 1 }); // this rectangle forces r1 to go back
+
+        r1.embed(r2);
+        r1.embed(r3);
+        r1.embed(r4);
+
+        this.graph.addCells([r1, r2, r3, r4, r5]);
+
+        r1.toBack({ deep: true });
+
+        assert.equal(r1.get('z'), -3);
+        assert.equal(r2.get('z'), 0);
+        assert.equal(r3.get('z'), -1);
+        assert.equal(r4.get('z'), -2);
+
+        r1.toBack({ deep: true });
+        r1.toBack({ deep: true }); // calling toBack again doesn't change anything
+
+        assert.equal(r1.get('z'), -3);
+        assert.equal(r2.get('z'), 0);
+        assert.equal(r3.get('z'), -1);
+        assert.equal(r4.get('z'), -2);
     });
 
     // tests for `dia.Element.fitToChildren()` can be found in `/test/jointjs/elements.js`

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -393,6 +393,8 @@ export namespace dia {
 
         position(): g.Point;
 
+        z(): number;
+
         angle(): number;
 
         getBBox(): g.Rect;


### PR DESCRIPTION
## Description

Fixes mixing up z-indexes of nested cells when `Cell.toFront` or `Cell.toBack` is called.

## Motivation and Context

Having elements like this:

```js
const r1 = new joint.shapes.basic.Rect({});
const r2 = new joint.shapes.basic.Rect({
    z: 10
});
const r3 = new joint.shapes.basic.Rect({
    z: 5
});

r1.embed(r2);
r1.embed(r3);
```

Calling `r1.toFront({ deep: true })` (in `master`) breaks stacking:

![image](https://user-images.githubusercontent.com/866325/226899807-d95da395-5758-4ae4-9a86-37ad49c90800.png)

This fix gives an expected result:

![image](https://user-images.githubusercontent.com/866325/226899495-527bc4e2-d7ca-4672-9ab1-d62be9131cc6.png)

-----

There is one drawback of the new solution. When we call `toFront` or `toBack` again and again, the internal condition `shouldUpdate` is always resolved as true and z-indexes are further recalculated, even though the stacking stays correct.

Let me know if you wanted to resolve this recalculation issue as well…