### PR TITLE
fix(dia.Paper): hide tools and highlighters when cell view is detached

### DIFF
--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -981,17 +981,24 @@ export const CellView = View.extend({
 
     // Lifecycle methods
 
-    onMount() {
-        if (this.el.childNodes.length === 0) return;
+    // Called when the view is attached to the DOM,
+    // as result of `cell.addTo(graph)` being called (isInitialMount === true)
+    // or `paper.options.viewport` returning `true` (isInitialMount === false).
+    onMount(isInitialMount) {
+        if (isInitialMount) return;
         this.mountTools();
         HighlighterView.mount(this);
     },
 
-    onUnmount() {
+    // Called when the view is detached from the DOM,
+    // as result of `paper.options.viewport` returning `false`.
+    onDetach() {
         this.unmountTools();
         HighlighterView.unmount(this);
     },
 
+    // Called when the view is removed from the DOM
+    // as result of `cell.remove()`.
     onRemove: function() {
         this.removeTools();
         this.removeHighlighters();

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -984,12 +984,12 @@ export const CellView = View.extend({
     onMount() {
         if (this.el.childNodes.length === 0) return;
         this.mountTools();
-        this.mountHighlighters();
+        HighlighterView.mount(this);
     },
 
     onUnmount() {
         this.unmountTools();
-        this.unmountHighlighters();
+        HighlighterView.unmount(this);
     },
 
     onRemove: function() {
@@ -1083,14 +1083,6 @@ export const CellView = View.extend({
 
     updateHighlighters: function(dirty = false) {
         HighlighterView.update(this, null, dirty);
-    },
-
-    mountHighlighters: function() {
-        HighlighterView.mount(this);
-    },
-
-    unmountHighlighters: function() {
-        HighlighterView.unmount(this);
     },
 
     transformHighlighters: function() {

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -153,17 +153,6 @@ export const CellView = View.extend({
         this.startListening();
     },
 
-    onMount() {
-        // To be overridden
-    },
-
-    onUnmount() {
-        const { _toolsView } = this;
-        if (_toolsView) {
-            _toolsView.unmount();
-        }
-    },
-
     startListening: function() {
         this.listenTo(this.model, 'change', this.onAttributesChange);
     },
@@ -990,6 +979,19 @@ export const CellView = View.extend({
         processedAttrs.normal = roProcessedAttrs.normal;
     },
 
+    // Lifecycle methods
+
+    onMount() {
+        if (this.el.childNodes.length === 0) return;
+        this.mountTools();
+        this.mountHighlighters();
+    },
+
+    onUnmount() {
+        this.unmountTools();
+        this.unmountHighlighters();
+    },
+
     onRemove: function() {
         this.removeTools();
         this.removeHighlighters();
@@ -1016,8 +1018,18 @@ export const CellView = View.extend({
         return this;
     },
 
-    requestToolsUpdate(opt) {
-        this.requestUpdate(this.getFlag(Flags.TOOLS), opt);
+    unmountTools() {
+        const { _toolsView } = this;
+        if (_toolsView && _toolsView.isMounted()) {
+            _toolsView.unmount();
+        }
+    },
+
+    mountTools() {
+        const { _toolsView } = this;
+        if (_toolsView && !_toolsView.isMounted()) {
+            _toolsView.mount();
+        }
     },
 
     updateTools: function(opt) {
@@ -1071,6 +1083,14 @@ export const CellView = View.extend({
 
     updateHighlighters: function(dirty = false) {
         HighlighterView.update(this, null, dirty);
+    },
+
+    mountHighlighters: function() {
+        HighlighterView.mount(this);
+    },
+
+    unmountHighlighters: function() {
+        HighlighterView.unmount(this);
     },
 
     transformHighlighters: function() {

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -1019,17 +1019,16 @@ export const CellView = View.extend({
     },
 
     unmountTools() {
-        const { _toolsView } = this;
-        if (_toolsView && _toolsView.isMounted()) {
-            _toolsView.unmount();
-        }
+        const toolsView = this._toolsView;
+        if (toolsView) toolsView.unmount();
+        return this;
     },
 
     mountTools() {
-        const { _toolsView } = this;
-        if (_toolsView && !_toolsView.isMounted()) {
-            _toolsView.mount();
-        }
+        const toolsView = this._toolsView;
+        // Prevent unnecessary re-appending of the tools.
+        if (toolsView && !toolsView.isMounted()) toolsView.mount();
+        return this;
     },
 
     updateTools: function(opt) {

--- a/src/dia/HighlighterView.mjs
+++ b/src/dia/HighlighterView.mjs
@@ -103,8 +103,8 @@ export const HighlighterView = mvc.View.extend({
                 this.detachedTransformGroup = null;
             } else {
                 vGroup = V('g').addClass('highlight-transform').append(el);
-                this.transformGroup = vGroup;
             }
+            this.transformGroup = vGroup;
             paper.getLayerView(layerName).insertSortedNode(vGroup.node, options.z);
         } else {
             // TODO: prepend vs append

--- a/src/dia/HighlighterView.mjs
+++ b/src/dia/HighlighterView.mjs
@@ -25,6 +25,7 @@ export const HighlighterView = mvc.View.extend({
     node: null,
     updateRequested: false,
     transformGroup: null,
+    detachedTransformGroup: null,
 
     requestUpdate(cellView, nodeSelector) {
         const { paper } = cellView;
@@ -91,12 +92,19 @@ export const HighlighterView = mvc.View.extend({
     },
 
     mount() {
-        const { MOUNTABLE, cellView, el, options, transformGroup } = this;
+        const { MOUNTABLE, cellView, el, options, transformGroup, detachedTransformGroup } = this;
         if (!MOUNTABLE || transformGroup) return;
         const { vel: cellViewRoot, paper } = cellView;
         const { layer: layerName } = options;
         if (layerName) {
-            const vGroup = this.transformGroup = V('g').addClass('highlight-transform').append(el);
+            let vGroup;
+            if (detachedTransformGroup) {
+                vGroup = detachedTransformGroup;
+                this.detachedTransformGroup = null;
+            } else {
+                vGroup = V('g').addClass('highlight-transform').append(el);
+                this.transformGroup = vGroup;
+            }
             paper.getLayerView(layerName).insertSortedNode(vGroup.node, options.z);
         } else {
             // TODO: prepend vs append
@@ -112,6 +120,7 @@ export const HighlighterView = mvc.View.extend({
         if (!MOUNTABLE) return;
         if (transformGroup) {
             this.transformGroup = null;
+            this.detachedTransformGroup = transformGroup;
             transformGroup.remove();
         } else {
             vel.remove();
@@ -280,6 +289,14 @@ export const HighlighterView = mvc.View.extend({
         toArray(this.get(cellView, id)).forEach(view => {
             if (view.UPDATABLE) view.transform();
         });
+    },
+
+    unmount(cellView, id = null) {
+        toArray(this.get(cellView, id)).forEach(view => view.unmount());
+    },
+
+    mount(cellView, id = null) {
+        toArray(this.get(cellView, id)).forEach(view => view.mount());
     },
 
     uniqueId(node, opt = '') {

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -439,15 +439,6 @@ export const LinkView = CellView.extend({
         }
     },
 
-    onMount: function() {
-        this.mountLabels();
-    },
-
-    unmount: function() {
-        CellView.prototype.unmount.apply(this, arguments);
-        this.unmountLabels();
-    },
-
     findLabelNode: function(labelIndex, selector) {
         const labelRoot = this._labelCache[labelIndex];
         if (!labelRoot) return null;
@@ -2551,6 +2542,18 @@ export const LinkView = CellView.extend({
         }
 
         return data;
+    },
+
+    // Lifecycle methods
+
+    onMount: function() {
+        CellView.prototype.onMount.apply(this, arguments);
+        this.mountLabels();
+    },
+
+    onUnmount: function() {
+        CellView.prototype.onUnmount.apply(this, arguments);
+        this.unmountLabels();
     },
 
     onRemove: function() {

--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -2551,8 +2551,8 @@ export const LinkView = CellView.extend({
         this.mountLabels();
     },
 
-    onUnmount: function() {
-        CellView.prototype.onUnmount.apply(this, arguments);
+    onDetach: function() {
+        CellView.prototype.onDetach.apply(this, arguments);
         this.unmountLabels();
     },
 

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -259,18 +259,12 @@ export const Paper = View.extend({
 
         // no docs yet
         onViewUpdate: function(view, flag, priority, opt, paper) {
-            const { mounting, isolate } = opt;
-            if (mounting) {
-                if (view.hasTools()) view.requestToolsUpdate();
-                return;
-            }
             // Do not update connected links when:
             // 1. the view was just inserted (added to the graph and rendered)
             // 2. the view was just mounted (added back to the paper by viewport function)
-            //    (Note: we already exited above)
             // 3. the change was marked as `isolate`.
             // 4. the view model was just removed from the graph
-            if ((flag & (view.FLAG_INSERT | view.FLAG_REMOVE)) || isolate) return;
+            if ((flag & (view.FLAG_INSERT | view.FLAG_REMOVE)) || opt.mounting || opt.isolate) return;
             paper.requestConnectedLinksUpdate(view, priority, opt);
         },
 
@@ -1008,7 +1002,7 @@ export const Paper = View.extend({
                         // Unmount View
                         if (!isDetached) {
                             this.registerUnmountedView(view);
-                            view.unmount();
+                            this.unmountView(view);
                         }
                         updates.unmounted[cid] |= currentFlag;
                         delete priorityUpdates[cid];
@@ -1116,11 +1110,16 @@ export const Paper = View.extend({
             }
             unmountCount++;
             var flag = this.registerUnmountedView(view);
-            if (flag) view.unmount();
+            if (flag) this.unmountView(view);
         }
         // Get rid of views, that have been unmounted
         mountedCids.splice(0, i);
         return unmountCount;
+    },
+
+    unmountView(view) {
+        view.unmount();
+        view.onUnmount();
     },
 
     checkViewport: function(opt) {

--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -56,7 +56,7 @@ export const ToolsView = mvc.View.extend({
                 tool.update();
             }
         }
-        if (!isRendered || !this.isMounted()) {
+        if (!this.isMounted()) {
             this.mount();
         }
         if (!isRendered) {

--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -127,11 +127,6 @@ export const ToolsView = mvc.View.extend({
 
     isMounted: function() {
         return this.el.parentNode !== null;
-    },
-
-    unmount: function() {
-        this.vel.remove();
-        return this;
     }
 
 });

--- a/src/mvc/View.mjs
+++ b/src/mvc/View.mjs
@@ -20,6 +20,7 @@ export const View = Backbone.View.extend({
     UPDATE_PRIORITY: 2,
     FLAG_INSERT: 1<<30,
     FLAG_REMOVE: 1<<29,
+    FLAG_INIT: 1<<28,
 
     constructor: function(options) {
 

--- a/src/mvc/View.mjs
+++ b/src/mvc/View.mjs
@@ -43,11 +43,10 @@ export const View = Backbone.View.extend({
         } else {
             this.$el.remove();
         }
-        this.onUnmount();
     },
 
-    onUnmount: function() {
-        // to be overridden
+    isMounted: function() {
+        return this.el.parentNode !== null;
     },
 
     renderChildren: function(children) {

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -185,17 +185,17 @@ QUnit.module('HighlighterView', function(hooks) {
                 // Layer = Back/Front
                 ['back', 'front'].forEach(function(layer) {
                     var vLayer = V(paper.getLayerNode(layer));
-                    var backChildrenCount = vLayer.children().length;
+                    var layerChildrenCount = vLayer.children().length;
                     highlighter = joint.dia.HighlighterView.add(elementView, 'body', id, {
                         layer: layer
                     });
                     assert.ok(highlighter.vel.parent().hasClass('highlight-transform'));
                     assert.ok(vLayer.contains(highlighter.el));
-                    assert.equal(vLayer.children().length, backChildrenCount + 1);
+                    assert.equal(vLayer.children().length, layerChildrenCount + 1);
                     joint.dia.HighlighterView.update(elementView, id);
-                    assert.equal(vLayer.children().length, backChildrenCount + 1);
+                    assert.equal(vLayer.children().length, layerChildrenCount + 1);
                     joint.dia.HighlighterView.remove(elementView, id);
-                    assert.equal(vLayer.children().length, backChildrenCount);
+                    assert.equal(vLayer.children().length, layerChildrenCount);
                 });
 
                 // Layer = Null
@@ -220,6 +220,54 @@ QUnit.module('HighlighterView', function(hooks) {
                 assert.equal(frontLayerNode.children[2], h2.el.parentNode);
             });
 
+        });
+
+        QUnit.module('Mount & Unmount', function() {
+
+            QUnit.test('are mounted back with the same transformation as when they were unmounted', function(assert) {
+                const id = 'highlighter-id';
+                const layer = 'back';
+                const highlighter = joint.dia.HighlighterView.add(elementView, 'body', id, { layer });
+                const transformation = V.matrixToTransformString(highlighter.el.getCTM());
+                assert.ok(highlighter.el.isConnected);
+                highlighter.unmount();
+                assert.notEqual(V.matrixToTransformString(highlighter.el.getCTM()), transformation);
+                assert.notOk(highlighter.el.isConnected);
+                highlighter.mount();
+                assert.equal(
+                    V.matrixToTransformString(highlighter.el.getCTM()),
+                    transformation,
+                    'Highlighter should be mounted with the same transformation as before.'
+                );
+                assert.ok(highlighter.el.isConnected);
+                joint.dia.HighlighterView.remove(elementView, id);
+            });
+
+            QUnit.test('are mounted and unmounted with the element view', function(assert) {
+                ['back', null].forEach(layer => {
+                    const id = 'highlighter-id';
+                    const highlighter = joint.dia.HighlighterView.add(elementView, 'root', id, { layer });
+                    assert.ok(highlighter.el.isConnected);
+                    paper.dumpViews({ viewport: () => false });
+                    assert.notOk(highlighter.el.isConnected);
+                    paper.dumpViews({ viewport: () => true });
+                    assert.ok(highlighter.el.isConnected);
+                    joint.dia.HighlighterView.remove(elementView, id);
+                });
+            });
+
+            QUnit.test('are mounted and unmounted with the link view', function(assert) {
+                ['back', null].forEach(layer => {
+                    const id = 'highlighter-id';
+                    const highlighter = joint.dia.HighlighterView.add(linkView, 'root', id, { layer });
+                    assert.ok(highlighter.el.isConnected);
+                    paper.dumpViews({ viewport: () => false });
+                    assert.notOk(highlighter.el.isConnected);
+                    paper.dumpViews({ viewport: () => true });
+                    assert.ok(highlighter.el.isConnected);
+                    joint.dia.HighlighterView.remove(linkView, id);
+                });
+            });
         });
 
         QUnit.test('Highlight element by a node', function(assert) {

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -250,8 +250,16 @@ QUnit.module('HighlighterView', function(hooks) {
                     assert.ok(highlighter.el.isConnected);
                     paper.dumpViews({ viewport: () => false });
                     assert.notOk(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.notOk(highlighter.transformGroup);
+                        assert.ok(highlighter.detachedTransformGroup);
+                    }
                     paper.dumpViews({ viewport: () => true });
                     assert.ok(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.ok(highlighter.transformGroup);
+                        assert.notOk(highlighter.detachedTransformGroup);
+                    }
                     joint.dia.HighlighterView.remove(elementView, id);
                 });
             });
@@ -263,8 +271,16 @@ QUnit.module('HighlighterView', function(hooks) {
                     assert.ok(highlighter.el.isConnected);
                     paper.dumpViews({ viewport: () => false });
                     assert.notOk(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.notOk(highlighter.transformGroup);
+                        assert.ok(highlighter.detachedTransformGroup);
+                    }
                     paper.dumpViews({ viewport: () => true });
                     assert.ok(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.ok(highlighter.transformGroup);
+                        assert.notOk(highlighter.detachedTransformGroup);
+                    }
                     joint.dia.HighlighterView.remove(linkView, id);
                 });
             });

--- a/test/jointjs/dia/Paper.js
+++ b/test/jointjs/dia/Paper.js
@@ -1227,6 +1227,66 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                                     paper.checkViewport({ viewport: function() { return false; } });
                                     assert.equal(cellNodesCount(paper), 1);
                                 });
+
+                                QUnit.test('cell view life cycle', function(assert) {
+
+                                    paper.freeze();
+
+                                    const rect1 = (new joint.shapes.standard.Rectangle()).addTo(graph);
+                                    const rect1view = rect1.findView(paper);
+                                    const onDetachSpy = sinon.spy(rect1view, 'onDetach');
+                                    const onMountSpy = sinon.spy(rect1view, 'onMount');
+                                    const onRemoveSpy = sinon.spy(rect1view, 'onRemove');
+                                    const resetSpies = () => {
+                                        onDetachSpy.resetHistory();
+                                        onMountSpy.resetHistory();
+                                        onRemoveSpy.resetHistory();
+                                    };
+
+                                    paper.unfreeze();
+
+                                    assert.equal(onMountSpy.callCount, 1);
+                                    assert.equal(onDetachSpy.callCount, 0);
+                                    assert.equal(onRemoveSpy.callCount, 0);
+                                    assert.ok(onMountSpy.calledWithExactly(true));
+                                    resetSpies();
+
+                                    paper.dumpViews({ viewport: function() { return false; } });
+                                    assert.equal(onDetachSpy.callCount, 1);
+                                    assert.equal(onMountSpy.callCount, 0);
+                                    assert.equal(onRemoveSpy.callCount, 0);
+                                    resetSpies();
+
+                                    paper.dumpViews({ viewport: function() { return true; } });
+                                    assert.equal(onDetachSpy.callCount, 0);
+                                    assert.equal(onMountSpy.callCount, 1);
+                                    assert.equal(onRemoveSpy.callCount, 0);
+                                    assert.ok(onMountSpy.calledWithExactly(false));
+                                    resetSpies();
+
+                                    paper.dumpViews({ viewport: function() { return false; } });
+                                    assert.equal(onDetachSpy.callCount, 1);
+                                    assert.equal(onMountSpy.callCount, 0);
+                                    assert.equal(onRemoveSpy.callCount, 0);
+                                    resetSpies();
+
+                                    paper.dumpViews({ viewport: function() { return true; } });
+                                    assert.equal(onDetachSpy.callCount, 0);
+                                    assert.equal(onMountSpy.callCount, 1);
+                                    assert.equal(onRemoveSpy.callCount, 0);
+                                    assert.ok(onMountSpy.calledWithExactly(false));
+                                    resetSpies();
+
+                                    rect1.remove();
+                                    assert.equal(onDetachSpy.callCount, 0);
+                                    assert.equal(onMountSpy.callCount, 0);
+                                    assert.equal(onRemoveSpy.callCount, 1);
+                                    resetSpies();
+
+                                    onDetachSpy.restore();
+                                    onMountSpy.restore();
+                                    onRemoveSpy.restore();
+                                });
                             });
                         });
                     });

--- a/test/jointjs/dia/elementTools.js
+++ b/test/jointjs/dia/elementTools.js
@@ -41,16 +41,16 @@ QUnit.module('elementTools', function(hooks) {
 
     QUnit.module('Mount & Unmount', function() {
 
-        QUnit.test('are mounted and unmounted  with the element view', function(assert) {
+        QUnit.test('are mounted and unmounted with the element view', function(assert) {
             const remove = new joint.elementTools.Remove();
             const toolsView = new joint.dia.ToolsView({ tools: [remove] });
             elementView.addTools(toolsView);
             assert.ok(toolsView.el.parentNode);
             assert.ok(toolsView.isMounted());
-            paper.checkViewport({ viewport: () => false });
+            paper.dumpViews({ viewport: () => false });
             assert.notOk(toolsView.el.parentNode);
             assert.notOk(toolsView.isMounted());
-            paper.checkViewport({ viewport: () => true });
+            paper.dumpViews({ viewport: () => true });
             assert.ok(toolsView.el.parentNode);
             assert.ok(toolsView.isMounted());
         });

--- a/test/jointjs/dia/linkTools.js
+++ b/test/jointjs/dia/linkTools.js
@@ -47,16 +47,16 @@ QUnit.module('linkTools', function(hooks) {
 
     QUnit.module('Mount & Unmount', function() {
 
-        QUnit.test('are mounted and unmounted  with the link view', function(assert) {
+        QUnit.test('are mounted and unmounted with the link view', function(assert) {
             const remove = new joint.linkTools.Remove();
             const toolsView = new joint.dia.ToolsView({ tools: [remove] });
             linkView.addTools(toolsView);
             assert.ok(toolsView.el.parentNode);
             assert.ok(toolsView.isMounted());
-            paper.checkViewport({ viewport: () => false });
+            paper.dumpViews({ viewport: () => false });
             assert.notOk(toolsView.el.parentNode);
             assert.notOk(toolsView.isMounted());
-            paper.checkViewport({ viewport: () => true });
+            paper.dumpViews({ viewport: () => true });
             assert.ok(toolsView.el.parentNode);
             assert.ok(toolsView.isMounted());
         });

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3353,6 +3353,7 @@ export namespace mvc {
         DETACHABLE: boolean;
         FLAG_INSERT: number;
         FLAG_REMOVE: number;
+        FLAG_INIT: number;
 
         vel: E extends HTMLElement ? null : Vectorizer;
 

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -875,9 +875,9 @@ export namespace dia {
 
         protected getNodeShape(magnet: SVGElement): g.Shape;
 
-        protected onMount(): void;
+        protected onMount(isInitialMount: boolean): void;
 
-        protected onUnmount(): void;
+        protected onDetach(): void;
 
         static addPresentationAttributes(attributes: CellView.PresentationAttributes): CellView.PresentationAttributes;
     }
@@ -1739,6 +1739,10 @@ export namespace dia {
         protected renderView(cell: Cell): CellView;
 
         protected resetViews(cells?: Cell[], opt?: { [key: string]: any }): void;
+
+        protected insertView(cellView: CellView, isInitialInsert: boolean): void;
+
+        protected detachView(cellView: CellView): void;
     }
 
     namespace PaperLayer {

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -805,8 +805,6 @@ export namespace dia {
 
         requestUpdate(flags: number, opt?: { [key: string]: any }): void;
 
-        requestToolsUpdate(flags: number, opt?: { [key: string]: any }): void;
-
         dragLinkStart(evt: dia.Event, magnet: SVGElement, x: number, y: number): void;
 
         dragLink(evt: dia.Event, x: number, y: number): void;
@@ -872,6 +870,10 @@ export namespace dia {
         protected getNodeData(magnet: SVGElement): CellView.NodeData;
 
         protected getNodeShape(magnet: SVGElement): g.Shape;
+
+        protected onMount(): void;
+
+        protected onUnmount(): void;
 
         static addPresentationAttributes(attributes: CellView.PresentationAttributes): CellView.PresentationAttributes;
     }
@@ -1133,8 +1135,6 @@ export namespace dia {
         protected notifyPointermove(evt: dia.Event, x: number, y: number): void;
 
         protected notifyPointerup(evt: dia.Event, x: number, y: number): void;
-
-        protected onMount(): void;
 
         protected mountLabels(): void;
 
@@ -3401,8 +3401,6 @@ export namespace mvc {
         protected onSetTheme(oldTheme: string, newTheme: string): void;
 
         protected onRemove(): void;
-
-        protected onUnmount(): void;
     }
 
     type ModifiedCallback<CallbackArgs extends any[], EventCallback extends Callback> = (...args: [...CallbackArgs, ...Parameters<EventCallback>]) => any;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -783,6 +783,10 @@ export namespace dia {
 
         updateTools(opt?: { [key: string]: any }): this;
 
+        mountTools(): this;
+
+        unmountTools(): this;
+
         getNodeMatrix(node: SVGElement): SVGMatrix;
 
         getNodeRotateMatrix(node: SVGElement): SVGMatrix;


### PR DESCRIPTION
## Description

When the cell view was detached (`paper.options.viewport` returned `false`) it was removed from the DOM, but the tools and highlighters attached to the cell view remained there.

- **fix(dia.ToolsView)**: is not removed from the DOM when the view is unmounted
- **fix(dia.HighlighterView)**: is not removed from the DOM when the view is unmounted

It reverts most of the changes introduced in this #2122 and approach this problem from a different angle.
- it resolves the same issue for highlighters (when the `highligher.options.layer` option is used).
- the #2122 mounted back the tool only if there was another update request along with insert request
- it redefines (while keeping it backwards compatible) the lifecycle cell view methods (`onMount(initial)`, `onDetach()`, `onRemove()`)
  *Note: The name `onDetach()` was chosen instead of `onUnmount()` to distinguish between detaching the view and removing it (in both cases the view is unmounted).*

- it makes sure that the highlighter view does not loose its position (`transform` attribute) after being detached from the DOM.
  *Note: When the cellView is detached and then mounted back, but does not change otherwise, you don't have to update the cellView, nor the toolsView and HighlighterView. All you have to do is append them back to the DOM.*)

