### PR TITLE
feat(dia.Paper): events handling improvements

### DIFF
--- a/demo/roi/css/roi.css
+++ b/demo/roi/css/roi.css
@@ -1,0 +1,50 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #f0f0f0;
+}
+
+#paper {
+    position: absolute;
+    inset: 0 0 0 0;
+}
+
+input:invalid {
+    background-color: ivory;
+    border: 2px solid lightgray;
+    outline: 2px solid red;
+}
+
+* {
+    font-family: sans-serif;
+}
+
+.jj-form {
+    font-size: 14px;
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    text-align: center;
+    margin: 0px;
+    padding: 10px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: start;
+    touch-action: none;
+}
+
+.jj-field {
+     display: flex;
+     flex-direction: row;
+     align-items: center;
+     justify-content: space-between;
+     width: 100%;
+     padding: 5px 0;
+}
+
+.jj-input {
+    width: 100%;
+    text-align:right;
+}

--- a/demo/roi/css/roi.css
+++ b/demo/roi/css/roi.css
@@ -1,12 +1,18 @@
+
+* {
+    font-family: sans-serif;
+}
+
 body {
     margin: 0;
     padding: 0;
     background-color: #f0f0f0;
 }
 
-#paper {
-    position: absolute;
-    inset: 0 0 0 0;
+fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
 }
 
 input:invalid {
@@ -15,36 +21,68 @@ input:invalid {
     outline: 2px solid red;
 }
 
-* {
-    font-family: sans-serif;
+#paper {
+    position: absolute;
+    inset: 0 0 0 0;
 }
 
 .jj-form {
-    font-size: 14px;
-    width: 100%;
-    height: 100%;
     position: fixed;
+    font-size: 14px;
     text-align: center;
-    margin: 0px;
+    touch-action: none;
     padding: 10px;
-    box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: start;
-    touch-action: none;
+    box-sizing: border-box;
+    height: 100%;
 }
 
-.jj-field {
-     display: flex;
-     flex-direction: row;
-     align-items: center;
-     justify-content: space-between;
-     width: 100%;
-     padding: 5px 0;
+.jj-field-vertical {
+    display: flex;
+    flex-direction: column;
+}
+
+.jj-field-vertical label {
+    margin-top: 15px;
+}
+
+.jj-field-vertical .jj-input {
+    margin-top: 10px;
+}
+
+.jj-field-horizontal label {
+    display: flex;
+    align-items: center;
+    text-align: left;
+}
+
+.jj-field-horizontal label > span:first-child {
+    width: 30%;
+}
+
+.jj-field-horizontal .jj-input {
+    width: 70%;
 }
 
 .jj-input {
+    box-sizing: border-box;
+    text-align: right;
+    margin: 5px 0;
+}
+
+.jj-field-vertical .jj-input {
     width: 100%;
-    text-align:right;
+}
+
+.jj-input-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.jj-input-unit {
+    flex-shrink: 0;
+    padding-left: 5px;
+    text-align: right;
 }

--- a/demo/roi/index.html
+++ b/demo/roi/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf8"/>
+        <title>Risk of Investment</title>
+        <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="./css/roi.css" />
+    </head>
+    <body>
+        <div id="paper"></div>
+        <!-- Dependencies: -->
+        <script src="../../node_modules/jquery/dist/jquery.js"></script>
+        <script src="../../node_modules/lodash/lodash.js"></script>
+        <script src="../../node_modules/backbone/backbone.js"></script>
+        <script src="../../build/joint.js"></script>
+        <script src="./src/roi.js"></script>
+    </body>
+</html>

--- a/demo/roi/src/roi.js
+++ b/demo/roi/src/roi.js
@@ -159,23 +159,30 @@ class Investment extends ForeignObjectElement {
                     xmlns="http://www.w3.org/1999/xhtml"
                 >
                     <h2>Investment</h2>
-                    <p id="test">How much did you invest?</p>
-                    <input @selector="funds" class="jj-input" type="number"/>
-                    <p>What year it was?</p>
-                    <select @selector="year" class="jj-input" type="number">
-                        <option value="2013">2013</option>
-                        <option value="2014">2014</option>
-                        <option value="2015">2015</option>
-                        <option value="2016">2016</option>
-                        <option value="2017">2017</option>
-                        <option value="2018">2018</option>
-                        <option value="2019">2019</option>
-                        <option value="2020">2020</option>
-                        <option value="2021">2021</option>
-                        <option value="2022">2022</option>
-                        <option value="2023">2023</option>
-                    </select>
-
+                    <div class="jj-field-vertical">
+                        <label>
+                            How much did you invest?
+                            <input @selector="funds" class="jj-input" type="number"/>
+                        </label>
+                    </div>
+                    <div class="jj-field-vertical">
+                        <label>
+                            What year it was?
+                            <select @selector="year" class="jj-input" type="number">
+                                <option value="2013">2013</option>
+                                <option value="2014">2014</option>
+                                <option value="2015">2015</option>
+                                <option value="2016">2016</option>
+                                <option value="2017">2017</option>
+                                <option value="2018">2018</option>
+                                <option value="2019">2019</option>
+                                <option value="2020">2020</option>
+                                <option value="2021">2021</option>
+                                <option value="2022">2022</option>
+                                <option value="2023">2023</option>
+                            </select>
+                        </label>
+                    </div>
                 </div>
             </foreignObject>
         `;
@@ -211,17 +218,20 @@ class Product extends ForeignObjectElement {
                     class="jj-form"
                     xmlns="http://www.w3.org/1999/xhtml"
                 >
-                    <p>What percentage did you invest in <b @selector="label"></b>?</p>
-                    <div class="jj-field">
-                        <input @selector="percentage"
-                            class="jj-input"
-                            type="number"
-                            style="width: 100%;"
-                            min="0"
-                            max="100"
-                            step="1"
-                        />
-                        <label style="margin-left: 4px;">%</label>
+                    <div class="jj-field-vertical">
+                        <label>
+                            What percentage did you invest in <strong @selector="label"></strong>?
+                            <span class="jj-input-container">
+                                <input @selector="percentage"
+                                    class="jj-input"
+                                    type="number"
+                                    min="0"
+                                    max="100"
+                                    step="1"
+                                />
+                                <span class="jj-input-unit">%</span>
+                            </span>
+                        </label>
                     </div>
                 </div>
             </foreignObject>
@@ -266,27 +276,33 @@ class ProductPerformance extends ForeignObjectElement {
                     class="jj-form"
                     xmlns="http://www.w3.org/1999/xhtml"
                 >
-                    <b @selector="label"></b>
-                    <div class="jj-field">
-                        <label for="value">Value</label>
-                        <input @selector="value"
-                            class="jj-input"
-                            name="value"
-                            type="number"
-                            readonly="true"
-                            style="width: 100px;"
-                        />
-                    </div>
-                    <div class="jj-field">
-                        <label for="roi">ROI</label>
-                        <input @selector="roi"
-                            class="jj-input"
-                            name="roi"
-                            type="number"
-                            readonly="true"
-                            style="width: 100px;"
-                        />
-                    </div>
+                    <fieldset>
+                        <legend>
+                            <strong @selector="label"></strong>
+                        </legend>
+                        <div class="jj-field-horizontal">
+                            <label>
+                                <span>Value</span>
+                                <input @selector="value"
+                                    class="jj-input"
+                                    name="value"
+                                    type="number"
+                                    readonly="true"
+                                />
+                            </label>
+                        </div>
+                        <div class="jj-field-horizontal">
+                            <label>
+                                <span>ROI</span>
+                                <input @selector="roi"
+                                    class="jj-input"
+                                    name="roi"
+                                    type="number"
+                                    readonly="true"
+                                />
+                            </label>
+                        </div>
+                        </fieldset>
                 </div>
             </foreignObject>
         `;
@@ -321,33 +337,35 @@ class OverallPerformance extends ForeignObjectElement {
             <foreignObject @selector="foreignObject" overflow="hidden">
                 <div @selector="content"
                     class="jj-form"
+                    style="justify-content: space-between"
                     xmlns="http://www.w3.org/1999/xhtml"
-                    style="justify-content: space-between;"
                 >
-                    <p>This is your portfolio now in <b>${currentYear}</b>.</p>
-                    <div style="width: 100%">
-                        <p>Your overall performance of investment is:</p>
-                        <div class="jj-field">
-                            <label for="value">Value</label>
-                            <input @selector="value"
-                                class="jj-input"
-                                name="value"
-                                type="number"
-                                readonly="true"
-                                style="width: 150px;"
-                            />
+                    <p>This is your portfolio now in <strong>${currentYear}</strong>.</p>
+                    <fieldset>
+                        <legend style="margin-bottom:10px">Your overall performance of investment is:</legend>
+                        <div class="jj-field-horizontal">
+                            <label>
+                                <span>Value</span>
+                                <input @selector="value"
+                                    class="jj-input"
+                                    name="value"
+                                    type="number"
+                                    readonly="true"
+                                />
+                            </label>
                         </div>
-                        <div class="jj-field">
-                            <label for="roi">ROI</label>
-                            <input @selector="roi"
-                                class="jj-input"
-                                name="roi"
-                                type="number"
-                                readonly="true"
-                                style="width: 150px;"
-                            />
+                        <div class="jj-field-horizontal">
+                            <label>
+                                <span>ROI</span>
+                                <input @selector="roi"
+                                    class="jj-input"
+                                    name="roi"
+                                    type="number"
+                                    readonly="true"
+                                />
+                            </label>
                         </div>
-                    </div>
+                    </fieldset>
                 </div>
             </foreignObject>
         `;
@@ -585,7 +603,7 @@ const link6 = new Link({
     }
 });
 
-const products  = [gold, bitcoin, sp500];
+const products = [gold, bitcoin, sp500];
 const productPerformances = [goldPerformance, bitcoinPerformance, sp500Performance];
 const links = [link1, link2, link3, link4, link5, link6];
 graph.resetCells([investment, ...products, performance, ...productPerformances, ...links]);
@@ -608,7 +626,7 @@ graph.on('change:attrs', (cell, attrs, { calc, previousValue, propertyValue }) =
         sortedProducts.forEach((product, index) => {
             const percentage = product.getPercentage() + diff;
             product.setPercentage(Math.max(percentage, 0));
-            diff = (percentage < 0) ? percentage: 0;
+            diff = (percentage < 0) ? percentage : 0;
         });
     }
     calculatePerformance();
@@ -634,7 +652,7 @@ function calculateProductValue(product) {
     const productName = product.getName();
     const buyUnitPrice = data[year][productName];
     const sellUnitPrice = data[currentYear][productName];
-    return funds * product.getPercentage() / 100 * (sellUnitPrice / buyUnitPrice) ;
+    return funds * product.getPercentage() / 100 * (sellUnitPrice / buyUnitPrice);
 }
 
 function calculateProductROI(percentage, value) {
@@ -644,4 +662,3 @@ function calculateProductROI(percentage, value) {
 }
 
 calculatePerformance();
-

--- a/demo/roi/src/roi.js
+++ b/demo/roi/src/roi.js
@@ -1,0 +1,655 @@
+const { shapes: defaultShapes, dia, util } = joint;
+
+const MAIN_COLOR = '#D4D9D7';
+const SECONDARY_COLOR = '#EAECEA';
+const BTC_COLOR = '#9C9EC8';
+const GOLD_COLOR = '#F7E3AE';
+const SP500_COLOR = '#FFCCD6';
+
+const currentYear = 2023;
+
+const data = {
+    '2013': {
+        gold: 1685.50,
+        bitcoin: 13.51,
+        sp500: 1480.40
+    },
+    '2014': {
+        gold: 1219.75,
+        bitcoin: 771.40,
+        sp500: 1822.36
+    },
+    '2015': {
+        gold: 1184.25,
+        bitcoin: 314.25,
+        sp500: 2028.18
+    },
+    '2016': {
+        gold: 1060.20,
+        bitcoin: 434.33,
+        sp500: 1918.60
+    },
+    '2017': {
+        gold: 1162.00,
+        bitcoin: 998.33,
+        sp500: 2275.12
+    },
+    '2018': {
+        gold: 1312.80,
+        bitcoin: 13657.20,
+        sp500: 2789.80
+    },
+    '2019': {
+        gold: 1287.20,
+        bitcoin: 3800,
+        sp500: 2607.39
+    },
+    '2020': {
+        gold: 1520.55,
+        bitcoin: 7197.92,
+        sp500: 3278.20
+    },
+    '2021': {
+        gold: 1947.60,
+        bitcoin: 29624.63,
+        sp500: 3793.75
+    },
+    '2022': {
+        gold: 1800.10,
+        bitcoin: 47434.29,
+        sp500: 4573.82
+    },
+    '2023': {
+        gold: 1824.16,
+        bitcoin: 16610.44,
+        sp500: 3960.66
+    }
+};
+
+// TODO: fixed in other PR
+joint.dia.attributes.value = {
+    set: function(value, _, node) {
+        node.value = value;
+    }
+};
+
+const shapes = { ...defaultShapes };
+const graph = new dia.Graph({}, { cellNamespace: shapes });
+const paper = new dia.Paper({
+    el: document.getElementById('paper'),
+    width: '100%',
+    height: '100%',
+    model: graph,
+    async: true,
+    cellViewNamespace: shapes,
+    sorting: dia.Paper.sorting.APPROX,
+    defaultConnector: {
+        name: 'curve'
+    },
+    defaultConnectionPoint: {
+        name: 'anchor',
+    },
+    background: {
+        color: '#f6f4f4',
+    },
+    preventDefaultViewAction: false,
+    interactive: {
+        stopDelegation: false
+    },
+    elementView: dia.ElementView.extend({
+
+        events: {
+            'change input,select': 'onInputChange',
+        },
+
+        onInputChange: function(evt) {
+            const input = evt.target;
+            if (!input.validity.valid) return;
+            const valuePath = input.getAttribute('joint-selector') + '/value';
+            const currentValue = this.model.attr(valuePath);
+            this.model.attr(valuePath, input.value, { previousValue: currentValue, calc: true });
+        }
+    })
+});
+
+// Define various shapes for the demo.
+
+class ForeignObjectElement extends dia.Element {
+
+    defaults() {
+        return {
+            ...super.defaults,
+            attrs: {
+                body: {
+                    rx: 10,
+                    ry: 10,
+                    width: 'calc(w)',
+                    height: 'calc(h)',
+                    stroke: '#333333',
+                    fill: MAIN_COLOR,
+                    strokeWidth: 2
+                },
+                foreignObject: {
+                    width: 'calc(w)',
+                    height: 'calc(h)',
+                }
+            }
+        };
+    }
+}
+
+class Investment extends ForeignObjectElement {
+    defaults() {
+        return {
+            ...super.defaults(),
+            type: 'Investment',
+            size: {
+                width: 140,
+                height: 225
+            },
+        };
+    }
+
+    preinitialize() {
+        this.markup = util.svg/* xml */`
+            <rect @selector="body" />
+            <foreignObject @selector="foreignObject" overflow="hidden">
+                <div @selector="content"
+                    class="jj-form"
+                    xmlns="http://www.w3.org/1999/xhtml"
+                >
+                    <h2>Investment</h2>
+                    <p id="test">How much did you invest?</p>
+                    <input @selector="funds" class="jj-input" type="number"/>
+                    <p>What year it was?</p>
+                    <select @selector="year" class="jj-input" type="number">
+                        <option value="2013">2013</option>
+                        <option value="2014">2014</option>
+                        <option value="2015">2015</option>
+                        <option value="2016">2016</option>
+                        <option value="2017">2017</option>
+                        <option value="2018">2018</option>
+                        <option value="2019">2019</option>
+                        <option value="2020">2020</option>
+                        <option value="2021">2021</option>
+                        <option value="2022">2022</option>
+                        <option value="2023">2023</option>
+                    </select>
+
+                </div>
+            </foreignObject>
+        `;
+    }
+
+    getFunds() {
+        return Number(this.attr('funds/value'));
+    }
+
+    getYear() {
+        return Number(this.attr('year/value'));
+    }
+}
+
+class Product extends ForeignObjectElement {
+
+    defaults() {
+        return {
+            ...super.defaults(),
+            type: 'Product',
+            size: {
+                width: 140,
+                height: 120
+            },
+        };
+    }
+
+    preinitialize() {
+        this.markup = util.svg/* xml */`
+            <rect @selector="body" />
+            <foreignObject @selector="foreignObject" overflow="hidden">
+                <div @selector="content"
+                    class="jj-form"
+                    xmlns="http://www.w3.org/1999/xhtml"
+                >
+                    <p>
+                        <span>What percentage did you invest in</span>
+                        <b @selector="label" style="margin-left: 4px"></b>
+                        <span>?</span>
+                    </p>
+                    <div class="jj-field">
+                        <input @selector="percentage"
+                            class="jj-input"
+                            type="number"
+                            style="width: 100%;"
+                            min="0"
+                            max="100"
+                            step="1"
+                        />
+                        <label style="margin-left: 4px;">%</label>
+                    </div>
+                </div>
+            </foreignObject>
+        `;
+    }
+
+    getPercentage() {
+        return Number(this.attr('percentage/value'));
+    }
+
+    setPercentage(value) {
+        this.attr('percentage/value', value);
+    }
+
+    getValue() {
+        return Number(this.attr('value/value'));
+    }
+
+    getName() {
+        return this.get('name');
+    }
+}
+
+class ProductPerformance extends ForeignObjectElement {
+
+    defaults() {
+        return {
+            ...super.defaults(),
+            type: 'ProductPerformance',
+            size: {
+                width: 200,
+                height: 100
+            },
+        };
+    }
+
+    preinitialize() {
+        this.markup = util.svg/* xml */`
+            <rect @selector="body" />
+            <foreignObject @selector="foreignObject" overflow="hidden">
+                <div @selector="content"
+                    class="jj-form"
+                    xmlns="http://www.w3.org/1999/xhtml"
+                >
+                    <b @selector="label"></b>
+                    <div class="jj-field">
+                        <label for="value">Value</label>
+                        <input @selector="value"
+                            class="jj-input"
+                            name="value"
+                            type="number"
+                            readonly="true"
+                            style="width: 100px;"
+                        />
+                    </div>
+                    <div class="jj-field">
+                        <label for="roi">ROI</label>
+                        <input @selector="roi"
+                            class="jj-input"
+                            name="roi"
+                            type="number"
+                            readonly="true"
+                            style="width: 100px;"
+                        />
+                    </div>
+                </div>
+            </foreignObject>
+        `;
+    }
+
+    setValue(value) {
+        this.attr('value/value', value);
+    }
+
+    getValue() {
+        return Number(this.attr('value/value'));
+    }
+
+    setROI(roi) {
+        this.attr('roi/value', roi);
+    }
+}
+
+
+class OverallPerformance extends ForeignObjectElement {
+
+    defaults() {
+        return {
+            ...super.defaults(),
+            type: 'OverallPerformance',
+        };
+    }
+
+    preinitialize() {
+        this.markup = util.svg/* xml */`
+            <rect @selector="body" />
+            <foreignObject @selector="foreignObject" overflow="hidden">
+                <div @selector="content"
+                    class="jj-form"
+                    xmlns="http://www.w3.org/1999/xhtml"
+                    style="justify-content: space-between;"
+                >
+                    <p>
+                        <span>This is your portfolio now in </span>
+                        <b style="margin-left: 4px;">${currentYear}</b>
+                        <span>.</span>
+                    </p>
+                    <div style="width: 100%">
+                        <p>Your overall performance of investment is:</p>
+                        <div class="jj-field">
+                            <label for="value">Value</label>
+                            <input @selector="value"
+                                class="jj-input"
+                                name="value"
+                                type="number"
+                                readonly="true"
+                                style="width: 150px;"
+                            />
+                        </div>
+                        <div class="jj-field">
+                            <label for="roi">ROI</label>
+                            <input @selector="roi"
+                                class="jj-input"
+                                name="roi"
+                                type="number"
+                                readonly="true"
+                                style="width: 150px;"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+        `;
+    }
+
+    setValue(value) {
+        this.attr('value/value', value);
+    }
+
+    setROI(roi) {
+        this.attr('roi/value', roi);
+    }
+}
+
+class Link extends shapes.standard.DoubleLink {
+
+    defaults() {
+        return util.defaultsDeep({
+            type: 'Link',
+            attrs: {
+                line: {
+                    stroke: '#333333',
+                    targetMarker: {
+                        'stroke-width': 2,
+                    }
+                },
+                outline: {
+                    strokeWidth: 8
+                }
+            }
+        }, super.defaults);
+    }
+}
+
+// Create shapes and populate the graph.
+
+const investment = new Investment({
+    position: { x: 100, y: 280 },
+    z: 1,
+    attrs: {
+        funds: {
+            value: 100,
+            tabindex: 1,
+        },
+        year: {
+            value: 2018,
+            tabindex: 2,
+        }
+    }
+
+});
+
+const gold = new Product({
+    position: { x: 300, y: 100 },
+    name: 'gold',
+    z: 3,
+    attrs: {
+        body: {
+            fill: GOLD_COLOR
+        },
+        label: {
+            html: 'Gold'
+        },
+        percentage: {
+            value: 25,
+            tabindex: 3,
+        }
+    }
+});
+
+const bitcoin = new Product({
+    position: { x: 300, y: 330 },
+    name: 'bitcoin',
+    z: 5,
+    attrs: {
+        body: {
+            fill: BTC_COLOR
+        },
+        label: {
+            html: 'Bitcoin'
+        },
+        percentage: {
+            value: 25,
+            tabindex: 4,
+        }
+    }
+});
+
+const sp500 = new Product({
+    position: { x: 300, y: 560 },
+    name: 'sp500',
+    z: 7,
+    attrs: {
+        body: {
+            fill: SP500_COLOR
+        },
+        label: {
+            html: 'S&P 500'
+        },
+        percentage: {
+            value: 50,
+            tabindex: 5,
+        }
+    }
+});
+
+const goldPerformance = new ProductPerformance({
+    position: { x: 600, y: 200 },
+    z: 0,
+    attrs: {
+        label: {
+            html: 'Gold'
+        },
+        value: {
+            tabindex: 6,
+        },
+        roi: {
+            tabindex: 7,
+        }
+    }
+});
+
+const bitcoinPerformance = new ProductPerformance({
+    position: { x: 600, y: 320 },
+    z: 0,
+    attrs: {
+        label: {
+            html: 'Bitcoin'
+        },
+        value: {
+            tabindex: 8,
+        },
+        roi: {
+            tabindex: 9,
+        }
+    }
+});
+
+const sp500Performance = new ProductPerformance({
+    position: { x: 600, y: 440 },
+    z: 0,
+    attrs: {
+        label: {
+            html: 'S&P 500'
+        },
+        value: {
+            tabindex: 10,
+        },
+        roi: {
+            tabindex: 11,
+        }
+    }
+});
+
+const performance = new OverallPerformance({
+    position: { x: 500, y: 300 },
+    z: -1,
+    attrs: {
+        body: {
+            fill: SECONDARY_COLOR
+        },
+        value: {
+            tabindex: 12,
+        },
+        roi: {
+            tabindex: 13,
+        }
+    }
+});
+
+const link1 = new Link({
+    source: { id: investment.id, anchor: { name: 'top', args: { dy: 1 }}},
+    target: { id: gold.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 2,
+    attrs: {
+        line: {
+            stroke: MAIN_COLOR,
+        }
+    }
+});
+
+const link2 = new Link({
+    source: { id: investment.id, anchor: { name: 'right', args: { dx: -1 }}},
+    target: { id: bitcoin.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 2,
+    attrs: {
+        line: {
+            stroke: MAIN_COLOR,
+        }
+    }
+});
+
+const link3 = new Link({
+    source: { id: investment.id, anchor: { name: 'bottom', args: { dy: -1 }}},
+    target: { id: sp500.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 2,
+    attrs: {
+        line: {
+            stroke: MAIN_COLOR,
+        }
+    }
+});
+
+const link4 = new Link({
+    source: { id: gold.id, anchor: { name: 'right', args: { dx: -1 }}},
+    target: { id: goldPerformance.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 4,
+    attrs: {
+        line: {
+            stroke: GOLD_COLOR,
+        }
+    }
+});
+
+const link5 = new Link({
+    source: { id: bitcoin.id, anchor: { name: 'right', args: { dx: -1 }}},
+    target: { id: bitcoinPerformance.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 5,
+    attrs: {
+        line: {
+            stroke: BTC_COLOR,
+        }
+    }
+
+});
+
+const link6 = new Link({
+    source: { id: sp500.id, anchor: { name: 'right', args: { dx: -1 }}},
+    target: { id: sp500Performance.id, anchor: { name: 'left', args: { dx: -5 }}},
+    z: 7,
+    attrs: {
+        line: {
+            stroke: SP500_COLOR,
+        }
+    }
+});
+
+const products  = [gold, bitcoin, sp500];
+const productPerformances = [goldPerformance, bitcoinPerformance, sp500Performance];
+const links = [link1, link2, link3, link4, link5, link6];
+graph.resetCells([investment, ...products, performance, ...productPerformances, ...links]);
+performance.embed(productPerformances);
+performance.fitEmbeds({ padding: { horizontal: 30, top: 50, bottom: 130 }});
+
+// Setup automatic calculation of performance
+
+graph.on('change:attrs', (cell, attrs, { calc, previousValue, propertyValue }) => {
+    if (!calc) return;
+    if (cell instanceof Product) {
+        let diff = previousValue - propertyValue;
+        const productIndex = products.findIndex(p => p.id === cell.id);
+        // sort products so the first product to modify is
+        // below the one that was changed
+        const sortedProducts = [
+            ...products.slice(productIndex + 1, products.length),
+            ...products.slice(0, productIndex)
+        ];
+        sortedProducts.forEach((product, index) => {
+            const percentage = product.getPercentage() + diff;
+            product.setPercentage(Math.max(percentage, 0));
+            diff = (percentage < 0) ? percentage: 0;
+        });
+    }
+    calculatePerformance();
+});
+
+function calculatePerformance() {
+    productPerformances.forEach(productPerf => {
+        const [product] = graph.getNeighbors(productPerf, { inbound: true });
+        const value = calculateProductValue(product);
+        const roi = calculateProductROI(product.getPercentage(), value);
+        productPerf.setValue(value.toFixed(2));
+        productPerf.setROI(roi.toFixed(2));
+    });
+    const overallValue = productPerformances.reduce((total, productPerf) => total + productPerf.getValue(), 0);
+    const overallRoi = calculateProductROI(100, overallValue);
+    performance.setValue(overallValue.toFixed(2));
+    performance.setROI(overallRoi.toFixed(2));
+}
+
+function calculateProductValue(product) {
+    const year = investment.getYear();
+    const funds = investment.getFunds();
+    const productName = product.getName();
+    const buyUnitPrice = data[year][productName];
+    const sellUnitPrice = data[currentYear][productName];
+    return funds * product.getPercentage() / 100 * (sellUnitPrice / buyUnitPrice) ;
+}
+
+function calculateProductROI(percentage, value) {
+    const funds = investment.getFunds();
+    const cost = funds * percentage / 100;
+    return (value - cost) / cost * 100;
+}
+
+calculatePerformance();
+

--- a/demo/roi/src/roi.js
+++ b/demo/roi/src/roi.js
@@ -211,11 +211,7 @@ class Product extends ForeignObjectElement {
                     class="jj-form"
                     xmlns="http://www.w3.org/1999/xhtml"
                 >
-                    <p>
-                        <span>What percentage did you invest in</span>
-                        <b @selector="label" style="margin-left: 4px"></b>
-                        <span>?</span>
-                    </p>
+                    <p>What percentage did you invest in <b @selector="label"></b>?</p>
                     <div class="jj-field">
                         <input @selector="percentage"
                             class="jj-input"
@@ -328,11 +324,7 @@ class OverallPerformance extends ForeignObjectElement {
                     xmlns="http://www.w3.org/1999/xhtml"
                     style="justify-content: space-between;"
                 >
-                    <p>
-                        <span>This is your portfolio now in </span>
-                        <b style="margin-left: 4px;">${currentYear}</b>
-                        <span>.</span>
-                    </p>
+                    <p>This is your portfolio now in <b>${currentYear}</b>.</p>
                     <div style="width: 100%">
                         <p>Your overall performance of investment is:</p>
                         <div class="jj-field">

--- a/demo/roi/src/roi.js
+++ b/demo/roi/src/roi.js
@@ -87,10 +87,10 @@ const paper = new dia.Paper({
         name: 'curve'
     },
     defaultConnectionPoint: {
-        name: 'anchor',
+        name: 'anchor'
     },
     background: {
-        color: '#f6f4f4',
+        color: '#f6f4f4'
     },
     preventDefaultViewAction: false,
     interactive: {
@@ -99,7 +99,7 @@ const paper = new dia.Paper({
     elementView: dia.ElementView.extend({
 
         events: {
-            'change input,select': 'onInputChange',
+            'change input,select': 'onInputChange'
         },
 
         onInputChange: function(evt) {
@@ -131,7 +131,7 @@ class ForeignObjectElement extends dia.Element {
                 },
                 foreignObject: {
                     width: 'calc(w)',
-                    height: 'calc(h)',
+                    height: 'calc(h)'
                 }
             }
         };
@@ -146,7 +146,7 @@ class Investment extends ForeignObjectElement {
             size: {
                 width: 140,
                 height: 225
-            },
+            }
         };
     }
 
@@ -206,7 +206,7 @@ class Product extends ForeignObjectElement {
             size: {
                 width: 140,
                 height: 120
-            },
+            }
         };
     }
 
@@ -264,7 +264,7 @@ class ProductPerformance extends ForeignObjectElement {
             size: {
                 width: 200,
                 height: 100
-            },
+            }
         };
     }
 
@@ -329,7 +329,7 @@ class OverallPerformance extends ForeignObjectElement {
     defaults() {
         return {
             ...super.defaults(),
-            type: 'OverallPerformance',
+            type: 'OverallPerformance'
         };
     }
 
@@ -392,7 +392,7 @@ class Link extends shapes.standard.DoubleLink {
                 line: {
                     stroke: '#333333',
                     targetMarker: {
-                        'stroke-width': 2,
+                        'stroke-width': 2
                     }
                 },
                 outline: {
@@ -412,11 +412,11 @@ const investment = new Investment({
         funds: {
             value: 100,
             // Do tab indexes greater than zero violate accessibility? See the accessibility notes at the end of the demo.
-            tabindex: 1,
+            tabindex: 1
         },
         year: {
             value: 2018,
-            tabindex: 2,
+            tabindex: 2
         }
     }
 
@@ -435,7 +435,7 @@ const gold = new Product({
         },
         percentage: {
             value: 25,
-            tabindex: 3,
+            tabindex: 3
         }
     }
 });
@@ -453,7 +453,7 @@ const bitcoin = new Product({
         },
         percentage: {
             value: 25,
-            tabindex: 4,
+            tabindex: 4
         }
     }
 });
@@ -471,7 +471,7 @@ const sp500 = new Product({
         },
         percentage: {
             value: 50,
-            tabindex: 5,
+            tabindex: 5
         }
     }
 });
@@ -484,10 +484,10 @@ const goldPerformance = new ProductPerformance({
             html: 'Gold'
         },
         value: {
-            tabindex: 6,
+            tabindex: 6
         },
         roi: {
-            tabindex: 7,
+            tabindex: 7
         }
     }
 });
@@ -500,10 +500,10 @@ const bitcoinPerformance = new ProductPerformance({
             html: 'Bitcoin'
         },
         value: {
-            tabindex: 8,
+            tabindex: 8
         },
         roi: {
-            tabindex: 9,
+            tabindex: 9
         }
     }
 });
@@ -516,10 +516,10 @@ const sp500Performance = new ProductPerformance({
             html: 'S&P 500'
         },
         value: {
-            tabindex: 10,
+            tabindex: 10
         },
         roi: {
-            tabindex: 11,
+            tabindex: 11
         }
     }
 });
@@ -532,10 +532,10 @@ const performance = new OverallPerformance({
             fill: SECONDARY_COLOR
         },
         value: {
-            tabindex: 12,
+            tabindex: 12
         },
         roi: {
-            tabindex: 13,
+            tabindex: 13
         }
     }
 });
@@ -546,7 +546,7 @@ const link1 = new Link({
     z: 2,
     attrs: {
         line: {
-            stroke: MAIN_COLOR,
+            stroke: MAIN_COLOR
         }
     }
 });
@@ -557,7 +557,7 @@ const link2 = new Link({
     z: 2,
     attrs: {
         line: {
-            stroke: MAIN_COLOR,
+            stroke: MAIN_COLOR
         }
     }
 });
@@ -568,7 +568,7 @@ const link3 = new Link({
     z: 2,
     attrs: {
         line: {
-            stroke: MAIN_COLOR,
+            stroke: MAIN_COLOR
         }
     }
 });
@@ -579,7 +579,7 @@ const link4 = new Link({
     z: 4,
     attrs: {
         line: {
-            stroke: GOLD_COLOR,
+            stroke: GOLD_COLOR
         }
     }
 });
@@ -590,7 +590,7 @@ const link5 = new Link({
     z: 5,
     attrs: {
         line: {
-            stroke: BTC_COLOR,
+            stroke: BTC_COLOR
         }
     }
 
@@ -602,7 +602,7 @@ const link6 = new Link({
     z: 7,
     attrs: {
         line: {
-            stroke: SP500_COLOR,
+            stroke: SP500_COLOR
         }
     }
 });

--- a/demo/shapes/src/foreign-object.js
+++ b/demo/shapes/src/foreign-object.js
@@ -9,7 +9,7 @@ const paper = new joint.dia.Paper({
     async: true,
     cellViewNamespace: joint.shapes,
     preventDefaultBlankAction: false,
-    preventDefaultViewAction: false,
+    preventDefaultViewAction: false
 });
 
 // Disable the default touch action on the paper.
@@ -60,7 +60,7 @@ const Example = joint.dia.Element.define('example.ForeignObject', {
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
-                justifyContent: 'center',
+                justifyContent: 'center'
                 // Prevents the browser from scrolling the page when the user
                 // tries to touch the foreignObject.
                 // Works in Chrome, but not in Safari. If set on the paper,
@@ -69,7 +69,7 @@ const Example = joint.dia.Element.define('example.ForeignObject', {
             },
             children: [{
                 tagName: 'span',
-                textContent: 'First Name',
+                textContent: 'First Name'
             }, {
                 tagName: 'input',
                 selector: 'firstname',
@@ -112,7 +112,7 @@ const Example2 = joint.dia.Element.define('example.ForeignObject2', {
         },
         foreignObject: {
             width: 'calc(w)',
-            height: 'calc(h)',
+            height: 'calc(h)'
         }
     }
 }, {

--- a/docs/src/joint/api/dia/CellView/prototype/isDefaultInteractionPrevented.html
+++ b/docs/src/joint/api/dia/CellView/prototype/isDefaultInteractionPrevented.html
@@ -1,0 +1,4 @@
+<pre class="docs-method-signature"><code>cellView.isDefaultInteractionPrevented(event)</code></pre>
+<p>Returns whether <a href="#dia.CellView.prototype.preventDefaultInteraction">preventDefaultInteraction</a> was ever called on this <code>event</code> object.</p>
+
+

--- a/docs/src/joint/api/dia/CellView/prototype/preventDefaultInteraction.html
+++ b/docs/src/joint/api/dia/CellView/prototype/preventDefaultInteraction.html
@@ -1,0 +1,46 @@
+<pre class="docs-method-signature"><code>cellView.preventDefaultInteraction(event)</code></pre>
+<p>The method tells the view that its default interactivity action should not be taken as it normally would be.</p>
+
+<p>For example, if the view is a <a href="#dia.ElementView">joint.dia.ElementView</a> and the user clicks on it, the view will normally enter the <a href="#dia.Paper.prototype.options.interactive">interactive mode</a> and starts moving the element.
+
+<p>Calling <code>preventDefaultInteraction</code> will prevent the view from entering the interactive mode. The view will still trigger all events, but it will not react to them in the default way.</p>
+
+<p>It is useful when you want to handle the pointer events yourself. For example, you can use it to implement your own custom interaction with the view. A selection lasso can be drawn whenever the user holds down the shift key and starts dragging from any point on the paper (regardless of whether it is an element, a link or a blank space).</p>
+
+<pre><code>paper.on('element:pointerdown', (elementView, evt) => {
+    if (evt.shiftKey) {
+        // prevent element movement
+        elementView.preventDefaultInteraction(evt);
+        // start drawing selection lasso
+    }
+});</code></pre>
+
+<p>The following table shows which default interaction will be stopped depending on what point the method was called.</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>Paper <a href="#dia.Paper.events">events</a></th>
+            <th>Description</th>
+            <th>Paper <a href="#dia.Paper.prototype.options.interactive">interactive option</a></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>'element:pointerdown'</code></td>
+            <td>Prevents element movement.</td>
+            <td><i>elementMove</i></td>
+        </tr>
+        <tr>
+            <td><code>'element:magnet:pointerdown'</code></td>
+            <td>Prevents adding link from magnet and element movement.</td>
+            <td><i>addLinkFromMagnet</i></td>
+        </tr>
+        <tr>
+            <td><code>'link:pointerdown'</code></td>
+            <td>Prevents link label and link movement.</td>
+            <td><i>labelMove</i> and <i>linkMove</i></td>
+        </tr>
+    </tbody>
+</table>
+

--- a/docs/src/joint/api/dia/Paper/events.html
+++ b/docs/src/joint/api/dia/Paper/events.html
@@ -346,6 +346,19 @@
         <p>Triggered when interacting with a magnet target.</p>
         <p>The callback function is passed <code>elementView</code>, <code>evt</code>, <code>magnetSVGElement</code>, <code>x</code>, <code>y</code> as arguments.</p>
         <table>
+
+          <tr>
+            <th>element:magnet:pointerdown</th>
+            <td>Triggered when pointer is pressed down on a magnet element.</td>
+          </tr>
+          <tr>
+            <th>element:magnet:pointermove</th>
+            <td>Triggered when pointer is moved after pointerdown on the magnet element.</td>
+          </tr>
+          <tr>
+            <th>element:magnet:pointerup</th>
+            <td>Triggered when pointer is released after pointerdown on the magnet element.</td>
+          </tr>
           <tr>
             <th>element:magnet:pointerclick</th>
             <td>Triggered when pointer is clicked on an element magnet and no link was created yet from this magnet (controlled by <a href="#dia.Paper.prototype.options.magnetThreshold">magnetThreshold</a> option). Calling <code>evt.stopPropagation()</code> prevents triggering <code>cell:pointerclick</code> and <code>element:pointerclick</code> events.</td>

--- a/docs/src/joint/api/dia/Paper/prototype/options/preventDefaultViewAction.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/preventDefaultViewAction.html
@@ -1,0 +1,1 @@
+<code>preventDefaultViewAction</code> - Prevents default action when a cell view is clicked. For example, setting the option to <code>false</code> will cause clicking on the view to blur the document active element. It defaults to <code>true</code>.

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -1065,6 +1065,15 @@ export const CellView = View.extend({
     // Interaction. The controller part.
     // ---------------------------------
 
+    preventDefaultAction(evt) {
+        this.eventData(evt, { defaultActionPrevented: true  });
+    },
+
+    isDefaultActionPrevented(evt) {
+        const { defaultActionPrevented = false } = this.eventData(evt);
+        return defaultActionPrevented;
+    },
+
     // Interaction is handled by the paper and delegated to the view in interest.
     // `x` & `y` parameters passed to these functions represent the coordinates already snapped to the paper grid.
     // If necessary, real coordinates can be obtained from the `evt` event object.

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -1065,13 +1065,13 @@ export const CellView = View.extend({
     // Interaction. The controller part.
     // ---------------------------------
 
-    preventDefaultAction(evt) {
-        this.eventData(evt, { defaultActionPrevented: true  });
+    preventDefaultInteraction(evt) {
+        this.eventData(evt, { defaultInteractionPrevented: true  });
     },
 
-    isDefaultActionPrevented(evt) {
-        const { defaultActionPrevented = false } = this.eventData(evt);
-        return defaultActionPrevented;
+    isDefaultInteractionPrevented(evt) {
+        const { defaultInteractionPrevented = false } = this.eventData(evt);
+        return defaultInteractionPrevented;
     },
 
     // Interaction is handled by the paper and delegated to the view in interest.

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -1078,7 +1078,7 @@ export const CellView = View.extend({
     // `x` & `y` parameters passed to these functions represent the coordinates already snapped to the paper grid.
     // If necessary, real coordinates can be obtained from the `evt` event object.
 
-    // These functions are supposed to be overriden by the views that inherit from `joint.dia.Cell`,
+    // These functions are supposed to be overridden by the views that inherit from `joint.dia.Cell`,
     // i.e. `joint.dia.Element` and `joint.dia.Link`.
 
     pointerdblclick: function(evt, x, y) {

--- a/src/dia/ElementView.mjs
+++ b/src/dia/ElementView.mjs
@@ -698,8 +698,8 @@ export const ElementView = CellView.extend({
     onmagnet: function(evt, x, y) {
 
         const { currentTarget: targetMagnet } = evt;
-        this.eventData(evt, { targetMagnet });
         this.magnetpointerdown(evt, targetMagnet, x, y);
+        this.eventData(evt, { targetMagnet });
         this.dragMagnetStart(evt, x, y);
     },
 
@@ -754,25 +754,26 @@ export const ElementView = CellView.extend({
 
         const { paper } = this;
 
-        if (!this.isDefaultActionPrevented(evt) && this.can('addLinkFromMagnet')) {
+        if (this.isDefaultActionPrevented(evt) || !this.can('addLinkFromMagnet')) {
+            return;
+        }
 
-            const { targetMagnet = evt.currentTarget } = this.eventData(evt);
+        const { targetMagnet = evt.currentTarget } = this.eventData(evt);
 
-            evt.stopPropagation();
+        evt.stopPropagation();
 
-            if (paper.options.validateMagnet(this, targetMagnet, evt)) {
+        if (paper.options.validateMagnet(this, targetMagnet, evt)) {
 
-                if (paper.options.magnetThreshold <= 0) {
-                    this.dragLinkStart(evt, targetMagnet, x, y);
-                }
-
-                this.eventData(evt, { action: 'magnet' });
-                this.stopPropagation(evt);
-
-            } else {
-
-                this.pointerdown(evt, x, y);
+            if (paper.options.magnetThreshold <= 0) {
+                this.dragLinkStart(evt, targetMagnet, x, y);
             }
+
+            this.eventData(evt, { action: 'magnet' });
+            this.stopPropagation(evt);
+
+        } else {
+
+            this.pointerdown(evt, x, y);
         }
 
         paper.delegateDragEvents(this, evt.data);

--- a/src/dia/ElementView.mjs
+++ b/src/dia/ElementView.mjs
@@ -737,7 +737,7 @@ export const ElementView = CellView.extend({
 
     dragStart: function(evt, x, y) {
 
-        if (this.isDefaultActionPrevented(evt)) return;
+        if (this.isDefaultInteractionPrevented(evt)) return;
 
         var view = this.getDelegatedView();
         if (!view || !view.can('elementMove')) return;
@@ -767,7 +767,7 @@ export const ElementView = CellView.extend({
             this.eventData(evt, { preventPointerEvents: true });
         }
 
-        if (this.isDefaultActionPrevented(evt) || !this.can('addLinkFromMagnet')) {
+        if (this.isDefaultInteractionPrevented(evt) || !this.can('addLinkFromMagnet')) {
             // Stop the default action, which is to start dragging a link.
             return;
         }

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1943,6 +1943,8 @@ export const LinkView = CellView.extend({
 
         if (this.can('labelMove')) {
 
+            if (this.isDefaultActionPrevented(evt)) return;
+
             var labelNode = evt.currentTarget;
             var labelIdx = parseInt(labelNode.getAttribute('label-idx'), 10);
 
@@ -2012,6 +2014,8 @@ export const LinkView = CellView.extend({
     },
 
     dragStart: function(evt, x, y) {
+
+        if (this.isDefaultActionPrevented(evt)) return;
 
         if (!this.can('linkMove')) return;
 

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -2032,7 +2032,17 @@ export const LinkView = CellView.extend({
         var data = this.eventData(evt);
         var label = { position: this.getLabelPosition((x + data.dx), (y + data.dy), data.positionAngle, data.positionArgs) };
         if (this.paper.options.snapLabels) delete label.position.offset;
-        this.model.label(data.labelIdx, label);
+        // The `touchmove' events are not fired
+        // when the original event target is removed from the DOM.
+        // The labels are currently re-rendered completely when only
+        // the position changes. This is why we need to make sure that
+        // the label is updated synchronously.
+        // TODO: replace `touchmove` with `pointermove` (breaking change).
+        const setOptions = { ui: true };
+        if (this.paper.isAsync() && evt.type === 'touchmove') {
+            setOptions.async = false;
+        }
+        this.model.label(data.labelIdx, label, setOptions);
     },
 
     dragVertex: function(evt, x, y) {

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1943,7 +1943,7 @@ export const LinkView = CellView.extend({
 
         if (this.can('labelMove')) {
 
-            if (this.isDefaultActionPrevented(evt)) return;
+            if (this.isDefaultInteractionPrevented(evt)) return;
 
             var labelNode = evt.currentTarget;
             var labelIdx = parseInt(labelNode.getAttribute('label-idx'), 10);
@@ -2015,7 +2015,7 @@ export const LinkView = CellView.extend({
 
     dragStart: function(evt, x, y) {
 
-        if (this.isDefaultActionPrevented(evt)) return;
+        if (this.isDefaultInteractionPrevented(evt)) return;
 
         if (!this.can('linkMove')) return;
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -349,7 +349,16 @@ export const Paper = View.extend({
 
     SORT_DELAYING_BATCHES: ['add', 'to-front', 'to-back'],
     UPDATE_DELAYING_BATCHES: ['translate'],
-    FORM_CONTROL_TAG_NAMES: ['SELECT', 'TEXTAREA', 'INPUT', 'OPTION', 'BUTTON'],
+    FORM_CONTROL_TAG_NAMES: ['TEXTAREA', 'INPUT', 'BUTTON', 'SELECT', 'OPTION'] ,
+    GUARDED_TAG_NAMES: [
+        // Guard <select> for consistency. When you click on it:
+        // Chrome: triggers `pointerdown`, `pointerup`, `pointerclick` to open
+        // Firefox: triggers `pointerdown` on open, `pointerup` (and `pointerclick` only if you haven't moved).
+        //          on close. However, if you open and then close by clicking elsewhere on the page,
+        //           no other event is triggered.
+        // Safari: when you open it, it triggers `pointerdown`. That's it.
+        'SELECT',
+    ],
     MIN_SCALE: 1e-6,
 
     init: function() {
@@ -2509,11 +2518,17 @@ export const Paper = View.extend({
             return evt.data.guarded;
         }
 
+        const { target } = evt;
+
+        if (this.GUARDED_TAG_NAMES.includes(target.tagName)) {
+            return true;
+        }
+
         if (view && view.model && (view.model instanceof Cell)) {
             return false;
         }
 
-        if (this.svg === evt.target || this.el === evt.target || $.contains(this.svg, evt.target)) {
+        if (this.svg === target || this.el === target || $.contains(this.svg, target)) {
             return false;
         }
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2112,7 +2112,7 @@ export const Paper = View.extend({
             // Custom event
             const eventNode = target.closest('[event]');
             if (eventNode && this.svg.contains(eventNode)) {
-                const eventEvt = $.Event(evt, {
+                const eventEvt = $.Event(evt.originalEvent, {
                     data: evt.data,
                     currentTarget: eventNode,
                     isNormalized: true
@@ -2129,7 +2129,7 @@ export const Paper = View.extend({
             // Element magnet
             const magnetNode = target.closest('[magnet]');
             if (magnetNode && this.svg.contains(magnetNode)) {
-                const magnetEvt = $.Event(evt, {
+                const magnetEvt = $.Event(evt.originalEvent, {
                     data: evt.data,
                     currentTarget: magnetNode,
                     isNormalized: true
@@ -2151,7 +2151,7 @@ export const Paper = View.extend({
 
         if (isContextMenu) {
             this.contextMenuFired = true;
-            const contextmenuEvt = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            const contextmenuEvt = $.Event(evt.originalEvent, { type: 'contextmenu', data: evt.data });
             this.contextMenuTrigger(contextmenuEvt);
         } else {
             const localPoint = this.snapToGrid(evt.clientX, evt.clientY);
@@ -2216,7 +2216,7 @@ export const Paper = View.extend({
         }
 
         if (!normalizedEvt.isPropagationStopped()) {
-            this.pointerclick($.Event(evt, { type: 'click', data: evt.data }));
+            this.pointerclick($.Event(evt.originalEvent, { type: 'click', data: evt.data }));
         }
 
         evt.stopImmediatePropagation();
@@ -2412,7 +2412,11 @@ export const Paper = View.extend({
         if (evt.button === 2) {
             this.contextMenuFired = true;
             this.magnetContextMenuFired = true;
-            const contextmenuEvt = $.Event(evt, { type: 'contextmenu', data: evt.data });
+            const contextmenuEvt = $.Event(evt.originalEvent, {
+                type: 'contextmenu',
+                data: evt.data,
+                currentTarget: evt.currentTarget,
+            });
             this.magnetContextMenuTrigger(contextmenuEvt);
             if (contextmenuEvt.isPropagationStopped()) {
                 evt.stopPropagation();

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -349,7 +349,11 @@ export const Paper = View.extend({
 
     SORT_DELAYING_BATCHES: ['add', 'to-front', 'to-back'],
     UPDATE_DELAYING_BATCHES: ['translate'],
+    // If you interact with these elements,
+    // the default interaction such as `element move` is prevented.
     FORM_CONTROL_TAG_NAMES: ['TEXTAREA', 'INPUT', 'BUTTON', 'SELECT', 'OPTION'] ,
+    // If you interact with these elements, the events are not propagated to the paper
+    // i.e. paper events such as `element:pointerdown` are not triggered.
     GUARDED_TAG_NAMES: [
         // Guard <select> for consistency. When you click on it:
         // Chrome: triggers `pointerdown`, `pointerup`, `pointerclick` to open

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2138,8 +2138,9 @@ export const Paper = View.extend({
             if (eventNode && rootViewEl !== eventNode && view.el.contains(eventNode)) {
                 const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
                     data: evt.data,
+                    // Originally the event listener was attached to the event element.
+                    currentTarget: eventNode
                 }));
-                eventEvt.currentTarget = eventNode;
                 this.onevent(eventEvt);
                 if (eventEvt.isDefaultPrevented()) {
                     evt.preventDefault();
@@ -2153,9 +2154,10 @@ export const Paper = View.extend({
             const magnetNode = target.closest('[magnet]');
             if (magnetNode && view.el !== magnetNode && view.el.contains(magnetNode)) {
                 const magnetEvt = normalizeEvent($.Event(evt.originalEvent, {
-                    data: evt.data
+                    data: evt.data,
+                    // Originally the event listener was attached to the magnet element.
+                    currentTarget: magnetNode
                 }));
-                magnetEvt.currentTarget = magnetNode;
                 this.onmagnet(magnetEvt);
                 if (magnetEvt.isDefaultPrevented()) {
                     evt.preventDefault();

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2128,7 +2128,7 @@ export const Paper = View.extend({
             if (isTargetFormNode) {
                 // If the target is a form element, we do not want to start dragging the element.
                 // For example, we want to be able to select text by dragging the mouse.
-                view.preventDefaultAction(evt);
+                view.preventDefaultInteraction(evt);
             }
 
             const rootViewEl = view.el;

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2131,14 +2131,15 @@ export const Paper = View.extend({
                 view.preventDefaultAction(evt);
             }
 
+            const rootViewEl = view.el;
+
             // Custom event
             const eventNode = target.closest('[event]');
-            if (eventNode && this.svg.contains(eventNode)) {
-                const eventEvt = $.Event(evt.originalEvent, {
+            if (eventNode && rootViewEl !== eventNode && view.el.contains(eventNode)) {
+                const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
                     data: evt.data,
-                    currentTarget: eventNode,
-                    isNormalized: true
-                });
+                }));
+                eventEvt.currentTarget = eventNode;
                 this.onevent(eventEvt);
                 if (eventEvt.isDefaultPrevented()) {
                     evt.preventDefault();
@@ -2150,12 +2151,11 @@ export const Paper = View.extend({
 
             // Element magnet
             const magnetNode = target.closest('[magnet]');
-            if (magnetNode && this.svg.contains(magnetNode)) {
-                const magnetEvt = $.Event(evt.originalEvent, {
-                    data: evt.data,
-                    currentTarget: magnetNode,
-                    isNormalized: true
-                });
+            if (magnetNode && view.el !== magnetNode && view.el.contains(magnetNode)) {
+                const magnetEvt = normalizeEvent($.Event(evt.originalEvent, {
+                    data: evt.data
+                }));
+                magnetEvt.currentTarget = magnetNode;
                 this.onmagnet(magnetEvt);
                 if (magnetEvt.isDefaultPrevented()) {
                     evt.preventDefault();

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -349,6 +349,7 @@ export const Paper = View.extend({
 
     SORT_DELAYING_BATCHES: ['add', 'to-front', 'to-back'],
     UPDATE_DELAYING_BATCHES: ['translate'],
+    FORM_CONTROL_TAG_NAMES: ['SELECT', 'TEXTAREA', 'INPUT', 'OPTION', 'BUTTON'],
     MIN_SCALE: 1e-6,
 
     init: function() {
@@ -2101,12 +2102,24 @@ export const Paper = View.extend({
         const { target, button } = evt;
         const view = this.findView(target);
         const isContextMenu = (button === 2);
+
         if (view) {
 
             if (!isContextMenu && this.guard(evt, view)) return;
 
-            if (this.options.preventDefaultViewAction) {
+            const isTargetFormNode = this.FORM_CONTROL_TAG_NAMES.includes(target.tagName);
+
+            if (this.options.preventDefaultViewAction && !isTargetFormNode) {
+                // If the target is a form element, we do not want to prevent the default action.
+                // For example, we want to be able to select text in a text input or
+                // to be able to click on a checkbox.
                 evt.preventDefault();
+            }
+
+            if (isTargetFormNode) {
+                // If the target is a form element, we do not want to start dragging the element.
+                // For example, we want to be able to select text by dragging the mouse.
+                view.preventDefaultAction(evt);
             }
 
             // Custom event

--- a/src/dia/attributes/index.mjs
+++ b/src/dia/attributes/index.mjs
@@ -319,7 +319,7 @@ const attributesNS = {
             if (isCalcAttribute(x)) {
                 textAttrs.x = evalCalcAttribute(x, refBBox);
             }
-            
+
             let fontSizeAttr = attrs['font-size'] || attrs['fontSize'];
             if (isCalcAttribute(fontSizeAttr)) {
                 fontSizeAttr = evalCalcAttribute(fontSizeAttr, refBBox);

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -269,6 +269,7 @@ export const toKebabCase = function(string) {
 
 export const normalizeEvent = function(evt) {
 
+    if (evt.isNormalized) return evt;
     var normalizedEvent = evt;
     var touchEvt = evt.originalEvent && evt.originalEvent.changedTouches && evt.originalEvent.changedTouches[0];
     if (touchEvt) {
@@ -288,6 +289,8 @@ export const normalizeEvent = function(evt) {
         var useElement = target.correspondingUseElement;
         if (useElement) normalizedEvent.target = useElement;
     }
+
+    normalizedEvent.isNormalized = true;
 
     return normalizedEvent;
 };

--- a/src/util/util.mjs
+++ b/src/util/util.mjs
@@ -269,30 +269,30 @@ export const toKebabCase = function(string) {
 
 export const normalizeEvent = function(evt) {
 
-    if (evt.isNormalized) return evt;
-    var normalizedEvent = evt;
-    var touchEvt = evt.originalEvent && evt.originalEvent.changedTouches && evt.originalEvent.changedTouches[0];
-    if (touchEvt) {
-        for (var property in evt) {
-            // copy all the properties from the input event that are not
-            // defined on the touch event (functions included).
-            if (touchEvt[property] === undefined) {
-                touchEvt[property] = evt[property];
+    if (evt.normalized) return evt;
+
+    const { originalEvent, target } = evt;
+
+    // If the event is a touch event, normalize it to a mouse event.
+    const touch = originalEvent && originalEvent.changedTouches && originalEvent.changedTouches[0];
+    if (touch) {
+        for (let property in touch) {
+            // copy all the properties from the first touch that are not
+            // defined on TouchEvent (clientX, clientY, pageX, pageY, screenX, screenY, identifier, ...)
+            if (evt[property] === undefined) {
+                evt[property] = touch[property];
             }
         }
-        normalizedEvent = touchEvt;
     }
-
     // IE: evt.target could be set to SVGElementInstance for SVGUseElement
-    var target = normalizedEvent.target;
     if (target) {
-        var useElement = target.correspondingUseElement;
-        if (useElement) normalizedEvent.target = useElement;
+        const useElement = target.correspondingUseElement;
+        if (useElement) evt.target = useElement;
     }
 
-    normalizedEvent.isNormalized = true;
+    evt.normalized = true;
 
-    return normalizedEvent;
+    return evt;
 };
 
 export const normalizeWheel = function(evt) {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
         'QUnit': true,
         'sinon': true,
         'blanket': true,
-        'simulate': true
+        'simulate': true,
+        'fixtures': true,
     },
     'overrides': [{
         'files': ['ts/*.ts'],

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -2,13 +2,12 @@ QUnit.module('basic', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        this.$fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        this.$fixture.append($paper);
-
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });
@@ -19,8 +18,6 @@ QUnit.module('basic', function(hooks) {
         this.paper.remove();
         this.graph = null;
         this.paper = null;
-        this.$fixture.empty();
-        this.$fixture = null;
     });
 
     this.setupTestNestedGraph = function(graph) {

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -4,14 +4,13 @@ QUnit.module('cell', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
 
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });

--- a/test/jointjs/cellView.js
+++ b/test/jointjs/cellView.js
@@ -9,10 +9,9 @@ QUnit.module('cellView', function(hooks) {
 
         // !! TODO !!
         // Should be able to create a CellView instance without the graph or paper.
-
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
+        const fixtureEl = fixtures.getElement();
         paper = new joint.dia.Paper;
-        paper.render().$el.appendTo($fixture);
+        fixtureEl.appendChild(paper.render().el);
 
         var cell = new joint.dia.Element({
             type: 'element',

--- a/test/jointjs/connectors.js
+++ b/test/jointjs/connectors.js
@@ -2,14 +2,13 @@ QUnit.module('connectors', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
 
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });

--- a/test/jointjs/elements.js
+++ b/test/jointjs/elements.js
@@ -2,14 +2,13 @@ QUnit.module('elements', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
 
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });

--- a/test/jointjs/embedding.js
+++ b/test/jointjs/embedding.js
@@ -1,13 +1,14 @@
 QUnit.module('embedding', function(hooks) {
+
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
 
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-            el: $paper,
+            el: paperEl,
             gridSize: 1,
             model: this.graph,
             embeddingMode: true
@@ -20,7 +21,6 @@ QUnit.module('embedding', function(hooks) {
         this.graph = null;
         this.paper = null;
     });
-
 
     QUnit.test('sanity', function(assert) {
 

--- a/test/jointjs/links.js
+++ b/test/jointjs/links.js
@@ -2,14 +2,13 @@ QUnit.module('links', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
 
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });
@@ -790,7 +789,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l0-label0 - expect default dimensions (based on text size)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l0-label1 - expect default dimensions (based on text size)
                         size: { width: 100, height: 30 }, // this should have no effect
@@ -833,7 +832,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l1-label0 - expect default dimensions (based on text size)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l1-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -865,7 +864,7 @@ QUnit.module('links', function(hooks) {
                     },
                     labels: [{
                         // l2-label0 - expect instance-specific `defaultLabel.size` dimensions = (102,32)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l2-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -901,7 +900,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l3-label0 - expect class-specific `defaultLabel.size` dimensions = (103, 33)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l3-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -933,7 +932,7 @@ QUnit.module('links', function(hooks) {
                     },
                     labels: [{
                         // l4-label0 - expect instance-specific `defaultLabel.size` dimensions = (104,34)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l4-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -974,7 +973,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l0-label0 - expect default dimensions (based on text size)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l0-label1 - expect default dimensions (based on text size)
                         size: { width: 100, height: 30 }, // this should have no effect
@@ -1025,7 +1024,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l1-label0 - expect default dimensions (based on text size)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l1-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -1057,7 +1056,7 @@ QUnit.module('links', function(hooks) {
                     },
                     labels: [{
                         // l2-label0 - expect instance-specific `defaultLabel.size` dimensions = (102,32)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l2-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -1093,7 +1092,7 @@ QUnit.module('links', function(hooks) {
                     target: { id: r2.id },
                     labels: [{
                         // l3-label0 - expect class-specific `defaultLabel.size` dimensions = (103, 33)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l3-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },
@@ -1125,7 +1124,7 @@ QUnit.module('links', function(hooks) {
                     },
                     labels: [{
                         // l4-label0 - expect instance-specific `defaultLabel.size` dimensions = (104,34)
-                        attrs: { text: { text: 'test'}}
+                        attrs: { text: { text: 'test' }}
                     },{
                         // l4-label1 - expect `label.size` dimensions = (101,31)
                         size: { width: 101, height: 31 },

--- a/test/jointjs/mvc.listener.js
+++ b/test/jointjs/mvc.listener.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const createPaperHTMLElement = () => {
-    const fixtureEl = document.createElement('div');
-    fixtureEl.setAttribute('id', 'qunit-fixture');
-    document.body.appendChild(fixtureEl);
 
+    const fixtureEl = fixtures.getElement();
     const paperEl = document.createElement('div');
     fixtureEl.appendChild(paperEl);
-
     return paperEl;
 };
 
@@ -33,11 +30,11 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
             this.graph = null;
             this.rect = null;
         });
-        
+
         QUnit.test('stop listening', (assert) => {
             const newPosition = { x: 100, y: 100 };
             const newSize = { width: 100, height: 100 };
-            
+
             const positionCb = sinon.spy();
             const sizeCb = sinon.spy();
             const rectEvents = {
@@ -80,7 +77,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
 
                 listener.listenTo(this.graph, graphEvents);
                 listener.listenTo(paper, paperEvents);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 this.rect.remove();
                 assert.ok(graphCb.calledWith(...args, this.rect, newPosition));
@@ -102,7 +99,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
 
                 const listener = new joint.mvc.Listener();
                 listener.listenTo(this.graph, events);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 this.rect.remove();
                 assert.ok(removeCb.calledWith(this.rect));
@@ -123,7 +120,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
 
                 const listener = new joint.mvc.Listener(...args);
                 listener.listenTo(this.graph, events);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 this.rect.remove();
                 assert.ok(removeCb.calledWith(...args, this.rect));
@@ -145,7 +142,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
 
                 const listener = new joint.mvc.Listener(...args);
                 listener.listenTo(this.graph, events, context);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 this.rect.remove();
                 assert.ok(removeCb.calledOn(context));
@@ -169,7 +166,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
                 const paperCb = sinon.spy();
                 listener.listenTo(this.graph, 'change:position', graphCb);
                 listener.listenTo(paper, 'render:done', paperCb);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 assert.ok(graphCb.calledWith(this.rect, newPosition));
                 assert.ok(paperCb.called);
@@ -183,7 +180,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
                 const listener = new joint.mvc.Listener();
                 const callback = sinon.spy();
                 listener.listenTo(this.graph, 'change:position', callback);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 assert.ok(callback.calledWith(this.rect, newPosition));
             });
@@ -195,7 +192,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
                 const listener = new joint.mvc.Listener(...args);
                 const callback = sinon.spy();
                 listener.listenTo(this.graph, 'change:position', callback);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 assert.ok(callback.calledWith(...args, this.rect, newPosition));
             });
@@ -208,7 +205,7 @@ QUnit.module('joint.mvc.Listener', (hooks) => {
                 const listener = new joint.mvc.Listener(...args);
                 const callback = sinon.spy();
                 listener.listenTo(this.graph, 'change:position', callback, context);
-            
+
                 this.rect.position(newPosition.x, newPosition.y);
                 assert.ok(callback.calledOn(context));
                 assert.ok(callback.calledWith(...args, this.rect, newPosition));

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -777,12 +777,12 @@ QUnit.module('paper', function(hooks) {
 
         paper.options.moveThreshold = 2;
         paper.on('element:pointermove', spy);
-        var data = {};
-        paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
-        paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
-        paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
-        paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Processed
-        paper.pointerup($.Event('mouseup', { target: elRect, data: data }));
+
+        simulate.mousedown({ el: elRect });
+        simulate.mousemove({ el: elRect }); // Ignored
+        simulate.mousemove({ el: elRect }); // Ignored
+        simulate.mousemove({ el: elRect }); // Processed
+        simulate.mouseup({ el: elRect });
 
         assert.ok(spy.calledOnce);
     });
@@ -805,50 +805,44 @@ QUnit.module('paper', function(hooks) {
 
             var graph = this.graph;
             var paper = this.paper;
-            var data;
 
             paper.options.magnetThreshold = 0;
-            data = {};
 
-            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
+            simulate.mousedown({ el: elRect });
             assert.equal(graph.getLinks().length, 1);
-            paper.pointerup($.Event('mouseup', { target: elRect, data: data }));
+            simulate.mouseup({ el: elRect });
         });
 
         QUnit.test('magnetThreshold: number (1+)', function(assert) {
 
             var graph = this.graph;
             var paper = this.paper;
-            var data;
 
             paper.options.magnetThreshold = 2;
-            data = {};
 
-            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
-            paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
-            paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
+            simulate.mousedown({ el: elRect });
+            simulate.mousemove({ el: elRect }); // Ignored
+            simulate.mousemove({ el: elRect }); // Ignored
             assert.equal(graph.getLinks().length, 0);
-            paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Processed
+            simulate.mousemove({ el: elRect }); // Processed
             assert.equal(graph.getLinks().length, 1);
-            paper.pointerup($.Event('mouseup', { target: elRect, data: data }));
+            simulate.mouseup({ el: elRect });
         });
 
         QUnit.test('magnetThreshold: string ("onleave")', function(assert) {
 
             var graph = this.graph;
             var paper = this.paper;
-            var data;
 
             paper.options.magnetThreshold = 'onleave';
-            data = {};
 
-            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
-            paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
-            paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
+            simulate.mousedown({ el: elRect });
+            simulate.mousemove({ el: elRect }); // Ignored
+            simulate.mousemove({ el: elRect }); // Ignored
             assert.equal(graph.getLinks().length, 0);
-            paper.pointermove($.Event('mousemove', { target: paper.svg, data: data })); // Processed
+            simulate.mousemove({ el: paper.svg }); // Processed
             assert.equal(graph.getLinks().length, 1);
-            paper.pointerup($.Event('mouseup', { target: elRect, data: data }));
+            simulate.mouseup({ el: paper.svg });
         });
     });
 

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -810,7 +810,7 @@ QUnit.module('paper', function(hooks) {
             paper.options.magnetThreshold = 0;
             data = {};
 
-            paper.onmagnet($.Event('mousedown', { currentTarget: elRect, data: data }));
+            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
             assert.equal(graph.getLinks().length, 1);
             paper.pointerup($.Event('mouseup', { target: elRect, data: data }));
         });
@@ -824,7 +824,7 @@ QUnit.module('paper', function(hooks) {
             paper.options.magnetThreshold = 2;
             data = {};
 
-            paper.onmagnet($.Event('mousedown', { currentTarget: elRect, data: data }));
+            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
             paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
             paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
             assert.equal(graph.getLinks().length, 0);
@@ -842,7 +842,7 @@ QUnit.module('paper', function(hooks) {
             paper.options.magnetThreshold = 'onleave';
             data = {};
 
-            paper.onmagnet($.Event('mousedown', { currentTarget: elRect, data: data }));
+            paper.pointerdown($.Event('mousedown', { target: elRect, data: data }));
             paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
             paper.pointermove($.Event('mousemove', { target: elRect, data: data })); // Ignored
             assert.equal(graph.getLinks().length, 0);
@@ -909,7 +909,7 @@ QUnit.module('paper', function(hooks) {
         this.paper.options.linkPinning = true;
         source.attr('.', { magnet: true });
         data = {};
-        sourceView.dragMagnetStart({ currentTarget: sourceView.el, target: sourceView.el, type: 'mousedown', data: data, stopPropagation: function() {} }, 150, 150);
+        sourceView.dragMagnetStart({ currentTarget: sourceView.el, target: sourceView.el, type: 'mousedown', data: data, stopPropagation: () => {}, isPropagationStopped: () => false }, 150, 150);
         sourceView.pointermove({ type: 'mousemove', data: data }, 150, 400);
 
         newLink = _.reject(this.graph.getLinks(), { id: 'link' })[0];
@@ -2298,7 +2298,7 @@ QUnit.module('paper', function(hooks) {
                     ));
                 });
 
-                QUnit.test(magnetType + 'magnet:contextmenu', function(assert) {
+                QUnit.test(magnetType + ' magnet:contextmenu', function(assert) {
 
                     el.attr(['body', 'magnet'], magnetType);
 
@@ -2342,6 +2342,41 @@ QUnit.module('paper', function(hooks) {
                         localPoint.x,
                         localPoint.y
                     ));
+                });
+
+                QUnit.test(magnetType + ' magnet:pointerdown', function(assert) {
+
+                    assert.expect(3);
+                    elRect.setAttribute('magnet', magnetType);
+                    const paper = this.paper;
+                    paper.on({
+                        'element:magnet:pointerdown': function(view, evt) {
+                            assert.ok(true);
+                            evt.stopPropagation();
+                        },
+                        'element:pointerdown': function(view, evt) {
+                            assert.ok(false);
+                        },
+                        'element:magnet:pointermove': function(view, evt) {
+                            assert.ok(true);
+                        },
+                        'element:pointermove': function(view, evt) {
+                            assert.ok(false);
+                        },
+                        'element:magnet:pointerup': function(view, evt) {
+                            assert.ok(true);
+                        },
+                        'element:pointerup': function(view, evt) {
+                            assert.ok(false);
+                        },
+                        'element:pointerclick': function(view, evt) {
+                            assert.ok(false);
+                        }
+                    });
+
+                    simulate.mousedown({ el: elRect });
+                    simulate.mousemove({ el: elRect });
+                    simulate.mouseup({ el: elRect });
                 });
             });
         });

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2537,29 +2537,75 @@ QUnit.module('paper', function(hooks) {
             assert.deepEqual(getEventNames(spy), eventOrder.slice(0, eventOrder.indexOf('blank:pointerup') + 1));
         });
 
-        QUnit.test('event.data', function(assert) {
+        QUnit.module('event.data', function() {
 
-            assert.expect(2);
-            var paper = this.paper;
-            paper.options.clickThreshold = 5;
-            paper.on({
-                'element:pointerdown': function(view, evt) {
-                    evt.data = { test: 1 };
-                },
-                'element:pointermove': function(view, evt) {
-                    evt.data.test += 1;
-                },
-                'element:pointerup': function(view, evt) {
-                    assert.equal(evt.data.test, 2);
-                },
-                'element:pointerclick': function(view, evt) {
-                    assert.equal(evt.data.test, 2);
-                }
+            QUnit.test('element', function(assert) {
+
+                assert.expect(3);
+                var paper = this.paper;
+                paper.options.clickThreshold = 5;
+                paper.on({
+                    'element:pointerdown': function(view, evt) {
+                        evt.data = { test: 1 };
+                    },
+                    'element:pointermove': function(view, evt) {
+                        assert.equal(evt.data.test, 1);
+                        evt.data.test += 1;
+                    },
+                    'element:pointerup': function(view, evt) {
+                        assert.equal(evt.data.test, 2);
+                        evt.data.test += 1;
+                    },
+                    'element:pointerclick': function(view, evt) {
+                        assert.equal(evt.data.test, 3);
+                    }
+                });
+
+                simulate.mousedown({ el: elRect });
+                simulate.mousemove({ el: elRect });
+                simulate.mouseup({ el: elRect });
             });
 
-            simulate.mousedown({ el: elRect });
-            simulate.mousemove({ el: elRect });
-            simulate.mouseup({ el: elRect });
+            QUnit.test('magnet', function(assert) {
+
+                assert.expect(6);
+                elRect.setAttribute('magnet', true);
+                const paper = this.paper;
+                paper.options.clickThreshold = 5;
+                paper.on({
+                    'element:magnet:pointerdown': function(view, evt) {
+                        evt.data = { test: 1 };
+                        view.preventDefaultAction(evt);
+                    },
+                    'element:pointerdown': function(view, evt) {
+                        assert.equal(evt.data.test, 1);
+                        evt.data.test += 1;
+                    },
+                    'element:magnet:pointermove': function(view, evt) {
+                        assert.equal(evt.data.test, 2);
+                        evt.data.test += 1;
+                    },
+                    'element:pointermove': function(view, evt) {
+                        assert.equal(evt.data.test, 3);
+                        evt.data.test += 1;
+                    },
+                    'element:magnet:pointerup': function(view, evt) {
+                        assert.equal(evt.data.test, 4);
+                        evt.data.test += 1;
+                    },
+                    'element:pointerup': function(view, evt) {
+                        assert.equal(evt.data.test, 5);
+                        evt.data.test += 1;
+                    },
+                    'element:pointerclick': function(view, evt) {
+                        assert.equal(evt.data.test, 6);
+                    }
+                });
+
+                simulate.mousedown({ el: elRect });
+                simulate.mousemove({ el: elRect });
+                simulate.mouseup({ el: elRect });
+            });
         });
 
         QUnit.module('preventDefaultAction()', function() {

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2119,6 +2119,35 @@ QUnit.module('paper', function(hooks) {
             });
         }
 
+        QUnit.test('originalEvent', function(assert) {
+
+            const paper = this.paper;
+            const events = [
+                'element:pointerdown',
+                'element:pointermove',
+                'element:pointerup',
+                'element:pointerclick',
+                'element:magnet:pointerdown',
+                'element:magnet:pointermove',
+                'element:magnet:pointerup',
+                'element:magnet:pointerclick',
+            ];
+
+            assert.expect(events.length);
+            events.forEach(function(eventName) {
+                paper.on(eventName, function(view, evt) {
+                    assert.ok(evt.originalEvent instanceof MouseEvent);
+                });
+            });
+
+            paper.options.clickThreshold = 1;
+            el.attr(['body', 'magnet'], 'passive');
+            simulate.mousedown({ el: elRect });
+            simulate.mousemove({ el: elRect });
+            simulate.mouseup({ el: elRect });
+
+        });
+
         QUnit.module('Labels', function(hooks) {
 
             var link, linkView;
@@ -2483,9 +2512,6 @@ QUnit.module('paper', function(hooks) {
 
             paper.on('all', spy);
 
-            const magnet = document.createElement('div');
-            magnet.setAttribute('magnet', 'true');
-            elRect.appendChild(magnet);
 
             simulate.click({
                 el: elRect,
@@ -2500,8 +2526,10 @@ QUnit.module('paper', function(hooks) {
             assert.equal(events[1], 'element:contextmenu');
             spy.resetHistory();
 
+            elRect.setAttribute('magnet', 'true');
+
             simulate.click({
-                el: magnet,
+                el: elRect,
                 button: 2,
                 clientX: 1200,
                 clientY: 1300
@@ -2518,7 +2546,7 @@ QUnit.module('paper', function(hooks) {
                 evt.stopPropagation();
             });
             simulate.click({
-                el: magnet,
+                el: elRect,
                 button: 2,
                 clientX: 1200,
                 clientY: 1300

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2706,7 +2706,7 @@ QUnit.module('paper', function(hooks) {
                 paper.on({
                     'element:magnet:pointerdown': function(view, evt) {
                         evt.data = { test: 1 };
-                        view.preventDefaultAction(evt);
+                        view.preventDefaultInteraction(evt);
                     },
                     'element:pointerdown': function(view, evt) {
                         assert.equal(evt.data.test, 1);
@@ -2739,7 +2739,7 @@ QUnit.module('paper', function(hooks) {
             });
         });
 
-        QUnit.module('preventDefaultAction()', function() {
+        QUnit.module('preventDefaultInteraction()', function() {
 
             QUnit.test('element move', function(assert) {
 
@@ -2748,7 +2748,7 @@ QUnit.module('paper', function(hooks) {
                 const position = el.position();
                 paper.on({
                     'element:pointerdown': function(view, evt) {
-                        view.preventDefaultAction(evt);
+                        view.preventDefaultInteraction(evt);
                     },
                     'element:pointerup': function(view, evt) {
                         const newPosition = el.position();
@@ -2771,7 +2771,7 @@ QUnit.module('paper', function(hooks) {
                 const cellsCount = graph.getCells().length;
                 paper.on({
                     'element:magnet:pointerdown': function(view, evt) {
-                        view.preventDefaultAction(evt);
+                        view.preventDefaultInteraction(evt);
                     },
                     'element:magnet:pointerup': function(view, evt) {
                         // link is not created
@@ -2799,7 +2799,7 @@ QUnit.module('paper', function(hooks) {
                 const position = link.getSourcePoint();
                 paper.on({
                     'link:pointerdown': function(view, evt) {
-                        view.preventDefaultAction(evt);
+                        view.preventDefaultInteraction(evt);
                     },
                     'link:pointerup': function(view, evt) {
                         const newPosition = link.getSourcePoint();
@@ -2830,7 +2830,7 @@ QUnit.module('paper', function(hooks) {
                 const elLabel = link.findView(paper).findLabelNode(0);
                 paper.on({
                     'link:pointerdown': function(view, evt) {
-                        view.preventDefaultAction(evt);
+                        view.preventDefaultInteraction(evt);
                     },
                     'link:pointerup': function(view, evt) {
                         const newPosition = link.prop('labels/0/position/distance');
@@ -2841,6 +2841,55 @@ QUnit.module('paper', function(hooks) {
                 simulate.mousedown({ el: elLabel });
                 simulate.mousemove({ el: elLabel, clientX: 123, clientY: 987 });
                 simulate.mouseup({ el: elLabel });
+            });
+        });
+
+        QUnit.module('isDefaultInteractionPrevented()', function() {
+
+            QUnit.test('sanity', function(assert) {
+
+                assert.expect(4);
+                const paper = this.paper;
+                paper.on({
+                    'element:pointerdown': function(view, evt) {
+                        assert.notOk(view.isDefaultInteractionPrevented(evt));
+                        view.preventDefaultInteraction(evt);
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                    'element:pointermove': function(view, evt) {
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                    'element:pointerup': function(view, evt) {
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                });
+
+                simulate.mousedown({ el: elRect });
+                simulate.mousemove({ el: elRect });
+                simulate.mouseup({ el: elRect });
+            });
+
+            QUnit.test('sanity < TOUCH EVENTS', function(assert) {
+
+                assert.expect(4);
+                const paper = this.paper;
+                paper.on({
+                    'element:pointerdown': function(view, evt) {
+                        assert.notOk(view.isDefaultInteractionPrevented(evt));
+                        view.preventDefaultInteraction(evt);
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                    'element:pointermove': function(view, evt) {
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                    'element:pointerup': function(view, evt) {
+                        assert.ok(view.isDefaultInteractionPrevented(evt));
+                    },
+                });
+
+                simulate.touchstart({ target: elRect });
+                simulate.touchmove({ target: elRect, clientX: 123, clientY: 987 });
+                simulate.touchend({ target: elRect });
             });
         });
     });

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -2,14 +2,12 @@ QUnit.module('routers', function(hooks) {
 
     hooks.beforeEach(function() {
 
-        var $fixture = $('<div>', { id: 'qunit-fixture' }).appendTo(document.body);
-        var $paper = $('<div/>');
-        $fixture.append($paper);
-
+        const fixtureEl = fixtures.getElement();
+        const paperEl = document.createElement('div');
+        fixtureEl.appendChild(paperEl);
         this.graph = new joint.dia.Graph;
         this.paper = new joint.dia.Paper({
-
-            el: $paper,
+            el: paperEl,
             gridSize: 10,
             model: this.graph
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -150,5 +150,59 @@ window.simulate = {
 
         this.mousedown(opt);
         return this.mouseup(opt);
+    },
+
+    touchevent: function(touchInit) {
+
+        const touchEvt = new TouchEvent(touchInit.type, {
+            cancelable: true,
+            bubbles: true,
+            changedTouches: [new Touch({
+                ...touchInit,
+                identifier: Date.now(),
+            })],
+        });
+
+        if (touchInit.target) {
+            touchInit.target.dispatchEvent(touchEvt);
+        }
+        return touchEvt;
+    },
+
+    touchstart: function(touchInit) {
+        return this.touchevent({ ...touchInit, type: 'touchstart' });
+    },
+
+    touchmove: function(touchInit) {
+        return this.touchevent({ ...touchInit, type: 'touchmove' });
+    },
+
+    touchend: function(touchInit) {
+        return this.touchevent({ ...touchInit, type: 'touchend' });
     }
 };
+
+window.fixtures = {
+    getElement: function() {
+        let fixtureEl = document.getElementById('qunit-fixture');
+        if (fixtureEl) return fixtureEl;
+        fixtureEl = document.createElement('div');
+        fixtureEl.id = 'qunit-fixture';
+        document.body.appendChild(fixtureEl);
+        return fixtureEl;
+    },
+
+    moveToViewport: function() {
+        const fixtureEl = this.getElement();
+        fixtureEl.style.top = '0px';
+        fixtureEl.style.left = '0px';
+    },
+
+    moveOffscreen: function() {
+        const fixtureEl = this.getElement();
+        // The actual move offscreen is done in the CSS file.
+        fixtureEl.style.top = '';
+        fixtureEl.style.left = '';
+    }
+};
+

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1255,6 +1255,7 @@ export namespace dia {
             // events
             guard?: (evt: dia.Event, view: CellView) => boolean;
             preventContextMenu?: boolean;
+            preventDefaultViewAction?: boolean;
             preventDefaultBlankAction?: boolean;
             clickThreshold?: number;
             moveThreshold?: number;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1433,6 +1433,9 @@ export namespace dia {
         $grid: JQuery;
         $background: JQuery;
 
+        GUARDED_TAG_NAMES: string[];
+        FORM_CONTROLS_TAG_NAMES: string[];
+
         matrix(): SVGMatrix;
         matrix(ctm: SVGMatrix | Vectorizer.Matrix): this;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -811,9 +811,9 @@ export namespace dia {
 
         dragLinkEnd(evt: dia.Event, x: number, y: number): void;
 
-        preventDefaultAction(evt: dia.Event): void;
+        preventDefaultInteraction(evt: dia.Event): void;
 
-        isDefaultActionPrevented(evt: dia.Event): boolean;
+        isDefaultInteractionPrevented(evt: dia.Event): boolean;
 
         protected removeHighlighters(): void;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -811,6 +811,10 @@ export namespace dia {
 
         dragLinkEnd(evt: dia.Event, x: number, y: number): void;
 
+        preventDefaultAction(evt: dia.Event): void;
+
+        isDefaultActionPrevented(evt: dia.Event): boolean;
+
         protected removeHighlighters(): void;
 
         protected updateHighlighters(): void;


### PR DESCRIPTION
## Description

- **feat(dia.Paper)**: add `element:magnet:pointerdown`, `element:magnet:pointermove` and `element:magnet:pointerup`

  New set of events are now triggered when the user interacts with a magnet. This together with `preventDefaultInteraction()` allows anyone to implement a custom magnet interaction *e.g. instead of creating a new link, it can create a link connected to an element*.

- **feat(dia.Paper)**: better event handling of form control elements inside foreign objects

  When the form inputs are part of the element markup (inside the `<foreignObject>`) the default JointJS interaction should be prevented e.g you don't want the element to be moved while your focus is at a `<textarea>`. You need to be able to select the text inside instead.

- **feat(dia.Paper)**: add `preventDefaultViewAction` option

  When you use form controls (input, select, textarea) in your diagram, you might want to blur the active document element when the user clicks on the element view. By default, the default browser action is prevented when clicking an element view. This option allows you to run the default.

- **fix(dia.Paper)**:  event handlers now correctly receive `dia.Event` on touch screens , `originalEvent` now always points to a native event

  The `dia.Event` send to event handlers is always created from native events i.e. `originalEvent` property points to a source native event.

- **fix(dia.Paper)**:  #1118

  If a magnet is not valid, and the user just clicks on the magnet the `element:magnet:pointerclick` is fired.

- **feat(dia.LinkView)**:  fix label dragging on touch screens in the async mode

  It was not possible to drag a label on touch devices while the async mode was turned on. This was because the label gets re-rendered after each label move. Removing the original target from the DOM caused the `touchmove` events stop triggering.

- **feat(dia.CellView)**: add `preventDefaultInteraction()`  and `isDefaultInteractionPrevented()` 

  Adds API to dynamically prevent default JointJS interaction (such as element and link movement, adding a link from magnets, and label dragging). The default interaction now can be disabled based on the event (e.g. was a `shift` key pressed? what was the `target` DOM element of the event?) - as compared to the `paper.options.interactive` feature, which has access only to the cell view).
  ```js
  paper.on('element:pointerdown', (elementView, evt) => {
      if (evt.shiftKey) {
          // prevent element movement
          elementView.preventDefaultInteraction(evt);
          // start drawing selection lasso
      }
  });
  ```

- **fix(util)**: fix `normalizeEvent` to always return a `dia.Event`.

  Make sure the utility always returns a `dia.Event` (`jQuery.Event`) on touch devices. It was returning a [Touch](https://developer.mozilla.org/en-US/docs/Web/API/Touch) object enriched with `TouchEvents` properties and methods),

- **test**: make sure there is a single `qunit-fixture` container, the ability to move fixtures to the viewport and offscreen

  The fixture container for all JointJS rendering tests can be now moved from offscreen to the viewport and back. It is necessary for some of the touch events tests to have their target in the browser viewport. The `document.elementFromPoint()` that we use internally to find the element under the pointer requires the point to be in the viewport (e.g. using negative coordinates always returns `null`).

- **test**: add utilities for testing touch events

  It's possible to test the framework with simulated `TouchEvents`.
  ```js
  simulate.touchstart({ target: elRect });
  simulate.touchmove({ target: elRect, clientX: 123, clientY: 987 });
  simulate.touchend({ target: elRect });
  ```

- **feat(demo.ROI)**: add new demo with foreign objects

  <img width="789" alt="image" src="https://user-images.githubusercontent.com/3967880/229535294-070b83d1-280d-4428-9ca2-db67f394f3f0.png">

