### PR TITLE
docs(tutorials): add cell namespace tutorial

### DIFF
--- a/docs/src/joint/api/dia/Graph/constructor.html
+++ b/docs/src/joint/api/dia/Graph/constructor.html
@@ -1,15 +1,24 @@
 <p>
-                    <b>joint.dia.Graph</b> is the model holding all the cells (elements and links) of the diagram. It's a <a href="https://backbonejs.org/#Model">Backbone model</a>.
-                    The collection of all the cells is stored in the property <b><code>cells</code></b>.
-                </p><p>
-                  The graph is a powerful data model behind all JointJS diagrams. It not only provides an efficient storage
-                  for directed graphs but also offers useful algorithms for traversing the graphs.
-                </p><p>
-                  Additionally, the graph accepts an option object in its constructor function that can contain the <code>cellNamespace</code> option.
-                    This option can be used to change the default behavior of JointJS which by default reads cell model definitions from the <code>joint.shapes</code> namespace.
-                    For example, if a cell is of type <code>'myshapes.MyElement'</code>, then the graph looks up <code>joint.shapes.myshapes.MyElement</code>
-                    model when deserializing a graph from the JSON format. If the graph is instantiated as e.g. <code>var graph = new joint.dia.Graph({}, { cellNamespace: myShapesNamespace })</code>, then
-                    the graph will read the model definition from the <code>myShapesNamespace.myshapes.MyElement</code> object instead. This is useful in situations where you don't want to - for any reason -
-                  use the <code>joint.shapes</code> namespace for defining your own custom shapes. This option is often used in combination with the
-                  <code>cellViewNamespace</code> option on the <a href="#dia.Paper.prototype.options.cellViewNamespace">joint.dia.Paper</a> object.
-                </p>
+  <code>joint.dia.Graph</code> is the model holding all cells (elements and links) of the diagram. It's a 
+  <a href="https://backbonejs.org/#Model">Backbone model</a>. The collection of all the cells is stored in the property <b><code>cells</code></b>.
+</p>
+
+<p>
+  The graph is a powerful data model behind all JointJS diagrams. It not only provides efficient storage for directed graphs, but also offers useful 
+  algorithms for traversing the graphs.
+</p>
+
+<p>
+  In order for JointJS to find the correct constructor for your cell, the <code>graph</code> option <code>cellNamespace</code> must be provided in 
+  its constructor function when a graph is instantiated. Built-in shapes are usually located in the <code>joint.shapes</code> namespace, so this is 
+  a common namespace to use. It's possible to add custom shapes to this namespace, or alternatively, you may like to use a different namespace 
+  completely.
+</p>
+
+<p>
+  For example, if <code>joint.shapes</code> is provided as the value of <code>cellNamespace</code>, and a cell is of type <code>'custom.Element'</code>,
+  then the graph looks up the <code>joint.shapes.custom.Element</code> model when deserializing a graph from JSON format. If the graph is instantiated
+  as e.g. <code>const graph = new joint.dia.Graph({}, { cellNamespace: myCustomNamespace })</code>, then the <code>graph</code> will read the model
+  definition from the <code>myCustomNamespace.custom.Element</code> object instead. This option is often used in combination with the
+  <code>cellViewNamespace</code> option on the <a href="#dia.Paper.prototype.options.cellViewNamespace">joint.dia.Paper</a> object.
+</p>

--- a/docs/src/joint/api/dia/Graph/constructor.html
+++ b/docs/src/joint/api/dia/Graph/constructor.html
@@ -11,5 +11,5 @@
                     model when deserializing a graph from the JSON format. If the graph is instantiated as e.g. <code>var graph = new joint.dia.Graph({}, { cellNamespace: myShapesNamespace })</code>, then
                     the graph will read the model definition from the <code>myShapesNamespace.myshapes.MyElement</code> object instead. This is useful in situations where you don't want to - for any reason -
                   use the <code>joint.shapes</code> namespace for defining your own custom shapes. This option is often used in combination with the
-                  <code>cellNamespaceView</code> option on the <a href="#dia.Paper.prototype.options.cellViewNamespace">joint.dia.Paper</a> object.
+                  <code>cellViewNamespace</code> option on the <a href="#dia.Paper.prototype.options.cellViewNamespace">joint.dia.Paper</a> object.
                 </p>

--- a/docs/src/joint/api/dia/Paper/prototype/options/cellViewNamespace.html
+++ b/docs/src/joint/api/dia/Paper/prototype/options/cellViewNamespace.html
@@ -1,7 +1,14 @@
-<code>cellViewNamespace</code> - this option can be used to change the default behavior of JointJS which by default reads cell view definitions from the <code>joint.shapes</code> namespace.
-                              For example, if a cell is of type <code>'myshapes.MyElement'</code>, then the paper looks up <code>joint.shapes.myshapes.MyElementView</code>
-                              object type when rendering the cell onto the screen. If <code>cellViewNamespace</code> is set,
-                              the paper will read the view definition from the <code>myShapesNamespace.myshapes.MyElementView</code> object instead. This is useful in situations where you - for any reason - don't want to 
-                              use the <code>joint.shapes</code> namespace for defining your own custom shapes. This option is often used in combination with
-                              <code>cellNamespace</code> option on the <a href="#dia.Graph.constructor"><code>joint.dia.Graph</code></a> object.
-                
+<p>
+    <code>cellViewNamespace</code> - In order for the JointJS <code>paper</code> to read cell view definitions from the correct location, 
+    the <code>paper</code> option <code>cellViewNamespace</code> must be provided. Built-in cell view definitions are usually located in the 
+    <code>joint.shapes</code> namespace, so this is a common namespace to use. It's possible to a add custom cell view to this namespace, or 
+    alternatively, you may like to use a different namespace completely.
+</p>
+
+<p>
+    For example, if <code>joint.shapes</code> is provided as the value of <code>cellViewNamespace</code>, and a cell is of type 
+    <code>'custom.Element'</code>, then the <code>paper</code> looks up the <code>joint.shapes.custom.ElementView</code> object type when rendering the 
+    cell onto the screen. If <code>cellViewNamespace</code> is set with a value of <code>myCustomNamespace</code>, the paper will read view 
+    definitions from the <code>myCustomNamespace.custom.ElementView</code> object instead. This option is often used in combination with the
+    <code>cellNamespace</code> option on the <a href="#dia.Graph.constructor"><code>joint.dia.Graph</code></a> object.
+</p>

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+
+        <meta name="description" content="Create interactive diagrams in JavaScript easily. JointJS plugins for ERD, Org chart, FSA, UML, PN, DEVS, LDM diagrams are ready to use." />
+        <meta name="keywords" content="JointJS, JavaScript, diagrams, diagramming library, UML, charts" />
+
+        <link rel="stylesheet" href="css/tutorial.css" />
+        <link rel="stylesheet" href="../node_modules/prism-themes/themes/prism-one-light.css">
+
+        <!-- Dependencies: -->
+        <script src="../node_modules/jquery/dist/jquery.js"></script>
+        <script src="../node_modules/lodash/lodash.js"></script>
+        <script src="../node_modules/backbone/backbone.js"></script>
+
+        <link rel="stylesheet" type="text/css" href="../build/joint.min.css" />
+        <script type="text/javascript" src="../build/joint.min.js"></script>
+
+        <title>JointJS - JavaScript diagramming library - Getting started.</title>
+
+    </head>
+    <body class="language-javascript tutorial-page">
+
+        <div class="tutorial">
+
+            <h1>Cell Namespace</h1>
+
+            <!-- <ul>
+                <li>Explain why type is important, define/class example</li>
+                <li>JSON example / error if not set up correctly</li>
+                <li>Custom View needs to be set up in the same manner</li>
+            </ul> -->
+
+            <p>
+                A simple, but important aspect of working with JointJS is to ensure that JointJS knows where to look for built-in and custom shapes.
+                In order to achieve this, it's a requirement to tell JointJS where to read cell view definitions. Failure to do so
+                will result in an error in our application. Built-in shapes are usually located in the <code>joint.shapes</code> namespace, so this 
+                is a common namespace to use. It's possible to add custom shapes to this namespace, or alternatively, you may like to use a different 
+                namespace completely. The choice is yours, but you need to state the namespace at the outset when using JointJS.
+            </p>
+
+            <p>
+                How do we tell JointJS which namespace to use? There are 2 important options to be aware of when creating your diagrams. The
+                first is the <code>graph</code> option <code>cellNamespace</code>, and the second is the <code>paper</code> option 
+                <code>cellViewNamespace</code>. In the following example, for a cell of type <code>'standard.Rectangle'</code>, the 
+                <code>graph</code> looks up the <code>'joint.shapes.standard.Rectangle'</code> path to find the correct constructor. If you don't 
+                plan on creating custom shapes, or playing around with namespaces, the following setup should be fine for your application.
+            </p>
+
+            <pre><code>const namespace = joint.shapes;
+            
+const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
+
+const paper = new joint.dia.Paper({
+    ...
+    cellViewNamespace: namespace
+    ...
+});
+
+graph.fromJSON({
+    cells: [
+        { 
+            type: 'standard.Rectangle', 
+            size: { width: 80, height: 50 },
+            position: { x: 10, y: 10 }
+        }
+    ]
+});
+</code></pre>
+
+        <p>
+            On the other hand, if you are feeling a little adventurous, and would like to create your own custom namespace, the following example 
+            should get you started. One crucial difference to take note of is that now our <code>type</code> is <code>'Rectangle'</code>. That's 
+            because our custom namespace is just an object which contains our <code>Link</code> and <code>Rectangle</code> constructors.
+        </p>
+
+        <pre><code>const { Rectangle, Link } = joint.shapes.standard;
+            
+const customNamespace = { Rectangle, Link };
+            
+const graph = new joint.dia.Graph({}, { cellNamespace: customNamespace });
+
+const paper = new joint.dia.Paper({
+    ...
+    cellViewNamespace: customNamespace
+    ...
+});
+
+graph.fromJSON({
+    cells: [
+        { 
+            type: 'Rectangle', 
+            size: { width: 80, height: 50 },
+            position: { x: 10, y: 10 }
+        }
+    ]
+});
+</code></pre>
+
+        <p>
+            If we were to continue using <code>'standard.Rectangle'</code> as our type in the 2nd example, this would result in a common error 
+            in JointJS. If you see the dreaded error <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console,
+            it's likely your namespace is not set up correctly, and JointJS cannot find the correct shape.
+        </p>
+
+        <div class="paper" id="paper-cell-namespace"></div>
+        <p>JointJS source code: <a href="js/cell-namespace.js" target="_blank">cell-namespace.js</a></p>
+
+        </div><!--end tutorial-->
+
+        <script src="../node_modules/prismjs/prism.js"></script>
+
+        <script src="js/cell-namespace.js"></script>
+    </body>
+</html>

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -35,10 +35,12 @@
 
             <p>
                 How do we tell JointJS which namespace to use? There are 2 important options to be aware of when creating your diagrams. The
-                first is the <code>graph</code> option <code>cellNamespace</code>, and the second is the <code>paper</code> option 
-                <code>cellViewNamespace</code>. In the following example, for a cell of type <code>'standard.Rectangle'</code>, the 
-                <code>graph</code> looks up the <code>'joint.shapes.standard.Rectangle'</code> path to find the correct constructor. If you don't 
-                plan on creating custom shapes, or playing around with namespaces, the following setup should be fine for your application.
+                first is the <code>graph</code> option <a href="/docs/jointjs#dia.Graph.constructor" target="_blank"><code>cellNamespace</code></a>, 
+                and the second is the <code>paper</code> option 
+                <a href="/docs/jointjs#dia.Paper.prototype.options.cellViewNamespace" target="_blank"><code>cellViewNamespace</code></a>. In the 
+                following example, for a cell of type <code>'standard.Rectangle'</code>, the <code>graph</code> looks up the 
+                <code>'joint.shapes.standard.Rectangle'</code> path to find the correct constructor. If you don't plan on creating custom shapes, 
+                or playing around with namespaces, the following setup should be fine for your application.
             </p>
 
             <pre><code>const namespace = joint.shapes;
@@ -71,14 +73,14 @@ graph.fromJSON({
 
             <p>
                 While our custom namespace is just an object that contains our <code>Link</code> and <code>Rectangle</code> constructors, 
-                the <code>type</code> property of each cell will still state the location as within the <code>'standard'</code> namespace upon making 
+                the <code>type</code> property of each cell will still state the location as within the <code>standard</code> namespace upon making 
                 an instance. In order to set up namespaces correctly, this is something we will have to address.
             </p>
 
             <p>
                 With the aim of updating the <code>type</code>, we take advantage of the 
                 <a href="/docs/jointjs#dia.Element.prototype.prop" target="_blank""><code>prop()</code></a> method, so JointJS no longer looks for 
-                the constructor within a namespace <code>'standard'</code>, but at the top level of our <code>customNamespace</code>. After the 
+                the constructor within a namespace <code>standard</code>, but at the top level of our <code>customNamespace</code>. After the 
                 addition of our <code>rect</code> element, if we were to overwrite the <code>graph</code> via <code>graph.toJSON()</code> passing it 
                 the value returned from <code>graph.toJSON()</code>, no error would occur. We can take this as confirmation that our namespaces are 
                 now set up correctly.
@@ -123,23 +125,23 @@ graph.fromJSON(graph.toJSON());
             <p>
                 With the intention of strengthening this concept in our minds, let's define another shape, so that we are more familiar with this process. 
                 Below, we create a class <code>RectangleTwoLabels</code> with a <code>type</code> property of <code>'custom.RectangleTwoLabels'</code>.
-                JointJS will now expect that our custom <code>RectangleTwoLabels</code> element will be located within the <code>'custom'</code> 
+                JointJS will now expect that our custom <code>RectangleTwoLabels</code> element will be located within the <code>custom</code> 
                 namespace.
             </p>
 
             <p>
-                As we want our <code>'custom'</code> namespace to be at the same level of nesting as built-in JointJS shapes, we will structure our 
+                As we want our <code>custom</code> namespace to be at the same level of nesting as built-in JointJS shapes, we will structure our 
                 cell namespace accordingly. First, we declare a <code>namespace</code> variable, then using the 
                 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals" target="_blank">spread operator</a>,
                 ensure that <code>namespace</code> contains all of the properties of <code>joint.shapes</code>. These properties correspond to shape 
-                namespaces such as <code>'standard'</code>.
+                namespaces such as <code>standard</code>.
             </p>
 
             <p>
                 Afterwards, taking advantage of 
                 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign" target="_blank"><code>Object.assign()</code></a>, 
                 the properties of <code>customNamespace</code> are copied to our <code>namespace</code> object. As a result,
-                <code>'standard'</code> and <code>'custom'</code> are both defined at the same level in our <code>namespace</code> object.
+                <code>standard</code> and <code>custom</code> are both defined at the same level in our <code>namespace</code> object.
             </p>
 
             <p>
@@ -179,7 +181,7 @@ new joint.dia.Paper({
 </code></pre>
 
             <p>
-               With the objective of defining our <code>'custom'</code> namespace at the same nesting level of <code>'standard'</code> taken care of,
+               With the objective of defining our <code>custom</code> namespace at the same nesting level of <code>standard</code> taken care of,
                it's now possible to add cells to our <code>graph</code> with the confidence that we shouldn't run into any errors regarding cell 
                namespaces.
             </p>

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -25,10 +25,6 @@
 
             <h1>Cell Namespace</h1>
 
-            <!-- <ul>
-                <li>Custom View needs to be set up in the same manner</li>
-            </ul> -->
-
             <p>
                 A simple, but important aspect of working with JointJS is to ensure that JointJS knows where to look for built-in and custom shapes.
                 In order to achieve this, it's a requirement to tell JointJS where to read cell view definitions. Failure to do so
@@ -67,24 +63,25 @@ graph.fromJSON({
 </code></pre>
 
             <p>
-                On the other hand, if you are feeling a little adventurous, and would like to create your own namespace, the following example may
-                interest you. Supposing you wanted a custom namespace which contains just 2 built-in JointJS shapes. How would you go about this?
-                Using destructuring, we can retrieve the shapes we want from the <code>joint.shapes.standard</code> namespace, and then add the
-                shapes to our <code>customNamespace</code>.
+                On the other hand, if you are feeling a little adventurous, and would like to create your own namespace, the next example may
+                interest you. Supposing you wanted to create a custom namespace which contains just 2 built-in JointJS shapes. How would you go about 
+                this? Using destructuring, we could retrieve the shapes we want from the <code>joint.shapes.standard</code> namespace, and then add 
+                the shapes to our <code>customNamespace</code> object.
             </p>
 
             <p>
-                It's important to note that while our custom namespace is just an object that contains our <code>Link</code> and 
-                <code>Rectangle</code> constructors, the default <code>type</code> property of each cell created will still state the location as 
-                within the <code>standard</code> namespace. In order to set up namespaces correctly, this is something we will have to address.
+                While our custom namespace is just an object that contains our <code>Link</code> and <code>Rectangle</code> constructors, 
+                the <code>type</code> property of each cell will still state the location as within the <code>'standard'</code> namespace upon making 
+                an instance. In order to set up namespaces correctly, this is something we will have to address.
             </p>
 
             <p>
-                Below, the <code>prop()</code> method is used to update the type, so JointJS no longer looks for the constructor within a namespace 
-                <code>standard</code>, but at the top level of our <code>customNamespace.</code> This in turn means that after adding the 
-                <code>rect</code> element to the <code>graph</code>, overwriting the <code>graph</code> with <code>graph.toJSON()</code> passing 
-                in the value returned from <code>graph.toJSON()</code> does not result in an error. This is confirmation that our namespaces are 
-                set up correctly.
+                With the aim of updating the <code>type</code>, we take advantage of the 
+                <a href="/docs/jointjs#dia.Element.prototype.prop" target="_blank""><code>prop()</code></a> method, so JointJS no longer looks for 
+                the constructor within a namespace <code>'standard'</code>, but at the top level of our <code>customNamespace</code>. After the 
+                addition of our <code>rect</code> element, if we were to overwrite the <code>graph</code> via <code>graph.toJSON()</code> passing it 
+                the value returned from <code>graph.toJSON()</code>, no error would occur. We can take this as confirmation that our namespaces are 
+                now set up correctly.
             </p>
 
             <pre><code>const { Rectangle, Link } = joint.shapes.standard;
@@ -99,7 +96,7 @@ const paper = new joint.dia.Paper({
     ...
 });
 
-// Including "type: 'Rectangle'" when creating an instance would accomplish the same as using prop()
+// Including `type: 'Rectangle'` when creating an instance would accomplish the same as using prop()
 const rect = new Rectangle({
     size: { width: 80, height: 50 },
     position: { x: 10, y: 10 }
@@ -111,27 +108,28 @@ console.log(rect.prop('type')); // Rectangle
 
 rect.addTo(graph);
 
+// No error occurs as `type` is now `Rectangle`
 graph.fromJSON(graph.toJSON());
 </code></pre>
 
             <p>
-                If we were to continue using <code>'standard.Rectangle'</code> as our type in the 2nd example, this would result in a common error 
-                in JointJS. If you see the dreaded error <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console,
-                it's likely your namespace is not set up correctly, and JointJS cannot find the correct shape.
+                If we were to continue using <code>'standard.Rectangle'</code> as our <code>type</code> above, this would result in a common JointJS
+                error. If you see the dreaded <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console, it's likely 
+                your namespace is not set up correctly, and JointJS cannot find the correct shape.
             </p>
 
             <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">A More Detailed Look</h2>
             
             <p>
-                In order to strengthen this concept in our minds, let's create a few more shapes, so that we are more familiar with this process. 
-                In the following example, we create a class <code>RectangleTwoLabels</code> with a <code>type</code> property of 
-                <code>'custom.RectangleTwoLabels'</code>. JointJS now expects that our custom <code>RectangleTwoLabels</code> element will be located 
-                within the <code>'custom'</code> namespace.
+                With the intention of strengthening this concept in our minds, let's define another shape, so that we are more familiar with this process. 
+                Below, we create a class <code>RectangleTwoLabels</code> with a <code>type</code> property of <code>'custom.RectangleTwoLabels'</code>.
+                JointJS will now expect that our custom <code>RectangleTwoLabels</code> element will be located within the <code>'custom'</code> 
+                namespace.
             </p>
 
             <p>
                 As we want our <code>'custom'</code> namespace to be at the same level of nesting as built-in JointJS shapes, we will structure our 
-                cell namespace accordingly. First, we create an object variable <code>namespace</code>, then using the 
+                cell namespace accordingly. First, we declare a <code>namespace</code> variable, then using the 
                 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals" target="_blank">spread operator</a>,
                 ensure that <code>namespace</code> contains all of the properties of <code>joint.shapes</code>. These properties correspond to shape 
                 namespaces such as <code>'standard'</code>.
@@ -140,13 +138,13 @@ graph.fromJSON(graph.toJSON());
             <p>
                 Afterwards, taking advantage of 
                 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign" target="_blank"><code>Object.assign()</code></a>, 
-                the properties of <code>customNamespace</code> are copied to our <code>namespace</code> object. The result is that 
+                the properties of <code>customNamespace</code> are copied to our <code>namespace</code> object. As a result,
                 <code>'standard'</code> and <code>'custom'</code> are both defined at the same level in our <code>namespace</code> object.
             </p>
 
             <p>
                 Lastly, we make sure that <code>namespace</code> is set as the value of our <code>cellNamespace</code> and <code>cellViewNamespace</code>
-                properties respectively.
+                options respectively.
             </p>
             
             <pre><code>class RectangleTwoLabels extends joint.shapes.standard.Rectangle {
@@ -180,19 +178,28 @@ new joint.dia.Paper({
 });
 </code></pre>
 
+            <p>
+               With the objective of defining our <code>'custom'</code> namespace at the same nesting level of <code>'standard'</code> taken care of,
+               it's now possible to add cells to our <code>graph</code> with the confidence that we shouldn't run into any errors regarding cell 
+               namespaces.
+            </p>
+
             <pre><code>graph.fromJSON({
     cells: [
         {
             type: 'standard.Rectangle', 
             size: { width: 100, height: 60 },
             position: { x: 50, y: 50 },
-            attrs: { label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
+            attrs: { body: { fill: '#C9ECF5' }, label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
         },
         { 
             type: 'custom.RectangleTwoLabels', 
             size: { width: 140, height: 80 },
-            position: { x: 180, y: 30 },
-            attrs: { 
+            position: { x: 200, y: 30 },
+            attrs: {
+                body: {
+                    fill: '#F5BDB0'
+                }, 
                 label: { 
                     text: 'custom.RectangleTwoLabels',
                     textWrap: { width: 'calc(w-10)' } 
@@ -214,7 +221,92 @@ new joint.dia.Paper({
             <div class="paper" id="paper-cell-namespace"></div>
             <p>JointJS source code: <a href="js/cell-namespace.js" target="_blank">cell-namespace.js</a></p>
 
-            <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">Create Custom Views in same manner</h2>
+            <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">Don't Forget Custom Views!</h2>
+
+            <p>
+                Last but not least, the topics covered so far also apply to our custom views. Placing a custom view in the correct location is 
+                necessary, because the JointJS <code>paper</code> will search for any model types with a suffix of 'View' in our provided namespace.
+            </p>
+
+            <p>
+                In this snippet, we create a simple rectangle shape with text input. We also define a custom view that on user input, sets the input 
+                value on the model, and also logs the value to the console. This time around, we choose <code>joint.shapes</code> as our 
+                <code>cellNamespace</code> and <code>cellViewNamespace</code> values, and <code>'example.RectangleInput'</code> as the <code>type</code>
+                for our custom element. Those things combined means JointJS assumes our custom element & view will be located at 
+                <code>'joint.shapes.example.RectangleInput'</code> and <code>'joint.shapes.example.RectangleInputView'</code> respectively.
+            </p>
+
+            <pre><code>const namespace = joint.shapes;
+
+const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
+
+const paper = new joint.dia.Paper({
+    ...
+    cellViewNamespace: namespace,
+    ...
+});
+
+class RectangleInput extends joint.dia.Element {
+    defaults() {
+        return {
+            ...super.defaults,
+            type: 'example.RectangleInput',
+            attrs: {
+                foreignObject: {
+                    width: 'calc(w)',
+                    height: 'calc(h)'
+                }
+            }
+        };
+    }
+    
+    preinitialize() {
+        this.markup = joint.util.svg/* xml */`
+            &lt;foreignObject @selector="foreignObject"&gt;
+                &lt;div
+                    xmlns="http:www.w3.org/1999/xhtml"
+                    style="background:white;border:1px solid black;height:100%;display:flex;justify-content:center;align-items:center;"
+                >
+                    &lt;input
+                        placeholder="Type something"
+                    /&gt;
+                &lt;/div&gt;
+            &lt;/foreignObject&gt;
+        `;
+    }
+}
+
+const RectangleInputView = joint.dia.ElementView.extend({
+
+    events: {
+        // Name of event + CSS selector : custom view method name
+        'input input': 'onInput'
+    },
+
+    onInput: function(evt) {
+        console.log('Input Value:', evt.target.value);
+        this.model.attr('name/props/value', evt.target.value);
+    }
+});
+
+Object.assign(namespace, {
+    example: {
+        RectangleInput,
+        RectangleInputView 
+    }
+});
+
+const rectangleInput = new RectangleInput();
+rectangleInput.position(10, 10);
+rectangleInput.resize(200, 120);
+rectangleInput.addTo(graph);
+</code></pre>
+
+            <p>
+                That's all we will cover in this tutorial. Thanks for staying with us if you got this far, and we hope you will have more confidence 
+                when working with cell namespaces in JointJS. If you would like to explore any of the features mentioned here in more detail, you 
+                can find more information in our <a href="/docs/jointjs" target="_blank">JointJS documentation</a>.
+            </p>
 
         </div><!--end tutorial-->
 

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -232,7 +232,7 @@ new joint.dia.Paper({
                 In this snippet, we create a simple rectangle shape with text input. We also define a custom view that on user input, sets the input 
                 value on the model, and also logs the value to the console. This time around, we choose <code>joint.shapes</code> as our 
                 <code>cellNamespace</code> and <code>cellViewNamespace</code> values, and <code>'example.RectangleInput'</code> as the <code>type</code>
-                for our custom element. Those things combined means JointJS assumes our custom element & view will be located at 
+                for our custom element. Those things combined mean JointJS assumes our custom element & view will be located at 
                 <code>'joint.shapes.example.RectangleInput'</code> and <code>'joint.shapes.example.RectangleInputView'</code> respectively.
             </p>
 

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -26,8 +26,6 @@
             <h1>Cell Namespace</h1>
 
             <!-- <ul>
-                <li>Explain why type is important, define/class example</li>
-                <li>JSON example / error if not set up correctly</li>
                 <li>Custom View needs to be set up in the same manner</li>
             </ul> -->
 
@@ -68,13 +66,28 @@ graph.fromJSON({
 });
 </code></pre>
 
-        <p>
-            On the other hand, if you are feeling a little adventurous, and would like to create your own custom namespace, the following example 
-            should get you started. One crucial difference to take note of is that now our <code>type</code> is <code>'Rectangle'</code>. That's 
-            because our custom namespace is just an object which contains our <code>Link</code> and <code>Rectangle</code> constructors.
-        </p>
+            <p>
+                On the other hand, if you are feeling a little adventurous, and would like to create your own namespace, the following example may
+                interest you. Supposing you wanted a custom namespace which contains just 2 built-in JointJS shapes. How would you go about this?
+                Using destructuring, we can retrieve the shapes we want from the <code>joint.shapes.standard</code> namespace, and then add the
+                shapes to our <code>customNamespace</code>.
+            </p>
 
-        <pre><code>const { Rectangle, Link } = joint.shapes.standard;
+            <p>
+                It's important to note that while our custom namespace is just an object that contains our <code>Link</code> and 
+                <code>Rectangle</code> constructors, the default <code>type</code> property of each cell created will still state the location as 
+                within the <code>standard</code> namespace. In order to set up namespaces correctly, this is something we will have to address.
+            </p>
+
+            <p>
+                Below, the <code>prop()</code> method is used to update the type, so JointJS no longer looks for the constructor within a namespace 
+                <code>standard</code>, but at the top level of our <code>customNamespace.</code> This in turn means that after adding the 
+                <code>rect</code> element to the <code>graph</code>, overwriting the <code>graph</code> with <code>graph.toJSON()</code> passing 
+                in the value returned from <code>graph.toJSON()</code> does not result in an error. This is confirmation that our namespaces are 
+                set up correctly.
+            </p>
+
+            <pre><code>const { Rectangle, Link } = joint.shapes.standard;
             
 const customNamespace = { Rectangle, Link };
             
@@ -86,25 +99,122 @@ const paper = new joint.dia.Paper({
     ...
 });
 
-graph.fromJSON({
-    cells: [
-        { 
-            type: 'Rectangle', 
-            size: { width: 80, height: 50 },
-            position: { x: 10, y: 10 }
-        }
-    ]
+// Including "type: 'Rectangle'" when creating an instance would accomplish the same as using prop()
+const rect = new Rectangle({
+    size: { width: 80, height: 50 },
+    position: { x: 10, y: 10 }
+});
+
+console.log(rect.prop('type')); // standard.Rectangle
+rect.prop('type', 'Rectangle');
+console.log(rect.prop('type')); // Rectangle
+
+rect.addTo(graph);
+
+graph.fromJSON(graph.toJSON());
+</code></pre>
+
+            <p>
+                If we were to continue using <code>'standard.Rectangle'</code> as our type in the 2nd example, this would result in a common error 
+                in JointJS. If you see the dreaded error <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console,
+                it's likely your namespace is not set up correctly, and JointJS cannot find the correct shape.
+            </p>
+
+            <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">A More Detailed Look</h2>
+            
+            <p>
+                In order to strengthen this concept in our minds, let's create a few more shapes, so that we are more familiar with this process. 
+                In the following example, we create a class <code>RectangleTwoLabels</code> with a <code>type</code> property of 
+                <code>'custom.RectangleTwoLabels'</code>. JointJS now expects that our custom <code>RectangleTwoLabels</code> element will be located 
+                within the <code>'custom'</code> namespace.
+            </p>
+
+            <p>
+                As we want our <code>'custom'</code> namespace to be at the same level of nesting as built-in JointJS shapes, we will structure our 
+                cell namespace accordingly. First, we create an object variable <code>namespace</code>, then using the 
+                <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals" target="_blank">spread operator</a>,
+                ensure that <code>namespace</code> contains all of the properties of <code>joint.shapes</code>. These properties correspond to shape 
+                namespaces such as <code>'standard'</code>.
+            </p>
+
+            <p>
+                Afterwards, taking advantage of 
+                <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign" target="_blank"><code>Object.assign()</code></a>, 
+                the properties of <code>customNamespace</code> are copied to our <code>namespace</code> object. The result is that 
+                <code>'standard'</code> and <code>'custom'</code> are both defined at the same level in our <code>namespace</code> object.
+            </p>
+
+            <p>
+                Lastly, we make sure that <code>namespace</code> is set as the value of our <code>cellNamespace</code> and <code>cellViewNamespace</code>
+                properties respectively.
+            </p>
+            
+            <pre><code>class RectangleTwoLabels extends joint.shapes.standard.Rectangle {
+    defaults() {
+        return {
+            ...super.defaults,
+            type: 'custom.RectangleTwoLabels'
+        };
+    }
+    
+    preinitialize() {
+        this.markup = joint.util.svg/* xml */ `
+            &lt;rect @selector="body" /&gt;
+            &lt;text @selector="label" /&gt;
+            &lt;text @selector="labelSecondary" /&gt;
+        `;
+    }
+}
+
+const namespace = { ...joint.shapes };
+const customNamespace = { custom: { RectangleTwoLabels }}; 
+
+Object.assign(namespace, customNamespace);
+
+const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
+
+new joint.dia.Paper({
+    ...
+    cellViewNamespace: namespace
+    ...
 });
 </code></pre>
 
-        <p>
-            If we were to continue using <code>'standard.Rectangle'</code> as our type in the 2nd example, this would result in a common error 
-            in JointJS. If you see the dreaded error <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console,
-            it's likely your namespace is not set up correctly, and JointJS cannot find the correct shape.
-        </p>
+            <pre><code>graph.fromJSON({
+    cells: [
+        {
+            type: 'standard.Rectangle', 
+            size: { width: 100, height: 60 },
+            position: { x: 50, y: 50 },
+            attrs: { label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
+        },
+        { 
+            type: 'custom.RectangleTwoLabels', 
+            size: { width: 140, height: 80 },
+            position: { x: 180, y: 30 },
+            attrs: { 
+                label: { 
+                    text: 'custom.RectangleTwoLabels',
+                    textWrap: { width: 'calc(w-10)' } 
+                }, 
+                labelSecondary: { 
+                    text: 'SecondaryLabel', 
+                    x: 'calc(w/2)', 
+                    y: 'calc(h+15)', 
+                    textAnchor: 'middle', 
+                    textVerticalAnchor: 'middle',
+                    fontSize: 14 
+                }
+            }
+        },
+    ]
+});
+</code></pre>
+            
+            <div class="paper" id="paper-cell-namespace"></div>
+            <p>JointJS source code: <a href="js/cell-namespace.js" target="_blank">cell-namespace.js</a></p>
 
-        <div class="paper" id="paper-cell-namespace"></div>
-        <p>JointJS source code: <a href="js/cell-namespace.js" target="_blank">cell-namespace.js</a></p>
+            <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">Create Custom Views in same manner</h2>
 
         </div><!--end tutorial-->
 

--- a/tutorials/cell-namespace.html
+++ b/tutorials/cell-namespace.html
@@ -34,11 +34,65 @@
             </p>
 
             <p>
-                How do we tell JointJS which namespace to use? There are 2 important options to be aware of when creating your diagrams. The
-                first is the <code>graph</code> option <a href="/docs/jointjs#dia.Graph.constructor" target="_blank"><code>cellNamespace</code></a>, 
-                and the second is the <code>paper</code> option 
-                <a href="/docs/jointjs#dia.Paper.prototype.options.cellViewNamespace" target="_blank"><code>cellViewNamespace</code></a>. In the 
-                following example, for a cell of type <code>'standard.Rectangle'</code>, the <code>graph</code> looks up the 
+                Let's begin by creating a simple, custom <code>Rectangle</code> definition which extends <code>joint.dia.Element</code>.
+            </p>
+
+            <pre><code>class Rectangle extends joint.dia.Element {
+    defaults() {
+        return {
+            ...super.defaults,
+            type: 'Rectangle',
+            position: { x: 10, y: 10 },
+            attrs: {
+                body: {
+                    width: 100,
+                    height: 70
+                }
+            }
+        };
+    }
+    
+    preinitialize() {
+        this.markup = joint.util.svg/* xml */ `
+            &lt;rect @selector="body" /&gt;
+        `;
+    }
+}
+</code></pre>
+
+            <p>
+                We will also declare a variable which will contain our shapes, and act as our cell namespace.
+            </p>
+
+            <pre><code>// Built-in JointJS shapes and our custom Rectangle are added
+const namespace = { ...joint.shapes, Rectangle };
+</code></pre>
+
+            <p>
+                If you want a little more organization and nesting in your cell namespace, you can define a <code>type</code> using dot notation, 
+                and structure your shape definitions how you would like.
+            </p>
+
+            <pre><code>class Rectangle extends joint.dia.Element {
+    defaults() {
+        return {
+            ...
+            type: 'custom.Rectangle',
+            ...
+        };
+    }
+    ...
+}
+
+const namespace = { ...joint.shapes, custom: { Rectangle }};
+</code></pre>
+
+            <p>
+                Now that we have created a cell namespace, how do we tell JointJS which namespace to use? There are 2 important options to be aware 
+                of when creating your diagrams. The first is the <code>graph</code> option 
+                <a href="/docs/jointjs#dia.Graph.constructor" target="_blank"><code>cellNamespace</code></a>, and the second is the <code>paper</code> 
+                option <a href="/docs/jointjs#dia.Paper.prototype.options.cellViewNamespace" target="_blank"><code>cellViewNamespace</code></a>. In 
+                the following example, for a cell of type <code>'standard.Rectangle'</code>, the <code>graph</code> looks up the 
                 <code>'joint.shapes.standard.Rectangle'</code> path to find the correct constructor. If you don't plan on creating custom shapes, 
                 or playing around with namespaces, the following setup should be fine for your application.
             </p>
@@ -64,62 +118,6 @@ graph.fromJSON({
 });
 </code></pre>
 
-            <p>
-                On the other hand, if you are feeling a little adventurous, and would like to create your own namespace, the next example may
-                interest you. Supposing you wanted to create a custom namespace which contains just 2 built-in JointJS shapes. How would you go about 
-                this? Using destructuring, we could retrieve the shapes we want from the <code>joint.shapes.standard</code> namespace, and then add 
-                the shapes to our <code>customNamespace</code> object.
-            </p>
-
-            <p>
-                While our custom namespace is just an object that contains our <code>Link</code> and <code>Rectangle</code> constructors, 
-                the <code>type</code> property of each cell will still state the location as within the <code>standard</code> namespace upon making 
-                an instance. In order to set up namespaces correctly, this is something we will have to address.
-            </p>
-
-            <p>
-                With the aim of updating the <code>type</code>, we take advantage of the 
-                <a href="/docs/jointjs#dia.Element.prototype.prop" target="_blank""><code>prop()</code></a> method, so JointJS no longer looks for 
-                the constructor within a namespace <code>standard</code>, but at the top level of our <code>customNamespace</code>. After the 
-                addition of our <code>rect</code> element, if we were to overwrite the <code>graph</code> via <code>graph.toJSON()</code> passing it 
-                the value returned from <code>graph.toJSON()</code>, no error would occur. We can take this as confirmation that our namespaces are 
-                now set up correctly.
-            </p>
-
-            <pre><code>const { Rectangle, Link } = joint.shapes.standard;
-            
-const customNamespace = { Rectangle, Link };
-            
-const graph = new joint.dia.Graph({}, { cellNamespace: customNamespace });
-
-const paper = new joint.dia.Paper({
-    ...
-    cellViewNamespace: customNamespace
-    ...
-});
-
-// Including `type: 'Rectangle'` when creating an instance would accomplish the same as using prop()
-const rect = new Rectangle({
-    size: { width: 80, height: 50 },
-    position: { x: 10, y: 10 }
-});
-
-console.log(rect.prop('type')); // standard.Rectangle
-rect.prop('type', 'Rectangle');
-console.log(rect.prop('type')); // Rectangle
-
-rect.addTo(graph);
-
-// No error occurs as `type` is now `Rectangle`
-graph.fromJSON(graph.toJSON());
-</code></pre>
-
-            <p>
-                If we were to continue using <code>'standard.Rectangle'</code> as our <code>type</code> above, this would result in a common JointJS
-                error. If you see the dreaded <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console, it's likely 
-                your namespace is not set up correctly, and JointJS cannot find the correct shape.
-            </p>
-
             <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">A More Detailed Look</h2>
             
             <p>
@@ -138,15 +136,10 @@ graph.fromJSON(graph.toJSON());
             </p>
 
             <p>
-                Afterwards, taking advantage of 
-                <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign" target="_blank"><code>Object.assign()</code></a>, 
-                the properties of <code>customNamespace</code> are copied to our <code>namespace</code> object. As a result,
-                <code>standard</code> and <code>custom</code> are both defined at the same level in our <code>namespace</code> object.
-            </p>
-
-            <p>
-                Lastly, we make sure that <code>namespace</code> is set as the value of our <code>cellNamespace</code> and <code>cellViewNamespace</code>
-                options respectively.
+                Afterwards, we also place our new <code>custom</code> namespace which contains our custom shape definition <code>RectangleTwoLabels</code>
+                alongside our built-in shapes. As a result, <code>standard</code> and <code>custom</code> are both defined at the same level in our 
+                <code>namespace</code> object. Lastly, we make sure that <code>namespace</code> is set as the value of our <code>cellNamespace</code> 
+                and <code>cellViewNamespace</code> options respectively. 
             </p>
             
             <pre><code>class RectangleTwoLabels extends joint.shapes.standard.Rectangle {
@@ -166,10 +159,7 @@ graph.fromJSON(graph.toJSON());
     }
 }
 
-const namespace = { ...joint.shapes };
-const customNamespace = { custom: { RectangleTwoLabels }}; 
-
-Object.assign(namespace, customNamespace);
+const namespace = { ...joint.shapes, custom: { RectangleTwoLabels }};
 
 const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
 
@@ -222,6 +212,12 @@ new joint.dia.Paper({
             
             <div class="paper" id="paper-cell-namespace"></div>
             <p>JointJS source code: <a href="js/cell-namespace.js" target="_blank">cell-namespace.js</a></p>
+
+            <p>
+                Discovering your cell namespaces are not organized correctly should result in a common JointJS error. If you see the dreaded 
+                <code>Uncaught Error: dia.ElementView: markup required</code> appearing in your console, it's likely 
+                your namespace is not set up correctly, and JointJS cannot find the correct shape.
+            </p>
 
             <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">Don't Forget Custom Views!</h2>
 
@@ -302,6 +298,32 @@ const rectangleInput = new RectangleInput();
 rectangleInput.position(10, 10);
 rectangleInput.resize(200, 120);
 rectangleInput.addTo(graph);
+</code></pre>
+
+            <h2 style="font-size:19px;text-align:initial;text-transform:none;margin:0;">Quick Validation Tips</h2>
+
+            <p>
+                If you are experimenting with cell namespaces, you may like to perform some quick validation, or double-check exactly what 
+                <code>type</code> values you are working with. Taking advantage of the 
+                <a href="/docs/jointjs#dia.Element.prototype.prop" target="_blank""><code>prop()</code></a> method on both Elements & Links allows you 
+                to quickly access the <code>type</code> value, so it can be useful to keep track of where your shapes are located.
+            </p>
+
+            <pre><code>const rect = new Rectangle({
+    size: { width: 80, height: 50 },
+    position: { x: 10, y: 10 }
+});
+
+console.log(rect.prop('type')); // standard.Rectangle
+</code></pre>
+
+            <p>
+                A concise way to check if your namespaces are set up correctly is to overwrite the <code>graph</code> via <code>graph.toJSON()</code> 
+                passing it the value returned from <code>graph.toJSON()</code>. If no error occurs, you can be more confident that your namespaces are 
+                organized correctly.
+            </p>
+
+            <pre><code>graph.fromJSON(graph.toJSON());
 </code></pre>
 
             <p>

--- a/tutorials/js/cell-namespace.js
+++ b/tutorials/js/cell-namespace.js
@@ -17,10 +17,7 @@
         }
     }
 
-    const namespace = { ...joint.shapes };
-    const customNamespace = { custom: { RectangleTwoLabels }}; 
-
-    Object.assign(namespace, customNamespace);
+    const namespace = { ...joint.shapes, custom: { RectangleTwoLabels }};
 
     const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
 

--- a/tutorials/js/cell-namespace.js
+++ b/tutorials/js/cell-namespace.js
@@ -44,13 +44,16 @@
                 type: 'standard.Rectangle', 
                 size: { width: 100, height: 60 },
                 position: { x: 50, y: 50 },
-                attrs: { label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
+                attrs: { body: { fill: '#C9ECF5' }, label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
             },
             { 
                 type: 'custom.RectangleTwoLabels', 
                 size: { width: 140, height: 80 },
-                position: { x: 180, y: 30 },
-                attrs: { 
+                position: { x: 200, y: 30 },
+                attrs: {
+                    body: {
+                        fill: '#F5BDB0'
+                    }, 
                     label: { 
                         text: 'custom.RectangleTwoLabels',
                         textWrap: { width: 'calc(w-10)' } 
@@ -67,5 +70,4 @@
             },
         ]
     });
-
 }());

--- a/tutorials/js/cell-namespace.js
+++ b/tutorials/js/cell-namespace.js
@@ -1,0 +1,30 @@
+(function cellNamespace() {
+
+    // const namespace = joint.shapes;
+
+    const { Link, Rectangle } = joint.shapes.standard;
+
+    const customNamespace = { Link, Rectangle };
+
+    const graph = new joint.dia.Graph({}, { cellNamespace: customNamespace });
+
+    new joint.dia.Paper({
+        el: document.getElementById('paper-cell-namespace'),
+        model: graph,
+        width: 600,
+        height: 100,
+        gridSize: 1,
+        cellViewNamespace: customNamespace
+    });
+
+    graph.fromJSON({
+        cells: [
+            { 
+                type: 'Rectangle', 
+                size: { width: 80, height: 50 },
+                position: { x: 10, y: 10 }
+            }
+        ]
+    });
+
+}());

--- a/tutorials/js/cell-namespace.js
+++ b/tutorials/js/cell-namespace.js
@@ -1,29 +1,70 @@
 (function cellNamespace() {
 
-    // const namespace = joint.shapes;
+    class RectangleTwoLabels extends joint.shapes.standard.Rectangle {
+        defaults() {
+            return {
+                ...super.defaults,
+                type: 'custom.RectangleTwoLabels'
+            };
+        }
+      
+        preinitialize() {
+            this.markup = joint.util.svg/* xml */ `
+               <rect @selector="body" />
+               <text @selector="label" />
+               <text @selector="labelSecondary" />
+            `;
+        }
+    }
 
-    const { Link, Rectangle } = joint.shapes.standard;
+    const namespace = { ...joint.shapes };
+    const customNamespace = { custom: { RectangleTwoLabels }}; 
 
-    const customNamespace = { Link, Rectangle };
+    Object.assign(namespace, customNamespace);
 
-    const graph = new joint.dia.Graph({}, { cellNamespace: customNamespace });
+    const graph = new joint.dia.Graph({}, { cellNamespace: namespace });
 
     new joint.dia.Paper({
         el: document.getElementById('paper-cell-namespace'),
         model: graph,
-        width: 600,
-        height: 100,
-        gridSize: 1,
-        cellViewNamespace: customNamespace
+        width: 400,
+        height: 150,
+        cellViewNamespace: namespace,
+        background: {
+            color: '#F7F7F7'
+        },
+        gridSize: 15,
+        drawGrid: { name: 'dot', args: { color: '#BDBDBD' }}
     });
+
 
     graph.fromJSON({
         cells: [
+            {
+                type: 'standard.Rectangle', 
+                size: { width: 100, height: 60 },
+                position: { x: 50, y: 50 },
+                attrs: { label: { text: 'standard.Rectangle', textWrap: { width: 'calc(w-10)' }}}
+            },
             { 
-                type: 'Rectangle', 
-                size: { width: 80, height: 50 },
-                position: { x: 10, y: 10 }
-            }
+                type: 'custom.RectangleTwoLabels', 
+                size: { width: 140, height: 80 },
+                position: { x: 180, y: 30 },
+                attrs: { 
+                    label: { 
+                        text: 'custom.RectangleTwoLabels',
+                        textWrap: { width: 'calc(w-10)' } 
+                    }, 
+                    labelSecondary: { 
+                        text: 'SecondaryLabel', 
+                        x: 'calc(w/2)', 
+                        y: 'calc(h+15)', 
+                        textAnchor: 'middle', 
+                        textVerticalAnchor: 'middle',
+                        fontSize: 14 
+                    }
+                }
+            },
         ]
     });
 


### PR DESCRIPTION
## Description

Add `cell namespace` tutorial & update relevant options in `docs`

- add tutorial
- update graph option `cellNamespace` & paper option `cellViewNamespace` in docs
- fix typo in graph constructor docs - `cellNamespaceView` => `cellViewNamespace`. - Fixes #2270 