### PR TITLE
types(dia.Paper): fix labels layer name

### DIFF
--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1195,7 +1195,7 @@ export namespace dia {
 
         enum Layers {
             CELLS = 'cells',
-            LABEL = 'labels',
+            LABELS = 'labels',
             BACK = 'back',
             FRONT = 'front',
             TOOLS = 'tools',


### PR DESCRIPTION
Fixes incorrect paper layer name `LABELS`.
