### PR TITLE
fix(dia.Paper): hide tools when cell view is unmounted

### DIFF
--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -30,6 +30,10 @@ const HighlightingTypes = {
     ELEMENT_AVAILABILITY: 'elementAvailability'
 };
 
+const Flags = {
+    TOOLS: 'TOOLS',
+};
+
 // CellView base view and controller.
 // --------------------------------------------
 
@@ -151,6 +155,13 @@ export const CellView = View.extend({
 
     onMount() {
         // To be overridden
+    },
+
+    onUnmount() {
+        const { _toolsView } = this;
+        if (_toolsView) {
+            _toolsView.unmount();
+        }
     },
 
     startListening: function() {
@@ -1005,6 +1016,10 @@ export const CellView = View.extend({
         return this;
     },
 
+    requestToolsUpdate(opt) {
+        this.requestUpdate(this.getFlag(Flags.TOOLS), opt);
+    },
+
     updateTools: function(opt) {
 
         var toolsView = this._toolsView;
@@ -1192,6 +1207,8 @@ export const CellView = View.extend({
         this.options.interactive = value;
     }
 }, {
+
+    Flags,
 
     Highlighting: HighlightingTypes,
 

--- a/src/dia/ElementView.mjs
+++ b/src/dia/ElementView.mjs
@@ -7,9 +7,9 @@ import { elementViewPortPrototype } from './ports.mjs';
 import { Rect, snapToGrid } from '../g/index.mjs';
 
 const Flags = {
+    TOOLS: CellView.Flags.TOOLS,
     UPDATE: 'UPDATE',
     TRANSLATE: 'TRANSLATE',
-    TOOLS: 'TOOLS',
     RESIZE: 'RESIZE',
     PORTS: 'PORTS',
     ROTATE: 'ROTATE',

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -8,9 +8,9 @@ import * as connectors from '../connectors/index.mjs';
 import $ from 'jquery';
 
 const Flags = {
+    TOOLS: CellView.Flags.TOOLS,
     RENDER: 'RENDER',
     UPDATE: 'UPDATE',
-    TOOLS: 'TOOLS',
     LEGACY_TOOLS: 'LEGACY_TOOLS',
     LABELS: 'LABELS',
     VERTICES: 'VERTICES',

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -259,12 +259,18 @@ export const Paper = View.extend({
 
         // no docs yet
         onViewUpdate: function(view, flag, priority, opt, paper) {
+            const { mounting, isolate } = opt;
+            if (mounting) {
+                if (view.hasTools()) view.requestToolsUpdate();
+                return;
+            }
             // Do not update connected links when:
             // 1. the view was just inserted (added to the graph and rendered)
             // 2. the view was just mounted (added back to the paper by viewport function)
+            //    (Note: we already exited above)
             // 3. the change was marked as `isolate`.
             // 4. the view model was just removed from the graph
-            if ((flag & (view.FLAG_INSERT | view.FLAG_REMOVE)) || opt.mounting || opt.isolate) return;
+            if ((flag & (view.FLAG_INSERT | view.FLAG_REMOVE)) || isolate) return;
             paper.requestConnectedLinksUpdate(view, priority, opt);
         },
 

--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -56,8 +56,10 @@ export const ToolsView = mvc.View.extend({
                 tool.update();
             }
         }
-        if (!isRendered) {
+        if (!isRendered || !this.isMounted()) {
             this.mount();
+        }
+        if (!isRendered) {
             // Make sure tools are visible (if they were hidden and the tool removed)
             this.blurTool();
             this.isRendered = true;
@@ -120,6 +122,15 @@ export const ToolsView = mvc.View.extend({
                 relatedView.el.appendChild(el);
             }
         }
+        return this;
+    },
+
+    isMounted: function() {
+        return this.el.isConnected;
+    },
+
+    unmount: function() {
+        this.vel.remove();
         return this;
     }
 

--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -126,7 +126,7 @@ export const ToolsView = mvc.View.extend({
     },
 
     isMounted: function() {
-        return this.el.isConnected;
+        return this.el.parentNode !== null;
     },
 
     unmount: function() {

--- a/src/mvc/View.mjs
+++ b/src/mvc/View.mjs
@@ -43,6 +43,11 @@ export const View = Backbone.View.extend({
         } else {
             this.$el.remove();
         }
+        this.onUnmount();
+    },
+
+    onUnmount: function() {
+        // to be overridden
     },
 
     renderChildren: function(children) {

--- a/test/jointjs/dia/elementTools.js
+++ b/test/jointjs/dia/elementTools.js
@@ -39,6 +39,22 @@ QUnit.module('elementTools', function(hooks) {
         elementView = null;
     });
 
+    QUnit.module('Mount & Unmount', function() {
+
+        QUnit.test('are mounted and unmounted  with the element view', function(assert) {
+            const remove = new joint.elementTools.Remove();
+            const toolsView = new joint.dia.ToolsView({ tools: [remove] });
+            elementView.addTools(toolsView);
+            assert.ok(toolsView.el.parentNode);
+            assert.ok(toolsView.isMounted());
+            paper.checkViewport({ viewport: () => false });
+            assert.notOk(toolsView.el.parentNode);
+            assert.notOk(toolsView.isMounted());
+            paper.checkViewport({ viewport: () => true });
+            assert.ok(toolsView.el.parentNode);
+            assert.ok(toolsView.isMounted());
+        });
+    });
 
     QUnit.module('Remove', function() {
         [{

--- a/test/jointjs/dia/linkTools.js
+++ b/test/jointjs/dia/linkTools.js
@@ -45,6 +45,23 @@ QUnit.module('linkTools', function(hooks) {
         linkView = null;
     });
 
+    QUnit.module('Mount & Unmount', function() {
+
+        QUnit.test('are mounted and unmounted  with the link view', function(assert) {
+            const remove = new joint.linkTools.Remove();
+            const toolsView = new joint.dia.ToolsView({ tools: [remove] });
+            linkView.addTools(toolsView);
+            assert.ok(toolsView.el.parentNode);
+            assert.ok(toolsView.isMounted());
+            paper.checkViewport({ viewport: () => false });
+            assert.notOk(toolsView.el.parentNode);
+            assert.notOk(toolsView.isMounted());
+            paper.checkViewport({ viewport: () => true });
+            assert.ok(toolsView.el.parentNode);
+            assert.ok(toolsView.isMounted());
+        });
+    });
+
     QUnit.module('TargetAnchor', function() {
         [{
             resetAnchor: true,

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -805,6 +805,8 @@ export namespace dia {
 
         requestUpdate(flags: number, opt?: { [key: string]: any }): void;
 
+        requestToolsUpdate(flags: number, opt?: { [key: string]: any }): void;
+
         dragLinkStart(evt: dia.Event, magnet: SVGElement, x: number, y: number): void;
 
         dragLink(evt: dia.Event, x: number, y: number): void;
@@ -1791,6 +1793,10 @@ export namespace dia {
         hide(): this;
 
         mount(): this;
+
+        unmount(): this;
+
+        isMounted(): boolean;
 
         protected simulateRelatedView(el: SVGElement): void;
     }
@@ -3395,6 +3401,8 @@ export namespace mvc {
         protected onSetTheme(oldTheme: string, newTheme: string): void;
 
         protected onRemove(): void;
+
+        protected onUnmount(): void;
     }
 
     type ModifiedCallback<CallbackArgs extends any[], EventCallback extends Callback> = (...args: [...CallbackArgs, ...Parameters<EventCallback>]) => any;


### PR DESCRIPTION
## Description

When the cell view was unmounted (`paper.options.viewport` returned `false`), it was removed from the DOM, but the tools attached to the cell view remained there.
