### PR TITLE
fix(dia.Cell): fix to prevent cell id undefined

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -114,7 +114,7 @@ export const Cell = Backbone.Model.extend({
     initialize: function(options) {
 
         const idAttribute = this.getIdAttribute();
-        if (!options || !(idAttribute in options)) {
+        if (!options || options[idAttribute] === undefined) {
             this.set(idAttribute, this.generateId(), { silent: true });
         }
 

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -84,6 +84,19 @@ QUnit.module('cell', function(hooks) {
             clone.set('myId', newId);
             assert.equal(graph.getCell(newId), clone);
         });
+
+        QUnit.test('id', function(assert) {
+            const TestElement1 = new joint.dia.Cell({ id: 0 });
+            assert.equal(TestElement1.id, 0);
+            const TestElement2 = new joint.dia.Cell({ id: 1 });
+            assert.equal(TestElement2.id, 1);
+            const TestElement3 = new joint.dia.Cell({ id: '2' });
+            assert.equal(TestElement3.id, '2');
+            const TestElement4 = new (joint.dia.Cell.extend({ generateId() { return 'my-id'; } }))({});
+            assert.equal(TestElement4.id, 'my-id');
+            const TestElement5 = new (joint.dia.Cell.extend({ generateId() { return 'my-id'; } }))({ id: undefined });
+            assert.equal(TestElement5.id, 'my-id');
+        });
     });
 
     QUnit.module('lifecycle methods', function() {


### PR DESCRIPTION
## Description

Prevent cell models without ids. The issue was introduced by this [PR](https://github.com/clientIO/joint/pull/1524).

## Motivation and Context

This is a common way how to create an element. It's desirable to generate custom id if the id provided was `undefined`.

```js
const json =  { /* no id */ };
const { id } = json;
const rect = new joint.shapes.standard.Rectangle({ id });
assert.ok(rect.id !== undefined);
```

