### PR TITLE
fix(dia.LinkView): prevent hidden doubleLinkTools to affect link bounding box

### DIFF
--- a/src/dia/LinkView.mjs
+++ b/src/dia/LinkView.mjs
@@ -1117,11 +1117,11 @@ export const LinkView = CellView.extend({
 
                 toolPosition = this.getPointAtLength(connectionLength - doubleLinkToolsOffset);
                 this._tool2Cache.attr('transform', 'translate(' + toolPosition.x + ', ' + toolPosition.y + ') ' + scale);
-                this._tool2Cache.attr('visibility', 'visible');
+                this._tool2Cache.attr('display', 'inline');
 
             } else if (this.options.doubleLinkTools) {
 
-                this._tool2Cache.attr('visibility', 'hidden');
+                this._tool2Cache.attr('display', 'none');
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

When moving around elements and links that have doubleLinkTools: true in their LinkView but link length is short enough for the secondary tool to be hidden, the tool position is not updated. 

This causes miscalculations in paper size and paddings in various scenarios:
- the secondary tool starts at 0,0 and does not get moved when the LinkView is repositioned
- shortening the link while in bottom-right corner of a large paper hides the secondary tool. Then moving the link and all other elements towards top-left does not cause the paper to autoshrink because the tool is left behind at the position where it was before being hidden.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->
