### PR TITLE
fix(dia.Paper): allow immediate propagation on pointerup

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2313,7 +2313,6 @@ export const Paper = View.extend({
             this.pointerclick($.Event(evt.originalEvent, { type: 'click', data: evt.data }));
         }
 
-        evt.stopImmediatePropagation();
         this.delegateEvents();
     },
 

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2246,6 +2246,23 @@ QUnit.module('paper', function(hooks) {
 
         });
 
+        QUnit.test('pointerup does not stop immediate propagation', function(assert) {
+            assert.expect(2);
+            const view = new joint.mvc.View();
+            simulate.mousedown({ el: elRect });
+            view.delegateDocumentEvents({
+                mousemove: () => {
+                    assert.ok(true, 'mousemove');
+                },
+                mouseup: () => {
+                    assert.ok(true, 'mouseup');
+                },
+            });
+            simulate.mousemove({ el: elRect });
+            simulate.mouseup({ el: elRect });
+            view.undelegateDocumentEvents();
+        });
+
         QUnit.module('Labels', function(hooks) {
 
             var link, linkView;


### PR DESCRIPTION
## Description

Prevent the paper from stopping other listeners of the `pointerup`  event attached on document from being called.

i.e. there is no need for calling [stopImmediatePropagation(https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation)] on `pointerup` (at least it is not covered by any test, nor it shows any issues during intensive testing).

The original [PR](https://github.com/clientIO/joint/commit/48db61cd85b9360558e365263fcaf0164908d1ff), which introduced the `evt.stopImmediatePropagation()` call, unfortunately did not go into a description of the reasons.

```js
QUnit.test('pointerup does not stop immediate propagation', function(assert) {
    const view = new joint.mvc.View();
    simulate.mousedown({ el: elRect });
    // start listening to the document mousemove and mouseup events after
    // the paper `element:pointerdown' event.
    view.delegateDocumentEvents({
        mousemove: () => {
            assert.ok(true, 'mousemove');
        },
        mouseup: () => {
            assert.ok(true, 'mouseup');
        },
    });
    simulate.mousemove({ el: elRect });
    simulate.mouseup({ el: elRect });
    view.undelegateDocumentEvents();
    assert.expect(2);
});
```