### PR TITLE
fix(dia.Paper): throw error when calling unfreeze after paper removal

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -99,8 +99,6 @@ export const Paper = View.extend({
 
     className: 'paper',
 
-    idle: false,
-
     options: {
 
         width: 800,
@@ -259,16 +257,8 @@ export const Paper = View.extend({
 
         frozen: false,
 
-        // Freeze paper when waiting for view updates
-        freezeWhenIdle: false,
-
         // no docs yet
         onViewUpdate: function(view, flag, priority, opt, paper) {
-            if (this.options.freezeWhenIdle && this.isIdle()) {
-                this.idle = false;
-                this.unfreeze();
-            }
-
             const { mounting, isolate } = opt;
             if (mounting) {
                 if (view.hasTools()) view.requestToolsUpdate();
@@ -981,10 +971,6 @@ export const Paper = View.extend({
         if (typeof afterFn === 'function') {
             afterFn.call(this, stats, opt, this);
         }
-        this.idle = true;
-        if (this.options.freezeWhenIdle) {
-            this.freeze();
-        }
         this.trigger('render:done', stats, opt);
     },
 
@@ -1208,10 +1194,6 @@ export const Paper = View.extend({
 
     isFrozen: function() {
         return !!this.options.frozen;
-    },
-
-    isIdle: function() {
-        return this.idle;
     },
 
     isExactSorting: function() {

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -73,7 +73,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         paper.model.addCell({ type: 'standard.Rectangle' });
         paper.model.addCell({ type: 'standard.Link' });
         paper.remove();
-        assert.throws(paper.unfreeze, Error);
+        assert.throws(() => paper.unfreeze(), Error);
     });
 
     QUnit.module('options', function() {

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -67,6 +67,15 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         assert.equal(getNumberOfViews(), initialCount);
     });
 
+
+    QUnit.test('unfreeze throws error after removing', function(assert) {
+        paper = new Paper({ el: paperEl, async: true });
+        paper.model.addCell({ type: 'standard.Rectangle' });
+        paper.model.addCell({ type: 'standard.Link' });
+        paper.remove();
+        assert.throws(paper.unfreeze, Error);
+    });
+
     QUnit.module('options', function() {
 
         QUnit.test('cloning', function(assert) {


### PR DESCRIPTION
Throw an error when user trying to call `paper.unfreeze()` after removing the paper. Previously `unfreeze` was trying to run next frame which is not needed anymore.

This is to prevent unnecessary memory leaks (infinite `nextAnimationFrame` loop).