### PR TITLE
fix(demo.Container): fix missing fitAncestorElements function for Child elements

### DIFF
--- a/demo/container/src/index.js
+++ b/demo/container/src/index.js
@@ -19,6 +19,7 @@
             var element = view.model;
             // Hide any element or link which is embedded inside a collapsed parent (or parent of the parent).
             var hidden = element.getAncestors().some(function(ancestor) {
+                // `isCollapsed()` method is defined at `joint.shapes.container.Parent` in `./joint.shapes.container.js`
                 return ancestor.isCollapsed();
             });
             return !hidden;
@@ -110,17 +111,21 @@
     link_4_5.reparent();
     link_1_b.reparent();
 
+    // `toggle()` method is defined at `joint.shapes.container.Parent` in `./joint.shapes.container.js`
     container_b.toggle(false);
     container_a.toggle(false);
 
     paper.on('element:button:pointerdown', function(elementView) {
         var element = elementView.model;
+        // `toggle()` method is defined at `joint.shapes.container.Parent` in `./joint.shapes.container.js`
         element.toggle();
+        // `fitAncestorElements()` method is defined at `joint.shapes.container.Base` in `./joint.shapes.container.js`
         element.fitAncestorElements();
     });
 
     paper.on('element:pointermove', function(elementView) {
         var element = elementView.model;
+        // `fitAncestorElements()` method is defined at `joint.shapes.container.Base` in `./joint.shapes.container.js`
         element.fitAncestorElements();
     });
 

--- a/demo/container/src/joint.shapes.container.js
+++ b/demo/container/src/joint.shapes.container.js
@@ -30,20 +30,7 @@
                     bottom: padding
                 }
             });
-        },
-
-        fitToChildElements: function() {
-            var padding = 10;
-            this.fitToChildren({
-                padding: {
-                    top: headerHeight + padding,
-                    left: padding,
-                    right: padding,
-                    bottom: padding
-                }
-            })
-        },
-
+        }
     });
 
     joint.shapes.container.Base.define('container.Child', {
@@ -190,7 +177,6 @@
                 this.resize(140, 30);
             } else {
                 buttonD = 'M 2 7 12 7';
-                // `fitToChildElements()` method is defined at `joint.shapes.container.Base`
                 this.fitToChildElements();
             }
             this.attr(['buttonIcon','d'], buttonD);
@@ -199,6 +185,18 @@
 
         isCollapsed: function() {
             return Boolean(this.get('collapsed'));
+        },
+
+        fitToChildElements: function() {
+            var padding = 10;
+            this.fitToChildren({
+                padding: {
+                    top: headerHeight + padding,
+                    left: padding,
+                    right: padding,
+                    bottom: padding
+                }
+            })
         }
     });
 

--- a/demo/container/src/joint.shapes.container.js
+++ b/demo/container/src/joint.shapes.container.js
@@ -13,7 +13,40 @@
         }
     });
 
-    joint.dia.Element.define('container.Child', {
+    var headerHeight = 30;
+    var buttonSize = 14;
+
+    joint.dia.Element.define('container.Base', {
+        // no default attributes
+    }, {
+        fitAncestorElements: function() {
+            var padding = 10;
+            this.fitParent({
+                deep: true,
+                padding: {
+                    top: headerHeight + padding,
+                    left: padding,
+                    right: padding,
+                    bottom: padding
+                }
+            });
+        },
+
+        fitToChildElements: function() {
+            var padding = 10;
+            this.fitToChildren({
+                padding: {
+                    top: headerHeight + padding,
+                    left: padding,
+                    right: padding,
+                    bottom: padding
+                }
+            })
+        },
+
+    });
+
+    joint.shapes.container.Base.define('container.Child', {
         size: { width: 50, height: 50 },
         attrs: {
             root: {
@@ -57,10 +90,7 @@
         }]
     });
 
-    var headerHeight = 30;
-    var buttonSize = 14;
-
-    joint.dia.Element.define('container.Parent', {
+    joint.shapes.container.Base.define('container.Parent', {
         collapsed: false,
         attrs: {
             root: {
@@ -128,7 +158,6 @@
             }
         }
     }, {
-
         markup: [{
             tagName: 'rect',
             selector: 'shadow'
@@ -161,6 +190,7 @@
                 this.resize(140, 30);
             } else {
                 buttonD = 'M 2 7 12 7';
+                // `fitToChildElements()` method is defined at `joint.shapes.container.Base`
                 this.fitToChildElements();
             }
             this.attr(['buttonIcon','d'], buttonD);
@@ -169,31 +199,6 @@
 
         isCollapsed: function() {
             return Boolean(this.get('collapsed'));
-        },
-
-        fitToChildElements: function() {
-            var padding = 10;
-            this.fitToChildren({
-                padding: {
-                    top: headerHeight + padding,
-                    left: padding,
-                    right: padding,
-                    bottom: padding
-                }
-            })
-        },
-
-        fitAncestorElements: function() {
-            var padding = 10;
-            this.fitParent({
-                deep: true,
-                padding: {
-                    top: headerHeight + padding,
-                    left: padding,
-                    right: padding,
-                    bottom: padding
-                }
-            });
         }
     });
 


### PR DESCRIPTION
## Description

PR #2080 broke the Container demo by assuming that container.Child elements would have access to newly-written container.Parent method `fitAncestorElements()`. This caused errors to be written to the console whenever a container.Child element was dragged.

## Motivation and Context

This PR fixes the problem by creating a new container.Base class and putting the `fitAncestorElements()` method there. The container.Child and container.Parent both extend this class.