### PR TITLE
fix(util): fix forIn() for arrays

### DIFF
--- a/src/util/utilHelpers.mjs
+++ b/src/util/utilHelpers.mjs
@@ -220,10 +220,13 @@ const arrayLikeKeys = (value, inherited) => {
     }
     for (const key in value) {
         if ((inherited || hasOwnProperty.call(value, key)) &&
-        !(skipIndexes && (
-            (key === 'length' ||
-            typeof key === 'number' && key > -1 && key % 1 === 0 && key < length)
-        ))) {
+            !(skipIndexes && (
+                // Safari 9 has enumerable `arguments.length` in strict mode.
+                key === 'length' ||
+                // Skip index properties.
+                isIndex(key, length)
+            ))
+        ) {
             result.push(key);
         }
     }
@@ -254,8 +257,8 @@ const isIterateeCall = (value, index, object) => {
     }
     const type = typeof index;
 
-    const isPossibleIteratee = type == 'number' ? 
-        (isArrayLike(object) && index > -1 && index < object.length) : 
+    const isPossibleIteratee = type == 'number' ?
+        (isArrayLike(object) && index > -1 && index < object.length) :
         (type == 'string' && index in object);
 
     if (isPossibleIteratee) {
@@ -441,7 +444,7 @@ const getSymbolsIn = (object) => {
 
 const getAllKeysIn = (object) => {
     const result = [];
-    
+
     for (const key in object) {
         result.push(key);
     }
@@ -885,7 +888,7 @@ const intersect = (arrays) => {
 
     while (othIndex--) {
         array = arrays[othIndex];
-        
+
         maxLength = Math.min(array.length, maxLength);
         caches[othIndex] = length >= 120 && array.length >= 120
             ? new SetCache(othIndex && array)
@@ -983,14 +986,14 @@ const baseClone = (value, isDeep = false, isFlat = false, isFull = true, customi
     }
 
     stack.set(value, result);
-    
+
     if (isMap(value)) {
         value.forEach((subValue, key) => {
             result.set(key, baseClone(subValue, isDeep, isFlat, isFull, customizer, key, value, stack));
         });
 
         return result;
-    } 
+    }
 
     if (isSet(value)) {
         value.forEach(subValue => {
@@ -998,8 +1001,8 @@ const baseClone = (value, isDeep = false, isFlat = false, isFull = true, customi
         });
 
         return result;
-    } 
-    
+    }
+
     if(isTypedArray(value)) {
         return result;
     }
@@ -2030,7 +2033,7 @@ export const clone = (value) => baseClone(value);
 
 export const cloneDeep = (value) => baseClone(value, true);
 
-export const isEmpty = (value) => { 
+export const isEmpty = (value) => {
     if (value == null) {
         return true;
     }
@@ -2265,12 +2268,12 @@ export const flattenDeep = (array) => {
 
 export const without = (array, ...values) => isArrayLike(array) ? diff(array, values) : [];
 
-export const difference = (array, ...values) => 
+export const difference = (array, ...values) =>
     isObjectLike(array) && isArrayLike(array) ?
         diff(array, values.flat(1)) : [];
-        
+
 export const intersection = (...arrays) => {
-    const mapped = arrays.map((array) => 
+    const mapped = arrays.map((array) =>
         isObjectLike(array) && isArrayLike(array) ?
             array : []
     );

--- a/test/jointjs/utilHelpers.js
+++ b/test/jointjs/utilHelpers.js
@@ -1,4 +1,4 @@
-// code originates from https://github.com/lodash/lodash/blob/4.17.15-post/test/test.js 
+// code originates from https://github.com/lodash/lodash/blob/4.17.15-post/test/test.js
 
 QUnit.module('Lodash util helpers', function() {
     function toArgs(array) {
@@ -21,21 +21,21 @@ QUnit.module('Lodash util helpers', function() {
 
     /** Used to check whether methods support array views. */
     const arrayViews = typedArrays.concat('DataView');
-        
+
     const falsey = [null, undefined, false, 0, NaN, ''];
 
     const MAX_ARRAY_LENGTH = 4294967295;
     const MAX_ARRAY_INDEX = MAX_ARRAY_LENGTH - 1;
-    
+
     QUnit.module('assign', function() {
-        
+
         QUnit.test('should assign source properties to `object`', function(assert) {
             const actual = joint.util.assign({ 'a': 1 }, { 'b': 2 });
             assert.deepEqual(actual, { 'a': 1, 'b': 2 });
         });
 
         QUnit.test('should accept multiple sources', function(assert) {
-            const actual = joint.util.assign({ 'a': 1, 'b': 2 }, { 'a': 3, 'b': 2, 'c': 1 });   
+            const actual = joint.util.assign({ 'a': 1, 'b': 2 }, { 'a': 3, 'b': 2, 'c': 1 });
             assert.deepEqual(actual, { 'a': 3, 'b': 2, 'c': 1 });
         });
 
@@ -54,7 +54,7 @@ QUnit.module('Lodash util helpers', function() {
     });
 
     QUnit.module('defaults', function() {
-        
+
         QUnit.test('should assign source properties if missing on `object`', function(assert) {
             const actual = joint.util.defaults({ 'a': 1 }, { 'a': 2, 'b': 2 });
             assert.deepEqual(actual, { 'a': 1, 'b': 2 });
@@ -561,7 +561,7 @@ QUnit.module('Lodash util helpers', function() {
     });
 
     QUnit.module('clone and cloneDeep', function() {
-        
+
         QUnit.test('should perform a shallow clone', function(assert) {
             const array = [{ 'a': 0 }, { 'b': 1 }];
             const actual = joint.util.clone(array);
@@ -788,7 +788,7 @@ QUnit.module('Lodash util helpers', function() {
     QUnit.module('isEmpty', function() {
 
         const empties = [[], {}].concat(falsey.slice(1));
-        
+
         QUnit.test('should return `true` for empty values', function(assert) {
             const expected = empties.map(() => true);
             const actual = empties.map((val) => joint.util.isEmpty(val));
@@ -2290,6 +2290,18 @@ QUnit.module('Lodash util helpers', function() {
             const keys = [];
             joint.util.forIn(new Foo, function(value, key) { keys.push(key); });
             assert.deepEqual(keys.sort(), ['a', 'b']);
+        });
+
+        QUnit.test('should provide correct `key` arguments', function(assert) {
+            const args = [];
+            joint.util.forIn({ 'a': 1, 'b': 2 }, function(value, key) { args.push(key); });
+            assert.deepEqual(args, ['a', 'b']);
+        });
+
+        QUnit.test('should provide correct `key` arguments for arrays', function(assert) {
+            const args = [];
+            joint.util.forIn([1, 2], function(value, key) { args.push(key); });
+            assert.deepEqual(args, ['0', '1']);
         });
     });
 


### PR DESCRIPTION
## Description

The `forIn()` function was incorrectly ported from Lodash. When it was called on an array, it iterated over the indexes twice.

```js
const args = [];
util.forIn(['a','b'], (value, key) => { args.push(key}; });
args = ['0', '1', '0', '1']; // it should be ['0', '1']
```
