### PR TITLE
feat(connectors.straight): add new connector to combine normal, rounded, and bevelled connectors

### DIFF
--- a/demo/flowchart/index.js
+++ b/demo/flowchart/index.js
@@ -43,7 +43,7 @@ const paper = new dia.Paper({
         }
     },
     defaultRouter: { name: 'rightAngle', args: { margin: unit * 7 }},
-    defaultConnector: bevelledConnector
+    defaultConnector: { name: 'straight', args: { cornerType: 'line', cornerPreserveAspectRatio: true }} // bevelled path
 });
 paperContainer.appendChild(paper.el);
 
@@ -333,26 +333,3 @@ paper.on('blank:pointerdown', () => {
     paper.removeTools();
     dia.HighlighterView.removeAll(paper);
 });
-
-// A custom connector that creates a bevelled path.
-
-function bevelledConnector(sourcePoint, targetPoint, routePoints, opt) {
-    const path = new g.Path();
-    path.appendSegment(g.Path.createSegment('M', sourcePoint));
-    let nextDistance;
-    for (let index = 0, n = routePoints.length; index < n; index++) {
-        const curr = new g.Point(routePoints[index]);
-        const prev = routePoints[index - 1] || sourcePoint;
-        const next = routePoints[index + 1] || targetPoint;
-        const prevDistance = nextDistance || (curr.distance(prev) / 2);
-        nextDistance = curr.distance(next) / 2;
-        const startMove = -Math.min(bevel, prevDistance);
-        const roundedStart = curr.clone().move(prev, startMove).round();
-        path.appendSegment(g.Path.createSegment('L', roundedStart));
-        const endMove = -Math.min(bevel, nextDistance);
-        const roundedEnd = curr.clone().move(next, endMove).round();
-        path.appendSegment(g.Path.createSegment('L', roundedEnd));
-    }
-    path.appendSegment(g.Path.createSegment('L', targetPoint));
-    return path;
-}

--- a/docs/src/joint/api/connectors/intro.html
+++ b/docs/src/joint/api/connectors/intro.html
@@ -1,31 +1,34 @@
 <p>Connectors take an array of link route points and generate SVG path commands so that the link can be rendered. The <code>connector</code> property of a link can be accessed with the <code>link.connector()</code> <a href="#dia.Link.prototype.connector">function</a>.</p>
 
-<p>There are four built-in connectors in JointJS:</p>
+<p>There are six built-in connectors in JointJS:</p>
 
 <ul>
-    <li><code>'jumpover'</code> - <a href="#connectors.jumpover">connector with bridges over link intersections</a></li>
-    <li><code>'normal'</code> - <a href="#connectors.normal">default simple connector</a></li>
-    <li><code>'rounded'</code> - <a href="#connectors.rounded">connector with rounded edges</a></li>
+    <li><code>'straight'</code> - <a href="#connectors.straight">connector with straight lines and different ways to handle corners (point, rounded, bevelled, gap)</a></li>
+    <li><code>'jumpover'</code> - <a href="#connectors.jumpover">connector with angled straight lines and bridges over link intersections</a></li>
+    <li><code>'normal'</code> - <a href="#connectors.normal">(<i>deprecated</i>) default connector with angled straight lines</a></li>
+    <li><code>'rounded'</code> - <a href="#connectors.rounded">(<i>deprecated</i>) connector with straight lines and rounded edges</a></li>
     <li><code>'smooth'</code> - <a href="#connectors.smooth">connector interpolated as a bezier curve</a></li>
     <li><code>'curve'</code> - <a href="#connectors.curve">connector interpolating as a curve defined by ending tangents</a></li>
 </ul>
 
 <p>Example:</p>
 
-<pre><code>link.connector('rounded', {
-    radius: 20
+<pre><code>link.connector('straight', {
+    cornerType: 'line',
+    cornerRadius: 20
 });</code></pre>
 
 <p>The default connector is <code>'normal'</code>; this can be changed with the <code>defaultConnector</code> <a href="#dia.Paper.prototype.options.defaultConnector">paper option</a>. Example:</p>
 
 <pre><code>paper.options.defaultConnector = {
-    name: 'rounded',
+    name: 'straight',
     args: {
-        radius: 20
+        cornerType: 'line',
+        cornerRadius: 20
     }
 }</code></pre>
 
-<p>All four of the built-in connectors accept the following optional argument, in addition to their own arguments:</p>
+<p>All of the built-in connectors accept the following optional argument, in addition to their own arguments:</p>
 
 <table>
     <tr>
@@ -37,7 +40,7 @@
 
 <p>Example:</p>
 
-<pre><code>link.connector('normal', {
+<pre><code>link.connector('straight', {
     raw: true
 });</code></pre>
 

--- a/docs/src/joint/api/connectors/normal.html
+++ b/docs/src/joint/api/connectors/normal.html
@@ -1,5 +1,12 @@
+<p>Deprecated. Use the <code>'straight'</code> <a href="#connectors.straight">connector</a> instead.</p>
+
+<p>Example:</p>
+
+<pre><code>link.connector('straight');</code></pre>
+
 <p>The <code>'normal'</code> connector is the default connector for links and it is the simplest connector. It simply connects provided route points with straight-line segments.</p>
 
 <p>Example:</p>
 
-<pre><code>link.connector('normal');</code></pre>
+<pre><code>// deprecated
+link.connector('normal');</code></pre>

--- a/docs/src/joint/api/connectors/rounded.html
+++ b/docs/src/joint/api/connectors/rounded.html
@@ -1,3 +1,13 @@
+<p>Deprecated. Use the <code>'straight'</code> <a href="#connectors.straight">connector</a> with <code>cornerType: 'cubic'</code> instead. (To exactly replicate the <code>'rounded'</code> connector functionality, you should also pass <code>precision: 0</code>.)</p>
+
+<p>Example:</p>
+
+<pre><code>link.connector('straight', {
+    cornerType: 'cubic',
+    precision: 0,
+    cornerRadius: 20
+});</code></pre>
+
 <p>The <code>'rounded'</code> connector connects provided route points with straight lines while smoothing all corners on the route. It accepts one additional argument, which can be passed within the <code>connector.args</code> property:</p>
 
 <table>
@@ -10,6 +20,7 @@
 
 <p>Example:</p>
 
-<pre><code>link.connector('rounded', {
+<pre><code>// deprecated
+link.connector('rounded', {
     radius: 20
 });</code></pre>

--- a/docs/src/joint/api/connectors/straight.html
+++ b/docs/src/joint/api/connectors/straight.html
@@ -1,0 +1,60 @@
+<p>The <code>'straight'</code> connector connects provided route points with straight lines while handling corners on the route in different ways depending on provided arguments (point, rounded, bevelled, gap). It accepts four additional arguments, which can be passed within the <code>connector.args</code> property:</p>
+
+<table>
+    <tr>
+        <th>cornerType</th>
+        <td><i>string</i></td>
+        <td>(<i>Optional</i>) How should corners on the route be handled? The default is <code>'point'</code>. The available values are the following:
+            <table>
+                <tr>
+                    <th><code>'point'</code></th>
+                    <td>Route segments meet at corner point with no special behavior. This corresponds to the behavior of the deprecated <code>'normal'</code> <a href="#connectors.normal">connector</a>.</td>
+                </tr>
+                <tr>
+                    <th><code>'cubic'</code></th>
+                    <td>A cubic curve segment is inserted to smooth the corner. The curve radius of the smoothed corner is determined by <code>cornerRadius</code> argument. This corresponds to the behavior of the deprecated <code>'rounded'</code> <a href="#connectors.rounded">connector</a>.</td>
+                </tr>
+                <tr>
+                    <th><code>'line'</code></th>
+                    <td>A straight line segment is inserted at the corner to form a bevel. The distance of the two endpoints of the bevel from the corner point is determined by <code>cornerRadius</code> argument.</td>
+                </tr>
+                <tr>
+                    <th><code>'gap'</code></th>
+                    <td>A gap is created at the corner. The distance of the two endpoints of the gap from the corner point is determined by the <code>cornerRadius</code> argument.</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    <tr>
+        <th>cornerRadius</th>
+        <td><i>number</i></td>
+        <td>(<i>Optional</i>) The distance of endpoints of line segments around corner points (e.g. curve radius for <code>'cubic'</code> corner type). Default is <code>10</code>. This argument is ignored for <code>cornerType: 'point'</code>.</td>
+    </tr>
+    <tr>
+        <th>cornerPreserveAspectRatio</th>
+        <td><i>boolean</i></td>
+        <td>(<i>Optional</i>) Should distance of both endpoints be adjusted if one of them needs to be placed closer to a corner point than specified by the <code>cornerRadius</code> argument; or are the two allowed to be independent? (This situation happens when the distance between two consecutive route points is lower than <code>cornerRadius * 2</code>.) Default is <code>false</code>. This argument is ignored for <code>cornerType: 'point'</code></td>
+    </tr>
+    <tr>
+        <th>precision</th>
+        <td><i>number</i></td>
+        <td>(<i>Optional</i>) To how many decimal places should the returned point coordinates be rounded? Default is <code>1</code>. This argument is ignored for <code>cornerType: 'point'</code>.</td>
+</table>
+
+<p>Example of a bevelled connector:</p>
+
+<pre><code>link.connector('straight', {
+    cornerType: 'line',
+    cornerPreserveAspectRatio: true
+});</code></pre>
+
+<p>To replicate the functionality of the deprecated <code>'rounded'</code> <a href="#connectors.rounded">connector</a>, you can do the following:</p>
+
+<pre><code>link.connector('straight', {
+    cornerType: 'cubic',
+    precision: 0
+});</code></pre>
+
+<p>To replicate the functionality of the deprecated <code>'normal'</code> <a href="#connectors.normal">connector</a>, you can do the following:</p>
+
+<pre><code>link.connector('straight');</code></pre>

--- a/docs/src/joint/api/connectors/straight.html
+++ b/docs/src/joint/api/connectors/straight.html
@@ -8,11 +8,11 @@
             <table>
                 <tr>
                     <th><code>'point'</code></th>
-                    <td>Route segments meet at corner point with no special behavior. This corresponds to the behavior of the deprecated <code>'normal'</code> <a href="#connectors.normal">connector</a>.</td>
+                    <td>Route segments meet at corner point with no special behavior.</td>
                 </tr>
                 <tr>
                     <th><code>'cubic'</code></th>
-                    <td>A cubic curve segment is inserted to smooth the corner. The curve radius of the smoothed corner is determined by <code>cornerRadius</code> argument. This corresponds to the behavior of the deprecated <code>'rounded'</code> <a href="#connectors.rounded">connector</a>.</td>
+                    <td>A cubic curve segment is inserted to smooth the corner. The curve radius of the smoothed corner is determined by <code>cornerRadius</code> argument.</td>
                 </tr>
                 <tr>
                     <th><code>'line'</code></th>
@@ -48,13 +48,20 @@
     cornerPreserveAspectRatio: true
 });</code></pre>
 
-<p>To replicate the functionality of the deprecated <code>'rounded'</code> <a href="#connectors.rounded">connector</a>, you can do the following:</p>
+<p>Example of a rounded connector:</p>
 
 <pre><code>link.connector('straight', {
     cornerType: 'cubic',
-    precision: 0
+    cornerRadius: 20
 });</code></pre>
 
-<p>To replicate the functionality of the deprecated <code>'normal'</code> <a href="#connectors.normal">connector</a>, you can do the following:</p>
+<p>Example of a connector with gaps at corners:</p>
+
+<pre><code>link.connector('straight', {
+    cornerType: 'gap',
+    cornerRadius: 2
+});</code></pre>
+
+<p>Example of a connector with simple angled lines connecting route points:</p>
 
 <pre><code>link.connector('straight');</code></pre>

--- a/src/connectors/index.mjs
+++ b/src/connectors/index.mjs
@@ -1,3 +1,4 @@
+export * from './straight.mjs';
 export * from './jumpover.mjs';
 export * from './normal.mjs';
 export * from './rounded.mjs';

--- a/src/connectors/normal.mjs
+++ b/src/connectors/normal.mjs
@@ -1,12 +1,12 @@
-import * as g from '../g/index.mjs';
+import { straight } from './straight.mjs';
 
-export const normal = function(sourcePoint, targetPoint, route, opt) {
+export const normal = function(sourcePoint, targetPoint, route = [], opt = {}) {
 
-    var raw = opt && opt.raw;
-    var points = [sourcePoint].concat(route).concat([targetPoint]);
+    const { raw } = opt;
+    const localOpt = {
+        cornerType: 'point',
+        raw
+    };
 
-    var polyline = new g.Polyline(points);
-    var path = new g.Path(polyline);
-
-    return (raw) ? path : path.serialize();
+    return straight(sourcePoint, targetPoint, route, localOpt);
 };

--- a/src/connectors/rounded.mjs
+++ b/src/connectors/rounded.mjs
@@ -1,55 +1,17 @@
-import * as g from '../g/index.mjs';
+import { straight } from './straight.mjs';
 
-export const rounded = function(sourcePoint, targetPoint, route, opt) {
+const CORNER_RADIUS = 10;
+const PRECISION = 0;
 
-    opt || (opt = {});
+export const rounded = function(sourcePoint, targetPoint, route = [], opt = {}) {
 
-    var offset = opt.radius || 10;
-    var raw = opt.raw;
-    var path = new g.Path();
-    var segment;
+    const { radius = CORNER_RADIUS, raw } = opt;
+    const localOpt = {
+        cornerType: 'cubic',
+        cornerRadius: radius,
+        precision: PRECISION,
+        raw
+    };
 
-    segment = g.Path.createSegment('M', sourcePoint);
-    path.appendSegment(segment);
-
-    var _13 = 1 / 3;
-    var _23 = 2 / 3;
-
-    var curr;
-    var prev, next;
-    var prevDistance, nextDistance;
-    var startMove, endMove;
-    var roundedStart, roundedEnd;
-    var control1, control2;
-
-    for (var index = 0, n = route.length; index < n; index++) {
-
-        curr = new g.Point(route[index]);
-
-        prev = route[index - 1] || sourcePoint;
-        next = route[index + 1] || targetPoint;
-
-        prevDistance = nextDistance || (curr.distance(prev) / 2);
-        nextDistance = curr.distance(next) / 2;
-
-        startMove = -Math.min(offset, prevDistance);
-        endMove = -Math.min(offset, nextDistance);
-
-        roundedStart = curr.clone().move(prev, startMove).round();
-        roundedEnd = curr.clone().move(next, endMove).round();
-
-        control1 = new g.Point((_13 * roundedStart.x) + (_23 * curr.x), (_23 * curr.y) + (_13 * roundedStart.y));
-        control2 = new g.Point((_13 * roundedEnd.x) + (_23 * curr.x), (_23 * curr.y) + (_13 * roundedEnd.y));
-
-        segment = g.Path.createSegment('L', roundedStart);
-        path.appendSegment(segment);
-
-        segment = g.Path.createSegment('C', control1, control2, roundedEnd);
-        path.appendSegment(segment);
-    }
-
-    segment = g.Path.createSegment('L', targetPoint);
-    path.appendSegment(segment);
-
-    return (raw) ? path : path.serialize();
+    return straight(sourcePoint, targetPoint, route, localOpt);
 };

--- a/src/connectors/straight.mjs
+++ b/src/connectors/straight.mjs
@@ -7,6 +7,8 @@ const CornerTypes = {
     GAP: 'gap'
 };
 
+const DEFINED_CORNER_TYPES = Object.values(CornerTypes);
+
 const CORNER_RADIUS = 10;
 const PRECISION = 1;
 
@@ -20,7 +22,7 @@ export const straight = function(sourcePoint, targetPoint, routePoints = [], opt
         raw = false
     } = opt;
 
-    if (Object.values(CornerTypes).indexOf(cornerType) === -1) {
+    if (DEFINED_CORNER_TYPES.indexOf(cornerType) === -1) {
         // unknown `cornerType` provided => error
         throw new Error('Invalid `cornerType` provided to `straight` connector.');
     }

--- a/src/connectors/straight.mjs
+++ b/src/connectors/straight.mjs
@@ -7,8 +7,6 @@ const CornerTypes = {
     GAP: 'gap'
 };
 
-const DEFINED_CORNER_TYPES = Object.keys(CornerTypes).map((key) => (CornerTypes[key]));
-
 const CORNER_RADIUS = 10;
 const PRECISION = 1;
 
@@ -22,7 +20,7 @@ export const straight = function(sourcePoint, targetPoint, routePoints = [], opt
         raw = false
     } = opt;
 
-    if (DEFINED_CORNER_TYPES.indexOf(cornerType) === -1) {
+    if (Object.values(CornerTypes).indexOf(cornerType) === -1) {
         // unknown `cornerType` provided => error
         throw new Error('Invalid `cornerType` provided to `straight` connector.');
     }

--- a/src/connectors/straight.mjs
+++ b/src/connectors/straight.mjs
@@ -1,0 +1,110 @@
+import * as g from '../g/index.mjs';
+
+const CornerTypes = {
+    POINT: 'point',
+    CUBIC: 'cubic',
+    LINE: 'line',
+    GAP: 'gap'
+};
+
+const DEFINED_CORNER_TYPES = Object.keys(CornerTypes).map((key) => (CornerTypes[key]));
+
+const CORNER_RADIUS = 10;
+const PRECISION = 1;
+
+export const straight = function(sourcePoint, targetPoint, routePoints = [], opt = {}) {
+
+    const {
+        cornerType = CornerTypes.POINT,
+        cornerRadius = CORNER_RADIUS,
+        cornerPreserveAspectRatio = false,
+        precision = PRECISION,
+        raw = false
+    } = opt;
+
+    if (DEFINED_CORNER_TYPES.indexOf(cornerType) === -1) {
+        // unknown `cornerType` provided => error
+        throw new Error('Invalid `cornerType` provided to `straight` connector.');
+    }
+
+    let path;
+
+    if ((cornerType === CornerTypes.POINT) || !cornerRadius) {
+        // default option => normal connector
+        // simply connect all points with straight lines
+        const points = [sourcePoint].concat(routePoints).concat([targetPoint]);
+        const polyline = new g.Polyline(points);
+        path = new g.Path(polyline);
+
+    } else {
+        // `cornerType` is not unknown and not 'point' (default) => must be one of other valid types
+        path = new g.Path();
+
+        // add initial gap segment = to source point
+        path.appendSegment(g.Path.createSegment('M', sourcePoint));
+
+        let nextDistance;
+        const routePointsLength = routePoints.length;
+        for (let i = 0; i < routePointsLength; i++) {
+
+            const curr = new g.Point(routePoints[i]);
+            const prev = (routePoints[i - 1] || sourcePoint);
+            const next = (routePoints[i + 1] || targetPoint);
+            const prevDistance = (nextDistance || (curr.distance(prev) / 2)); // try to re-use previously-computed `nextDistance`
+            nextDistance = (curr.distance(next) / 2);
+
+            let startMove, endMove;
+            if (!cornerPreserveAspectRatio) {
+                // `startMove` and `endMove` may be different
+                // (this happens when next or previous path point is closer than `2 * cornerRadius`)
+                startMove = -Math.min(cornerRadius, prevDistance);
+                endMove = -Math.min(cornerRadius, nextDistance);
+            } else {
+                // force `startMove` and `endMove` to be the same
+                startMove = endMove = -Math.min(cornerRadius, prevDistance, nextDistance);
+            }
+
+            // to find `cornerStart` and `cornerEnd`, the logic is as follows (using `cornerStart` as example):
+            // - find a point lying on the line `prev - startMove` such that...
+            // - ...the point lies `abs(startMove)` distance away from `curr`...
+            // - ...and its coordinates are rounded to whole numbers
+            const cornerStart = curr.clone().move(prev, startMove).round(precision);
+            const cornerEnd = curr.clone().move(next, endMove).round(precision);
+
+            // add in-between straight segment = from previous route point to corner start point
+            // (may have zero length)
+            path.appendSegment(g.Path.createSegment('L', cornerStart));
+
+            // add corner segment = from corner start point to corner end point
+            switch (cornerType) {
+                case CornerTypes.CUBIC: {
+                    // corner is rounded
+                    const _13 = (1 / 3);
+                    const _23 = (2 / 3);
+                    const control1 = new g.Point((_13 * cornerStart.x) + (_23 * curr.x), (_23 * curr.y) + (_13 * cornerStart.y));
+                    const control2 = new g.Point((_13 * cornerEnd.x) + (_23 * curr.x), (_23 * curr.y) + (_13 * cornerEnd.y));
+                    path.appendSegment(g.Path.createSegment('C', control1, control2, cornerEnd));
+                    break;
+                }
+                case CornerTypes.LINE: {
+                    // corner has bevel
+                    path.appendSegment(g.Path.createSegment('L', cornerEnd));
+                    break;
+                }
+                case CornerTypes.GAP: {
+                    // corner has empty space
+                    path.appendSegment(g.Path.createSegment('M', cornerEnd));
+                    break;
+                }
+                // default: no segment is created
+            }
+        }
+
+        // add final straight segment = from last corner end point to target point
+        // (= or from start point to end point, if there are no route points)
+        // (may have zero length)
+        path.appendSegment(g.Path.createSegment('L', targetPoint));
+    }
+
+    return ((raw) ? path : path.serialize());
+};

--- a/test/jointjs/connectors.js
+++ b/test/jointjs/connectors.js
@@ -42,17 +42,17 @@ QUnit.module('connectors', function(hooks) {
         l0.set('connector', { name: 'normal' });
         this.graph.addCell(l0);
         assert.equal(this.graph.getLinks().length, 1, 'A link with the normal connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l0).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the normal connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l0).getConnection().round(2).serialize(), 'M 102 110 L 150 200 L 320 104', 'A link with the normal connector was correctly rendered');
 
         var l1 = l0.clone().set('connector', { name: 'rounded' });
         this.graph.addCell(l1);
         assert.equal(this.graph.getLinks().length, 2, 'A link with the rounded connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l1).metrics.data, 'M 102 110 L 145 191 C 148.33333333333331 196.99999999999997 153 198.33333333333331 159 195 L 320 104', 'A link with the rounded connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l1).getConnection().round(2).serialize(), 'M 102 110 L 145 191 C 148.33 197 153 198.33 159 195 L 320 104', 'A link with the rounded connector was correctly rendered');
 
         var l2 = l0.clone().set('connector', { name: 'smooth' });
         this.graph.addCell(l2);
         assert.equal(this.graph.getLinks().length, 3, 'A link with the smooth connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l2).metrics.data, 'M 102 110 C 107.83333333333333 155.5 113.66666666666666 201 150 200 C 186.33333333333334 199 253.16666666666669 151.5 320 104', 'A link with the smooth connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l2).getConnection().round(2).serialize(), 'M 102 110 C 107.83 155.5 113.67 201 150 200 C 186.33 199 253.17 151.5 320 104', 'A link with the smooth connector was correctly rendered');
 
         var l3 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'non-existing' }});
         assert.throws(function() {
@@ -62,30 +62,30 @@ QUnit.module('connectors', function(hooks) {
         l3.set('connector', { name: 'straight' });
         this.graph.addCell(l3);
         assert.equal(this.graph.getLinks().length, 4, 'A link with the (default) straight connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l3).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the (default) straight connector was correctly rendered');
-        assert.checkDataPath(this.paper.findViewByModel(l3).metrics.data, this.paper.findViewByModel(l0).metrics.data, 'A link with the (default) straight connector was rendered same as if it had the normal connector');
+        assert.checkDataPath(this.paper.findViewByModel(l3).getConnection().round(2).serialize(), 'M 102 110 L 150 200 L 320 104', 'A link with the (default) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l3).getConnection().round(2).serialize(), this.paper.findViewByModel(l0).getConnection().round(2).serialize(), 'A link with the (default) straight connector was rendered same as if it had the normal connector');
 
         var l4 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'point' }});
         this.graph.addCell(l4);
         assert.equal(this.graph.getLinks().length, 5, 'A link with the (point) straight connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l4).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the (point) straight connector was correctly rendered');
-        assert.checkDataPath(this.paper.findViewByModel(l4).metrics.data, this.paper.findViewByModel(l0).metrics.data, 'A link with the (point) straight connector was rendered same as if it had the normal connector');
+        assert.checkDataPath(this.paper.findViewByModel(l4).getConnection().round(2).serialize(), 'M 102 110 L 150 200 L 320 104', 'A link with the (point) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l4).getConnection().round(2).serialize(), this.paper.findViewByModel(l0).getConnection().round(2).serialize(), 'A link with the (point) straight connector was rendered same as if it had the normal connector');
 
         var l5 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'cubic', precision: 0 }});
         this.graph.addCell(l5);
         assert.equal(this.graph.getLinks().length, 6, 'A link with the (cubic) straight connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l5).metrics.data, 'M 102 110 L 145 191 C 148.33333333333331 196.99999999999997 153 198.33333333333331 159 195 L 320 104', 'A link with the (cubic) straight connector was correctly rendered');
-        assert.checkDataPath(this.paper.findViewByModel(l5).metrics.data, this.paper.findViewByModel(l1).metrics.data, 'A link with the (cubic) straight connector was rendered same as if it had the rounded connector');
+        assert.checkDataPath(this.paper.findViewByModel(l5).getConnection().round(2).serialize(), 'M 102 110 L 145 191 C 148.33 197 153 198.33 159 195 L 320 104', 'A link with the (cubic) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l5).getConnection().round(2).serialize(), this.paper.findViewByModel(l1).getConnection().round(2).serialize(), 'A link with the (cubic) straight connector was rendered same as if it had the rounded connector');
 
         var l6 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'line' }});
         this.graph.addCell(l6);
         assert.equal(this.graph.getLinks().length, 7, 'A link with the (line) straight connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l6).metrics.data, 'M 102 110 L 145.3 191.2 L 158.7 195.1 L 320 104', 'A link with the (line) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l6).getConnection().round(2).serialize(), 'M 102 110 L 145.3 191.2 L 158.7 195.1 L 320 104', 'A link with the (line) straight connector was correctly rendered');
 
         var l7 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'gap' }});
         this.graph.addCell(l7);
         assert.equal(this.graph.getLinks().length, 8, 'A link with the (gap) straight connector was successfully added to the graph');
-        assert.checkDataPath(this.paper.findViewByModel(l7).metrics.data, 'M 102 110 L 145.3 191.2 M 158.7 195.1 L 320 104', 'A link with the (gap) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l7).getConnection().round(2).serialize(), 'M 102 110 L 145.3 191.2 M 158.7 195.1 L 320 104', 'A link with the (gap) straight connector was correctly rendered');
 
         var customCalled = 0;
         var l99 = l0.clone().set('connector', function() {

--- a/test/jointjs/connectors.js
+++ b/test/jointjs/connectors.js
@@ -36,43 +36,64 @@ QUnit.module('connectors', function(hooks) {
         });
 
         assert.throws(function() {
-
             this.graph.addCell(l0);
-
-        }, /non-existing/, 'Recognize an unexisting connector.');
+        }, /non-existing/, 'Recognize a non-existing connector.');
 
         l0.set('connector', { name: 'normal' });
-
         this.graph.addCell(l0);
-
-        assert.equal(this.graph.getLinks().length, 1,
-            'A link with the normal connector was succesfully added to the graph');
+        assert.equal(this.graph.getLinks().length, 1, 'A link with the normal connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l0).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the normal connector was correctly rendered');
 
         var l1 = l0.clone().set('connector', { name: 'rounded' });
-
         this.graph.addCell(l1);
-
-        assert.equal(this.graph.getLinks().length, 2,
-            'A link with the rounded connector was succesfully added to the graph');
+        assert.equal(this.graph.getLinks().length, 2, 'A link with the rounded connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l1).metrics.data, 'M 102 110 L 145 191 C 148.33333333333331 196.99999999999997 153 198.33333333333331 159 195 L 320 104', 'A link with the rounded connector was correctly rendered');
 
         var l2 = l0.clone().set('connector', { name: 'smooth' });
-
         this.graph.addCell(l2);
+        assert.equal(this.graph.getLinks().length, 3, 'A link with the smooth connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l2).metrics.data, 'M 102 110 C 107.83333333333333 155.5 113.66666666666666 201 150 200 C 186.33333333333334 199 253.16666666666669 151.5 320 104', 'A link with the smooth connector was correctly rendered');
 
-        assert.equal(this.graph.getLinks().length, 3,
-            'A link with the smooth connector was succesfully added to the graph');
+        var l3 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'non-existing' }});
+        assert.throws(function() {
+            this.graph.addCell(l3);
+        }, /Invalid `cornerType` provided to `straight` connector/, 'Recognize invalid corner type of straight connector.');
+
+        l3.set('connector', { name: 'straight' });
+        this.graph.addCell(l3);
+        assert.equal(this.graph.getLinks().length, 4, 'A link with the (default) straight connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l3).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the (default) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l3).metrics.data, this.paper.findViewByModel(l0).metrics.data, 'A link with the (default) straight connector was rendered same as if it had the normal connector');
+
+        var l4 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'point' }});
+        this.graph.addCell(l4);
+        assert.equal(this.graph.getLinks().length, 5, 'A link with the (point) straight connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l4).metrics.data, 'M 102 110 L 150 200 L 320 104', 'A link with the (point) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l4).metrics.data, this.paper.findViewByModel(l0).metrics.data, 'A link with the (point) straight connector was rendered same as if it had the normal connector');
+
+        var l5 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'cubic', precision: 0 }});
+        this.graph.addCell(l5);
+        assert.equal(this.graph.getLinks().length, 6, 'A link with the (cubic) straight connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l5).metrics.data, 'M 102 110 L 145 191 C 148.33333333333331 196.99999999999997 153 198.33333333333331 159 195 L 320 104', 'A link with the (cubic) straight connector was correctly rendered');
+        assert.checkDataPath(this.paper.findViewByModel(l5).metrics.data, this.paper.findViewByModel(l1).metrics.data, 'A link with the (cubic) straight connector was rendered same as if it had the rounded connector');
+
+        var l6 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'line' }});
+        this.graph.addCell(l6);
+        assert.equal(this.graph.getLinks().length, 7, 'A link with the (line) straight connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l6).metrics.data, 'M 102 110 L 145.3 191.2 L 158.7 195.1 L 320 104', 'A link with the (line) straight connector was correctly rendered');
+
+        var l7 = l0.clone().set('connector', { name: 'straight', args: { cornerType: 'gap' }});
+        this.graph.addCell(l7);
+        assert.equal(this.graph.getLinks().length, 8, 'A link with the (gap) straight connector was successfully added to the graph');
+        assert.checkDataPath(this.paper.findViewByModel(l7).metrics.data, 'M 102 110 L 145.3 191.2 M 158.7 195.1 L 320 104', 'A link with the (gap) straight connector was correctly rendered');
 
         var customCalled = 0;
-        var l3 = l0.clone().set('connector', function() {
+        var l99 = l0.clone().set('connector', function() {
             customCalled += 1;
             return 'M 0 0';
         });
-
-        this.graph.addCell(l3);
-
-        assert.equal(customCalled, 1,
-            'A link with the custom connector was succesfully added to the graph');
-
+        this.graph.addCell(l99);
+        assert.equal(customCalled, 1, 'A link with the custom connector was successfully added to the graph');
     });
 
     QUnit.test('curve connector direction auto', function(assert) {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3540,6 +3540,21 @@ export namespace connectors {
         radius?: number;
     }
 
+    enum CornerTypes {
+        POINT = 'point',
+        CUBIC = 'cubic',
+        LINE = 'line',
+        GAP = 'gap'
+    }
+
+    interface StraightConnectorArguments {
+        raw?: boolean;
+        cornerType?: CornerTypes;
+        cornerRadius?: number;
+        cornerPreserveAspectRatio?: boolean;
+        precision?: number;
+    }
+
     enum CurveDirections {
         AUTO = 'auto',
         HORIZONTAL = 'horizontal',
@@ -3576,6 +3591,7 @@ export namespace connectors {
         'rounded': RoundedConnectorArguments;
         'smooth': SmoothConnectorArguments;
         'jumpover': JumpOverConnectorArguments;
+        'straight': StraightConnectorArguments;
         'curve': CurveConnectorArguments;
         [key: string]: { [key: string]: any };
     }
@@ -3614,6 +3630,7 @@ export namespace connectors {
     export var rounded: GenericConnector<'rounded'>;
     export var smooth: GenericConnector<'smooth'>;
     export var jumpover: GenericConnector<'jumpover'>;
+    export var straight: GenericConnector<'straight'>;
     export var curve: CurveConnector;
 }
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3540,16 +3540,9 @@ export namespace connectors {
         radius?: number;
     }
 
-    enum CornerTypes {
-        POINT = 'point',
-        CUBIC = 'cubic',
-        LINE = 'line',
-        GAP = 'gap'
-    }
-
     interface StraightConnectorArguments {
         raw?: boolean;
-        cornerType?: CornerTypes;
+        cornerType?: 'point' | 'cubic' | 'line' | 'gap';
         cornerRadius?: number;
         cornerPreserveAspectRatio?: boolean;
         precision?: number;


### PR DESCRIPTION
## Description

Add a new connector `straight` which combines existing `normal` and `rounded` connectors with additional options to make path bevelled / with gaps at corners.

## Motivation and Context

Different functionality is enabled via options:
- `opt.cornerType` = what to do at corners?
   - `'point'` = default = connect path points with straight lines = `normal` connector functionality
   - `'cubic'` = draw a cubic segment at points = `rounded` connector functionality
   - `'line'` = draw a bevel segment at path points
   - `'gap'` = draw empty space at path points

- `opt.cornerRadius` = how far away from corner point does the rounding/bevel/gap start and end?
   - `10` by default (current default for rounded connector), ignored by `'point'`

- `opt.cornerPreserveAspectRatio` = if start and end are at different distances away from corner point (e.g. because route points are closer together than `opt.radius * 2`), do we force them to be the same (shorter) length?
   - `false` by default (important for rounded look), should be `true` for bevelled look

- `opt.precision` = default rounding precision on found points
   - `1` by default (important for bevelled look)

- `opt.raw` = if `true`, serialize result g.Path before returning