### PR TITLE
feat(Vectorizer): add option to support camel case attributes

### DIFF
--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1381,6 +1381,9 @@ const V = (function() {
         return xml;
     };
 
+    // Create an empty object which does not inherit any properties from `Object.prototype`.
+    // This is useful when we want to use an object as a dictionary without having to
+    // worry about inherited properties such as `toString`, `valueOf` etc.
     const _attributeNames = Object.create(null);
 
     // List of attributes for which not to split camel case words.
@@ -1452,11 +1455,20 @@ const V = (function() {
         }
     });
 
+    // Note: The `attributeNames` and `supportCamelCaseAttributes` properties are not enumerable
+    // in this version to avoid breaking changes. They will be made enumerable in the next major version.
+
     // Dictionary of attribute names
-    V.attributeNames = attributeNames;
+    Object.defineProperty(V, 'attributeNames', {
+        value: attributeNames,
+        writable: false,
+    });
 
     // Should camel case attributes be supported?
-    V.supportCamelCaseAttributes = false;
+    Object.defineProperty(V, 'supportCamelCaseAttributes', {
+        value: false,
+        writable: true,
+    });
 
     /**
      * @param {string} name

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -663,15 +663,17 @@ const V = (function() {
      */
     VPrototype.removeAttr = function(name) {
 
-        var qualifiedName = V.qualifyAttr(name);
-        var el = this.node;
+        const trueName = attributeNames[name];
 
-        if (qualifiedName.ns) {
-            if (el.hasAttributeNS(qualifiedName.ns, qualifiedName.local)) {
-                el.removeAttributeNS(qualifiedName.ns, qualifiedName.local);
+        const { ns, local } = V.qualifyAttr(trueName);
+        const el = this.node;
+
+        if (ns) {
+            if (el.hasAttributeNS(ns, local)) {
+                el.removeAttributeNS(ns, local);
             }
-        } else if (el.hasAttribute(name)) {
-            el.removeAttribute(name);
+        } else if (el.hasAttribute(trueName)) {
+            el.removeAttribute(trueName);
         }
         return this;
     };
@@ -692,7 +694,7 @@ const V = (function() {
         }
 
         if (V.isString(name) && V.isUndefined(value)) {
-            return this.node.getAttribute(name);
+            return this.node.getAttribute(attributeNames[name]);
         }
 
         if (typeof name === 'object') {
@@ -1257,23 +1259,24 @@ const V = (function() {
      */
     VPrototype.setAttribute = function(name, value) {
 
-        var el = this.node;
+        const el = this.node;
 
         if (value === null) {
             this.removeAttr(name);
             return this;
         }
 
-        var qualifiedName = V.qualifyAttr(name);
+        const trueName = attributeNames[name];
 
-        if (qualifiedName.ns) {
+        const { ns } = V.qualifyAttr(trueName);
+        if (ns) {
             // Attribute names can be namespaced. E.g. `image` elements
             // have a `xlink:href` attribute to set the source of the image.
-            el.setAttributeNS(qualifiedName.ns, name, value);
-        } else if (name === 'id') {
+            el.setAttributeNS(ns, trueName, value);
+        } else if (trueName === 'id') {
             el.id = value;
         } else {
-            el.setAttribute(name, value);
+            el.setAttribute(trueName, value);
         }
 
         return this;
@@ -1377,6 +1380,83 @@ const V = (function() {
 
         return xml;
     };
+
+    const _attributeNames = Object.create(null);
+
+    // List of attributes for which not to split camel case words.
+    [
+        'baseFrequency',
+        'baseProfile',
+        'clipPathUnits',
+        'contentScriptType',
+        'contentStyleType',
+        'diffuseConstant',
+        'edgeMode',
+        'externalResourcesRequired',
+        'filterRes', // deprecated
+        'filterUnits',
+        'gradientTransform',
+        'gradientUnits',
+        'kernelMatrix',
+        'kernelUnitLength',
+        'keyPoints',
+        'lengthAdjust',
+        'limitingConeAngle',
+        'markerHeight',
+        'markerUnits',
+        'markerWidth',
+        'maskContentUnits',
+        'maskUnits',
+        'numOctaves',
+        'pathLength',
+        'patternContentUnits',
+        'patternTransform',
+        'patternUnits',
+        'pointsAtX',
+        'pointsAtY',
+        'pointsAtZ',
+        'preserveAlpha',
+        'preserveAspectRatio',
+        'primitiveUnits',
+        'refX',
+        'refY',
+        'requiredExtensions',
+        'requiredFeatures',
+        'specularConstant',
+        'specularExponent',
+        'spreadMethod',
+        'startOffset',
+        'stdDeviation',
+        'stitchTiles',
+        'surfaceScale',
+        'systemLanguage',
+        'tableValues',
+        'targetX',
+        'targetY',
+        'textLength',
+        'viewBox',
+        'viewTarget', // deprecated
+        'xChannelSelector',
+        'yChannelSelector',
+        'zoomAndPan' // deprecated
+    ].forEach((name) => _attributeNames[name] = name);
+
+    const attributeNames = new Proxy(_attributeNames, {
+        get(cache, name) {
+            if (!V.supportCamelCaseAttributes) return name;
+            if (name in cache) {
+                return cache[name];
+            }
+            // Convert camel case to dash-separated words.
+            return (cache[name] = name.replace(/[A-Z]/g, '-$&').toLowerCase());
+        }
+    });
+
+    // Dictionary of attribute names
+    V.attributeNames = attributeNames;
+
+    // Should camel case attributes be supported?
+    V.supportCamelCaseAttributes = false;
 
     /**
      * @param {string} name

--- a/src/V/index.mjs
+++ b/src/V/index.mjs
@@ -1387,6 +1387,7 @@ const V = (function() {
     const _attributeNames = Object.create(null);
 
     // List of attributes for which not to split camel case words.
+    // It contains known SVG attribute names and may be extended with user-defined attribute names.
     [
         'baseFrequency',
         'baseProfile',
@@ -1446,6 +1447,10 @@ const V = (function() {
 
     const attributeNames = new Proxy(_attributeNames, {
         get(cache, name) {
+            // The cache is a dictionary of attribute names. See `_attributeNames` above.
+            // If the attribute name is not in the cache, it means that it is not
+            // a camel-case attribute name. In that case, we need to convert
+            // the attribute name to dash-separated words.
             if (!V.supportCamelCaseAttributes) return name;
             if (name in cache) {
                 return cache[name];

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -932,6 +932,11 @@ QUnit.module('vectorizer', function(hooks) {
                 V.supportCamelCaseAttributes = false;
             });
 
+            QUnit.test('constructor', function(assert) {
+                const vel = V('rect', { strokeWidth: 5 });
+                assert.equal(vel.node.getAttribute('stroke-width'), 5);
+            });
+
             QUnit.test('attr()', function(assert) {
                 const vel = V('rect');
                 vel.attr('strokeWidth', 5);
@@ -951,9 +956,8 @@ QUnit.module('vectorizer', function(hooks) {
             QUnit.test('removeAttr()', function(assert) {
                 const vel = V('rect');
                 vel.attr('strokeWidth', 5);
+                assert.equal(vel.node.getAttribute('stroke-width'), 5);
                 vel.removeAttr('strokeWidth');
-                assert.equal(vel.attr('strokeWidth'), null);
-                assert.equal(vel.attr('stroke-width'), null);
                 assert.equal(vel.node.getAttribute('stroke-width'), null);
             });
         });

--- a/test/vectorizer/vectorizer.js
+++ b/test/vectorizer/vectorizer.js
@@ -922,6 +922,42 @@ QUnit.module('vectorizer', function(hooks) {
             });
         });
 
+        QUnit.module('camel case support', function(hooks) {
+
+            hooks.before(function() {
+                V.supportCamelCaseAttributes = true;
+            });
+
+            hooks.after(function() {
+                V.supportCamelCaseAttributes = false;
+            });
+
+            QUnit.test('attr()', function(assert) {
+                const vel = V('rect');
+                vel.attr('strokeWidth', 5);
+                assert.equal(vel.attr('strokeWidth'), 5);
+                assert.equal(vel.attr('stroke-width'), 5);
+                assert.equal(vel.node.getAttribute('stroke-width'), 5);
+                vel.attr('stroke-width', 10);
+                assert.equal(vel.attr('strokeWidth'), 10);
+                assert.equal(vel.attr('stroke-width'), 10);
+                assert.equal(vel.node.getAttribute('stroke-width'), 10);
+                vel.attr('strokeWidth', null);
+                assert.equal(vel.attr('strokeWidth'), null);
+                assert.equal(vel.attr('stroke-width'), null);
+                assert.equal(vel.node.getAttribute('stroke-width'), null);
+            });
+
+            QUnit.test('removeAttr()', function(assert) {
+                const vel = V('rect');
+                vel.attr('strokeWidth', 5);
+                vel.removeAttr('strokeWidth');
+                assert.equal(vel.attr('strokeWidth'), null);
+                assert.equal(vel.attr('stroke-width'), null);
+                assert.equal(vel.node.getAttribute('stroke-width'), null);
+            });
+        });
+
         QUnit.test('remove simple', function(assert) {
 
             var a = V('a').attr('href', 'www.seznam.cz');


### PR DESCRIPTION
PR allows to use of both kebab-case and camel-case attribute names when setting/reading/removing attributes to/from SVGNodes.

```js
vel.attr('strokeWidth', 2);
vel.attr({ strokeOpacity: 0.5, stroke: 'red' });
vel.removeAttr('strokeWidth');
```

The feature needs to be enabled with `V.supportCamelCaseAttributes = true;`.
