### PR TITLE
fix(dia.attributes): prevent error when title is used on element with a text node

### DIFF
--- a/src/dia/attributes/index.mjs
+++ b/src/dia/attributes/index.mjs
@@ -427,9 +427,14 @@ const attributesNS = {
             var cache = $node.data(cacheName);
             if (cache === undefined || cache !== title) {
                 $node.data(cacheName, title);
+                if (node.tagName === 'title') {
+                    // The target node is a <title> element.
+                    node.textContent = title;
+                    return;
+                }
                 // Generally <title> element should be the first child element of its parent.
-                var firstChild = node.firstChild;
-                if (firstChild && firstChild.tagName.toUpperCase() === 'TITLE') {
+                var firstChild = node.firstElementChild;
+                if (firstChild && firstChild.tagName === 'title') {
                     // Update an existing title
                     firstChild.textContent = title;
                 } else {

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -1074,7 +1074,7 @@ QUnit.module('Attributes', function() {
             paper.remove();
         });
 
-        QUnit.test('used with <g>', function(assert) {
+        QUnit.test('used on <g>', function(assert) {
             let titleText;
             assert.equal(cellView.el.querySelectorAll('title').length, 0);
             titleText = 'test-title';
@@ -1087,7 +1087,7 @@ QUnit.module('Attributes', function() {
             assert.equal(cellView.el.firstChild.textContent, titleText);
         });
 
-        QUnit.test('used with <title>', function(assert) {
+        QUnit.test('used on <title>', function(assert) {
             let titleText;
             cell.set('markup', [
                 { tagName: 'title', selector: 'title' },
@@ -1103,6 +1103,27 @@ QUnit.module('Attributes', function() {
             cell.attr('title/title', titleText);
             assert.equal(cellView.el.querySelectorAll('title').length, 1);
             assert.equal(cellView.el.firstChild.textContent, titleText);
+        });
+
+        QUnit.test('used on element with text node', function(assert) {
+            let titleText;
+            const textNodeText = 'test-text-node';
+            cell.set('markup', [
+                textNodeText,
+                { tagName: 'rect', selector: 'body' },
+                { tagName: 'text', selector: 'label' }
+            ]);
+            assert.equal(cellView.el.querySelectorAll('title').length, 0);
+            titleText = 'test-title';
+            cell.attr('root/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, textNodeText);
+            assert.equal(cellView.el.firstElementChild.textContent, titleText);
+            titleText = 'test-title-2';
+            cell.attr('root/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, textNodeText);
+            assert.equal(cellView.el.firstElementChild.textContent, titleText);
         });
     });
 });

--- a/test/jointjs/dia/attributes.js
+++ b/test/jointjs/dia/attributes.js
@@ -1054,5 +1054,56 @@ QUnit.module('Attributes', function() {
             });
         });
     });
+
+    QUnit.module('Title Attribute', function(hooks) {
+
+        var paper, graph, cell, cellView;
+
+        hooks.beforeEach(function() {
+            graph = new joint.dia.Graph;
+            const fixtures = document.getElementById('qunit-fixture');
+            const paperEl = document.createElement('div');
+            fixtures.appendChild(paperEl);
+            paper = new joint.dia.Paper({ el: paperEl, model: graph });
+            cell = new joint.shapes.standard.Rectangle();
+            cell.addTo(graph);
+            cellView = cell.findView(paper);
+        });
+
+        hooks.afterEach(function() {
+            paper.remove();
+        });
+
+        QUnit.test('used with <g>', function(assert) {
+            let titleText;
+            assert.equal(cellView.el.querySelectorAll('title').length, 0);
+            titleText = 'test-title';
+            cell.attr('root/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, titleText);
+            titleText = 'test-title-2';
+            cell.attr('root/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, titleText);
+        });
+
+        QUnit.test('used with <title>', function(assert) {
+            let titleText;
+            cell.set('markup', [
+                { tagName: 'title', selector: 'title' },
+                { tagName: 'rect', selector: 'body' },
+                { tagName: 'text', selector: 'label' }
+            ]);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            titleText = 'test-title';
+            cell.attr('title/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, titleText);
+            titleText = 'test-title-2';
+            cell.attr('title/title', titleText);
+            assert.equal(cellView.el.querySelectorAll('title').length, 1);
+            assert.equal(cellView.el.firstChild.textContent, titleText);
+        });
+    });
 });
 


### PR DESCRIPTION
## Description

Setting `title` on an element with a text node threw an exception. The PR is supposed to prevent this.

```xml
<title @selector="myTitle">existing title<title>
```

```js
el.attr('myTitle/title', 'new title'); // does not throw an exception now
```




