### PR TITLE
fix(dia.Paper): target markers are rotated as expected when using marker.markup

### DIFF
--- a/docs/src/joint/api/dia/Paper/prototype/defineMarker.html
+++ b/docs/src/joint/api/dia/Paper/prototype/defineMarker.html
@@ -1,7 +1,6 @@
 <pre class="docs-method-signature"><code>paper.defineMarker(markerDefinition)</code></pre>
 
-
-<p>Define an SVG marker for later reuse within the paper. The method returns the marker id and the <code>markerDefinition</code> must be an object with the following properties:</p>
+<p>Define an SVG marker for later reuse within the paper. The method returns the marker id. The <code>markerDefinition</code> parameter can be an object with the following properties:</p>
 
 <table>
     <tr>
@@ -21,30 +20,79 @@
     </tr>
     <tr>
         <td>markup</td>
-        <td>string | array</td>
-        <td>String or JSON <a href="#dia.Cell.markup">Markup</a> of the marker content.</td>
+        <td>string&nbsp;|&nbsp;array</td>
+        <td>JSON or string <a href="#dia.Cell.markup">markup</a> of the marker content.</td>
     </tr>
 </table>
 
+<p>The coordinate system for defining path data within <code>marker</code> is as follows:</p>
+
+<table>
+  <tr>
+    <th>Point (<code>x,y</code>)</th>
+    <th>Relative position</th>
+  </tr>
+  <tr>
+    <td><code>0,0</code></td>
+    <td>At <code>marker-start</code>, <code>marker-end</code> or <code>marker-mid</code> point, as appropriate.</td>
+  </tr>
+  <tr>
+    <td rowspan="2"><code>n,0</code></td>
+    <td>If <code>n &gt; 0</code>, position along path direction (i.e. start -&gt; end).</td>
+  </tr>
+  <tr>
+    <!--n,0-->
+    <td>If <code>n &lt; 0</code>, position opposite to path direction (i.e. start &lt;- end).</td>
+  </tr>
+  <tr>
+    <td rowspan="2"><code>0,m</code></td>
+    <td>If <code>m &gt; 0</code>, position to the left of path direction.</td>
+  </tr>
+  <tr>
+    <!--0,m-->
+    <td>If <code>m &lt; 0</code>, position to the right of path direction.</td>
+  </tr>
+</table>
+
+<p>An example of JSON markup with <code>id</code> specified:</p>
+
 <pre><code>paper.defineMarker({
   id: 'my-marker',
-  // The coordinate system for defining the path data
-  // ------------------------------------------------
-  // 0,0: marker-start, marker-end or marker-mid
-  // n,0: n > 0 in path direction
-  //      n < 0 opposite path direction
-  // 0,m: m > 0 left to the path direction
-  //      m < 0 right to the path direction
+  markup: [{
+    tagName: 'circle',
+    attributes: {
+      'cx': '6',
+      'cy': '0',
+      'r': '12',
+      'fill': '#7b5cce'
+    }
+  }, {
+    tagName: 'polygon',
+    attributes: {
+      'points': '0,0 6,6 12,0 6,-6',
+      'fill': '#d63865',
+      'stroke': '#fff'
+    }
+  }]
+});
+
+// Draw the shape at the start of a path
+svgPathNode.setAttribute('marker-start', `url(#my-marker)`);</code></pre>
+
+<p>The same example in string markup:</p>
+
+<pre><code>paper.defineMarker({
+  id: 'my-marker',
   markup: `
-    &lt;circle cx="6" cy="0" r="12" fill="#7b5cce"/&gt;
+    &lt;circle cx="6" cy="0" r="12" fill="#7b5cce" /&gt;
     &lt;polygon points="0,0 6,6 12,0 6,-6" fill="#d63865" stroke="#fff" /&gt;
   `
 });
 
-svgNode.setAttribute('marker-start', `url(#my-marker)`);
-</code></pre>
+// Draw the shape at the end of a path
+svgPathNode.setAttribute('marker-start', `url(#my-marker)`);</code></pre>
 
-<p>An alternative definition of the <code>markerDefinition</code> is:</p>
+<p>Alternatively, defining a marker is possible via a flat object with the following properties:</p>
 
 <table>
   <tr>
@@ -60,24 +108,27 @@ svgNode.setAttribute('marker-start', `url(#my-marker)`);
   <tr>
       <td>type</td>
       <td>string</td>
-      <td>The type of the SVGElement representing the marker (<code>'path'</code>, <code>'circle'</code>, <code>'ellipse'</code>, <code>'rect'</code>, <code>'polyline'</code> and <code>'polygon'</code>).</td>
+      <td><i>(optional)</i> - The type of the SVGElement to generate to represent the marker (<code>'path'</code>, <code>'circle'</code>, <code>'ellipse'</code>, <code>'rect'</code>, <code>'polyline'</code> and <code>'polygon'</code>). Default is <code>'path'</code>.</td>
   </tr>
   <tr>
       <td>[SVGAttribute]</td>
       <td>any</td>
-      <td><i>(optional)</i> - a presentation SVG attribute (e.g <code>fill: 'red'</code>)</td>
+      <td><i>(optional)</i> - A presentation SVG attribute (e.g <code>fill: 'red'</code>) to be applied on the generated SVGElement (see <code>type</code>).</td>
   </tr>
 </table>
+
+<p>The coordinate system for defining path data is the same as above.</p>
+
+<p>An example of specifying marker content via a flat object and referring to it in code via its automatically-generated <code>id</code>:
 
 <pre><code>const markerId = paper.defineMarker({
   type: 'path', // SVG Path
   fill: '#666',
   stroke: '#333',
-  d: 'M 10 -10 0 0 10 10 z'
+  d: 'M 10 -10 0 0 10 10 Z'
 });
 
 // Draw an arrow at the start and the end of a path
-svgPath.setAttribute('marker-start', `url(#${markerId})`);
-svgPath.setAttribute('marker-end', `url(#${markerId})`);
+svgPathNode.setAttribute('marker-start', `url(#${markerId})`);
+svgPathNode.setAttribute('marker-end', `url(#${markerId})`);
 </code></pre>
-

--- a/docs/src/joint/api/dia/Paper/prototype/defineMarker.html
+++ b/docs/src/joint/api/dia/Paper/prototype/defineMarker.html
@@ -46,11 +46,11 @@
   </tr>
   <tr>
     <td rowspan="2"><code>0,m</code></td>
-    <td>If <code>m &gt; 0</code>, position to the left of path direction.</td>
+    <td>If <code>m &gt; 0</code>, position to the right of path direction.</td>
   </tr>
   <tr>
     <!--0,m-->
-    <td>If <code>m &lt; 0</code>, position to the right of path direction.</td>
+    <td>If <code>m &lt; 0</code>, position to the left of path direction.</td>
   </tr>
 </table>
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2876,7 +2876,7 @@ export const Paper = View.extend({
                 if (transform) {
                     // get children of document fragment = array
                     const markerContentVEls = this._applyTransformToVEls(transform, markerContentVEl.children());
-                    markerVEl.append(markerContentVEls)
+                    markerVEl.append(markerContentVEls);
                 } else {
                     markerVEl.append(markerContentVEl);
                 }

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2819,16 +2819,27 @@ export const Paper = View.extend({
 
     defineMarker: function(marker) {
         if (!isObject(marker)) {
-            throw new TypeError('dia.Paper: defineMarker() requires 1. argument to be an object.');
+            throw new TypeError('dia.Paper: defineMarker() requires first argument to be an object.');
         }
         const { svg, defs } = this;
         const {
             // Generate a hash code from the stringified filter definition. This gives us
             // a unique filter ID for different definitions.
             id = svg.id + hashCode(JSON.stringify(marker)),
+            // user-provided markup
+            // (e.g. defined when creating link via `attrs/line/sourceMarker/markup`)
             markup,
+            // user-provided attributes
+            // (e.g. defined when creating link via `attrs/line/sourceMarker/attrs`)
+            // note: `transform` attrs are ignored by browsers
             attrs = {},
-            // deprecated in favour of `attrs`
+            // automatically-applied transformations
+            // (e.g. as applied for `dia.attributes.targetMarker`)
+            // - applied alongside `transform` attributes specified within `markup`
+            // note: we cannot apply `transform` directly on `markerVEl` because it isn't passed on to individual instances
+            // - we need to apply `transform` on individual items within `markerContentVEl`
+            transform,
+            // deprecated - use `attrs/markerUnits` instead (which has higher priority)
             markerUnits = 'userSpaceOnUse'
         } = marker;
         // If the marker already exists in the document,
@@ -2844,19 +2855,53 @@ export const Paper = View.extend({
         markerVEl.attr(attrs);
         if (markup) {
             if (typeof markup === 'string') {
-                markerVEl.append(V(markup));
+                // marker object has a `markup` property of type string
+                // construct V from provided string
+                // - if markup describes a single element, we get a single V element here
+                // - otherwise, we get an array of V elements here
+                const markerContentVEl = V(markup);
+                if (transform) {
+                    // convert `markerContentVEl` to an array if necessary
+                    const markerContentVEls = this._applyTransformToVEls(transform, (Array.isArray(markerContentVEl)) ? markerContentVEl : [markerContentVEl]);
+                    markerVEl.append(markerContentVEls);
+                } else {
+                    markerVEl.append(markerContentVEl);
+                }
             } else {
+                // marker object has a `markup` property of type object
+                // construct V from object by parsing as DOM JSON
+                // - we get a single document fragment here
                 const { fragment } = parseDOMJSON(markup);
-                markerVEl.append(fragment);
+                const markerContentVEl = V(fragment);
+                if (transform) {
+                    // get children of document fragment = array
+                    const markerContentVEls = this._applyTransformToVEls(transform, markerContentVEl.children());
+                    markerVEl.append(markerContentVEls)
+                } else {
+                    markerVEl.append(markerContentVEl);
+                }
             }
         } else {
             // marker object is a flat structure
+            // construct V from `marker.type` and set its attributes to sibling properties from within `marker`
+            // - we get a single V element here
+            // - attributes applied here typically involve `stroke`, `fill`, `stroke-opacity`, `fill-opacity` and `transform`
             const { type = 'path' } = marker;
             const markerContentVEl = V(type, omit(marker, 'type', 'id', 'markup', 'attrs', 'markerUnits'));
             markerVEl.append(markerContentVEl);
         }
         markerVEl.appendTo(defs);
         return id;
+    },
+
+    _applyTransformToVEls: function(transform, vels) {
+        vels.forEach((vel) => {
+            // we must not overwrite existing `transform` parts - appending instead
+            const currentTransform = vel.attr('transform');
+            const newTransform = ((currentTransform) ? (currentTransform + ' ') : '') + transform;
+            vel.attr({ transform: newTransform });
+        });
+        return vels;
     }
 
 }, {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2819,7 +2819,7 @@ export const Paper = View.extend({
 
     defineMarker: function(marker) {
         if (!isObject(marker)) {
-            throw new TypeError('dia.Paper: defineMarker() requires first argument to be an object.');
+            throw new TypeError('dia.Paper: defineMarker() requires the first argument to be an object.');
         }
         const { svg, defs } = this;
         const {
@@ -2847,50 +2847,57 @@ export const Paper = View.extend({
         });
         markerVEl.id = id;
         markerVEl.attr(attrs);
+        let markerContentVEl;
         if (markup) {
+            let markupVEl;
             if (typeof markup === 'string') {
                 // Marker object has a `markup` property of type string.
-                // - We need to construct V from the provided string.
-                const markerContentVEl = V(markup);
-                markerVEl.append(markerContentVEl);
+                // - Construct V from the provided string.
+                markupVEl = V(markup);
+                // `markupVEl` is now either a single VEl, or an array of VEls.
+                // - Coerce it to an array.
+                markupVEl = (Array.isArray(markupVEl) ? markupVEl : [markupVEl])
             } else {
                 // Marker object has a `markup` property of type object.
-                // - We need to construct V from object by parsing it as DOM JSON.
+                // - Construct V from the object by parsing it as DOM JSON.
                 const { fragment } = parseDOMJSON(markup);
-                const markerContentVEl = V(fragment);
-                markerVEl.append(markerContentVEl);
+                markupVEl = V(fragment).children();
+            }
+            // `markupVEl` is an array with one or more VEls inside.
+            // - If there are multiple VEls, wrap them in a newly-constructed <g> element
+            if (markupVEl.length > 1) {
+                markerContentVEl = V('g').append(markupVEl);
+            } else {
+                markerContentVEl = markupVEl[0];
             }
         } else {
             // Marker object is a flat structure.
-            // - We need to construct a new V of type `marker.type`.
+            // - Construct a new V of type `marker.type`.
             const { type = 'path' } = marker;
-            const markerContentVEl = V(type);
-            markerVEl.append(markerContentVEl);
+            markerContentVEl = V(type);
         }
-        // Assign attributes to marker content node(s):
-        const contentVEls = markerVEl.children();
-        // - Attributes are taken from non-special properties of `marker`.
-        const contentAttrs = omit(marker, 'type', 'id', 'markup', 'attrs', 'markerUnits');
-        const contentAttrsKeys = Object.keys(contentAttrs);
-        contentVEls.forEach((contentVEl) => {
-            contentAttrsKeys.forEach((key) => {
-                const currentValue = contentVEl.attr(key);
-                const newValue = contentAttrs[key];
-                if (currentValue == null) {
-                    // Default logic:
-                    // - Assign newValue if marker content node does not have a value yet.
-                    contentVEl.attr(key, newValue);
-                } else {
-                    // Properties with special logic should be added as cases to this switch block:
-                    switch(key) {
-                        case 'transform':
-                            // - Prepend new `transform` to existing value.
-                            contentVEl.attr(key, (newValue + ' ' + currentValue));
-                            break;
-                    }
+        // `markerContentVEl` is a single VEl.
+        // Assign additional attributes to it (= context attributes + marker attributes):
+        // - Attribute values are taken from non-special properties of `marker`.
+        const markerAttrs = omit(marker, 'type', 'id', 'markup', 'attrs', 'markerUnits');
+        const markerAttrsKeys = Object.keys(markerAttrs);
+        markerAttrsKeys.forEach((key) => {
+            const value = markerAttrs[key];
+            const markupValue = markerContentVEl.attr(key); // value coming from markupVEl (if any) = higher priority
+            if (markupValue == null) {
+                // Default logic:
+                markerContentVEl.attr(key, value);
+            } else {
+                // Properties with special logic should be added as cases to this switch block:
+                switch(key) {
+                    case 'transform':
+                        // - Prepend `transform` to existing value.
+                        markerContentVEl.attr(key, (value + ' ' + markupValue));
+                        break;
                 }
-            });
+            }
         });
+        markerContentVEl.appendTo(markerVEl);
         markerVEl.appendTo(defs);
         return id;
     }

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2856,7 +2856,7 @@ export const Paper = View.extend({
                 markupVEl = V(markup);
                 // `markupVEl` is now either a single VEl, or an array of VEls.
                 // - Coerce it to an array.
-                markupVEl = (Array.isArray(markupVEl) ? markupVEl : [markupVEl])
+                markupVEl = (Array.isArray(markupVEl) ? markupVEl : [markupVEl]);
             } else {
                 // Marker object has a `markup` property of type object.
                 // - Construct V from the object by parsing it as DOM JSON.

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -732,8 +732,8 @@ QUnit.module('Attributes', function() {
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
                 var markerChildren = V(markerNode).children();
-                assert.equal(markerChildren[0].attr('transform'), 'rotate(90) rotate(180)');
-                assert.equal(markerChildren[1].attr('transform'), 'scale(2) rotate(180)');
+                assert.equal(markerChildren[0].attr('transform'), 'rotate(180) rotate(90)');
+                assert.equal(markerChildren[1].attr('transform'), 'rotate(180) scale(2)');
             });
 
             QUnit.test('vertexMarker - with type and id', function(assert) {

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -541,6 +541,84 @@ QUnit.module('Attributes', function() {
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
             });
 
+            QUnit.test('sourceMarker - json markup', function(assert) {
+
+                cell.attr('body/sourceMarker', {
+                    markup: [{
+                        tagName: 'circle',
+                        attributes: {
+                            'r': 10,
+                            'test-content-attribute': true
+                        }
+                    }],
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-start');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+            });
+
+            QUnit.test('targetMarker - string markup', function(assert) {
+
+                cell.attr('body/targetMarker', {
+                    markup: '<circle cx="6" cy="0" r="10" test-content-attribute="true" />',
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-end');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                V(markerNode).children().forEach((child) => {
+                    assert.equal(child.attr('transform'), 'rotate(180)');
+                });
+            });
+
+            QUnit.test('targetMarker - string markup - two sibling elements', function(assert) {
+
+                cell.attr('body/targetMarker', {
+                    markup: '<circle cx="6" cy="0" r="10" test-content-attribute="true" /><circle cx="6" cy="0" r="10" test-content-attribute="true" />',
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-end');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                V(markerNode).children().forEach((child) => {
+                    assert.equal(child.attr('transform'), 'rotate(180)');
+                });
+            });
+
             QUnit.test('targetMarker - json markup', function(assert) {
 
                 cell.attr('body/targetMarker', {
@@ -569,8 +647,94 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                V(markerNode).children().forEach((child) => {
+                    assert.equal(child.attr('transform'), 'rotate(180)');
+                });
             });
 
+            QUnit.test('targetMarker - json markup - two sibling elements', function(assert) {
+
+                cell.attr('body/targetMarker', {
+                    markup: [{
+                        tagName: 'circle',
+                        attributes: {
+                            'cx': 6,
+                            'cy': 0,
+                            'r': 10,
+                            'test-content-attribute': true
+                        }
+                    }, {
+                        tagName: 'circle',
+                        attributes: {
+                            'cx': 6,
+                            'cy': 0,
+                            'r': 10,
+                            'test-content-attribute': true
+                        }
+                    }],
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-end');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                V(markerNode).children().forEach((child) => {
+                    assert.equal(child.attr('transform'), 'rotate(180)');
+                });
+            });
+
+            QUnit.test('targetMarker - combining manual transform value with automatic transform value', function(assert) {
+
+                cell.attr('body/targetMarker', {
+                    markup: [{
+                        tagName: 'circle',
+                        attributes: {
+                            'cx': 6,
+                            'cy': 0,
+                            'r': 10,
+                            'test-content-attribute': true,
+                            'transform': 'rotate(90)'
+                        }
+                    }, {
+                        tagName: 'circle',
+                        attributes: {
+                            'cx': 6,
+                            'cy': 0,
+                            'r': 10,
+                            'test-content-attribute': true,
+                            'transform': 'scale(2)'
+                        }
+                    }],
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-end');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                var markerChildren = V(markerNode).children();
+                assert.equal(markerChildren[0].attr('transform'), 'rotate(90) rotate(180)');
+                assert.equal(markerChildren[1].attr('transform'), 'scale(2) rotate(180)');
+            });
 
             QUnit.test('vertexMarker - with type and id', function(assert) {
 

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -539,6 +539,11 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                // structure: marker node -> circle
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                assert.equal(markerNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerNodeChildren[0].attr('transform'), undefined);
             });
 
             QUnit.test('sourceMarker - json markup', function(assert) {
@@ -567,6 +572,11 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                // structure: marker node -> circle
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                assert.equal(markerNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerNodeChildren[0].attr('transform'), undefined);
             });
 
             QUnit.test('targetMarker - string markup', function(assert) {
@@ -589,9 +599,11 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
-                V(markerNode).children().forEach((child) => {
-                    assert.equal(child.attr('transform'), 'rotate(180)');
-                });
+                // structure: marker node -> circle (auto-rotate)
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                assert.equal(markerNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerNodeChildren[0].attr('transform'), 'rotate(180)');
             });
 
             QUnit.test('targetMarker - string markup - two sibling elements', function(assert) {
@@ -614,9 +626,18 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
-                V(markerNode).children().forEach((child) => {
-                    assert.equal(child.attr('transform'), 'rotate(180)');
-                });
+                // structure: marker node -> g (auto-rotate) -> circle + circle
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                var markerContentNode = markerNodeChildren[0];
+                assert.equal(markerContentNode.tagName(), 'G');
+                assert.equal(markerContentNode.attr('transform'), 'rotate(180)');
+                var markerContentNodeChildren = V(markerContentNode).children();
+                assert.equal(markerContentNodeChildren.length, 2);
+                assert.equal(markerContentNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[0].attr('transform'), undefined);
+                assert.equal(markerContentNodeChildren[1].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[1].attr('transform'), undefined);
             });
 
             QUnit.test('targetMarker - json markup', function(assert) {
@@ -647,9 +668,11 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
-                V(markerNode).children().forEach((child) => {
-                    assert.equal(child.attr('transform'), 'rotate(180)');
-                });
+                // structure: marker node -> circle (auto-rotate)
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                assert.equal(markerNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerNodeChildren[0].attr('transform'), 'rotate(180)');
             });
 
             QUnit.test('targetMarker - json markup - two sibling elements', function(assert) {
@@ -688,12 +711,57 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
-                V(markerNode).children().forEach((child) => {
-                    assert.equal(child.attr('transform'), 'rotate(180)');
-                });
+                // structure: marker node -> g (auto-rotate) -> circle + circle
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                var markerContentNode = markerNodeChildren[0];
+                assert.equal(markerContentNode.tagName(), 'G');
+                assert.equal(markerContentNode.attr('transform'), 'rotate(180)');
+                var markerContentNodeChildren = V(markerContentNode).children();
+                assert.equal(markerContentNodeChildren.length, 2);
+                assert.equal(markerContentNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[0].attr('transform'), undefined);
+                assert.equal(markerContentNodeChildren[1].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[1].attr('transform'), undefined);
             });
 
-            QUnit.test('targetMarker - combining manual transform value with automatic transform value', function(assert) {
+            QUnit.test('targetMarker - combining manual transform value with auto-rotate', function(assert) {
+
+                cell.attr('body/targetMarker', {
+                    markup: [{
+                        tagName: 'circle',
+                        attributes: {
+                            'cx': 6,
+                            'cy': 0,
+                            'r': 10,
+                            'test-content-attribute': true,
+                            'transform': 'translate(10,10) rotate(90) scale(2)'
+                        }
+                    }],
+                    attrs: {
+                        'test-attribute': true
+                    }
+                });
+
+                var bodyNode = cellView.findBySelector('body')[0];
+                var markerAttribute = bodyNode.getAttribute('marker-end');
+                var match = idRegex.exec(markerAttribute);
+                assert.ok(match);
+                var id = match[1];
+                assert.ok(paper.el.querySelector('[test-attribute="true"]'));
+                assert.ok(paper.isDefined(id));
+                var markerNode = paper.svg.getElementById(id);
+                assert.equal(V(markerNode).tagName(), 'MARKER');
+                assert.equal(markerNode.getAttribute('test-attribute'), 'true');
+                assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
+                // structure: marker node -> circle (auto-rotate . manual transform)
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                assert.equal(markerNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerNodeChildren[0].attr('transform'), 'rotate(180) translate(10,10) rotate(90) scale(2)');
+            });
+
+            QUnit.test('targetMarker - combining manual transform value with auto-rotate - two sibling elements', function(assert) {
 
                 cell.attr('body/targetMarker', {
                     markup: [{
@@ -731,9 +799,18 @@ QUnit.module('Attributes', function() {
                 assert.equal(V(markerNode).tagName(), 'MARKER');
                 assert.equal(markerNode.getAttribute('test-attribute'), 'true');
                 assert.ok(markerNode.querySelector('[test-content-attribute="true"]'));
-                var markerChildren = V(markerNode).children();
-                assert.equal(markerChildren[0].attr('transform'), 'rotate(180) rotate(90)');
-                assert.equal(markerChildren[1].attr('transform'), 'rotate(180) scale(2)');
+                // structure: marker node -> g (auto-rotate) -> circle (manual rotate) + circle (manual scale)
+                var markerNodeChildren = V(markerNode).children();
+                assert.equal(markerNodeChildren.length, 1);
+                var markerContentNode = markerNodeChildren[0];
+                assert.equal(markerContentNode.tagName(), 'G');
+                assert.equal(markerContentNode.attr('transform'), 'rotate(180)');
+                var markerContentNodeChildren = V(markerContentNode).children();
+                assert.equal(markerContentNodeChildren.length, 2);
+                assert.equal(markerContentNodeChildren[0].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[0].attr('transform'), 'rotate(90)');
+                assert.equal(markerContentNodeChildren[1].tagName(), 'CIRCLE');
+                assert.equal(markerContentNodeChildren[1].attr('transform'), 'scale(2)');
             });
 
             QUnit.test('vertexMarker - with type and id', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -109,7 +109,6 @@ export namespace dia {
         id?: string;
         markup: string | MarkupJSON;
         attrs?: attributes.NativeSVGAttributes;
-        transform?: string;
     }
 
     interface SVGSimpleMarkerJSON extends attributes.NativeSVGAttributes {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -109,6 +109,7 @@ export namespace dia {
         id?: string;
         markup: string | MarkupJSON;
         attrs?: attributes.NativeSVGAttributes;
+        transform?: string;
     }
 
     interface SVGSimpleMarkerJSON extends attributes.NativeSVGAttributes {


### PR DESCRIPTION
## Description

This PR fixes a bug in which target markers do not get rotated by 180 degrees when defined via `marker.markup`.

## Motivation and Context

The expected behavior is that the two ways to define markers (via `marker.type` + attributes as children of `_marker`, and via `marker.markup`) would produce the same results. That is already the case for `sourceMarker` and `vertexMarker` - but `targetMarker` is handled via extra logic which adds a `transform: rotate(180)` attribute to whatever marker definition is provided.

Due to the way markers were previously being processed in the `dia.Paper.defineMarker()` function, that added transformation attribute was not taken into account in the `marker.markup` case. This PR fixes that inconsistency.