### PR TITLE
fix(linkTools.Segments): throw explicit error when incompatible router in use

### DIFF
--- a/docs/src/joint/api/linkTools/Segments.html
+++ b/docs/src/joint/api/linkTools/Segments.html
@@ -38,6 +38,12 @@
     </tr>
 </table>
 
+<p class="docs-important-note">
+    The tool is meant to be used with <a href="#routers.normal">normal router</a> only.
+    It does not work with e.g. <a href="#routers.orthogonal">orthogonal router</a>.
+    It throws the <b>"Segments: incompatible router in use"</b> error if used with any other router.
+</p>
+
 <p>Example:</p>
 
 <pre><code>var segmentsTool = new joint.linkTools.Segments({

--- a/src/linkTools/Segments.mjs
+++ b/src/linkTools/Segments.mjs
@@ -321,6 +321,11 @@ export const Segments = ToolView.extend({
                 this.resetAnchor('target', data.targetAnchorDef);
             }
         }
+        if (vertices.some(v => !v)) {
+            // This can happen when the link is using a smart routing and the number of
+            // vertices is not the same as the number of route points.
+            throw new Error('Segments: incompatible router in use');
+        }
         link.vertices(vertices, { ui: true, tool: this.cid });
         this.updateHandle(handle, vertex, nextVertex, offset);
         if (!options.stopPropagation) relatedView.notifyPointermove(normalizedEvent, coords.x, coords.y);


### PR DESCRIPTION
Fore more details, see [#2044](https://github.com/clientIO/joint/issues/2044).