### PR TITLE
connectors.curve: types fix

### DIFF
--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -51,7 +51,7 @@ export const curve = function(sourcePoint, targetPoint, route = [], opt = {}, li
     else
         options.targetDirection = opt.targetDirection ? new Point(opt.targetDirection).normalize() : null;
 
-    const completeRoute = [sourcePoint, ...route.map(p => new Point(p)), targetPoint];
+    const completeRoute = [sourcePoint, ...route, targetPoint].map(p => new Point(p));
 
     // The calculation of a sourceTangent
     let sourceTangent;

--- a/test/ts/index.test.ts
+++ b/test/ts/index.test.ts
@@ -182,3 +182,9 @@ joint.routers.rightAngle([], {
     sourceDirection: joint.routers.rightAngle.Directions.ANCHOR_SIDE,
     targetDirection: joint.routers.rightAngle.Directions.MAGNET_SIDE
 });
+
+joint.connectors.curve({ x: 0, y: 0 }, { x: 20, y: 20 }, [], {
+    sourceDirection: joint.connectors.curve.TangentDirections.CLOSEST_POINT,
+    targetDirection: joint.connectors.curve.TangentDirections.CLOSEST_POINT,
+    direction: joint.connectors.curve.Directions.HORIZONTAL
+});

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3538,32 +3538,29 @@ export namespace connectors {
         radius?: number;
     }
 
-    namespace Curve {
+    enum CurveDirections {
+        AUTO = 'auto',
+        HORIZONTAL = 'horizontal',
+        VERTICAL = 'vertical',
+        CLOSEST_POINT = 'closest-point',
+        OUTWARDS = 'outwards'
+    }
 
-        enum Directions {
-            AUTO = 'auto',
-            HORIZONTAL = 'horizontal',
-            VERTICAL = 'vertical',
-            CLOSEST_POINT = 'closest-point',
-            OUTWARDS = 'outwards'
-        }
-
-        enum TangentDirections {
-            UP = 'up',
-            DOWN = 'down',
-            LEFT = 'left',
-            RIGHT = 'right',
-            AUTO = 'auto',
-            CLOSEST_POINT = 'closest-point',
-            OUTWARDS = 'outwards'
-        }
+    enum CurveTangentDirections {
+        UP = 'up',
+        DOWN = 'down',
+        LEFT = 'left',
+        RIGHT = 'right',
+        AUTO = 'auto',
+        CLOSEST_POINT = 'closest-point',
+        OUTWARDS = 'outwards'
     }
 
     interface CurveConnectorArguments {
         raw?: boolean;
-        direction?: Curve.Directions;
-        sourceDirection?: Curve.TangentDirections | dia.Point | number;
-        targetDirection?: Curve.TangentDirections | dia.Point | number;
+        direction?: CurveDirections;
+        sourceDirection?: CurveTangentDirections | dia.Point | number;
+        targetDirection?: CurveTangentDirections | dia.Point | number;
         sourceTangent?: dia.Point;
         targetTangent?: dia.Point;
         distanceCoefficient?: number;
@@ -3600,6 +3597,11 @@ export namespace connectors {
         args?: GenericConnectorArguments<K>;
     }
 
+    interface CurveConnector extends GenericConnector<'curve'> {
+        Directions: typeof CurveDirections;
+        TangentDirections: typeof CurveTangentDirections;
+    }
+
     type ConnectorArguments = GenericConnectorArguments<ConnectorType>;
 
     type Connector = GenericConnector<ConnectorType>;
@@ -3610,7 +3612,7 @@ export namespace connectors {
     export var rounded: GenericConnector<'rounded'>;
     export var smooth: GenericConnector<'smooth'>;
     export var jumpover: GenericConnector<'jumpover'>;
-    export var curve: GenericConnector<'curve'>;
+    export var curve: CurveConnector;
 }
 
 // anchors


### PR DESCRIPTION
Fixed types so they match js curve object structure. Also made small fix to the curve function itself (it threw errors on parameters as plain points for sourcePoint and targetPoint)