### PR TITLE
fix(dia.CellView): fix to get correct ref node bounding box

### DIFF
--- a/test/jointjs/cellView.js
+++ b/test/jointjs/cellView.js
@@ -125,6 +125,46 @@ QUnit.module('cellView', function(hooks) {
             cell.resize(100,100).position(0, 0);
         });
 
+        QUnit.module('ref', function(hooks) {
+            QUnit.test('should use the ref node ancestor transformation only if it is not a common ancestor', function(assert) {
+                const ax = 1;
+                const ay = 2;
+                const aw = 3;
+                const ah = 4;
+                const gx = 11;
+                const gy = 13;
+                [{
+                    attrs: {
+                        a: { ref: 'b', x: 'calc(x)', y: 'calc(y)', width: 'calc(w)', height: 'calc(h)' },
+                    },
+                    markup: joint.util.svg`
+                        <g transform="translate(${gx},${gy})">
+                            <rect @selector="b" x="${ax}" y="${ay}" width="${aw}" height="${ah}"/>
+                        </g>
+                        <rect @selector="a"/>
+                    `
+                }, {
+                    attrs: {
+                        a: { ref: 'b', x: 'calc(x)', y: 'calc(y)', width: 'calc(w)', height: 'calc(h)' },
+                    },
+                    markup: joint.util.svg`
+                        <g transform="translate(${gx},${gy})">
+                            <rect @selector="b" x="${ax}" y="${ay}" width="${aw}" height="${ah}"/>
+                            <rect @selector="a"/>
+                        </g>
+                    `
+                }].forEach(attributes => {
+                    cell.set(attributes);
+                    const [a] = cellView.findBySelector('a');
+                    const bbox = V(a).getBBox({ target: cellView.el });
+                    assert.equal(bbox.x, ax + gx);
+                    assert.equal(bbox.y, ay + gy);
+                    assert.equal(bbox.width, aw);
+                    assert.equal(bbox.height, ah);
+                });
+            });
+        });
+
         QUnit.module('Merging', function(hooks) {
 
             hooks.beforeEach(function() {


### PR DESCRIPTION
## Description

The size and position of the `ref` node used in SVG custom attributes (e.g., the `calc()` expression) must only be transformed using transformations that are defined between the `ref` node and the common parent of the `ref` node and the current node to which we want to set the custom attribute.

Previously, it was transformed by all transformations between the `ref` node and the root of the cell view.

### Example

```js
elementModel.attr({
  // set the size of rectangle `a` to the same size as `b`
  a: {
    x: 'calc(x)',
    y: 'calc(y)',
    width: 'calc(w)',
    height: 'calc(h)',
  }
});
```

#### Markup 1
```xml
<g transform="translate(11, 13)">
    <rect @selector="b" x="1" y="2" width="3" height="4"/>
    <rect @selector="a"/>
</g>
```
In this case, the reference bounding box can not be affected
by the `transform` attribute of the `<g>` element,
because the exact transformation will be applied to the `a` element
as well as to the `b` element.


The bounding box of `b` from the perspective of `a` is `{ x: 1, y: 2, width: 3, height: 4 }`

#### Markup 2
```xml
<g transform="translate(11, 13)">
    <rect @selector="b" x="1" y="2" width="3" height="4"/>
</g>
<rect @selector="a"/>
```
In this case, the reference bounding box have to be affected by the
`transform` attribute of the `<g>` element, because the `a` element
is not descendant of the `<g>` element and will not be affected
by the transformation.

The bounding box of `b` from the perspective of `a` is `{ x: 12, y: 15, width: 3, height: 4 }`
