### PR TITLE
docs(dia.attributes): fix calc typo

### DIFF
--- a/docs/src/joint/api/dia/attributes/intro.html
+++ b/docs/src/joint/api/dia/attributes/intro.html
@@ -142,7 +142,7 @@ All the standard SVG <a href="https://www.w3.org/TR/SVG/styling.html" target="_b
     <li>The <code>+</code>, <code>-</code> and <code>*</code> operators do not require whitespace.</li>
     <li>No extra parentheses are allowed.</li>
     <li>It is permitted to nest <code>calc()</code> functions, in which case the inner ones are evaluated first.
-        e.g <pre><code>'M 0 0 H calc(w - calc(h))'</code></pre>.
+        e.g. <pre><code>'M 0 0 H calc(w - calc(h))'</code></pre>
     </li>
 </ul>
 


### PR DESCRIPTION
## Description

- Fix misplaced `.` in `calc` docs

<img width="894" alt="Screenshot 2023-04-26 at 20 04 59" src="https://user-images.githubusercontent.com/42288565/234667029-dc367ab4-14ca-4e55-a51e-a6e9181b167b.png">
