### PR TITLE
fix(shapes.standard): fix cursor style on DoubleLink and ShadowLink

### DIFF
--- a/src/shapes/standard.mjs
+++ b/src/shapes/standard.mjs
@@ -598,7 +598,6 @@ export const Link = LinkBase.define('standard.Link', {
             stroke: '#333333',
             strokeWidth: 2,
             strokeLinejoin: 'round',
-            'xlink:fref': 'http://www.w3.org/1999/xlink',
             targetMarker: {
                 'type': 'path',
                 'd': 'M 10 -5 0 0 10 5 z',

--- a/src/shapes/standard.mjs
+++ b/src/shapes/standard.mjs
@@ -598,9 +598,10 @@ export const Link = LinkBase.define('standard.Link', {
             stroke: '#333333',
             strokeWidth: 2,
             strokeLinejoin: 'round',
+            'xlink:fref': 'http://www.w3.org/1999/xlink',
             targetMarker: {
                 'type': 'path',
-                'd': 'M 10 -5 0 0 10 5 z'
+                'd': 'M 10 -5 0 0 10 5 z',
             }
         },
         wrapper: {
@@ -654,13 +655,15 @@ export const DoubleLink = LinkBase.define('standard.DoubleLink', {
         tagName: 'path',
         selector: 'outline',
         attributes: {
-            'fill': 'none'
+            'fill': 'none',
+            'cursor': 'pointer',
         }
     }, {
         tagName: 'path',
         selector: 'line',
         attributes: {
-            'fill': 'none'
+            'fill': 'none',
+            'pointer-events': 'none'
         }
     }]
 });
@@ -708,13 +711,15 @@ export const ShadowLink = LinkBase.define('standard.ShadowLink', {
         tagName: 'path',
         selector: 'shadow',
         attributes: {
-            'fill': 'none'
+            'fill': 'none',
+            'pointer-events': 'none'
         }
     }, {
         tagName: 'path',
         selector: 'line',
         attributes: {
-            'fill': 'none'
+            'fill': 'none',
+            'cursor': 'pointer'
         }
     }]
 });

--- a/src/shapes/standard.mjs
+++ b/src/shapes/standard.mjs
@@ -600,7 +600,7 @@ export const Link = LinkBase.define('standard.Link', {
             strokeLinejoin: 'round',
             targetMarker: {
                 'type': 'path',
-                'd': 'M 10 -5 0 0 10 5 z',
+                'd': 'M 10 -5 0 0 10 5 z'
             }
         },
         wrapper: {
@@ -655,7 +655,7 @@ export const DoubleLink = LinkBase.define('standard.DoubleLink', {
         selector: 'outline',
         attributes: {
             'fill': 'none',
-            'cursor': 'pointer',
+            'cursor': 'pointer'
         }
     }, {
         tagName: 'path',


### PR DESCRIPTION
Unify cursor style for all `standard` links. Currently only `standard.Link` had its cursor set to `pointer`. This PR changes `standard.DoubleLink` and `standard.ShadowLink` to use the same cursor style.