### PR TITLE
perf(dia.Cell): make internal set() call more efficient

### DIFF
--- a/src/dia/Cell.mjs
+++ b/src/dia/Cell.mjs
@@ -615,7 +615,15 @@ export const Cell = Backbone.Model.extend({
             options.rewrite = false;
         }
 
-        return this.set(merge({}, this.attributes, props), options);
+        // Create a new object containing only the changed attributes.
+        const changedAttributes = {};
+        for (const key in props) {
+            // Merging the values of changed attributes with the current ones.
+            const { changedValue } = merge({}, { changedValue: this.attributes[key] }, { changedValue: props[key] });
+            changedAttributes[key] = changedValue;
+        }
+
+        return this.set(changedAttributes, options);
     },
 
     // A convenient way to unset nested properties

--- a/test/jointjs/cell.js
+++ b/test/jointjs/cell.js
@@ -439,6 +439,29 @@ QUnit.module('cell', function(hooks) {
                 assert.equal(el.prop('name/second'), 'doe');
             });
 
+            QUnit.test('path and value as object is set effectively', function(assert) {
+
+                // This test is here to make sure that the `set` method is called only once
+                // when setting multiple attributes at once and only the changed attributes
+                // are passed to the `set` method.
+
+                el.set('otherAttribute', 'otherValue');
+
+                const setSpy = sinon.spy(el, 'set');
+                let attributes;
+
+                el.prop({ age: 20, name: { first: 'john' }});
+                assert.ok(setSpy.calledOnce);
+                [attributes] = setSpy.lastCall.args;
+                assert.deepEqual(attributes, { age: 20, name: { first: 'john' }});
+
+                el.prop({ name: { second: 'doe' }});
+                assert.ok(setSpy.calledTwice);
+                [attributes] = setSpy.lastCall.args;
+                assert.deepEqual(attributes, { name: { first: 'john', second: 'doe' }});
+
+                setSpy.restore();
+            });
 
             QUnit.test('path as top-level attribute name and value as object', function(assert) {
 


### PR DESCRIPTION
Ensure that when calling the `prop(attributes)` method (where `attributes` is an object with one or more attributes), only changed attributes are passed to the `set` method ( enforcing fewer checks).

For more details, see https://github.com/clientIO/joint/issues/2296.