### PR TITLE
fix(dia.CellView): return correct target under the pointer for pointer events

### DIFF
--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -823,10 +823,16 @@ export const CellView = View.extend({
     },
 
     getEventTarget: function(evt, opt = {}) {
-        // Touchmove/Touchend event's target is not reflecting the element under the coordinates as mousemove does.
-        // It holds the element when a touchstart triggered.
         const { target, type, clientX = 0, clientY = 0 } = evt;
-        if (opt.fromPoint || type === 'touchmove' || type === 'touchend') {
+        if (
+            // Explicitly defined `fromPoint` option
+            opt.fromPoint ||
+            // Touchmove/Touchend event's target is not reflecting the element under the coordinates as mousemove does.
+            // It holds the element when a touchstart triggered.
+            type === 'touchmove' || type === 'touchend' ||
+            // Pointermove/Pointerup event with the pointer captured
+            ('pointerId' in evt && evt.target.hasPointerCapture(evt.pointerId))
+        ) {
             return document.elementFromPoint(clientX, clientY);
         }
 

--- a/src/dia/CellView.mjs
+++ b/src/dia/CellView.mjs
@@ -831,7 +831,7 @@ export const CellView = View.extend({
             // It holds the element when a touchstart triggered.
             type === 'touchmove' || type === 'touchend' ||
             // Pointermove/Pointerup event with the pointer captured
-            ('pointerId' in evt && evt.target.hasPointerCapture(evt.pointerId))
+            ('pointerId' in evt && target.hasPointerCapture(evt.pointerId))
         ) {
             return document.elementFromPoint(clientX, clientY);
         }


### PR DESCRIPTION
## Description

`cellView.getEventTarget()` now returns the target under the pointer even for `pointermove` and `pointerup` events for which pointer capture was set.

## Motivation and Context

It allows the link arrowhead move interaction to be run with `mouseevents`, `touchevents` and `pointerevents`.

*Note: I couldn't  find a way how to fire and capture pointer events from script to add a sensible test.*
