### PR TITLE
feat(routers.RightAngle): support user defined vertices

### DIFF
--- a/demo/right-angle-playground/css/style.css
+++ b/demo/right-angle-playground/css/style.css
@@ -1,0 +1,9 @@
+body {
+    margin: 0;
+    padding: 0;
+}
+
+#paper {
+    position: absolute;
+    inset: 0 0 0 0;
+}

--- a/demo/right-angle-playground/index.html
+++ b/demo/right-angle-playground/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf8"/>
+        <title>Right angle router playground</title>
+        <link rel="stylesheet" type="text/css" href="../../build/joint.css" />
+        <link rel="stylesheet" type="text/css" href="./css/style.css" />
+    </head>
+    <body>
+        <div id="paper"></div>
+        <!-- Dependencies: -->
+        <script src="../../node_modules/jquery/dist/jquery.js"></script>
+        <script src="../../node_modules/lodash/lodash.js"></script>
+        <script src="../../node_modules/backbone/backbone.js"></script>
+        <script src="../../build/joint.js"></script>
+        <script src="./src/index.js"></script>
+    </body>
+</html>

--- a/demo/right-angle-playground/src/index.js
+++ b/demo/right-angle-playground/src/index.js
@@ -9,8 +9,8 @@ class ResizeTool extends elementTools.Control {
     setPosition(view, coordinates) {
         const model = view.model;
         model.resize(
-            Math.max(coordinates.x, 1),
-            Math.max(coordinates.y, 1)
+            Math.max(Math.round(coordinates.x / 2) * 2, 10),
+            Math.max(Math.round(coordinates.y / 2) * 2, 10)
         );
     }
 }
@@ -110,14 +110,16 @@ rect2.findView(paper).addTools(
 
 const linkToolsView = new dia.ToolsView({
     tools: [
+        new linkTools.Vertices({
+            focusOpacity: 0.5,
+        }),
         new linkTools.TargetAnchor({
-            focusOpacity: 0.5
+            focusOpacity: 0.5,
+            scale: 1.2
         }),
         new linkTools.SourceAnchor({
-            focusOpacity: 0.5
-        }),
-        new linkTools.Vertices({
-            focusOpacity: 0.5
+            focusOpacity: 0.5,
+            scale: 1.2
         }),
     ]
 });

--- a/demo/right-angle-playground/src/index.js
+++ b/demo/right-angle-playground/src/index.js
@@ -1,4 +1,19 @@
-const { dia, shapes, linkTools } = joint;
+const { dia, shapes, linkTools, elementTools } = joint;
+class ResizeTool extends elementTools.Control {
+    getPosition(view) {
+        const model = view.model;
+        const { width, height } = model.size();
+        return { x: width, y: height };
+    }
+
+    setPosition(view, coordinates) {
+        const model = view.model;
+        model.resize(
+            Math.max(coordinates.x, 1),
+            Math.max(coordinates.y, 1)
+        );
+    }
+}
 
 const graph = new dia.Graph();
 
@@ -60,6 +75,26 @@ link2.vertices([
 ]);
 
 graph.addCells([rect, rect2, link, link2]);
+
+rect.findView(paper).addTools(
+    new dia.ToolsView({
+        tools: [
+            new ResizeTool({
+                selector: 'body'
+            })
+        ]
+    })
+);
+
+rect2.findView(paper).addTools(
+    new dia.ToolsView({
+        tools: [
+            new ResizeTool({
+                selector: 'body'
+            })
+        ]
+    })
+);
 
 const linkToolsView = new dia.ToolsView({
     tools: [

--- a/demo/right-angle-playground/src/index.js
+++ b/demo/right-angle-playground/src/index.js
@@ -29,6 +29,12 @@ const paper = new dia.Paper({
     defaultConnector: { name: 'rounded' },
     background: {
         color: '#151D29'
+    },
+    defaultLinkAnchor: { 
+        name: 'connectionRatio',
+        args: {
+            ratio: 0.25
+        }
     }
 });
 
@@ -74,7 +80,13 @@ link2.vertices([
     { x: 800, y: 500 },
 ]);
 
-graph.addCells([rect, rect2, link, link2]);
+const link3 = link.clone();
+link3.attr('line/stroke', '#DF423D');
+link3.source({ x: 1000, y: 600 });
+link3.target({ id: link2.id });
+link3.vertices([{ x: 900, y: 400 }]);
+
+graph.addCells([rect, rect2, link, link2, link3]);
 
 rect.findView(paper).addTools(
     new dia.ToolsView({
@@ -127,5 +139,30 @@ const link2ToolsView = new dia.ToolsView({
 });
 
 link2.findView(paper).addTools(link2ToolsView);
+
+const link3ToolsView = new dia.ToolsView({
+    tools: [
+        new linkTools.Vertices({
+            focusOpacity: 0.5
+        })
+    ]
+});
+
+link3.findView(paper).addTools(link3ToolsView);
+
+function scaleToFit() {
+    const graphBBox = graph.getBBox();
+    paper.scaleContentToFit({
+        contentArea: graphBBox.clone().inflate(0, 100)
+    });
+    const { sy } = paper.scale();
+    const area = paper.getArea();
+    const yTop = area.height / 2 - graphBBox.y - graphBBox.height / 2;
+    const xLeft = area.width / 2 - graphBBox.x - graphBBox.width / 2;
+    paper.translate(xLeft * sy, yTop * sy);
+}
+
+window.addEventListener('resize', () => scaleToFit());
+scaleToFit();
 
 paper.unfreeze();

--- a/demo/right-angle-playground/src/index.js
+++ b/demo/right-angle-playground/src/index.js
@@ -1,0 +1,96 @@
+const { dia, shapes, linkTools } = joint;
+
+const graph = new dia.Graph();
+
+const paper = new dia.Paper({
+    el: document.getElementById('paper'),
+    width: '100%',
+    height: '100%',
+    gridSize: 10,
+    async: true,
+    frozen: true,
+    model: graph,
+    defaultRouter: { name: 'rightAngle', args: { useVertices: true }},
+    defaultConnector: { name: 'rounded' },
+    background: {
+        color: '#151D29'
+    }
+});
+
+const rect = new shapes.standard.Rectangle({ 
+    position: { x: 120, y: 120 },
+    size: { width: 220, height: 60 },
+    attrs: {
+        body: {
+            stroke: 'none',
+            fill: '#DF423D',
+            rx: 10,
+            ry: 10,
+        }
+    }
+});
+
+const rect2 = rect.clone();
+
+rect2.resize(60, 220);
+rect2.position(400, 700);
+
+const link = new shapes.standard.Link({
+    attrs: {
+        line: {
+            stroke: 'white'
+        }
+    }
+});
+
+const link2 = link.clone();
+
+link.source({ id: rect.id, anchor: { name: 'top' }});
+link.target({ id: rect2.id, anchor: { name: 'right' }});
+link.vertices([
+    { x: 370, y: 420 },
+    { x: 500, y: 500 }
+]);
+
+link2.source({ x: 670, y: 100 });
+link2.target({ x: 800, y: 800 });
+link2.vertices([
+    { x: 670, y: 420 },
+    { x: 800, y: 500 },
+]);
+
+graph.addCells([rect, rect2, link, link2]);
+
+const linkToolsView = new dia.ToolsView({
+    tools: [
+        new linkTools.TargetAnchor({
+            focusOpacity: 0.5
+        }),
+        new linkTools.SourceAnchor({
+            focusOpacity: 0.5
+        }),
+        new linkTools.Vertices({
+            focusOpacity: 0.5
+        }),
+    ]
+});
+
+link.findView(paper).addTools(linkToolsView);
+
+const link2ToolsView = new dia.ToolsView({
+    tools: [
+        new linkTools.Vertices({
+            focusOpacity: 0.5
+        }),
+        new linkTools.SourceArrowhead({
+            focusOpacity: 0.5
+        }),
+        new linkTools.TargetArrowhead({
+            focusOpacity: 0.5
+        })
+    ]
+});
+
+link2.findView(paper).addTools(link2ToolsView);
+
+paper.unfreeze();

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -71,13 +71,14 @@ function resolveForTopSourceSide(source, target, nextInLine) {
     const sy1 = sy0 + height;
     const smx0 = sx0 - margin;
     const smx1 = sx1 + margin;
+    const smy0 = sy0 - margin;
 
-    const { x: ax, y: ay } = anchor;
+    const { x: ax } = anchor;
     const { x0: tx, y0: ty } = target;
 
-    if (tx === ax && ty < ay) return Directions.BOTTOM;
-    if (tx < ax && ty < ay) return Directions.RIGHT;
-    if (tx > ax && ty < ay) return Directions.LEFT;
+    if (tx === ax && ty < sy0) return Directions.BOTTOM;
+    if (tx < ax && ty < smy0) return Directions.RIGHT;
+    if (tx > ax && ty < smy0) return Directions.LEFT;
     if (tx < smx0 && ty >= sy0) return Directions.TOP;
     if (tx > smx1 && ty >= sy0) return Directions.TOP;
     if (tx >= smx0 && tx <= ax && ty > sy1) {
@@ -104,17 +105,16 @@ function resolveForBottomSourceSide(source, target, nextInLine) {
     const sy1 = sy0 + height;
     const smx0 = sx0 - margin;
     const smx1 = sx1 + margin;
-    const smy0 = sy0 - margin;
     const smy1 = sy1 + margin;
 
-    const { x: ax, y: ay } = anchor;
+    const { x: ax } = anchor;
     const { x0: tx, y0: ty } = target;
 
-    if (tx === ax && ty > ay) return Directions.TOP;
-    if (tx < ax && ty > smy0) return Directions.RIGHT;
+    if (tx === ax && ty > sy1) return Directions.TOP;
+    if (tx < ax && ty > smy1) return Directions.RIGHT;
     if (tx > ax && ty > smy1) return Directions.LEFT;
-    if (tx < smx0 && ty <= sy0) return Directions.BOTTOM;
-    if (tx > smx1 && ty <= sy0) return Directions.BOTTOM;
+    if (tx < smx0 && ty <= sy1) return Directions.BOTTOM;
+    if (tx > smx1 && ty <= sy1) return Directions.BOTTOM;
     if (tx >= smx0 && tx <= ax && ty < sy0) {
         if (nextInLine.point.x < tx) {
             return Directions.RIGHT;

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -681,7 +681,6 @@ function routeBetweenPoints(source, target) {
                 if ((y < tcy || !isSourceEl) && y > tmy0 && sox > tx1) {
                     y = tmy1;
                 }
-
                 return [
                     { x: sox, y },
                     { x: tox, y },
@@ -689,28 +688,19 @@ function routeBetweenPoints(source, target) {
                 ];
             }
             return [{ x: sox, y: toy }];
+        } else {
+            if (sx1 > tox) {
+                const y = Math.max(smy1, tmy1);
+                const x = Math.min(smx0, tmx0);
+                return [
+                    { x: sox, y },
+                    { x, y },
+                    { x, y: toy }
+                ];
+            }
         }
 
-        const x = Math.min(tmx0, middleOfVerticalSides);
-
-        if (sox < tox && sy0 <= toy) {
-            return [
-                { x: sox, y: soy },
-                { x, y: soy },
-                { x, y: toy }
-            ];
-        }
-
-        if (x < smx1 && soy > ty0) {
-            const y = Math.max(smy1, tmy1);
-            const x = Math.min(smx0, tmx0);
-
-            return [
-                { x: sox, y },
-                { x, y },
-                { x, y: toy }
-            ];
-        }
+        const x = middleOfVerticalSides;
 
         return [
             { x: sox, y: soy },

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -695,7 +695,7 @@ function routeBetweenPoints(source, target) {
             { x, y: toy }
         ];
     } else if (sourceSide === 'left' && targetSide === 'bottom') {
-        if (sox > tox && soy >= tmy1) {
+        if (sox >= tox && soy >= tmy1) {
             return [{ x: tox, y: soy }];
         }
 
@@ -797,7 +797,7 @@ function routeBetweenPoints(source, target) {
             { x: tox, y }
         ];
     } else if (sourceSide === 'right' && targetSide === 'bottom') {
-        if (sox < tox && soy >= tmy1) {
+        if (sox <= tox && soy >= tmy1) {
             return [{ x: tox, y: soy }];
         }
 

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -396,7 +396,8 @@ function routeBetweenPoints(source, target, margin) {
     } else if (sourceSide === 'top' && targetSide === 'right') {
         if (soy > toy) {
             if (sox < tox) {
-                let y = (sy0 + ty1) / 2;
+                let y = middleOfHorizontalSides;
+
                 if (y > tcy && y < tmy1 && sox < tmx0) {
                     y = tmy0;
                 }
@@ -410,7 +411,7 @@ function routeBetweenPoints(source, target, margin) {
             return [{ x: sox, y: toy }];
         }
 
-        const x = (sx0 + tx1) / 2;
+        const x = middleOfVerticalSides;
 
         if (tox < sox && toy > sy0 && toy < sy1) {
             return [
@@ -438,7 +439,8 @@ function routeBetweenPoints(source, target, margin) {
     } else if (sourceSide === 'top' && targetSide === 'left') {
         if (soy > toy) {
             if (sox > tox) {
-                let y = (sy0 + ty1) / 2;
+                let y = middleOfHorizontalSides;
+
                 if (y > tcy && y < tmy1 && sox > tmx1) {
                     y = tmy0;
                 }
@@ -451,7 +453,7 @@ function routeBetweenPoints(source, target, margin) {
             return [{ x: sox, y: toy }];
         }
 
-        const x = (sx1 + tx0) / 2;
+        const x = middleOfVerticalSides;
 
         if (sox < tox && sy1 >= toy) {
             return [
@@ -477,7 +479,8 @@ function routeBetweenPoints(source, target, margin) {
     } else if (sourceSide === 'bottom' && targetSide === 'right') {
         if (soy < toy) {
             if (sox < tox) {
-                let y = (sy1 + ty0) / 2;
+                let y = middleOfHorizontalSides;
+
                 if (y < tcy && y > tmy0 && sox < tmx0) {
                     y = tmy1;
                 }
@@ -510,7 +513,8 @@ function routeBetweenPoints(source, target, margin) {
     } else if (sourceSide === 'bottom' && targetSide === 'left') {
         if (soy < toy) {
             if (sox > tox) {
-                let y = (sy1 + ty0) / 2;
+                let y = middleOfHorizontalSides;
+
                 if (y < tcy && y > tmy0 && sox > tmx1) {
                     y = tmy1;
                 }
@@ -546,7 +550,8 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (sox >= tx1 && soy < toy) {
-            const x = (sx1 + tx0) / 2;
+            const x = middleOfVerticalSides;
+
             return [
                 { x, y: soy },
                 { x, y: toy },
@@ -555,7 +560,7 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (tox < sx1 && ty1 <= sy0) {
-            const y = (sy0 + ty1) / 2;
+            const y = middleOfHorizontalSides;
 
             return [
                 { x: sox, y: soy },
@@ -579,7 +584,8 @@ function routeBetweenPoints(source, target, margin) {
 
         if (sox >= tx1) {
             if (soy > toy) {
-                const x = (sx0 + tx1) / 2;
+                const x = middleOfVerticalSides;
+
                 return [
                     { x, y: soy },
                     { x, y: toy },
@@ -589,7 +595,7 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (tox <= sx1 && toy > soy) {
-            const y = (ty0 + sy1) / 2;
+            const y = middleOfHorizontalSides;
 
             return [
                 { x: sox, y: soy },
@@ -613,7 +619,8 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (sx1 < tx0 && soy > toy) {
-            let x = (sx1 + tx0) / 2;
+            let x = middleOfVerticalSides;
+
             return [
                 { x, y: soy },
                 { x, y: toy },
@@ -622,7 +629,7 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (tox < sox && ty0 > sy1) {
-            const y = (sy1 + ty0) / 2;
+            const y = middleOfHorizontalSides;
 
             return [
                 { x: sox, y: soy },
@@ -644,7 +651,8 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (sox <= tmx0 && soy < toy) {
-            const x = (sx1 + tx0) / 2;
+            const x = middleOfVerticalSides;
+
             return [
                 { x, y: soy },
                 { x, y: toy },
@@ -653,7 +661,7 @@ function routeBetweenPoints(source, target, margin) {
         }
 
         if (tox > sx0 && ty1 < sy0) {
-            const y = (sy0 + ty1) / 2;
+            const y = middleOfHorizontalSides;
 
             return [
                 { x: sox, y: soy },

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -698,8 +698,8 @@ function rightAngleRouter(vertices, opt, linkView) {
         const current = vertices[i];
 
         const next = vertices[i + 1] || targetPoint.point;
-        const nextBbox = new g.Rect(next.x, next.y, 0, 0);
-        const target = pointDataFromVertex(current, nextBbox);
+        const nextBBox = new g.Rect(next.x, next.y, 0, 0);
+        const target = pointDataFromVertex(current, nextBBox);
 
         resultVertices.push(...routeBetweenPoints(source, target, margin));
 

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -29,13 +29,13 @@ const ANGLE_DIRECTION_MAP = {
 };
 
 function getSegmentAngle(line) {
-    // TODO optimize this
+    // TODO: the angle() method is general and therefore unnecessarily heavy for orthogonal links
     return line.angle();
 }
 
 function simplifyPoints(points) {
-    // TODO optimize this
-    // threshold used for cases where the vertices were off by 0.2px
+    // TODO: use own more efficient implementation (filter points that do not change direction).
+    // To simplify segments that are almost aligned (start and end points differ by e.g. 0.5px), use a threshold of 1.
     return new g.Polyline(points).simplify({ threshold: 1 }).points;
 }
 
@@ -881,7 +881,7 @@ function rightAngleRouter(vertices, opt, linkView) {
         const [fromDirection] = resolveSides(sourcePoint, firstVertex);
         const toDirection = fromDirection;
         const dummySource = pointDataFromVertex(sourcePoint.point);
-        // we are creating a point that has a margin
+        // Points do not usually have margin. Here we create a point with a margin.
         dummySource.margin = margin;
         dummySource.direction = fromDirection;
         firstVertex.direction = toDirection;

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -958,10 +958,11 @@ function rightAngleRouter(vertices, opt, linkView) {
             lastVertex.direction = definedDirection;
 
             let lastSegmentRoute = routeBetweenPoints(lastVertex, targetPoint);
-            const [p1, p2] = new g.Polyline(lastSegmentRoute).simplify().points;
+            const [p1, p2] = new g.Polyline([...lastSegmentRoute, targetPoint.point]).simplify({ threshold: 1 }).points;
 
             const lastSegment = new g.Line(p1, p2);
-            const lastSegmentDirection = ANGLE_DIRECTION_MAP[lastSegment.angle()];
+            const roundedLastSegmentAngle = Math.round(lastSegment.angle());
+            const lastSegmentDirection = ANGLE_DIRECTION_MAP[roundedLastSegmentAngle];
 
             if (lastSegmentDirection !== definedDirection && definedDirection === OPPOSITE_DIRECTIONS[lastSegmentDirection]) {
                 lastVertex.margin = margin;

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -473,8 +473,8 @@ function routeBetweenPoints(source, target) {
         ];
     } else if (sourceSide === 'bottom' && targetSide === 'bottom') {
         let x;
-        let y1 = Math.max((sy1 + ty0) / 2, toy);
-        let y2 = Math.max((sy0 + ty1) / 2, soy);
+        let y1 = Math.max((sy0 + ty1) / 2, toy);
+        let y2 = Math.max((sy1 + ty0) / 2, soy);
 
         if (toy > soy) {
             if (sox >= tmx1 || sox <= tmx0) {

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -970,8 +970,14 @@ function rightAngleRouter(vertices, opt, linkView) {
     }
 
     vertices[vertices.length - 1].direction = OPPOSITE_DIRECTIONS[vertices[vertices.length - 1].direction];
-    resultVertices.push(...routeBetweenPoints(vertices[vertices.length - 1], targetPoint, margin));
 
+    const route = routeBetweenPoints(vertices[vertices.length - 1], targetPoint, margin);
+    // remove first point of route if it matches the last point of resultVertices
+    if (new g.Point(route[0].x, route[0].y).equals(resultVertices[resultVertices.length - 1])) {
+        route.shift();
+    }
+
+    resultVertices.push(...route);
     return resultVertices;
 }
 

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -684,6 +684,7 @@ function routeBetweenPoints(source, target, margin) {
 function rightAngleRouter(vertices, opt, linkView) {
     const { sourceDirection = Directions.AUTO, targetDirection = Directions.AUTO } = opt;
     const margin = opt.margin || 20;
+    const useVertices = opt.useVertices || false;
 
     const isSourcePort = !!linkView.model.source().port;
     const sourcePoint = pointDataFromAnchor(linkView.sourceView, linkView.sourceAnchor, linkView.sourceBBox, sourceDirection, isSourcePort, linkView.sourceAnchor);
@@ -693,6 +694,10 @@ function rightAngleRouter(vertices, opt, linkView) {
     // // First point is always the source anchor point
     let resultVertices = [];
     let source = sourcePoint;
+
+    if (!useVertices) {
+        return routeBetweenPoints(sourcePoint, targetPoint, margin);
+    }
 
     for (let i = 0; i < vertices.length; i++) {
         const current = vertices[i];

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -290,7 +290,7 @@ function getOutsidePoint(side, pointData, margin) {
     return outsidePoint;
 }
 
-function routeBetweenPoints(source, target, margin) {
+function routeBetweenPoints(source, target) {
     const { point: sourcePoint, x0: sx0, y0: sy0, view: sourceView, width: sourceWidth, height: sourceHeight, margin: sourceMargin } = source;
     const { point: targetPoint, x0: tx0, y0: ty0, width: targetWidth, height: targetHeight, margin: targetMargin } = target;
 

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -846,7 +846,7 @@ function rightAngleRouter(vertices, opt, linkView) {
     let resultVertices = [];
 
     if (!useVertices || vertices.length === 0) {
-        return routeBetweenPoints(sourcePoint, targetPoint, margin);
+        return new g.Polyline(routeBetweenPoints(sourcePoint, targetPoint, margin)).simplify().points;
     }
 
     const verticesData = vertices.map((v) => pointDataFromVertex(v));

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -41,7 +41,7 @@ function pointDataFromAnchor(view, point, bbox, direction, isPort, fallBackAncho
         direction = isPort ? Directions.MAGNET_SIDE : Directions.ANCHOR_SIDE;
     }
 
-    let {
+    const {
         x: x0,
         y: y0,
         width = 0,
@@ -61,7 +61,7 @@ function pointDataFromAnchor(view, point, bbox, direction, isPort, fallBackAncho
     };
 }
 
-function pointDataFromVertex({ x, y }, nextBbox) {
+function pointDataFromVertex({ x, y }, nextBBox) {
     const point = new g.Point(x, y);
 
     return {
@@ -72,7 +72,7 @@ function pointDataFromVertex({ x, y }, nextBbox) {
         bbox: null,
         width: 0,
         height: 0,
-        direction: nextBbox.sideNearestToPoint(point)
+        direction: nextBBox.sideNearestToPoint(point)
     };
 }
 

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -11,13 +11,6 @@ const Directions = {
 };
 
 const DEFINED_DIRECTIONS = [Directions.LEFT, Directions.RIGHT, Directions.TOP, Directions.BOTTOM];
-const ANGLE_DIRECTIONS = {
-    0: Directions.LEFT,
-    90: Directions.TOP,
-    180: Directions.RIGHT,
-    270: Directions.BOTTOM,
-    360: Directions.LEFT
-};
 
 const OPPOSITE_DIRECTIONS = {
     [Directions.LEFT]: Directions.RIGHT,
@@ -25,8 +18,6 @@ const OPPOSITE_DIRECTIONS = {
     [Directions.TOP]: Directions.BOTTOM,
     [Directions.BOTTOM]: Directions.TOP
 };
-
-const HORIZONTAL_DIRECTIONS = [Directions.LEFT, Directions.RIGHT];
 
 function getDirectionForLinkConnection(linkOrigin, connectionPoint, linkView) {
     const tangent = linkView.getTangentAtLength(linkView.getClosestPointLength(connectionPoint));
@@ -67,7 +58,7 @@ function pointDataFromAnchor(view, point, bbox, direction, isPort, fallBackAncho
         height,
         direction,
         isVertex: false
-    }
+    };
 }
 
 function pointDataFromVertex({ x, y }, nextBbox) {
@@ -82,7 +73,7 @@ function pointDataFromVertex({ x, y }, nextBbox) {
         width: 0,
         height: 0,
         direction: nextBbox.sideNearestToPoint(point)
-    }
+    };
 }
 
 function routeBetweenPoints(source, target, margin) {
@@ -96,14 +87,14 @@ function routeBetweenPoints(source, target, margin) {
 
     // Key coordinates including the margin
     const isSourceEl = sourceView && sourceView.model.isElement();
-    const sourceMargin = (isSourceEl ? margin : 0)
+    const sourceMargin = (isSourceEl ? margin : 0);
     const smx0 = sx0 - sourceMargin;
     const smx1 = sx1 + sourceMargin;
     const smy0 = sy0 - sourceMargin;
     const smy1 = sy1 + sourceMargin;
 
     const isTargetEl = targetView && targetView.model.isElement();
-    const targetMargin = (isTargetEl ? margin : 0)
+    const targetMargin = (isTargetEl ? margin : 0);
     const tmx0 = tx0 - targetMargin;
     const tmx1 = tx1 + targetMargin;
     const tmy0 = ty0 - targetMargin;
@@ -426,7 +417,7 @@ function routeBetweenPoints(source, target, margin) {
                 { x: sox, y: soy },
                 { x: x, y: soy },
                 { x: x, y: toy }
-            ]
+            ];
         }
 
         if ((x > smx0 && toy > sy0) || tx0 > sx1) {
@@ -693,7 +684,7 @@ function rightAngleRouter(vertices, opt, linkView) {
     const targetPoint = pointDataFromAnchor(linkView.targetView, linkView.targetAnchor, linkView.targetBBox, targetDirection, isTargetPort, linkView.targetAnchor);
     // // First point is always the source anchor point
     let resultVertices = [];
-    let source = sourcePoint
+    let source = sourcePoint;
 
     for (let i = 0; i < vertices.length; i++) {
         const current = vertices[i];

--- a/src/routers/rightAngle.mjs
+++ b/src/routers/rightAngle.mjs
@@ -66,9 +66,11 @@ function resolveSides(source, target) {
 }
 
 function resolveForTopSourceSide(source, target, nextInLine) {
-    const { x0: sx0, y0: sy0, width, height, point: anchor } = source;
+    const { x0: sx0, y0: sy0, width, height, point: anchor, margin } = source;
     const sx1 = sx0 + width;
     const sy1 = sy0 + height;
+    const smx0 = sx0 - margin;
+    const smx1 = sx1 + margin;
 
     const { x: ax, y: ay } = anchor;
     const { x0: tx, y0: ty } = target;
@@ -76,16 +78,16 @@ function resolveForTopSourceSide(source, target, nextInLine) {
     if (tx === ax && ty < ay) return Directions.BOTTOM;
     if (tx < ax && ty < ay) return Directions.RIGHT;
     if (tx > ax && ty < ay) return Directions.LEFT;
-    if (tx < sx0 && ty >= sy0) return Directions.TOP;
-    if (tx > sx1 && ty >= sy0) return Directions.TOP;
-    if (tx >= sx0 && tx <= ax && ty > sy1) {
+    if (tx < smx0 && ty >= sy0) return Directions.TOP;
+    if (tx > smx1 && ty >= sy0) return Directions.TOP;
+    if (tx >= smx0 && tx <= ax && ty > sy1) {
         if (nextInLine.point.x < tx) {
             return Directions.RIGHT;
         }
 
         return Directions.LEFT;
     }
-    if (tx <= sx1 && tx >= ax && ty > sy1) {
+    if (tx <= smx1 && tx >= ax && ty > sy1) {
         if (nextInLine.point.x < tx) {
             return Directions.RIGHT;
         }
@@ -97,25 +99,30 @@ function resolveForTopSourceSide(source, target, nextInLine) {
 }
 
 function resolveForBottomSourceSide(source, target, nextInLine) {
-    const { x0: sx0, y0: sy0, width, point: anchor } = source;
+    const { x0: sx0, y0: sy0, width, height, point: anchor, margin } = source;
     const sx1 = sx0 + width;
+    const sy1 = sy0 + height;
+    const smx0 = sx0 - margin;
+    const smx1 = sx1 + margin;
+    const smy0 = sy0 - margin;
+    const smy1 = sy1 + margin;
 
     const { x: ax, y: ay } = anchor;
     const { x0: tx, y0: ty } = target;
 
     if (tx === ax && ty > ay) return Directions.TOP;
-    if (tx < ax && ty > ay) return Directions.RIGHT;
-    if (tx > ax && ty > ay) return Directions.LEFT;
-    if (tx < sx0 && ty <= sy0) return Directions.BOTTOM;
-    if (tx > sx1 && ty <= sy0) return Directions.BOTTOM;
-    if (tx >= sx0 && tx <= ax && ty < sy0) {
+    if (tx < ax && ty > smy0) return Directions.RIGHT;
+    if (tx > ax && ty > smy1) return Directions.LEFT;
+    if (tx < smx0 && ty <= sy0) return Directions.BOTTOM;
+    if (tx > smx1 && ty <= sy0) return Directions.BOTTOM;
+    if (tx >= smx0 && tx <= ax && ty < sy0) {
         if (nextInLine.point.x < tx) {
             return Directions.RIGHT;
         }
 
         return Directions.LEFT;
     }
-    if (tx <= sx1 && tx >= ax && ty < sy0) {
+    if (tx <= smx1 && tx >= ax && ty < sy0) {
         if (nextInLine.point.x < tx) {
             return Directions.RIGHT;
         }
@@ -127,26 +134,29 @@ function resolveForBottomSourceSide(source, target, nextInLine) {
 }
 
 function resolveForLeftSourceSide(source, target, nextInLine) {
-    const { y0: sy0, x0: sx0, width, height, point: anchor } = source;
+    const { y0: sy0, x0: sx0, width, height, point: anchor, margin } = source;
     const sx1 = sx0 + width;
     const sy1 = sy0 + height;
+    const smx0 = sx0 - margin;
+    const smy0 = sy0 - margin;
+    const smy1 = sy1 + margin;
 
     const { x: ax, y: ay } = anchor;
     const { x0: tx, y0: ty } = target;
 
     if (tx < ax && ty === ay) return Directions.RIGHT;
-    if (tx < ax && ty < ay) return Directions.BOTTOM;
-    if (tx < ax && ty > ay) return Directions.TOP;
-    if (tx >= sx0 && ty <= sy0 && ty >= ay) return Directions.LEFT;
-    if (tx >= sx0 && ty >= sy1 && ty <= ay) return Directions.LEFT;
-    if (tx > sx1 && ty >= sy0 && ty <= ay) {
+    if (tx <= smx0 && ty < ay) return Directions.BOTTOM;
+    if (tx <= smx0 && ty > ay) return Directions.TOP;
+    if (tx >= sx0 && ty <= smy0) return Directions.LEFT;
+    if (tx >= sx0 && ty >= smy1) return Directions.LEFT;
+    if (tx > sx1 && ty >= smy0 && ty <= ay) {
         if (nextInLine.point.y < ty) {
             return Directions.BOTTOM;
         }
 
         return Directions.TOP;
     }
-    if (tx > sx1 && ty <= sy1 && ty >= ay) {
+    if (tx > sx1 && ty <= smy1 && ty >= ay) {
         if (nextInLine.point.y < ty) {
             return Directions.BOTTOM;
         }
@@ -158,26 +168,29 @@ function resolveForLeftSourceSide(source, target, nextInLine) {
 }
 
 function resolveForRightSourceSide(source, target, nextInLine) {
-    const { y0: sy0, x0: sx0, width, height, point: anchor } = source;
+    const { y0: sy0, x0: sx0, width, height, point: anchor, margin } = source;
     const sx1 = sx0 + width;
     const sy1 = sy0 + height;
+    const smx1 = sx1 + margin;
+    const smy0 = sy0 - margin;
+    const smy1 = sy1 + margin;
 
     const { x: ax, y: ay } = anchor;
     const { x0: tx, y0: ty } = target;
 
     if (tx > ax && ty === ay) return Directions.LEFT;
-    if (tx > ax && ty < ay) return Directions.BOTTOM;
-    if (tx > ax && ty > ay) return Directions.TOP;
-    if (tx <= sx0 && ty <= sy0 && ty >= ay) return Directions.RIGHT;
-    if (tx <= sx0 && ty >= sy1 && ty <= ay) return Directions.RIGHT;
-    if (tx < sx1 && ty >= sy0 && ty <= ay) {
+    if (tx >= smx1 && ty < ay) return Directions.BOTTOM;
+    if (tx >= smx1 && ty > ay) return Directions.TOP;
+    if (tx <= sx1 && ty <= smy0) return Directions.RIGHT;
+    if (tx <= sx1 && ty >= smy1) return Directions.RIGHT;
+    if (tx < sx0 && ty >= smy0 && ty <= ay) {
         if (nextInLine.point.y < ty) {
             return Directions.BOTTOM;
         }
 
         return Directions.TOP;
     }
-    if (tx < sx1 && ty <= sy1 && ty >= ay) {
+    if (tx < sx0 && ty <= smy1 && ty >= ay) {
         if (nextInLine.point.y < ty) {
             return Directions.BOTTOM;
         }
@@ -665,9 +678,10 @@ function routeBetweenPoints(source, target) {
             if (sox > tox) {
                 let y = middleOfHorizontalSides;
 
-                if ((y < tcy || !isSourceEl) && y > tmy0 && sox > tmx1) {
+                if ((y < tcy || !isSourceEl) && y > tmy0 && sox > tx1) {
                     y = tmy1;
                 }
+
                 return [
                     { x: sox, y },
                     { x: tox, y },
@@ -675,26 +689,36 @@ function routeBetweenPoints(source, target) {
                 ];
             }
             return [{ x: sox, y: toy }];
-        } else {
-            if (sx1 > tox) {
-                const y = Math.max(smy1, tmy1);
-                const x = Math.min(smx0, tmx0);
-                return [
-                    { x: sox, y },
-                    { x, y },
-                    { x, y: toy }
-                ];
-            }
         }
 
-        const x = middleOfVerticalSides;
+        const x = Math.min(tmx0, middleOfVerticalSides);
+
+        if (sox < tox && sy0 <= toy) {
+            return [
+                { x: sox, y: soy },
+                { x, y: soy },
+                { x, y: toy }
+            ];
+        }
+
+        if (x < smx1 && soy > ty0) {
+            const y = Math.max(smy1, tmy1);
+            const x = Math.min(smx0, tmx0);
+
+            return [
+                { x: sox, y },
+                { x, y },
+                { x, y: toy }
+            ];
+        }
 
         return [
             { x: sox, y: soy },
             { x, y: soy },
             { x, y: toy }
         ];
-    } else if (sourceSide === 'left' && targetSide === 'bottom') {
+    }
+    else if (sourceSide === 'left' && targetSide === 'bottom') {
         if (sox >= tox && soy >= tmy1) {
             return [{ x: tox, y: soy }];
         }

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -455,9 +455,9 @@ QUnit.module('routers', function(hooks) {
         return [r1, r2, l];
     };
 
-    this.addTestSubjectsWithVertex = function(sourceSide, targetSide, vertex) {
+    this.addTestSubjectsWithVertices = function(sourceSide, targetSide, vertices) {
         const [r1, r2, l] = this.addTestSubjects(sourceSide, targetSide, { ...rightAngleRouter, args: { margin, useVertices: true }});
-        l.vertices([vertex]);
+        l.vertices(vertices);
         return [r1, r2, l];
     };
 
@@ -1474,7 +1474,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: top, target: top', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'top', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('top', 'top', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1510,7 +1510,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: top, target: right', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'right', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('top', 'right', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1546,7 +1546,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: top, target: bottom', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'bottom', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('top', 'bottom', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1582,7 +1582,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: top, target: left', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'left', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('top', 'left', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1618,7 +1618,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: right, target: top', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'top', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('right', 'top', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1654,7 +1654,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: right, target: right', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'right', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('right', 'right', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1690,7 +1690,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: right, target: bottom', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'bottom', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('right', 'bottom', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1727,7 +1727,7 @@ QUnit.module('routers', function(hooks) {
     QUnit.test('rightAngle routing with vertex - source: right, target: left', function(assert) {
         const vertex = { x: 100, y: 100 };
 
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'left', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('right', 'left', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1763,7 +1763,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: top', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'top', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('bottom', 'top', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1799,7 +1799,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: right', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'right', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('bottom', 'right', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1835,7 +1835,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: bottom', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'bottom', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('bottom', 'bottom', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1871,7 +1871,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: left', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'left', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('bottom', 'left', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1907,7 +1907,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: left, target: top', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'top', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('left', 'top', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1943,7 +1943,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: left, target: right', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'right', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('left', 'right', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -1979,7 +1979,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: left, target: bottom', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'bottom', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('left', 'bottom', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -2015,7 +2015,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('rightAngle routing with vertex - source: left, target: left', function(assert) {
         const vertex = { x: 100, y: 100 };
-        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'left', vertex);
+        const [r1, r2, l] = this.addTestSubjectsWithVertices('left', 'left', [vertex]);
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
@@ -2047,5 +2047,69 @@ QUnit.module('routers', function(hooks) {
         d = this.paper.findViewByModel(l).metrics.data;
 
         assert.checkDataPath(d, 'M 150 25 L 100 25 L 100 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the source element bbox - source: top', function(assert) {
+        const vertices = [{ x: size.width * 0.75, y: size.height / 2 }, { x: 100, y: 100 }];
+        const [, , l] = this.addTestSubjectsWithVertices('top', 'top', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 53 -28 L 53 12.5 L 37.5 12.5 L 37.5 100 L 100 100 L 100 125 L 25 125 L 25 150', 'Source above target with vertex inside the source element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the source element bbox - source: right', function(assert) {
+        const vertices = [{ x: 0, y: size.y }, { x: 100, y: 100 }];
+        const [, , l] = this.addTestSubjectsWithVertices('right', 'top', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 -3 L 25 -3 L 25 0 L 0 0 L 0 100 L 100 100 L 100 125 L 25 125 L 25 150', 'Source above target with vertex inside the source element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the source element bbox - source: bottom', function(assert) {
+        const vertices = [{ x: size.width, y: size.y }, { x: 100, y: 100 }];
+        const [, , l] = this.addTestSubjectsWithVertices('bottom', 'top', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 78 L 53 78 L 53 25 L 50 25 L 50 0 L 100 0 L 100 111 L 25 111 L 25 150', 'Source above target with vertex inside the source element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the source element bbox - source: left', function(assert) {
+        const vertices = [{ x: size.width, y: size.y }, { x: 100, y: 100 }];
+        const [, , l] = this.addTestSubjectsWithVertices('left', 'top', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 -3 L 25 -3 L 25 0 L 100 0 L 100 111 L 25 111 L 25 150', 'Source above target with vertex inside the source element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the target element bbox - target: top', function(assert) {
+        const vertices = [{ x: 100, y: 100 }, { x: position.x + size.width * 0.75, y: position.y + size.height / 2 }];
+        const [, , l] = this.addTestSubjectsWithVertices('top', 'top', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 175 L 31.25 175 L 31.25 122 L 25 122 L 25 150', 'Source above target with vertex inside the target element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the target element bbox - target: right', function(assert) {
+        const vertices = [{ x: 100, y: 100 }, { x: position.x, y: position.y }];
+        const [, , l] = this.addTestSubjectsWithVertices('top', 'right', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 150 L 0 150 L 0 203 L 78 203 L 78 175 L 50 175', 'Source above target with vertex inside the target element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the target element bbox - target: bottom', function(assert) {
+        const vertices = [{ x: 100, y: 100 }, { x: position.x + size.width, y: position.y }];
+        const [, , l] = this.addTestSubjectsWithVertices('top', 'bottom', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 150 L 37.5 150 L 37.5 228 L 25 228 L 25 200', 'Source above target with vertex inside the target element bbox');
+    });
+
+    QUnit.test('rightAngle routing with vertex inside the target element bbox - target: left', function(assert) {
+        const vertices = [{ x: 100, y: 100 }, { x: position.x + size.width, y: position.y }];
+        const [, , l] = this.addTestSubjectsWithVertices('top', 'left', vertices);
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 150 L 25 150 L 25 147 L -28 147 L -28 175 L 0 175', 'Source above target with vertex inside the target element bbox');
     });
 });

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -1603,7 +1603,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 122 100 L 122 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1748,7 +1748,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 122 100 L 122 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -818,12 +818,22 @@ QUnit.module('routers', function(hooks) {
         `${position.y + width} ${height / 2}`
     ];
 
+    const rightVerticalPathSegments = [
+        `${width} ${height / 2}`,
+        `${width + margin} ${height / 2}`,
+        `${width + margin} ${height / 2 + position.y}`,
+        `${width} ${height / 2 + position.y}`,
+    ];
+
     QUnit.test('rightAngle routing - source: right, target: right', function(assert) {
         const [r1, r2, l] = this.addTestSubjects('right', 'right');
 
         let d = this.paper.findViewByModel(l).metrics.data;
+        let segments = joint.util.cloneDeep(rightVerticalPathSegments);
+        let moveSegment = segments.shift();
+        let path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
-        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 25 L 78 25 L 78 175 L 50 175', 'Source above target');
+        assert.checkDataPath(d, path, 'Source above target');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -832,16 +842,19 @@ QUnit.module('routers', function(hooks) {
         r2.position(position1.x, position1.y);
 
         d = this.paper.findViewByModel(l).metrics.data;
+        segments = joint.util.cloneDeep(rightVerticalPathSegments).reverse();
+        moveSegment = segments.shift();
+        path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
-        assert.checkDataPath(d, 'M 50 175 L 78 175 L 78 175 L 78 175 L 78 25 L 50 25', 'Target above source');
+        assert.checkDataPath(d, path, 'Target above source');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
-        let segments = joint.util.cloneDeep(rightHorizontalPathSegments);
-        let moveSegment = segments.shift();
-        let path = `M ${moveSegment} L ${segments.join(' L ')}`;
+        segments = joint.util.cloneDeep(rightHorizontalPathSegments);
+        moveSegment = segments.shift();
+        path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
         assert.checkDataPath(d, path, 'Source on the left of target');
 
@@ -1405,12 +1418,22 @@ QUnit.module('routers', function(hooks) {
         `${position.y} ${height / 2}`
     ];
 
+    const leftVerticalPathSegments = [
+        `0 ${height / 2}`,
+        `-${margin} ${height / 2}`,
+        `-${margin} ${height / 2 + position.y}`,
+        `0 ${height / 2 + position.y}`
+    ];
+
     QUnit.test('rightAngle routing - source: left, target: left', function(assert) {
         const [r1, r2, l] = this.addTestSubjects('left', 'left');
 
         let d = this.paper.findViewByModel(l).metrics.data;
+        let segments = joint.util.cloneDeep(leftVerticalPathSegments);
+        let moveSegment = segments.shift();
+        let path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 25 L -28 25 L -28 175 L 0 175', 'Source above target');
+        assert.checkDataPath(d, path, 'Source above target');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1419,16 +1442,19 @@ QUnit.module('routers', function(hooks) {
         r2.position(position1.x, position1.y);
 
         d = this.paper.findViewByModel(l).metrics.data;
+        segments = joint.util.cloneDeep(leftVerticalPathSegments).reverse();
+        moveSegment = segments.shift();
+        path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 175 L -28 175 L -28 25 L 0 25', 'Target above source');
+        assert.checkDataPath(d, path, 'Target above source');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
-        let segments = joint.util.cloneDeep(leftHorizontalPathSegments);
-        let moveSegment = segments.shift();
-        let path = `M ${moveSegment} L ${segments.join(' L ')}`;
+        segments = joint.util.cloneDeep(leftHorizontalPathSegments);
+        moveSegment = segments.shift();
+        path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
         assert.checkDataPath(d, path, 'Source on the left of target');
 
@@ -1505,7 +1531,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1560,7 +1586,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1570,7 +1596,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1587,7 +1613,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: top', function(assert) {
@@ -1596,7 +1622,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 25 L 100 25 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 100 25 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1649,7 +1675,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1678,7 +1704,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 175 L 78 175 L 78 175 L 100 175 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 50 175 L 78 175 L 100 175 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1695,7 +1721,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 125 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: left', function(assert) {
@@ -1705,7 +1731,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 25 L 100 25 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 100 25 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1715,7 +1741,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 175 L 78 175 L 78 175 L 100 175 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 50 175 L 78 175 L 100 175 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1732,7 +1758,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 125 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: top', function(assert) {
@@ -1794,7 +1820,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1849,7 +1875,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1859,7 +1885,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1876,7 +1902,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 50 L 175 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: left, target: top', function(assert) {
@@ -1938,7 +1964,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 75 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1974,7 +2000,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 75 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1993,7 +2019,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -2003,7 +2029,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -2020,6 +2046,6 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 });

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -443,10 +443,10 @@ QUnit.module('routers', function(hooks) {
     const height = 50;
     const size = { width, height };
     const margin = 28;
-    const router = { name: 'rightAngle', args: { margin }};
+    const rightAngleRouter = { name: 'rightAngle', args: { margin }};
     const position = { x: 0, y: 150 };
 
-    this.addTestSubjects = function(sourceSide, targetSide) {
+    this.addTestSubjects = function(sourceSide, targetSide, router = rightAngleRouter) {
         const r1 = new joint.shapes.standard.Rectangle({ size });
         const r2 = r1.clone().position(position.x, position.y);
         const l = new joint.shapes.standard.Link({ source: { id: r1.id, anchor: { name: sourceSide }}, target: { id: r2.id, anchor: { name: targetSide }}, router });
@@ -456,7 +456,7 @@ QUnit.module('routers', function(hooks) {
     };
 
     this.addTestSubjectsWithVertex = function(sourceSide, targetSide, vertex) {
-        const [r1, r2, l] = this.addTestSubjects(sourceSide, targetSide);
+        const [r1, r2, l] = this.addTestSubjects(sourceSide, targetSide, { ...rightAngleRouter, args: { margin, useVertices: true }});
         l.vertices([vertex]);
         return [r1, r2, l];
     };

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -1478,7 +1478,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 111 L 25 111 L 25 150', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1488,14 +1488,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 111 L 100 111 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 75 -28 L 75 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 125 100 L 125 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1505,7 +1505,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 125 -28 L 125 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 100 -28 L 100 100 L 75 100 L 75 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: top, target: right', function(assert) {
@@ -1524,14 +1524,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 111 L 100 111 L 100 25 L 50 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 100 L 100 100 L 100 25 L 78 25 L 50 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1541,7 +1541,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 125 -28 L 125 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 100 -28 L 100 100 L 75 100 L 75 25 L 50 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: top, target: bottom', function(assert) {
@@ -1560,14 +1560,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 100 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1577,7 +1577,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 100 -28 L 100 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: top, target: left', function(assert) {
@@ -1586,7 +1586,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 228 L -28 228 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1596,14 +1596,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 100 L 100 100 L 100 75 L -28 75 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 75 -28 L 75 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1613,7 +1613,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 100 -28 L 100 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: top', function(assert) {
@@ -1622,7 +1622,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 78 25 L 100 25 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 111 L 25 111 L 25 150', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1639,7 +1639,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 75 25 L 75 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 125 100 L 125 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1649,7 +1649,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 75 100 L 75 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: right', function(assert) {
@@ -1675,7 +1675,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1685,7 +1685,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 89 100 L 89 25 L 50 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: bottom', function(assert) {
@@ -1704,14 +1704,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 175 L 78 175 L 100 175 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 50 175 L 100 175 L 100 89 L 25 89 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1721,7 +1721,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: right, target: left', function(assert) {
@@ -1731,7 +1731,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 78 25 L 100 25 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 228 L -28 228 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1741,14 +1741,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 175 L 78 175 L 100 175 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 50 175 L 100 175 L 100 -28 L -28 -28 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 75 25 L 75 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1758,7 +1758,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: top', function(assert) {
@@ -1767,7 +1767,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 125 L 25 125 L 25 150', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1784,7 +1784,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 125 100 L 125 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1794,7 +1794,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 50 L 175 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 75 100 L 75 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: right', function(assert) {
@@ -1803,7 +1803,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 89 L 100 89 L 100 175 L 50 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 175 L 78 175 L 50 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1820,7 +1820,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1830,7 +1830,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 50 L 175 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 89 100 L 89 25 L 50 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: bottom, target: bottom', function(assert) {
@@ -1839,7 +1839,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 89 L 100 89 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1849,7 +1849,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 89 L 25 89 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1875,7 +1875,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 125 L -28 125 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1885,14 +1885,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 -28 L -28 -28 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 111 100 L 111 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1902,7 +1902,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 175 50 L 175 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: left, target: top', function(assert) {
@@ -1911,7 +1911,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 125 L 25 125 L 25 150', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1921,14 +1921,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 228 L 100 228 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 125 100 L 125 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1938,7 +1938,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 150 25 L 125 25 L 125 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 150 25 L 100 25 L 100 100 L 75 100 L 75 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: left, target: right', function(assert) {
@@ -1947,7 +1947,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 -28 L 100 -28 L 100 175 L 50 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 175 L 78 175 L 50 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1957,14 +1957,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 228 L 100 228 L 100 25 L 50 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 100 100 L 100 25 L 78 25 L 50 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1974,7 +1974,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 150 25 L 125 25 L 125 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 150 25 L 100 25 L 100 100 L 75 100 L 75 25 L 50 25', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: left, target: bottom', function(assert) {
@@ -1983,7 +1983,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 -28 L 100 -28 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -1993,14 +1993,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -2010,7 +2010,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 150 25 L 100 25 L 100 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
     });
 
     QUnit.test('rightAngle routing with vertex - source: left, target: left', function(assert) {
@@ -2019,7 +2019,7 @@ QUnit.module('routers', function(hooks) {
 
         let d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 125 L -28 125 L -28 175 L 0 175', 'Source above target with vertex');
 
         let position1 = r1.position();
         let position2 = r2.position();
@@ -2029,14 +2029,14 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 100 100 L 100 75 L -28 75 L -28 25 L 0 25', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 111 100 L 111 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -2046,6 +2046,6 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+        assert.checkDataPath(d, 'M 150 25 L 100 25 L 100 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 });

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -1603,7 +1603,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 122 100 L 122 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();
@@ -1748,7 +1748,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 125 100 L 125 25 L 150 25', 'Source on the left of target with vertex');
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 100 L 122 100 L 122 25 L 150 25', 'Source on the left of target with vertex');
 
         position1 = r1.position();
         position2 = r2.position();

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -22,7 +22,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('construction', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
         var r2 = r1.clone().translate(300);
 
         this.graph.addCell([r1, r2]);
@@ -59,8 +59,8 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('normal routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
-        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
+        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 } });
 
         var link = new joint.dia.Link({
             source: { id: r1.id },
@@ -81,8 +81,8 @@ QUnit.module('routers', function(hooks) {
 
         // One vertex.
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
-        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
+        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 } });
 
         var l1 = new joint.dia.Link({
             source: { id: r1.id },
@@ -100,8 +100,8 @@ QUnit.module('routers', function(hooks) {
 
         // No vertex.
 
-        var r3 = new joint.shapes.basic.Rect({ position: { x: 40, y: 40 }, size: { width: 50, height: 30 }});
-        var r4 = new joint.shapes.basic.Rect({ position: { x: 220, y: 120 }, size: { width: 50, height: 30 }});
+        var r3 = new joint.shapes.basic.Rect({ position: { x: 40, y: 40 }, size: { width: 50, height: 30 } });
+        var r4 = new joint.shapes.basic.Rect({ position: { x: 220, y: 120 }, size: { width: 50, height: 30 } });
 
         var l2 = new joint.dia.Link({
             source: { id: r3.id },
@@ -118,8 +118,8 @@ QUnit.module('routers', function(hooks) {
 
         // Check for spikes.
 
-        var r5 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
-        var r6 = new joint.shapes.basic.Rect({ position: { x: 350, y: 40 }, size: { width: 50, height: 30 }});
+        var r5 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
+        var r6 = new joint.shapes.basic.Rect({ position: { x: 350, y: 40 }, size: { width: 50, height: 30 } });
 
         var l3 = new joint.dia.Link({
             source: { id: r5.id },
@@ -138,7 +138,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('manhattan routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
         var r2 = r1.clone().translate(300);
 
         var r3 = r2.clone().translate(300);
@@ -333,13 +333,13 @@ QUnit.module('routers', function(hooks) {
 
         assert.ok(spyIsPointObstacle.called);
         assert.ok(spyIsPointObstacle.alwaysCalledWithExactly(sinon.match.instanceOf(g.Point)));
-        assert.checkDataPath(d, 'M 140 70 L 620 70','isPointObstacle option is taken into account');
+        assert.checkDataPath(d, 'M 140 70 L 620 70', 'isPointObstacle option is taken into account');
 
     });
 
     QUnit.test('metro routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
         var r2 = r1.clone().translate(300, 300);
 
         var r3 = r2.clone().translate(300, 300);
@@ -381,50 +381,50 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('oneSide routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
         var r2 = r1.clone().translate(300, 300);
-        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id }});
+        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id } });
 
         this.graph.addCell([r1, r2, l]);
 
         var v = this.paper.findViewByModel(l);
 
         // Left side
-        l.set('router', { name: 'oneSide', args: { padding: 20, side: 'left' }});
+        l.set('router', { name: 'oneSide', args: { padding: 20, side: 'left' } });
         var d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 20 70 L 0 70 L 0 370 L 320 370', 'Route goes only on the left side.');
 
         // Padding option
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'left' }});
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'left' } });
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 20 70 L -20 70 L -20 370 L 320 370', 'Route respects the padding.');
 
         // Right side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'right' }});
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'right' } });
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 140 70 L 480 70 L 480 370 L 440 370', 'Route goes only on the right side.');
 
         // Top side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'top' }});
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'top' } });
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 80 30 L 80 -10 L 380 -10 L 380 330', 'Route goes only on the top.');
 
         // Bottom side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'bottom' }});
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'bottom' } });
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 80 110 L 80 450 L 380 450 L 380 410', 'Route goes only on the bottom');
 
         // Wrong side specified
         assert.throws(function() {
-            l.set('router', { name: 'oneSide', args: { padding: 40, side: 'non-existing' }});
+            l.set('router', { name: 'oneSide', args: { padding: 40, side: 'non-existing' } });
         }, 'An error is thrown when a non-existing side is provided.');
     });
 
     QUnit.test('custom routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
         var r2 = r1.clone().translate(300, 300);
-        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id }});
+        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id } });
 
         this.graph.addCell([r1, r2, l]);
 
@@ -443,17 +443,23 @@ QUnit.module('routers', function(hooks) {
     const height = 50;
     const size = { width, height };
     const margin = 28;
-    const router = { name: 'rightAngle', args: { margin }};
+    const router = { name: 'rightAngle', args: { margin } };
     const position = { x: 0, y: 150 };
 
-    this.addTestSubjects = function(sourceSide, targetSide ){
+    this.addTestSubjects = function(sourceSide, targetSide) {
         const r1 = new joint.shapes.standard.Rectangle({ size });
         const r2 = r1.clone().position(position.x, position.y);
-        const l = new joint.shapes.standard.Link({ source: { id: r1.id, anchor: { name: sourceSide }}, target: { id: r2.id, anchor: { name: targetSide }}, router });
+        const l = new joint.shapes.standard.Link({ source: { id: r1.id, anchor: { name: sourceSide } }, target: { id: r2.id, anchor: { name: targetSide } }, router });
 
         this.graph.addCells([r1, r2, l]);
         return [r1, r2, l];
     };
+
+    this.addTestSubjectsWithVertex = function(sourceSide, targetSide, vertex) {
+        const [r1, r2, l] = this.addTestSubjects(sourceSide, targetSide);
+        l.vertices([vertex]);
+        return [r1, r2, l];
+    }
 
     const topVerticalPathSegments = [
         `${width / 2} 0`,
@@ -502,7 +508,7 @@ QUnit.module('routers', function(hooks) {
         path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
         assert.checkDataPath(d, path, 'Source on the left of target');
-    
+
         position1 = r1.position();
         position2 = r2.position();
 
@@ -1438,5 +1444,582 @@ QUnit.module('routers', function(hooks) {
         path = `M ${moveSegment} L ${segments.join(' L ')}`;
 
         assert.checkDataPath(d, path, 'Target on the left of source');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: top, target: top', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'top', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 150 L 25 111 L 100 111 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 75 -28 L 75 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 125 -28 L 125 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: top, target: right', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'right', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 175 L 50 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 150 L 25 111 L 100 111 L 100 25 L 50 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 125 -28 L 125 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: top, target: bottom', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'bottom', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L -28 -28 L -28 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: top, target: left', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('top', 'left', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 150 L 25 125 L 100 125 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 75 -28 L 75 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 0 L 175 -28 L 228 -28 L 228 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: right, target: top', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'top', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 25 L 100 25 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 175 L 100 175 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 75 25 L 75 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: right, target: right', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'right', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 175 L 50 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 175 L 100 175 L 100 25 L 50 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: right, target: bottom', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'bottom', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 100 25 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 175 L 78 175 L 78 175 L 100 175 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 89 25 L 89 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 125 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: right, target: left', function(assert) {
+        const vertex = { x: 100, y: 100 };
+
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('right', 'left', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 25 L 100 25 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 175 L 78 175 L 78 175 L 100 175 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 50 25 L 75 25 L 75 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 200 25 L 228 25 L 228 100 L 125 100 L 125 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: bottom, target: top', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'top', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: bottom, target: right', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'right', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 89 L 100 89 L 100 175 L 50 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 25 L 50 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: bottom, target: bottom', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'bottom', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 89 L 100 89 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: bottom, target: left', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('bottom', 'left', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 75 L 100 75 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 200 L 25 228 L 100 228 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 25 50 L 25 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 175 50 L 175 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: left, target: top', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'top', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 25 100 L 25 150', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 228 L 100 228 L 100 -28 L 25 -28 L 25 0', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 -28 L 175 -28 L 175 0', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 150 25 L 125 25 L 125 100 L 100 100 L 100 -28 L 25 -28 L 25 0', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: left, target: right', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'right', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 -28 L 100 -28 L 100 175 L 50 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 228 L 100 228 L 100 25 L 50 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 75 100 L 125 100 L 125 100 L 228 100 L 228 25 L 200 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 150 25 L 125 25 L 125 100 L 100 100 L 100 25 L 50 25', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: left, target: bottom', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'bottom', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 -28 L 100 -28 L 100 228 L 25 228 L 25 200', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 75 100 L 75 100 L 175 100 L 175 50', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 25 100 L 25 50', 'Target on the left of source with vertex');
+    });
+
+    QUnit.test('rightAngle routing with vertex - source: left, target: left', function(assert) {
+        const vertex = { x: 100, y: 100 };
+        const [r1, r2, l] = this.addTestSubjectsWithVertex('left', 'left', vertex);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 75 L 100 75 L 100 100 L 75 100 L 75 100 L -28 100 L -28 175 L 0 175', 'Source above target with vertex');
+
+        let position1 = r1.position();
+        let position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 125 L 100 125 L 100 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target above source with vertex');
+
+        r1.position(0, 0);
+        r2.position(position.y, position.x);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 0 25 L -28 25 L -28 100 L 100 100 L 100 25 L 150 25', 'Source on the left of target with vertex');
+
+        position1 = r1.position();
+        position2 = r2.position();
+
+        r1.position(position2.x, position2.y);
+        r2.position(position1.x, position1.y);
+
+        d = this.paper.findViewByModel(l).metrics.data;
+
+        assert.checkDataPath(d, 'M 150 25 L 111 25 L 111 100 L 75 100 L 75 100 L -28 100 L -28 25 L 0 25', 'Target on the left of source with vertex');
     });
 });

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -22,7 +22,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('construction', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300);
 
         this.graph.addCell([r1, r2]);
@@ -59,8 +59,8 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('normal routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
-        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
+        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 }});
 
         var link = new joint.dia.Link({
             source: { id: r1.id },
@@ -81,8 +81,8 @@ QUnit.module('routers', function(hooks) {
 
         // One vertex.
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
-        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
+        var r2 = new joint.shapes.basic.Rect({ position: { x: 125, y: 60 }, size: { width: 50, height: 30 }});
 
         var l1 = new joint.dia.Link({
             source: { id: r1.id },
@@ -100,8 +100,8 @@ QUnit.module('routers', function(hooks) {
 
         // No vertex.
 
-        var r3 = new joint.shapes.basic.Rect({ position: { x: 40, y: 40 }, size: { width: 50, height: 30 } });
-        var r4 = new joint.shapes.basic.Rect({ position: { x: 220, y: 120 }, size: { width: 50, height: 30 } });
+        var r3 = new joint.shapes.basic.Rect({ position: { x: 40, y: 40 }, size: { width: 50, height: 30 }});
+        var r4 = new joint.shapes.basic.Rect({ position: { x: 220, y: 120 }, size: { width: 50, height: 30 }});
 
         var l2 = new joint.dia.Link({
             source: { id: r3.id },
@@ -118,8 +118,8 @@ QUnit.module('routers', function(hooks) {
 
         // Check for spikes.
 
-        var r5 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 } });
-        var r6 = new joint.shapes.basic.Rect({ position: { x: 350, y: 40 }, size: { width: 50, height: 30 } });
+        var r5 = new joint.shapes.basic.Rect({ position: { x: 200, y: 60 }, size: { width: 50, height: 30 }});
+        var r6 = new joint.shapes.basic.Rect({ position: { x: 350, y: 40 }, size: { width: 50, height: 30 }});
 
         var l3 = new joint.dia.Link({
             source: { id: r5.id },
@@ -138,7 +138,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('manhattan routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300);
 
         var r3 = r2.clone().translate(300);
@@ -339,7 +339,7 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('metro routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300, 300);
 
         var r3 = r2.clone().translate(300, 300);
@@ -381,50 +381,50 @@ QUnit.module('routers', function(hooks) {
 
     QUnit.test('oneSide routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300, 300);
-        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id } });
+        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id }});
 
         this.graph.addCell([r1, r2, l]);
 
         var v = this.paper.findViewByModel(l);
 
         // Left side
-        l.set('router', { name: 'oneSide', args: { padding: 20, side: 'left' } });
+        l.set('router', { name: 'oneSide', args: { padding: 20, side: 'left' }});
         var d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 20 70 L 0 70 L 0 370 L 320 370', 'Route goes only on the left side.');
 
         // Padding option
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'left' } });
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'left' }});
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 20 70 L -20 70 L -20 370 L 320 370', 'Route respects the padding.');
 
         // Right side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'right' } });
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'right' }});
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 140 70 L 480 70 L 480 370 L 440 370', 'Route goes only on the right side.');
 
         // Top side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'top' } });
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'top' }});
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 80 30 L 80 -10 L 380 -10 L 380 330', 'Route goes only on the top.');
 
         // Bottom side
-        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'bottom' } });
+        l.set('router', { name: 'oneSide', args: { padding: 40, side: 'bottom' }});
         d = v.$('.connection').attr('d');
         assert.checkDataPath(d, 'M 80 110 L 80 450 L 380 450 L 380 410', 'Route goes only on the bottom');
 
         // Wrong side specified
         assert.throws(function() {
-            l.set('router', { name: 'oneSide', args: { padding: 40, side: 'non-existing' } });
+            l.set('router', { name: 'oneSide', args: { padding: 40, side: 'non-existing' }});
         }, 'An error is thrown when a non-existing side is provided.');
     });
 
     QUnit.test('custom routing', function(assert) {
 
-        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 } });
+        var r1 = new joint.shapes.basic.Rect({ position: { x: 20, y: 30 }, size: { width: 120, height: 80 }});
         var r2 = r1.clone().translate(300, 300);
-        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id } });
+        var l = new joint.dia.Link({ source: { id: r1.id }, target: { id: r2.id }});
 
         this.graph.addCell([r1, r2, l]);
 
@@ -443,13 +443,13 @@ QUnit.module('routers', function(hooks) {
     const height = 50;
     const size = { width, height };
     const margin = 28;
-    const router = { name: 'rightAngle', args: { margin } };
+    const router = { name: 'rightAngle', args: { margin }};
     const position = { x: 0, y: 150 };
 
     this.addTestSubjects = function(sourceSide, targetSide) {
         const r1 = new joint.shapes.standard.Rectangle({ size });
         const r2 = r1.clone().position(position.x, position.y);
-        const l = new joint.shapes.standard.Link({ source: { id: r1.id, anchor: { name: sourceSide } }, target: { id: r2.id, anchor: { name: targetSide } }, router });
+        const l = new joint.shapes.standard.Link({ source: { id: r1.id, anchor: { name: sourceSide }}, target: { id: r2.id, anchor: { name: targetSide }}, router });
 
         this.graph.addCells([r1, r2, l]);
         return [r1, r2, l];
@@ -459,7 +459,7 @@ QUnit.module('routers', function(hooks) {
         const [r1, r2, l] = this.addTestSubjects(sourceSide, targetSide);
         l.vertices([vertex]);
         return [r1, r2, l];
-    }
+    };
 
     const topVerticalPathSegments = [
         `${width / 2} 0`,

--- a/test/jointjs/routers.js
+++ b/test/jointjs/routers.js
@@ -1560,7 +1560,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 25 150 L 25 100 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 25 150 L 25 100 L 128 100 L 128 128 L 25 128 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);
@@ -1993,7 +1993,7 @@ QUnit.module('routers', function(hooks) {
 
         d = this.paper.findViewByModel(l).metrics.data;
 
-        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 100 100 L 25 100 L 25 50', 'Target above source with vertex');
+        assert.checkDataPath(d, 'M 0 175 L -28 175 L -28 100 L 128 100 L 128 128 L 25 128 L 25 50', 'Target above source with vertex');
 
         r1.position(0, 0);
         r2.position(position.y, position.x);

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3535,6 +3535,7 @@ export namespace routers {
 
     interface RightAngleRouterArguments {
         margin?: number;
+        useVertices?: boolean;
         sourceDirection?: RightAngleDirections;
         targetDirection?: RightAngleDirections;
     }

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3535,6 +3535,7 @@ export namespace routers {
 
     interface RightAngleRouterArguments {
         margin?: number;
+        /** @experimental before version 4.0 */
         useVertices?: boolean;
         sourceDirection?: RightAngleDirections;
         targetDirection?: RightAngleDirections;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Until now the `RightAngle` router didn't use the vertices that were provided. This change allows users to define vertices through which the link is supposed to go. The `RightAngle` router itself works the same way as it did, the only difference is that it takes in account the provided vertices and finds route between them.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

A simple upgrade of the algorithm that enables you to use the `RightAngle` router in more ways.

### Screenshots (if appropriate):
<img width="711" alt="image" src="https://github.com/clientIO/joint/assets/50818204/0aaccb9f-a00a-4d3d-aba2-833f664629c3">
