### PR TITLE
fix(cell.getEmbeddedCells): fix the depth-first algorithm, add tests

### DIFF
--- a/test/jointjs/basic.js
+++ b/test/jointjs/basic.js
@@ -927,8 +927,8 @@ QUnit.module('basic', function(hooks) {
         [{
             // Test Case { deep: true, breadthFirst: false }
             breadthFirst: false,
-            toFront: [0,0,1,2,4,5,3,6,7],
-            toBack: [0,0,-7,-6,-4,-3,-5,-2,-1]
+            toFront: [0,0,1,2,3,4,5,6,7],
+            toBack: [0,0,-7,-6,-5,-4,-3,-2,-1]
 
         }, {
             // Test Case { deep: true, breadthFirst: true }
@@ -1152,7 +1152,7 @@ QUnit.module('basic', function(hooks) {
         clones = this.graph.getCell('a').clone({ deep: true });
         assert.deepEqual(_.map(clones, function(c) {
             return c.get('name');
-        }), ['a', 'aa', 'c', 'l2', 'aaa'], 'clone({ deep: true }) returns clones including all embedded cells');
+        }), ['a', 'aa', 'l2', 'aaa', 'c'], 'clone({ deep: true }) returns clones including all embedded cells');
     });
 
     QUnit.module('embed(), unembed()', function() {

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -682,5 +682,85 @@ QUnit.module('cell', function(hooks) {
         });
     });
 
+    QUnit.module('getEmbeddedCells()', function(hooks) {
+        let topParent;
+
+        hooks.beforeEach(function() {
+            const Circle = joint.shapes.standard.Circle;
+
+            //             a(1)
+            //          /   |   \
+            //       b(3)  c(2)  d(4)
+            //      /   \        /  \
+            //    e(6)  f(5)   g(7)  h(8)
+            //    /   \        /   \
+            //  i(11)  j(9)  k(10)  l(12)
+
+            const a = new Circle({ id: 'a', z: 1 });
+
+            const b = new Circle({ id: 'b', z: 3 });
+            const c = new Circle({ id: 'c', z: 2 });
+            const d = new Circle({ id: 'd', z: 4 });
+
+            const e = new Circle({ id: 'e', z: 6 });
+            const f = new Circle({ id: 'f', z: 5 });
+
+            const g = new Circle({ id: 'g', z: 7 });
+            const h = new Circle({ id: 'h', z: 8 });
+
+            const i = new Circle({ id: 'i', z: 11 });
+            const j = new Circle({ id: 'j', z: 9 });
+
+            const k = new Circle({ id: 'k', z: 10 });
+            const l = new Circle({ id: 'l', z: 12 });
+
+            a.embed([b, c, d]);
+            b.embed([e, f]);
+            d.embed([g, h]);
+            e.embed([i, j]);
+            g.embed([k, l]);
+
+            this.graph.addCells([a, b, c, d, e, f, g, h, i, j, k, l]);
+
+            topParent = a;
+        });
+
+        [
+            {
+                breadthFirst: false,
+                sortSiblings: false,
+                expectedResult: ['b', 'e', 'i', 'j', 'f', 'c', 'd', 'g', 'k', 'l', 'h'],
+            },
+            {
+                breadthFirst: true,
+                sortSiblings: false,
+                expectedResult: ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'],
+            },
+            {
+                breadthFirst: false,
+                sortSiblings: true,
+                expectedResult: ['c', 'b', 'f', 'e', 'j', 'i', 'd', 'g', 'k', 'l', 'h'],
+            },
+            {
+                breadthFirst: true,
+                sortSiblings: true,
+                expectedResult: ['c', 'b', 'd', 'f', 'e', 'g', 'h', 'j', 'i', 'k', 'l'],
+            }
+        ].forEach(testCase => {
+            QUnit.test(`{deep: true, breadthFirst: ${testCase.breadthFirst}, sortSiblings: ${testCase.sortSiblings}}`, function(assert) {
+                const embeddedCells = topParent.getEmbeddedCells({
+                    deep: true,
+                    breadthFirst: testCase.breadthFirst,
+                    sortSiblings: testCase.sortSiblings,
+                });
+
+                assert.deepEqual(
+                    embeddedCells.map(cell => cell.id),
+                    testCase.expectedResult,
+                );
+            });
+        });
+    });
+
 });
 

--- a/test/jointjs/graph.js
+++ b/test/jointjs/graph.js
@@ -757,7 +757,7 @@ QUnit.module('graph', function(hooks) {
             assert.deepEqual(_.map(subgraph, 'id'), ['a'], 'getSubgraph() returns only the one element if deep is false');
 
             subgraph = graph.getSubgraph([graph.getCell('a')], { deep: true });
-            assert.deepEqual(_.map(subgraph, 'id'), ['a', 'aa', 'c', 'l2', 'aaa', 'l1'], 'getSubgraph() returns all the embedded elements and all the links that connect these elements');
+            assert.deepEqual(_.map(subgraph, 'id'), ['a', 'aa', 'l2', 'aaa', 'c', 'l1'], 'getSubgraph() returns all the embedded elements and all the links that connect these elements');
         });
 
         /* TODO: implement getSubgraph() for link to link connections

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -306,6 +306,7 @@ export namespace dia {
 
         interface GetEmbeddedCellsOptions extends EmbeddableOptions {
             breadthFirst?: boolean;
+            sortSiblings?: boolean;
         }
 
         interface TransitionOptions extends Options {


### PR DESCRIPTION
## Description

This pull request fixes the `cell.getEmbeddedCells` method. There was a bug that caused the result to always be sorted in a breadth-first manner, regardless of the value of the `breadthFirst` option.

It also adds a new internal option called `sortSiblings`, which enables sorting siblings by their `z` value.