### PR TITLE
fix(dia.HighlighterView): prevent highlighter mounting to unmounted cell views

### DIFF
--- a/src/dia/ToolsView.mjs
+++ b/src/dia/ToolsView.mjs
@@ -123,10 +123,6 @@ export const ToolsView = mvc.View.extend({
             }
         }
         return this;
-    },
-
-    isMounted: function() {
-        return this.el.parentNode !== null;
     }
 
 });

--- a/test/jointjs/dia/HighlighterView.js
+++ b/test/jointjs/dia/HighlighterView.js
@@ -264,6 +264,30 @@ QUnit.module('HighlighterView', function(hooks) {
                 });
             });
 
+            QUnit.test('are not mounted to an unmounted element view', function(assert) {
+                ['back', null].forEach(layer => {
+                    const id = 'highlighter-id';
+                    paper.dumpViews({ viewport: () => false });
+                    const highlighter = joint.dia.HighlighterView.add(elementView, 'root', id, { layer });
+                    assert.notOk(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.notOk(highlighter.transformGroup);
+                        assert.notOk(highlighter.detachedTransformGroup);
+                    }
+                    paper.dumpViews({ viewport: () => true });
+                    assert.ok(highlighter.el.isConnected);
+                    if (layer) {
+                        assert.ok(highlighter.transformGroup);
+                        const { tx, ty } = highlighter.transformGroup.translate();
+                        const { x, y } = element.position();
+                        assert.equal(tx, x);
+                        assert.equal(ty, y);
+                        assert.notOk(highlighter.detachedTransformGroup);
+                    }
+                    joint.dia.HighlighterView.remove(elementView, id);
+                });
+            });
+
             QUnit.test('are mounted and unmounted with the link view', function(assert) {
                 ['back', null].forEach(layer => {
                     const id = 'highlighter-id';

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1796,10 +1796,6 @@ export namespace dia {
 
         mount(): this;
 
-        unmount(): this;
-
-        isMounted(): boolean;
-
         protected simulateRelatedView(el: SVGElement): void;
     }
 
@@ -1868,9 +1864,9 @@ export namespace dia {
         nodeSelector: HighlighterView.NodeSelector | null;
         node: SVGElement | null;
         updateRequested: boolean;
+        postponedUpdate: boolean;
         transformGroup: Vectorizer | null;
-
-        public unmount(): void;
+        detachedTransformGroup: Vectorizer | null;
 
         protected findNode(cellView: dia.CellView, nodeSelector: HighlighterView.NodeSelector): SVGElement | null;
 
@@ -3396,6 +3392,8 @@ export namespace mvc {
         confirmUpdate(flag: number, opt: { [key: string]: any }): number;
 
         unmount(): void;
+
+        isMounted(): boolean;
 
         protected init(): void;
 


### PR DESCRIPTION
## Description

Prevent highlighter mounting and updates if it was attached to an unmounted cell view.

- it prevents displaying the standalone highlighter while the cell view is unmounted
- it improves the performance by not executing the update and mounting of the highlighter when not necessary
- the PR fixes a few typescript inconsistencies with inheritance mounting methods.

```js
  const elementView = graph.getCell('element1').findView(paper);
  paper.dumpViews({ viewport: () => false }); // hide all cell views
  const highlighter = joint.dia.HighlighterView.add(elementView, 'root', id, { layer: dia.Paper.Layers.FRONT });
  /* .... */
  assert.notOk(highlighter.el.isConnected);
  /* .... */
  paper.dumpViews({ viewport: () => false }); // show the element view
  assert.notOk(highlighter.el.isConnected); // only now the view is mounted and fully rendered
```
