### PR TITLE
dia.Paper.scaleContentToFit: adding alignment options

### DIFF
--- a/demo/paper/index.html
+++ b/demo/paper/index.html
@@ -42,8 +42,8 @@
             </div>
             <div class="form-group">
               <label for="width" title="Width of the paper in pixels">Width</label>
-              <input id="width" class="form-control" type="range" value="650" min="100" max="1200" autocomplete="off"/>
-              <output for="width">650</output>
+              <input id="width" class="form-control" type="range" value="600" min="100" max="1200" autocomplete="off"/>
+              <output for="width">600</output>
             </div>
             <div class="form-group">
               <label for="height" title="Height of the paper in pixels">Height</label>
@@ -52,8 +52,8 @@
             </div>
             <div class="form-group">
               <label for="grid" title="Size of the grid in pixels">Grid size</label>
-              <input id="grid" class="range" type="range" value="1" min="1" max="50" autocomplete="off"/>
-              <output for="grid">1</output>
+              <input id="grid" class="range" type="range" value="10" min="1" max="50" autocomplete="off"/>
+              <output for="grid">10</output>
             </div>
           </div>
         </div>
@@ -141,8 +141,8 @@
           </div>
           <div class="form-group">
             <label for="stf-max-scale" title="Set the maximum allowed scale factor">Max scale</label>
-            <input id="stf-max-scale" class="range" type="range" value="3.0" step="0.1" min="1" max="3" autocomplete="off"/>
-            <output for="stf-max-scale">3.0</output>
+            <input id="stf-max-scale" class="range" type="range" value="1.0" step="0.1" min="1" max="3" autocomplete="off"/>
+            <output for="stf-max-scale">1.0</output>
           </div>
           <div class="form-group">
             <label for="stf-scale-grid" title="Set the rounding factor for the resulting scale">Scale grid</label>
@@ -154,6 +154,23 @@
               <input id="stf-ratio" type="checkbox" checked autocomplete="off"/>Preserve aspect ratio
             </label>
           </div>
+          <div class="form-group">
+            <label for="stf-vertical-align">Vertical align</label>
+            <select id="stf-vertical-align">
+              <option value="top">top</option>
+              <option value="middle" selected>middle</option>
+              <option value="bottom">bottom</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="stf-horizontal-align">Horizontal align</label>
+            <select id="stf-horizontal-align">
+              <option value="left">left</option>
+              <option value="middle" selected>middle</option>
+              <option value="right">right</option>
+            </select>
+          </div>
+          <button id="stf-scale-to-fit"> Scale to fit</button>
         </div>
       </div>
 

--- a/demo/paper/index.html
+++ b/demo/paper/index.html
@@ -127,7 +127,7 @@
       </div>
 
       <div id="scale-to-fit" class="panel panel-primary">
-        <div class="panel-heading"><a href="http://resources.jointjs.com/docs/jointjs/#dia.Paper.prototype.scaleContentToFit" target="_top">Scale content to fit</a></div>
+        <div class="panel-heading"><a href="http://resources.jointjs.com/docs/jointjs/#dia.Paper.prototype.transformToFitContent" target="_top">Transform to fit content.</a></div>
         <div class="panel-body">
           <div class="form-group">
             <label for="stf-padding" title="Add an additional padding in the resulting, scaled, paper content">Padding</label>
@@ -170,7 +170,7 @@
               <option value="right">right</option>
             </select>
           </div>
-          <button id="stf-scale-to-fit"> Scale to fit</button>
+          <button id="stf-scale-to-fit">Transform to fit</button>
         </div>
       </div>
 

--- a/demo/paper/src/paper.js
+++ b/demo/paper/src/paper.js
@@ -147,6 +147,8 @@ var $stfMinScale = $('#stf-min-scale');
 var $stfMaxScale = $('#stf-max-scale');
 var $stfScaleGrid = $('#stf-scale-grid');
 var $stfRatio = $('#stf-ratio');
+var $stfVerticalAlign = $('#stf-vertical-align');
+var $stfHorizontalAlign = $('#stf-horizontal-align');
 var $bboxX = $('#bbox-x');
 var $bboxY = $('#bbox-y');
 var $bboxW = $('#bbox-width');
@@ -296,7 +298,9 @@ function scaleToFit() {
         minScale: parseFloat($stfMinScale.val()),
         maxScale: parseFloat($stfMaxScale.val()),
         scaleGrid: parseFloat($stfScaleGrid.val()),
-        preserveAspectRatio: $stfRatio.is(':checked')
+        preserveAspectRatio: $stfRatio.is(':checked'),
+        verticalAlign: $stfVerticalAlign.val(),
+        horizontalAlign: $stfHorizontalAlign.val(),
     });
 
     paper.viewport.getBoundingClientRect(); // MS Edge hack to fix the invisible text.
@@ -341,7 +345,8 @@ function updateBBox() {
 /* events */
 
 $('#fit-to-content input, #fit-to-content select').on('input change', fitToContent);
-$('#scale-to-fit input').on('input change', scaleToFit);
+$('#scale-to-fit').on('change', scaleToFit);
+$('#stf-scale-to-fit').on('click', scaleToFit);
 
 $ox.on('input change', function() {
     paper.setOrigin(parseInt(this.value, 10), parseInt($oy.val(), 10));
@@ -402,7 +407,9 @@ paper.on({
 
 graph.on('change', function() {
     svgContainer.hideAll();
-    updateBBox();
+    setTimeout(() => {
+        updateBBox();
+    }, 0);
 });
 
 updateBBox();

--- a/demo/paper/src/paper.js
+++ b/demo/paper/src/paper.js
@@ -287,13 +287,13 @@ function fitToContent() {
     svgContainer.showAll();
 }
 
-function scaleToFit() {
+function transformToFitContent() {
 
     svgContainer.removeAll();
 
     var padding = parseInt($stfPadding.val(), 10);
 
-    paper.scaleContentToFit({
+    paper.transformToFitContent({
         padding: padding,
         minScale: parseFloat($stfMinScale.val()),
         maxScale: parseFloat($stfMaxScale.val()),
@@ -345,8 +345,8 @@ function updateBBox() {
 /* events */
 
 $('#fit-to-content input, #fit-to-content select').on('input change', fitToContent);
-$('#scale-to-fit').on('change', scaleToFit);
-$('#stf-scale-to-fit').on('click', scaleToFit);
+$('#scale-to-fit').on('change', transformToFitContent);
+$('#stf-scale-to-fit').on('click', transformToFitContent);
 
 $ox.on('input change', function() {
     paper.setOrigin(parseInt(this.value, 10), parseInt($oy.val(), 10));

--- a/docs/src/joint/api/dia/Paper/prototype/scaleContentToFit.html
+++ b/docs/src/joint/api/dia/Paper/prototype/scaleContentToFit.html
@@ -1,16 +1,4 @@
 <pre class="docs-method-signature"><code>paper.scaleContentToFit([opt])</code></pre>
 <p>Scale the paper content so that it fits the paper dimensions.</p>
 
-<p>The function accepts an object with additional settings (all optional):</p>
-
-<ul>
-  <li><code>opt.padding</code> – a number or an object of the form <code>{ top?: [number], right?: [number], bottom?: [number], left?: [number], vertical?: [number], horizontal?: [number] }</code> that specifies the width of additional padding that should be added around the resulting (scaled) paper content. Default is <code>0</code>.</li>
-  <li><code>opt.preserveAspectRatio</code> – should the original aspect ratio of the paper content be preserved in the scaled version? Default is <code>true</code>.</li>
-  <li><code>opt.minScaleX</code>, <code>opt.minScaleY</code>, <code>opt.maxScaleX</code>, <code>opt.maxScaleY</code> – the minimum and maximum allowed scale factors for both axes.</li>
-  <li><code>opt.scaleGrid</code> – a number to be used as a rounding factor for the resulting scale. For example, if you pass <code>0.2</code> to this option and the scale factor is calculated as <code>1.15</code>, then the resulting scale factor will be rounded to <code>1.2</code>.</li>
-  <li><code>opt.useModelGeometry</code> – should paper content bounding box be calculated from cell models instead of views? Default is <code>false</code>. See the documentation of the <code>paper.getContentBBox</code> <a href="#dia.Paper.prototype.getContentBBox">function</a> for more details.</li>
-  <li><code>opt.fittingBBox</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area of the paper that the content should be scaled to. By default <code>opt.fittingBBox</code> is <code>{ x: 0, y: 0, width: paper.options.width, height: paper.options.height }</code>, i.e. the bounding box of the paper in the paper coordinate system.</li>
-  <li><code>opt.contentArea</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area representing the content in local coordinate system that should be scaled to fit the <code>opt.fittingBBox</code>. By default <code>opt.contentArea</code> is <code>paper.getContentArea(opt)</code>.</li>
-</ul>
-
-<p>The function is illustrated in our <a href="https://www.jointjs.com/demos/paper-attributes">paper demo</a>.</p>
+<p><i>Deprecated</i> alias of the <a href="#dia.Paper.prototype.transformToFitContent">transformToFitContent</a>.</p>

--- a/docs/src/joint/api/dia/Paper/prototype/transformToFitContent.html
+++ b/docs/src/joint/api/dia/Paper/prototype/transformToFitContent.html
@@ -1,0 +1,18 @@
+<pre class="docs-method-signature"><code>paper.transformToFitContent([opt])</code></pre>
+<p>Transforms the paper so that it fits the content.</p>
+
+<p>The function accepts an object with additional settings (all optional):</p>
+
+<ul>
+  <li><code>opt.padding</code> – a number or an object of the form <code>{ top?: [number], right?: [number], bottom?: [number], left?: [number], vertical?: [number], horizontal?: [number] }</code> that specifies the width of additional padding that should be added around the resulting (scaled) paper content. Default is <code>0</code>.</li>
+  <li><code>opt.preserveAspectRatio</code> – should the original aspect ratio of the paper content be preserved in the scaled version? Default is <code>true</code>.</li>
+  <li><code>opt.minScaleX</code>, <code>opt.minScaleY</code>, <code>opt.maxScaleX</code>, <code>opt.maxScaleY</code> – the minimum and maximum allowed scale factors for both axes.</li>
+  <li><code>opt.scaleGrid</code> – a number to be used as a rounding factor for the resulting scale. For example, if you pass <code>0.2</code> to this option and the scale factor is calculated as <code>1.15</code>, then the resulting scale factor will be rounded to <code>1.2</code>.</li>
+  <li><code>opt.useModelGeometry</code> – should paper content bounding box be calculated from cell models instead of views? Default is <code>false</code>. See the documentation of the <code>paper.getContentBBox</code> <a href="#dia.Paper.prototype.getContentBBox">function</a> for more details.</li>
+  <li><code>opt.fittingBBox</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area of the paper that the content should be scaled to. By default <code>opt.fittingBBox</code> is <code>{ x: 0, y: 0, width: paper.options.width, height: paper.options.height }</code>, i.e. the bounding box of the paper in the paper coordinate system.</li>
+  <li><code>opt.contentArea</code> – an object of the form <code>{ x: [number], y: [number], width: [number], height: [number] }</code> is the area representing the content in local coordinate system that should be scaled to fit the <code>opt.fittingBBox</code>. By default <code>opt.contentArea</code> is <code>paper.getContentArea(opt)</code>.</li>
+  <li><code>opt.verticalAlign</code> – a string which specifies how the content shold be vertically aligned in the transformed paper. The options are <code>'top'</code>, <code>'middle'</code> and <code>'bottom'</code>. By default the <code>opt.verticalAlign</code> is <code>'top'</code>.</li>
+  <li><code>opt.horizontalAlign</code> – a string which specifies how the content shold be horizontally aligned in the transformed paper. The options are <code>'left'</code>, <code>'middle'</code> and <code>'right'</code>. By default the <code>opt.horizontalAlign</code> is <code>'left'</code>.</li>
+</ul>
+
+<p>The function is illustrated in our <a href="https://www.jointjs.com/demos/paper-attributes">paper demo</a>.</p>

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1306,9 +1306,9 @@ export const Paper = View.extend({
 
         opt || (opt = {});
 
-        var contentBBox, contentLocalOrigin;
+        let contentBBox, contentLocalOrigin;
         if ('contentArea' in opt) {
-            var contentArea = opt.contentArea;
+            const contentArea = opt.contentArea;
             contentBBox = this.localToPaperRect(contentArea);
             contentLocalOrigin = new Point(contentArea);
         } else {
@@ -1323,7 +1323,9 @@ export const Paper = View.extend({
             preserveAspectRatio: true,
             scaleGrid: null,
             minScale: 0,
-            maxScale: Number.MAX_VALUE
+            maxScale: Number.MAX_VALUE,
+            verticalAlign: 'top',
+            horizontalAlign: 'left',
             //minScaleX
             //minScaleY
             //maxScaleX
@@ -1331,19 +1333,21 @@ export const Paper = View.extend({
             //fittingBBox
         });
 
-        var padding = normalizeSides(opt.padding);
+        console.log(opt);
 
-        var minScaleX = opt.minScaleX || opt.minScale;
-        var maxScaleX = opt.maxScaleX || opt.maxScale;
-        var minScaleY = opt.minScaleY || opt.minScale;
-        var maxScaleY = opt.maxScaleY || opt.maxScale;
+        const padding = normalizeSides(opt.padding);
 
-        var fittingBBox;
+        const minScaleX = opt.minScaleX || opt.minScale;
+        const maxScaleX = opt.maxScaleX || opt.maxScale;
+        const minScaleY = opt.minScaleY || opt.minScale;
+        const maxScaleY = opt.maxScaleY || opt.maxScale;
+
+        let fittingBBox;
         if (opt.fittingBBox) {
             fittingBBox = opt.fittingBBox;
         } else {
-            var currentTranslate = this.translate();
-            var computedSize = this.getComputedSize();
+            const currentTranslate = this.translate();
+            const computedSize = this.getComputedSize();
             fittingBBox = {
                 x: currentTranslate.tx,
                 y: currentTranslate.ty,
@@ -1359,10 +1363,10 @@ export const Paper = View.extend({
             height: -padding.top - padding.bottom
         });
 
-        var currentScale = this.scale();
+        const currentScale = this.scale();
 
-        var newSx = fittingBBox.width / contentBBox.width * currentScale.sx;
-        var newSy = fittingBBox.height / contentBBox.height * currentScale.sy;
+        let newSx = fittingBBox.width / contentBBox.width * currentScale.sx;
+        let newSy = fittingBBox.height / contentBBox.height * currentScale.sy;
 
         if (opt.preserveAspectRatio) {
             newSx = newSy = Math.min(newSx, newSy);
@@ -1371,7 +1375,7 @@ export const Paper = View.extend({
         // snap scale to a grid
         if (opt.scaleGrid) {
 
-            var gridSize = opt.scaleGrid;
+            const gridSize = opt.scaleGrid;
 
             newSx = gridSize * Math.floor(newSx / gridSize);
             newSy = gridSize * Math.floor(newSy / gridSize);
@@ -1381,9 +1385,42 @@ export const Paper = View.extend({
         newSx = Math.min(maxScaleX, Math.max(minScaleX, newSx));
         newSy = Math.min(maxScaleY, Math.max(minScaleY, newSy));
 
-        var origin = this.options.origin;
-        var newOx = fittingBBox.x - contentLocalOrigin.x * newSx - origin.x;
-        var newOy = fittingBBox.y - contentLocalOrigin.y * newSy - origin.y;
+        const origin = this.options.origin;
+        let newOx = fittingBBox.x - contentLocalOrigin.x * newSx - origin.x;
+        let newOy = fittingBBox.y - contentLocalOrigin.y * newSy - origin.y;
+
+        console.log(fittingBBox);
+        console.log(newSx);
+        console.log(newSy);
+        console.log(newOx);
+        console.log(newOy);
+
+        switch (opt.verticalAlign) {
+            case 'middle':
+                newOy = newOy + (fittingBBox.height / 2 - contentBBox.height / 2) * newSy;
+                break;
+            case 'bottom':
+                newOy = newOy + (fittingBBox.height - contentBBox.height) * newSy;
+                break;
+            case 'top':
+            default:
+                break;
+        }
+
+        switch (opt.horizontalAlign) {
+            case 'middle':
+                newOx = newOx + (fittingBBox.width / 2 - contentBBox.width / 2) * newSx;
+                break;
+            case 'right':
+                newOx = newOx + (fittingBBox.width - contentBBox.width) * newSx;
+                break;
+            case 'left':
+            default:
+                break;
+        }
+
+        console.log(newOx);
+        console.log(newOy);
 
         this.scale(newSx, newSy);
         this.translate(newOx, newOy);

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -1302,8 +1302,7 @@ export const Paper = View.extend({
         return new Rect(-tx / sx, -ty / sy, calcWidth / sx, calcHeight / sy);
     },
 
-    scaleContentToFit: function(opt) {
-
+    transformToFitContent: function(opt) {
         opt || (opt = {});
 
         let contentBBox, contentLocalOrigin;
@@ -1332,8 +1331,6 @@ export const Paper = View.extend({
             //maxScaleY
             //fittingBBox
         });
-
-        console.log(opt);
 
         const padding = normalizeSides(opt.padding);
 
@@ -1385,22 +1382,21 @@ export const Paper = View.extend({
         newSx = Math.min(maxScaleX, Math.max(minScaleX, newSx));
         newSy = Math.min(maxScaleY, Math.max(minScaleY, newSy));
 
+        const scaleDiff = {
+            x: newSx / currentScale.sx,
+            y: newSy / currentScale.sy
+        };
+
         const origin = this.options.origin;
         let newOx = fittingBBox.x - contentLocalOrigin.x * newSx - origin.x;
         let newOy = fittingBBox.y - contentLocalOrigin.y * newSy - origin.y;
 
-        console.log(fittingBBox);
-        console.log(newSx);
-        console.log(newSy);
-        console.log(newOx);
-        console.log(newOy);
-
         switch (opt.verticalAlign) {
             case 'middle':
-                newOy = newOy + (fittingBBox.height / 2 - contentBBox.height / 2) * newSy;
+                newOy = newOy + (fittingBBox.height - contentBBox.height * scaleDiff.y) / 2;
                 break;
             case 'bottom':
-                newOy = newOy + (fittingBBox.height - contentBBox.height) * newSy;
+                newOy = newOy + (fittingBBox.height - contentBBox.height * scaleDiff.y);
                 break;
             case 'top':
             default:
@@ -1409,21 +1405,22 @@ export const Paper = View.extend({
 
         switch (opt.horizontalAlign) {
             case 'middle':
-                newOx = newOx + (fittingBBox.width / 2 - contentBBox.width / 2) * newSx;
+                newOx = newOx + (fittingBBox.width - contentBBox.width * scaleDiff.x) / 2;
                 break;
             case 'right':
-                newOx = newOx + (fittingBBox.width - contentBBox.width) * newSx;
+                newOx = newOx + (fittingBBox.width - contentBBox.width * scaleDiff.x);
                 break;
             case 'left':
             default:
                 break;
         }
 
-        console.log(newOx);
-        console.log(newOy);
-
         this.scale(newSx, newSy);
         this.translate(newOx, newOy);
+    },
+
+    scaleContentToFit: function(opt) {
+        this.transformToFitContent(opt);
     },
 
     // Return the dimensions of the content area in local units (without transformations).

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -95,6 +95,294 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         });
     });
 
+    QUnit.module('transformToFitContent', function() {
+
+        hooks.beforeEach(function() {
+            const testGraph = new joint.dia.Graph();
+            testGraph.addCells([
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 75,
+                        'y': 175
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': 'a43d5761-c4d3-474d-b765-f4f899a61480',
+                    'attrs': {
+                        'body': {
+                            'd': 'M 0 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) 0 calc(h) Z'
+                        },
+                        'label': {
+                            'text': 'joint'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 200,
+                        'y': 275
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': 'b3b4231e-8699-4448-b65f-4c249f2742d7',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'dia'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 200,
+                        'y': 75
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '88d8ef50-9084-4644-9531-98d5f5d666f5',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'util'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 200,
+                        'y': 175
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '47cb7150-39ca-4c24-83f6-f46f5f081637',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'shapes'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 325,
+                        'y': 175
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '8496b157-c0eb-4e57-9bd2-839521e5d08c',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'basic'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 450,
+                        'y': 150
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': 'd9421776-1d2a-413d-bd05-94d76d924fe4',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'Path'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 450,
+                        'y': 200
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': 'e2147caf-b9f3-431a-839e-f0ac79449840',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'Text'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 325,
+                        'y': 250
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '081b2e35-348b-4d92-87d7-232a2ca936fe',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'Paper'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 325,
+                        'y': 300
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': 'ad464767-7004-45ff-825a-c3b093639a1e',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'Graph'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 325,
+                        'y': 100
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '0ceb97d4-dd9e-473c-879d-c1e5f04d7b49',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'getByPath'
+                        }
+                    }
+                },
+                {
+                    'type': 'standard.Path',
+                    'position': {
+                        'x': 325,
+                        'y': 50
+                    },
+                    'size': {
+                        'width': 100,
+                        'height': 40
+                    },
+                    'angle': 0,
+                    'id': '5648dd2a-d6c8-4935-8f9c-e0edcb5f2513',
+                    'attrs': {
+                        'body': {
+                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
+                        },
+                        'label': {
+                            'text': 'setByPath'
+                        }
+                    }
+                }
+            ]);
+
+            paper = new Paper({
+                el: paperEl,
+                model: testGraph,
+                async: false
+            });
+        });
+
+        QUnit.test('transformToFitContent()', function(assert) {
+
+            paper.transformToFitContent();
+
+            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'default transform scale');
+            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: -84.21052631578947 }, 'default transform translate');
+
+            paper.transformToFitContent({
+                verticalAlign: 'middle',
+                horizontalAlign: 'middle'
+            });
+
+            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'middle transform scale');
+            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: -28.421051828484778 }, 'middle transform translate');
+
+            paper.transformToFitContent({
+                verticalAlign: 'bottom',
+                horizontalAlign: 'right'
+            });
+
+            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'bottom right transform scale');
+            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: 27.368437917608972 }, 'bottom right transform translate');
+
+            paper.transformToFitContent({
+                maxScale: 1.3,
+                verticalAlign: 'middle',
+                horizontalAlign: 'middle'
+            });
+
+            assert.deepEqual(paper.scale(), { sx: 1.3, sy: 1.3 }, 'maxScale middle transform scale');
+            assert.deepEqual(paper.translate(), { tx: -6.250000000000071, ty: 46.5000065088272 }, 'maxScale middle transform translate');
+
+            paper.transformToFitContent({
+                padding: 50,
+                verticalAlign: 'middle',
+                horizontalAlign: 'middle'
+            });
+
+            assert.deepEqual(paper.scale(), { sx: 1.473684210526316, sy: 1.473684210526316 }, 'padding middle transform scale');
+            assert.deepEqual(paper.translate(), { tx: -60.5263157894737, ty: 12.631583271721595 }, 'padding middle transform translate');
+        });
+    });
+
     QUnit.module('async = FALSE', function(hooks) {
 
         hooks.beforeEach(function() {

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -114,50 +114,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 {
                     'type': 'standard.Rectangle',
                     'position': {
-                        'x': 200,
-                        'y': 275
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
-                        'x': 200,
-                        'y': 75
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
-                        'x': 200,
-                        'y': 175
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
-                        'x': 325,
-                        'y': 175
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
                         'x': 450,
                         'y': 150
                     },
@@ -181,34 +137,12 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
-                        'y': 250
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
-                        'x': 325,
                         'y': 300
                     },
                     'size': {
                         'width': 100,
                         'height': 40
                     }
-                },
-                {
-                    'type': 'standard.Rectangle',
-                    'position': {
-                        'x': 325,
-                        'y': 100
-                    },
-                    'size': {
-                        'width': 100,
-                        'height': 40
-                    },
                 },
                 {
                     'type': 'standard.Rectangle',

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -101,7 +101,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             const testGraph = new joint.dia.Graph();
             testGraph.addCells([
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 75,
                         'y': 175
@@ -110,19 +110,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         'width': 100,
                         'height': 40
                     },
-                    'angle': 0,
-                    'id': 'a43d5761-c4d3-474d-b765-f4f899a61480',
-                    'attrs': {
-                        'body': {
-                            'd': 'M 0 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) 0 calc(h) Z'
-                        },
-                        'label': {
-                            'text': 'joint'
-                        }
-                    }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 200,
                         'y': 275
@@ -130,20 +120,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': 'b3b4231e-8699-4448-b65f-4c249f2742d7',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'dia'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 200,
                         'y': 75
@@ -151,20 +131,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': '88d8ef50-9084-4644-9531-98d5f5d666f5',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'util'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 200,
                         'y': 175
@@ -172,20 +142,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': '47cb7150-39ca-4c24-83f6-f46f5f081637',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'shapes'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
                         'y': 175
@@ -193,20 +153,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': '8496b157-c0eb-4e57-9bd2-839521e5d08c',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(0.8 * w) calc(h / 2) calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'basic'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 450,
                         'y': 150
@@ -214,20 +164,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': 'd9421776-1d2a-413d-bd05-94d76d924fe4',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'Path'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 450,
                         'y': 200
@@ -235,20 +175,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': 'e2147caf-b9f3-431a-839e-f0ac79449840',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'Text'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
                         'y': 250
@@ -256,20 +186,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': '081b2e35-348b-4d92-87d7-232a2ca936fe',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'Paper'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
                         'y': 300
@@ -277,20 +197,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': 'ad464767-7004-45ff-825a-c3b093639a1e',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'Graph'
-                        }
                     }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
                         'y': 100
@@ -299,19 +209,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         'width': 100,
                         'height': 40
                     },
-                    'angle': 0,
-                    'id': '0ceb97d4-dd9e-473c-879d-c1e5f04d7b49',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'getByPath'
-                        }
-                    }
                 },
                 {
-                    'type': 'standard.Path',
+                    'type': 'standard.Rectangle',
                     'position': {
                         'x': 325,
                         'y': 50
@@ -319,16 +219,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     'size': {
                         'width': 100,
                         'height': 40
-                    },
-                    'angle': 0,
-                    'id': '5648dd2a-d6c8-4935-8f9c-e0edcb5f2513',
-                    'attrs': {
-                        'body': {
-                            'd': 'M calc(0.2 * w) 0 L calc(w) 0 calc(w) calc(h) calc(0.2 * w) calc(h) 0 calc(h / 2) Z'
-                        },
-                        'label': {
-                            'text': 'setByPath'
-                        }
                     }
                 }
             ]);

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -166,26 +166,42 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
         QUnit.test('transformToFitContent()', function(assert) {
 
+            const roundScale = function(scale, precision) {
+                const factorOfTen = Math.pow(10, precision);
+                return {
+                    sx: Math.round(scale.sx * factorOfTen) / factorOfTen,
+                    sy: Math.round(scale.sy * factorOfTen) / factorOfTen
+                };
+            };
+
+            const roundTranslate = function(translate, precision) {
+                const factorOfTen = Math.pow(10, precision);
+                return {
+                    tx: Math.round(translate.tx * factorOfTen) / factorOfTen,
+                    ty: Math.round(translate.ty * factorOfTen) / factorOfTen
+                };
+            };
+
             paper.transformToFitContent();
 
-            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'default transform scale');
-            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: -84.21052631578947 }, 'default transform translate');
+            assert.deepEqual(roundScale(paper.scale(), 4), { sx: 1.6842, sy: 1.6842 }, 'default transform scale');
+            assert.deepEqual(roundTranslate(paper.translate(), 4), { tx: -126.3158, ty: -84.2105 }, 'default transform translate');
 
             paper.transformToFitContent({
                 verticalAlign: 'middle',
                 horizontalAlign: 'middle'
             });
 
-            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'middle transform scale');
-            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: -28.421051828484778 }, 'middle transform translate');
+            assert.deepEqual(roundScale(paper.scale(), 4), { sx: 1.6842, sy: 1.6842 }, 'middle transform scale');
+            assert.deepEqual(roundTranslate(paper.translate(), 4), { tx: -126.3158, ty: -28.4211 }, 'middle transform translate');
 
             paper.transformToFitContent({
                 verticalAlign: 'bottom',
                 horizontalAlign: 'right'
             });
 
-            assert.deepEqual(paper.scale(), { sx: 1.6842105263157894, sy: 1.6842105263157894 }, 'bottom right transform scale');
-            assert.deepEqual(paper.translate(), { tx: -126.3157894736842, ty: 27.368437917608972 }, 'bottom right transform translate');
+            assert.deepEqual(roundScale(paper.scale(), 4), { sx: 1.6842, sy: 1.6842 }, 'bottom right transform scale');
+            assert.deepEqual(roundTranslate(paper.translate(), 4), { tx: -126.3158, ty: 27.3684 }, 'bottom right transform translate');
 
             paper.transformToFitContent({
                 maxScale: 1.3,
@@ -193,8 +209,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 horizontalAlign: 'middle'
             });
 
-            assert.deepEqual(paper.scale(), { sx: 1.3, sy: 1.3 }, 'maxScale middle transform scale');
-            assert.deepEqual(paper.translate(), { tx: -6.250000000000071, ty: 46.5000065088272 }, 'maxScale middle transform translate');
+            assert.deepEqual(roundScale(paper.scale(), 4), { sx: 1.3000, sy: 1.3000 }, 'maxScale middle transform scale');
+            assert.deepEqual(roundTranslate(paper.translate(), 4), { tx: -6.2500, ty: 46.5000 }, 'maxScale middle transform translate');
 
             paper.transformToFitContent({
                 padding: 50,
@@ -202,8 +218,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 horizontalAlign: 'middle'
             });
 
-            assert.deepEqual(paper.scale(), { sx: 1.473684210526316, sy: 1.473684210526316 }, 'padding middle transform scale');
-            assert.deepEqual(paper.translate(), { tx: -60.5263157894737, ty: 12.631583271721595 }, 'padding middle transform translate');
+            assert.deepEqual(roundScale(paper.scale(), 4), { sx: 1.4737, sy: 1.4737 }, 'padding middle transform scale');
+            assert.deepEqual(roundTranslate(paper.translate(), 4), { tx: -60.5263, ty: 12.6316 }, 'padding middle transform translate');
         });
     });
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1313,6 +1313,9 @@ export namespace dia {
             horizontalAlign?: 'left' | 'middle' | 'right';
         }
 
+        /**
+         * @deprecated
+        */
         type ScaleContentOptions = TransformToFitContentOptions;
 
         interface FitToContentOptions {
@@ -1507,6 +1510,9 @@ export namespace dia {
 
         getFitToContentArea(opt?: Paper.FitToContentOptions): g.Rect;
 
+        /**
+         * @deprecated use transformToFitContent
+         */
         scaleContentToFit(opt?: Paper.ScaleContentOptions): void;
 
         transformToFitContent(opt?: Paper.TransformToFitContentOptions): void;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1296,7 +1296,7 @@ export namespace dia {
             overflow?: boolean;
         }
 
-        interface ScaleContentOptions {
+        interface TransformToFitContentOptions {
             padding?: Padding;
             preserveAspectRatio?: boolean;
             minScale?: number;
@@ -1309,7 +1309,11 @@ export namespace dia {
             useModelGeometry?: boolean;
             fittingBBox?: BBox;
             contentArea?: BBox;
+            vertivalAlign?: 'top' | 'middle' | 'bottom';
+            horizontalAlign?: 'left' | 'middle' | 'right';
         }
+
+        type ScaleContentOptions = TransformToFitContentOptions;
 
         interface FitToContentOptions {
             gridWidth?: number;
@@ -1504,6 +1508,8 @@ export namespace dia {
         getFitToContentArea(opt?: Paper.FitToContentOptions): g.Rect;
 
         scaleContentToFit(opt?: Paper.ScaleContentOptions): void;
+
+        transformToFitContent(opt?: Paper.TransformToFitContentOptions): void;
 
         drawBackground(opt?: Paper.BackgroundOptions): this;
 


### PR DESCRIPTION
Added `verticalAlign` and `horizontalAlign` options for `dia.Paper.scaleContentToFit` function.

- opt.verticalAlign – a string which specifies how the content shold be vertically aligned in the transformed paper. The options are `'top'`, `'middle'` and `'bottom'`. By default the `opt.verticalAlign` is `'top'`.

- opt.horizontalAlign – a string which specifies how the content shold be horizontally aligned in the transformed paper. The options are `'left'`, `'middle'` and `'right'`. By default the `>opt.horizontalAlign` is `'left'`.

Also `dia.Paper.scaleContentToFit` is now deprecated in favor of an alias `dia.Paper.transformToFitContent` which shows what is actually happening inside the function. For example the demo [https://www.jointjs.com/demos/paper-attributes](url) shows changes in the paper attributes and now this function directly says that it changes the paper and not the content.
