### PR TITLE
docs(tutorials): fix link in foreign object tutorial

### DIFF
--- a/tutorials/foreign-object.html
+++ b/tutorials/foreign-object.html
@@ -532,7 +532,7 @@ button span {
 
         <p>
             The last point which we would like to cover when discussing HTML form controls is the special 
-            <a href="/docs/jointjs##dia.attributes.props" target="_blank"><code>props</code></a> attribute. When creating HTML elements, it's 
+            <a href="/docs/jointjs#dia.attributes.props" target="_blank"><code>props</code></a> attribute. When creating HTML elements, it's
             possible to define various attributes to initialize certain DOM properties. In some cases (such as <code>'id'</code>), 
             this is a one-to-one relationship, but in others (such as <code>'value'</code>), the attribute doesn't reflect the property, and it
             serves more like an initial and current state.


### PR DESCRIPTION
## Description

- Fix link in `foreignObject` tutorial. This link has already been fixed on `JointJS_Site` in the `3.7` documentation PR.

