### PR TITLE
fix(dia.LinkView): fix element detection when using snapLinkSelf: true

### DIFF
--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -2191,7 +2191,8 @@ export const LinkView = CellView.extend({
 
         const snapPoint = this._snapToPoints({ x: x, y: y }, points, radius);
 
-        this._connectArrowhead(document.elementFromPoint(snapPoint.x, snapPoint.y), snapPoint.x, snapPoint.y, this.eventData(evt));
+        const point = paper.localToClientPoint(snapPoint);
+        this._connectArrowhead(document.elementFromPoint(point.x, point.y), snapPoint.x, snapPoint.y, this.eventData(evt));
     },
 
     _snapArrowhead: function(evt, x, y) {


### PR DESCRIPTION
Fixed a bug when using `snapLinkSelf: true` the element was not targeted for connection.