### PR TITLE
g.Rect: performance improvement when using Manhattan router with Rect shapes

### DIFF
--- a/src/g/rect.mjs
+++ b/src/g/rect.mjs
@@ -139,7 +139,10 @@ Rect.prototype = {
 
     // @return {bool} true if point p is inside me.
     containsPoint: function(p) {
-        p = new Point(p);
+        
+        if (!(p instanceof Point)) {
+            p = new Point(p);
+        }
         return p.x >= this.x && p.x <= this.x + this.width && p.y >= this.y && p.y <= this.y + this.height;
     },
 

--- a/test/geometry/rect.js
+++ b/test/geometry/rect.js
@@ -161,7 +161,27 @@ QUnit.module('rect', function() {
         });
 
         QUnit.module('containsPoint(point)', function() {
+            
+            QUnit.test('returns TRUE when a point is inside the rect', function(assert) {
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(75, 75))), 'inside for Point');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint({ x: 75, y: 75 })), 'inside for object');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint('75@75')), 'inside for string coords separated by @');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint('75 75')), 'inside for string coords separated by space');
+            });
 
+            QUnit.test('returns TRUE when a point is a corner of the rect', function(assert) {
+                assert.ok(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(50, 50)));
+                assert.ok(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(50, 100)));
+                assert.ok(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(100, 50)));
+                assert.ok(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(100, 100)));
+            });
+
+            QUnit.test('returns TRUE when a point is outside the rect', function(assert) {
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(49, 75))), 'outside for Point');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint({ x: 101, y: 75 })), 'outside for object');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75@101')), 'outside for string coords separated by @');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75 49')), 'outside for string coords separated by space');
+            });
         });
 
         QUnit.module('containsRect(rect)', function() {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Rect.containsPoint is called many times with a Point instance as argument. Avoiding the new Point() call improves loading times significantly on large papers.

## Motivation and Context

Our app uses Manhattan router with shapes and links. We've had performance issues when loading a larger paper, due to the time spent performing layout. One of the issues was that the routing logic calls `Rect.containsPoint` many, many times (thousands), and this function constructs a new Point every time it is called. But, the argument it gets is *already* a Point instance, so creating a copy just for the comparison is not necessary.
