### PR TITLE
docs(tutorials): update incorrect href values in links tutorial

### DIFF
--- a/tutorials/links.html
+++ b/tutorials/links.html
@@ -297,8 +297,8 @@
                 connectors to support custom connecting strategies.</a></p>
 
             <p><a href="/docs/jointjs#dia.Link.geometry" target="_blank">Link geometry</a> is also affected by the
-                <a href="#anchors">anchor</a> and <a href="#connectionPoints">connectionPoint</a> methods applied to
-                link source and target, as well as the <a href="#connectionStrategies">connectionStrategy</a> set on the
+                <a href="/docs/jointjs/#anchors" target="_blank">anchor</a> and <a href="/docs/jointjs/#connectionPoints" target="_blank">connectionPoint</a> methods applied to
+                link source and target, as well as the <a href="/docs/jointjs/#connectionStrategies" target="_blank">connectionStrategy</a> set on the
                 paper.</p>
 
             <h3 id="link-styling">Link Styling</h3>


### PR DESCRIPTION
## Description

- Update incorrect `href` values in links tutorial
- Open links in new window (consistent with other link behaviour in tutorials)

