### PR TITLE
fix(demo.ROI): fix zooming in Safari

### DIFF
--- a/demo/roi/css/roi.css
+++ b/demo/roi/css/roi.css
@@ -27,7 +27,7 @@ input:invalid {
 }
 
 .jj-form {
-    position: fixed;
+    position: static;
     font-size: 14px;
     text-align: center;
     touch-action: none;


### PR DESCRIPTION
## Description

`position: fixed` is causing issues after the paper gets transformed (zoomed) in Safari.