### PR TITLE
feat(dia.Cell): add foregroundEmbeds option to the Cell.toFront and Cell.toBack

### DIFF
--- a/demo/embedding/front-and-back.html
+++ b/demo/embedding/front-and-back.html
@@ -7,33 +7,45 @@
 
     <link rel="stylesheet" type="text/css" href="../../build/joint.css"/>
     <style>
-		body {
-			background: #f7f7f7;
-		}
-		#demo {
-			width: 400px;
-			margin: 40px auto;
-			text-align: center;
-		}
-		#paper {
-			-webkit-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
-			-moz-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
-			box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
-			border-radius: 10px;
-			margin-bottom: 30px;
-			background: white;
-		}
-		button {
-			padding: 10px 15px;
-			margin: 0 8px 8px 0;
-			font-family: monospace;
-		}
+        body {
+            background: #f7f7f7;
+        }
+
+        input[type=checkbox] {
+            vertical-align: middle;
+        }
+
+        #demo {
+            width: 400px;
+            margin: 40px auto;
+            text-align: center;
+        }
+
+        #paper {
+            -webkit-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+            -moz-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+            box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.25);
+            border-radius: 10px;
+            margin-bottom: 30px;
+            background: white;
+        }
+
+        button {
+            padding: 10px 15px;
+            margin: 0 8px 8px 0;
+            font-family: monospace;
+        }
     </style>
 </head>
 <body>
     <div id="demo">
         <div id="paper"></div>
 
+        <p>
+            <label>
+                <input id="placeEmbeddedAboveParent" type="checkbox" checked> <code>opt.placeEmbeddedAboveParent</code>
+            </label>
+        </p>
         <p>
             <button id="toFrontButton">red.toFront()</button>
             <button id="toBackButton">red.toBack()</button>

--- a/demo/embedding/front-and-back.html
+++ b/demo/embedding/front-and-back.html
@@ -43,7 +43,7 @@
 
         <p>
             <label>
-                <input id="placeEmbeddedAboveParent" type="checkbox" checked> <code>opt.placeEmbeddedAboveParent</code>
+                <input id="foregroundEmbeds" type="checkbox" checked> <code>opt.foregroundEmbeds</code>
             </label>
         </p>
         <p>

--- a/demo/embedding/front-and-back.js
+++ b/demo/embedding/front-and-back.js
@@ -66,15 +66,15 @@ graph.addCells([r1, r2, r3, r4, r5]);
 
 updateLabels();
 
-const placeEmbeddedAboveParent = document.getElementById('placeEmbeddedAboveParent');
+const foregroundEmbeds = document.getElementById('foregroundEmbeds');
 
 document.getElementById('toFrontButton').addEventListener('click', () => {
-    r1.toFront({ deep: true, placeEmbeddedAboveParent: placeEmbeddedAboveParent.checked });
+    r1.toFront({ deep: true, foregroundEmbeds: foregroundEmbeds.checked });
     updateLabels();
 });
 
 
 document.getElementById('toBackButton').addEventListener('click', () => {
-    r1.toBack({ deep: true, placeEmbeddedAboveParent: placeEmbeddedAboveParent.checked });
+    r1.toBack({ deep: true, foregroundEmbeds: foregroundEmbeds.checked });
     updateLabels();
 });

--- a/demo/embedding/front-and-back.js
+++ b/demo/embedding/front-and-back.js
@@ -13,14 +13,15 @@ new joint.dia.Paper({
 
 
 var r1 = new joint.shapes.standard.Rectangle({
-    position: { x: 40, y: 40 },
+    position: { x: 75, y: 36 },
     size: { width: 250, height: 300 },
+    z: 2,
     attrs: {
         body: { fill: '#E74C3C' }
     }
 });
 var r2 = new joint.shapes.standard.Rectangle({
-    position: { x: 60, y: 50 },
+    position: { x: 198, y: 49 },
     size: { width: 100, height: 100 },
     z: 10,
     attrs: {
@@ -28,41 +29,52 @@ var r2 = new joint.shapes.standard.Rectangle({
     }
 });
 var r3 = new joint.shapes.standard.Rectangle({
-    position: { x: 140, y: 80 },
+    position: { x: 278, y: 100 },
     size: { width: 100, height: 90 },
-    z: 5,
+    z: 1,
     attrs: {
         body: { fill: '#46acd9' }
     }
 });
 var r4 = new joint.shapes.standard.Rectangle({
-    position: { x: 260, y: 210 },
+    position: { x: 34, y: 264 },
     size: { width: 100, height: 100 },
     z: 5,
     attrs: {
         body: { fill: '#7ac949' },
     }
 });
+var r5 = new joint.shapes.standard.Rectangle({
+    position: { x: 112, y: 65 },
+    size: { width: 100, height: 60 },
+    z: 8,
+    attrs: {
+        body: { fill: '#bf7feb' },
+    }
+});
 
 const updateLabels = () => {
-    [r1, r2, r3, r4].forEach((element) => {
+    [r1, r2, r3, r4, r5].forEach((element) => {
         element.attr('label/text', 'Z = ' + element.get('z'));
     });
 };
 
 r1.embed(r2);
 r1.embed(r3);
-graph.addCells([r1, r2, r3, r4]);
+r2.embed(r5);
+graph.addCells([r1, r2, r3, r4, r5]);
 
 updateLabels();
 
+const placeEmbeddedAboveParent = document.getElementById('placeEmbeddedAboveParent');
+
 document.getElementById('toFrontButton').addEventListener('click', () => {
-    r1.toFront({ deep: true });
+    r1.toFront({ deep: true, placeEmbeddedAboveParent: placeEmbeddedAboveParent.checked });
     updateLabels();
 });
 
 
 document.getElementById('toBackButton').addEventListener('click', () => {
-    r1.toBack({ deep: true });
+    r1.toBack({ deep: true, placeEmbeddedAboveParent: placeEmbeddedAboveParent.checked });
     updateLabels();
 });

--- a/docs/src/joint/api/dia/Element/prototype/toBack.html
+++ b/docs/src/joint/api/dia/Element/prototype/toBack.html
@@ -5,9 +5,9 @@
     search (BFS) fashion.
 </p>
 
-<p>If <code>opt.placeEmbeddedAboveParent</code> is <code>true</code> (as by default), all the embedded
+<p>If <code>opt.foregroundEmbeds</code> is <code>true</code> (as by default), all the embedded
     cells will get a higher <code>z</code> index than that of this element. This is especially useful in hierarchical diagrams where if you want to send an element to the back, you don't want its children (embedded cells) to be hidden behind that element. If
-    <code>opt.placeEmbeddedAboveParent</code> is <code>false</code>, the original order within the group is preserved, allowing children to remain behind their parents.
+    <code>opt.foregroundEmbeds</code> is <code>false</code>, the original order within the group is preserved, allowing children to remain behind their parents.
 </p>
 
 <p>Set <code>opt.breadthFirst</code> to <code>false</code> to index the elements using Depth-first search (DFS).</p>

--- a/docs/src/joint/api/dia/Element/prototype/toBack.html
+++ b/docs/src/joint/api/dia/Element/prototype/toBack.html
@@ -1,9 +1,13 @@
 <pre class="docs-method-signature"><code>element.toBack([opt])</code></pre>
 
-<p>Move the element so it is behind all other cells (elements/links).
-If <code>opt.deep</code> is <code>true</code>, all the embedded cells of this
-element will get higher <code>z</code> index than that of this element in a Breadth-first search (BFS) fashion. This
-is especially useful in hierarchical diagrams where if you want to send an element to the back, you don't want
-its children (embedded cells) to be hidden behind that element.</p>
+<p>Move the element so it is behind all other cells (elements/links). If <code>opt.deep</code> is
+    <code>true</code>, all the embedded cells of this element will be updated in a Breadth-first
+    search (BFS) fashion.
+</p>
+
+<p>If <code>opt.placeEmbeddedAboveParent</code> is <code>true</code> (as by default), all the embedded
+    cells will get a higher <code>z</code> index than that of this element. This is especially useful in hierarchical diagrams where if you want to send an element to the back, you don't want its children (embedded cells) to be hidden behind that element. If
+    <code>opt.placeEmbeddedAboveParent</code> is <code>false</code>, the original order within the group is preserved, allowing children to remain behind their parents.
+</p>
 
 <p>Set <code>opt.breadthFirst</code> to <code>false</code> to index the elements using Depth-first search (DFS).</p>

--- a/docs/src/joint/api/dia/Element/prototype/toFront.html
+++ b/docs/src/joint/api/dia/Element/prototype/toFront.html
@@ -4,10 +4,10 @@
     If <code>opt.deep</code> is <code>true</code>, all the embedded cells of this element will be updated
     in a Breadth-first search (BFS) fashion.</p>
 
-<p>If <code>opt.placeEmbeddedAboveParent</code> is <code>true</code> (as by default), all the embedded
+<p>If <code>opt.foregroundEmbeds</code> is <code>true</code> (as by default), all the embedded
     cells will get a higher <code>z</code> index than that of this element. This is especially useful
     in hierarchical diagrams where if you want to send an element to the front, you don't want its children (embedded cells)
-    to be hidden behind that element. If <code>opt.placeEmbeddedAboveParent</code> is <code>false</code>,
+    to be hidden behind that element. If <code>opt.foregroundEmbeds</code> is <code>false</code>,
     the original order within the group is preserved, allowing children to remain behind their parents.</p>
 
 <p>Set <code>opt.breadthFirst</code> to <code>false</code> to index the elements using Depth-first search (DFS).</p>

--- a/docs/src/joint/api/dia/Element/prototype/toFront.html
+++ b/docs/src/joint/api/dia/Element/prototype/toFront.html
@@ -1,10 +1,14 @@
 <pre class="docs-method-signature"><code>element.toFront([opt])</code></pre>
 
 <p>Move the element so it is on top of all other cells (element/links).
-If <code>opt.deep</code> is <code>true</code>, all the embedded cells of this
-element will get higher <code>z</code> index than that of this element in a Breadth-first search (BFS) fashion. This
-is especially useful in hierarchical diagrams where if you want to send an element to the front, you don't want
-its children (embedded cells) to be hidden behind that element.</p>
+    If <code>opt.deep</code> is <code>true</code>, all the embedded cells of this element will be updated
+    in a Breadth-first search (BFS) fashion.</p>
+
+<p>If <code>opt.placeEmbeddedAboveParent</code> is <code>true</code> (as by default), all the embedded
+    cells will get a higher <code>z</code> index than that of this element. This is especially useful
+    in hierarchical diagrams where if you want to send an element to the front, you don't want its children (embedded cells)
+    to be hidden behind that element. If <code>opt.placeEmbeddedAboveParent</code> is <code>false</code>,
+    the original order within the group is preserved, allowing children to remain behind their parents.</p>
 
 <p>Set <code>opt.breadthFirst</code> to <code>false</code> to index the elements using Depth-first search (DFS).</p>
 

--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -228,19 +228,17 @@ export const Cell = Backbone.Model.extend({
     toFront: function(opt) {
         var graph = this.graph;
         if (graph) {
-            opt = defaults(opt || {}, { placeEmbeddedAboveParent: true });
-
-            console.log(opt);
+            opt = defaults(opt || {}, { foregroundEmbeds: true });
 
             let cells;
             if (opt.deep) {
-                cells = this.getEmbeddedCells({ deep: true, breadthFirst: opt.breadthFirst !== false, sortSiblings: opt.placeEmbeddedAboveParent });
+                cells = this.getEmbeddedCells({ deep: true, breadthFirst: opt.breadthFirst !== false, sortSiblings: opt.foregroundEmbeds });
                 cells.unshift(this);
             } else {
                 cells = [this];
             }
 
-            const sortedCells = opt.placeEmbeddedAboveParent ? cells : sortBy(cells, cell => cell.z());
+            const sortedCells = opt.foregroundEmbeds ? cells : sortBy(cells, cell => cell.z());
 
             const maxZ = graph.maxZIndex();
             let z = maxZ - cells.length + 1;
@@ -273,17 +271,17 @@ export const Cell = Backbone.Model.extend({
     toBack: function(opt) {
         var graph = this.graph;
         if (graph) {
-            opt = defaults(opt || {}, { placeEmbeddedAboveParent: true });
+            opt = defaults(opt || {}, { foregroundEmbeds: true });
 
             let cells;
             if (opt.deep) {
-                cells = this.getEmbeddedCells({ deep: true, breadthFirst: opt.breadthFirst !== false, sortSiblings: opt.placeEmbeddedAboveParent });
+                cells = this.getEmbeddedCells({ deep: true, breadthFirst: opt.breadthFirst !== false, sortSiblings: opt.foregroundEmbeds });
                 cells.unshift(this);
             } else {
                 cells = [this];
             }
 
-            const sortedCells = opt.placeEmbeddedAboveParent ? cells : sortBy(cells, cell => cell.z());
+            const sortedCells = opt.foregroundEmbeds ? cells : sortBy(cells, cell => cell.z());
 
             let z = graph.minZIndex();
 

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -888,7 +888,7 @@ QUnit.module('basic', function(hooks) {
 
         assert.ok(b1Z < a1Z, 'b root z is lower than a root z');
 
-        a1.toFront({ deep: true, foregroundEmbeds: false });
+        a1.toFront({ deep: true });
 
         assert.equal(a1.get('z'), a1Z, 'a1 doesn\'t change z during a toFront() if it is already in place');
 
@@ -941,7 +941,7 @@ QUnit.module('basic', function(hooks) {
             QUnit.test('toBack(), toFront() > breadthFirst = ' + testCase.breadthFirst, function(assert) {
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst, foregroundEmbeds: false });
+                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toFront,
@@ -950,7 +950,7 @@ QUnit.module('basic', function(hooks) {
                 });
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst, foregroundEmbeds: false });
+                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toBack,

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -888,7 +888,7 @@ QUnit.module('basic', function(hooks) {
 
         assert.ok(b1Z < a1Z, 'b root z is lower than a root z');
 
-        a1.toFront({ deep: true, placeEmbeddedAboveParent: false });
+        a1.toFront({ deep: true, foregroundEmbeds: false });
 
         assert.equal(a1.get('z'), a1Z, 'a1 doesn\'t change z during a toFront() if it is already in place');
 
@@ -941,7 +941,7 @@ QUnit.module('basic', function(hooks) {
             QUnit.test('toBack(), toFront() > breadthFirst = ' + testCase.breadthFirst, function(assert) {
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst, placeEmbeddedAboveParent: false });
+                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst, foregroundEmbeds: false });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toFront,
@@ -950,7 +950,7 @@ QUnit.module('basic', function(hooks) {
                 });
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst, placeEmbeddedAboveParent: false });
+                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst, foregroundEmbeds: false });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toBack,
@@ -1025,7 +1025,7 @@ QUnit.module('basic', function(hooks) {
         assert.equal(r4.get('z'), -2);
     });
 
-    QUnit.test('toFront() with placeEmbeddedAboveParent: false', function(assert) {
+    QUnit.test('toFront() with foregroundEmbeds: false', function(assert) {
         const Rect = joint.shapes.standard.Rectangle;
 
         const r1 = new Rect({ z: 2 });
@@ -1041,15 +1041,15 @@ QUnit.module('basic', function(hooks) {
 
         this.graph.addCells([r1, r2, r3, r4, r5]);
 
-        r1.toFront({ deep: true, placeEmbeddedAboveParent: false });
+        r1.toFront({ deep: true, foregroundEmbeds: false });
 
         assert.equal(r1.get('z'), 8);
         assert.equal(r2.get('z'), 10);
         assert.equal(r3.get('z'), 9);
         assert.equal(r4.get('z'), 7);
 
-        r1.toFront({ deep: true, placeEmbeddedAboveParent: false });
-        r1.toFront({ deep: true, placeEmbeddedAboveParent: false }); // calling toFront again doesn't change anything
+        r1.toFront({ deep: true, foregroundEmbeds: false });
+        r1.toFront({ deep: true, foregroundEmbeds: false }); // calling toFront again doesn't change anything
 
         assert.equal(r1.get('z'), 8);
         assert.equal(r2.get('z'), 10);
@@ -1057,7 +1057,7 @@ QUnit.module('basic', function(hooks) {
         assert.equal(r4.get('z'), 7);
     });
 
-    QUnit.test('toBack() with placeEmbeddedAboveParent: false', function(assert) {
+    QUnit.test('toBack() with foregroundEmbeds: false', function(assert) {
         const Rect = joint.shapes.standard.Rectangle;
 
         const r1 = new Rect({ z: 3 });
@@ -1073,15 +1073,15 @@ QUnit.module('basic', function(hooks) {
 
         this.graph.addCells([r1, r2, r3, r4, r5]);
 
-        r1.toBack({ deep: true, placeEmbeddedAboveParent: false });
+        r1.toBack({ deep: true, foregroundEmbeds: false });
 
         assert.equal(r1.get('z'), -2);
         assert.equal(r2.get('z'), 0);
         assert.equal(r3.get('z'), -1);
         assert.equal(r4.get('z'), -3);
 
-        r1.toBack({ deep: true, placeEmbeddedAboveParent: false });
-        r1.toBack({ deep: true, placeEmbeddedAboveParent: false }); // calling toBack again doesn't change anything
+        r1.toBack({ deep: true, foregroundEmbeds: false });
+        r1.toBack({ deep: true, foregroundEmbeds: false }); // calling toBack again doesn't change anything
 
         assert.equal(r1.get('z'), -2);
         assert.equal(r2.get('z'), 0);

--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -888,7 +888,7 @@ QUnit.module('basic', function(hooks) {
 
         assert.ok(b1Z < a1Z, 'b root z is lower than a root z');
 
-        a1.toFront({ deep: true });
+        a1.toFront({ deep: true, placeEmbeddedAboveParent: false });
 
         assert.equal(a1.get('z'), a1Z, 'a1 doesn\'t change z during a toFront() if it is already in place');
 
@@ -941,7 +941,7 @@ QUnit.module('basic', function(hooks) {
             QUnit.test('toBack(), toFront() > breadthFirst = ' + testCase.breadthFirst, function(assert) {
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst });
+                    el.toFront({ deep: true, breadthFirst: testCase.breadthFirst, placeEmbeddedAboveParent: false });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toFront,
@@ -950,7 +950,7 @@ QUnit.module('basic', function(hooks) {
                 });
 
                 Array.from({ length: 2 }).forEach(function() {
-                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst });
+                    el.toBack({ deep: true, breadthFirst: testCase.breadthFirst, placeEmbeddedAboveParent: false });
                     assert.deepEqual(
                         cells.map(function(cell) { return cell.get('z'); }),
                         testCase.toBack,
@@ -1023,6 +1023,70 @@ QUnit.module('basic', function(hooks) {
         assert.equal(r2.get('z'), 0);
         assert.equal(r3.get('z'), -1);
         assert.equal(r4.get('z'), -2);
+    });
+
+    QUnit.test('toFront() with placeEmbeddedAboveParent: false', function(assert) {
+        const Rect = joint.shapes.standard.Rectangle;
+
+        const r1 = new Rect({ z: 2 });
+        const r2 = new Rect({ z: 6 });
+        const r3 = new Rect({ z: 4 });
+        const r4 = new Rect({ z: 1 });
+
+        const r5 = new Rect({ z: 3 }); // this rectangle forces r1 to go front
+
+        r1.embed(r2);
+        r1.embed(r3);
+        r1.embed(r4);
+
+        this.graph.addCells([r1, r2, r3, r4, r5]);
+
+        r1.toFront({ deep: true, placeEmbeddedAboveParent: false });
+
+        assert.equal(r1.get('z'), 8);
+        assert.equal(r2.get('z'), 10);
+        assert.equal(r3.get('z'), 9);
+        assert.equal(r4.get('z'), 7);
+
+        r1.toFront({ deep: true, placeEmbeddedAboveParent: false });
+        r1.toFront({ deep: true, placeEmbeddedAboveParent: false }); // calling toFront again doesn't change anything
+
+        assert.equal(r1.get('z'), 8);
+        assert.equal(r2.get('z'), 10);
+        assert.equal(r3.get('z'), 9);
+        assert.equal(r4.get('z'), 7);
+    });
+
+    QUnit.test('toBack() with placeEmbeddedAboveParent: false', function(assert) {
+        const Rect = joint.shapes.standard.Rectangle;
+
+        const r1 = new Rect({ z: 3 });
+        const r2 = new Rect({ z: 7 });
+        const r3 = new Rect({ z: 5 });
+        const r4 = new Rect({ z: 2 });
+
+        const r5 = new Rect({ z: 1 }); // this rectangle forces r1 to go back
+
+        r1.embed(r2);
+        r1.embed(r3);
+        r1.embed(r4);
+
+        this.graph.addCells([r1, r2, r3, r4, r5]);
+
+        r1.toBack({ deep: true, placeEmbeddedAboveParent: false });
+
+        assert.equal(r1.get('z'), -2);
+        assert.equal(r2.get('z'), 0);
+        assert.equal(r3.get('z'), -1);
+        assert.equal(r4.get('z'), -3);
+
+        r1.toBack({ deep: true, placeEmbeddedAboveParent: false });
+        r1.toBack({ deep: true, placeEmbeddedAboveParent: false }); // calling toBack again doesn't change anything
+
+        assert.equal(r1.get('z'), -2);
+        assert.equal(r2.get('z'), 0);
+        assert.equal(r3.get('z'), -1);
+        assert.equal(r4.get('z'), -3);
     });
 
     // tests for `dia.Element.fitToChildren()` can be found in `/test/jointjs/elements.js`

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -309,6 +309,10 @@ export namespace dia {
             sortSiblings?: boolean;
         }
 
+        interface ToFrontAndBackOptions extends GetEmbeddedCellsOptions {
+            placeEmbeddedAboveParent?: boolean;
+        }
+
         interface TransitionOptions extends Options {
             delay?: number;
             duration?: number;
@@ -335,9 +339,9 @@ export namespace dia {
 
         remove(opt?: Cell.DisconnectableOptions): this;
 
-        toFront(opt?: Cell.GetEmbeddedCellsOptions): this;
+        toFront(opt?: Cell.ToFrontAndBackOptions): this;
 
-        toBack(opt?: Cell.GetEmbeddedCellsOptions): this;
+        toBack(opt?: Cell.ToFrontAndBackOptions): this;
 
         parent(): string;
         parent(parentId: Cell.ID): this;

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -310,7 +310,7 @@ export namespace dia {
         }
 
         interface ToFrontAndBackOptions extends GetEmbeddedCellsOptions {
-            placeEmbeddedAboveParent?: boolean;
+            foregroundEmbeds?: boolean;
         }
 
         interface TransitionOptions extends Options {


### PR DESCRIPTION
## Description

This pull request adds a new option called `foregroundEmbeds` to the `Cell.toFront` and `Cell.toBack` methods. By default, this option is set to `true`. When set to `true`, all the embedded cells will get a higher z-index than their parent element.

## Motivation and Context

In pull request #2088, there was an unintentional breaking change in the `Cell.toFront` and `Cell.toBack` methods, which violated the following statement in the documentation:

> If `opt.deep` is `true`, all the embedded cells of this element will get higher `z` index than that of this element in a Breadth-first search (BFS) fashion.

This pull request addresses the issue by supporting both behaviors. Users can now decide whether to preserve the original stacking of a group or always have the embedded cells with a higher z-index than their parent.