### PR TITLE
fix(connectors.Curve): wrong enum mapping fix

### DIFF
--- a/src/connectors/curve.mjs
+++ b/src/connectors/curve.mjs
@@ -410,7 +410,7 @@ function getTargetTangentDirection(linkView, route, direction, options) {
             case TangentDirections.LEFT:
                 return new Point(-1, 0);
             case TangentDirections.RIGHT:
-                return new Point(0, 1);
+                return new Point(1, 0);
             case TangentDirections.AUTO:
                 return getAutoTargetDirection(linkView, route, options);
             case TangentDirections.CLOSEST_POINT:


### PR DESCRIPTION
Fixed wrong `TangentDirections.RIGHT` mapping for target directions.