### PR TITLE
dia.Paper: autoFreeze option

### DIFF
--- a/demo/performance/async.js
+++ b/demo/performance/async.js
@@ -45,6 +45,7 @@ var paper = new Paper({
     sorting: Paper.sorting.APPROX,
     defaultAnchor: { name: 'modelCenter' },
     defaultConnectionPoint: { name: 'boundary' },
+    autoFreeze: true,
     viewport: function(view, isInViewport) {
         if (leaveDraggedInViewport && view.cid === draggedCid) return true;
         if (leaveRenderedInViewport && isInViewport) return true;

--- a/docs/src/joint/api/dia/Paper/prototype/options/autoFreeze.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/autoFreeze.html
@@ -1,0 +1,2 @@
+<code>autoFreeze</code> - when <code>true</code> on an <a href="#dia.Paper.prototype.options.async"><code>async</code></a> paper, the paper freezes itself after there are no more updates. It prevents calling of the
+<a href="#dia.Paper.prototype.options.viewport"><code>viewport</code></a> callback. It unfreezes itself after there is some view to update and then goes to the frozen state after all updates are done.

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -99,6 +99,8 @@ export const Paper = View.extend({
 
     className: 'paper',
 
+    idle: false,
+
     options: {
 
         width: 800,
@@ -256,6 +258,8 @@ export const Paper = View.extend({
         sorting: sortingTypes.EXACT,
 
         frozen: false,
+
+        autoFreeze: false,
 
         // no docs yet
         onViewUpdate: function(view, flag, priority, opt, paper) {
@@ -749,6 +753,11 @@ export const Paper = View.extend({
 
     requestViewUpdate: function(view, flag, priority, opt) {
         opt || (opt = {});
+        if (this.options.autoFreeze && this.isIdle()) {
+            this.idle = false;
+            console.log('unfreeze');
+            this.unfreeze();
+        }
         this.scheduleViewUpdate(view, flag, priority, opt);
         var isAsync = this.isAsync();
         if (this.isFrozen() || (isAsync && opt.async !== false)) return;
@@ -938,6 +947,11 @@ export const Paper = View.extend({
                 } else {
                     data.processed = processed;
                 }
+            } else {
+                if (this.options.autoFreeze) {
+                    console.log('freeze');
+                    this.freeze();
+                }
             }
             // Progress callback
             var progressFn = opt.progress;
@@ -971,6 +985,7 @@ export const Paper = View.extend({
         if (typeof afterFn === 'function') {
             afterFn.call(this, stats, opt, this);
         }
+        this.idle = true;
         this.trigger('render:done', stats, opt);
     },
 
@@ -1194,6 +1209,10 @@ export const Paper = View.extend({
 
     isFrozen: function() {
         return !!this.options.frozen;
+    },
+
+    isIdle: function() {
+        return this.idle;
     },
 
     isExactSorting: function() {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -755,7 +755,6 @@ export const Paper = View.extend({
         opt || (opt = {});
         if (this.options.autoFreeze && this.isIdle()) {
             this.idle = false;
-            console.log('unfreeze');
             this.unfreeze();
         }
         this.scheduleViewUpdate(view, flag, priority, opt);
@@ -949,7 +948,6 @@ export const Paper = View.extend({
                 }
             } else {
                 if (this.options.autoFreeze) {
-                    console.log('freeze');
                     this.freeze();
                 }
             }
@@ -985,7 +983,6 @@ export const Paper = View.extend({
         if (typeof afterFn === 'function') {
             afterFn.call(this, stats, opt, this);
         }
-        this.idle = true;
         this.trigger('render:done', stats, opt);
     },
 


### PR DESCRIPTION
Added an option which allows paper to freeze itself after all updates are done. It prevents invoking `viewport` callback when there are no updates to the views.
