### PR TITLE
types: expose fallbackRouter in ManhattanRouterArguments

### DIFF
--- a/docs/src/joint/api/routers/manhattan.html
+++ b/docs/src/joint/api/routers/manhattan.html
@@ -51,6 +51,11 @@
         <td><i>(point) => boolean</i></td>
         <td>A function that determines whether a given point is an obstacle or not. If used, the <i>padding</i>, <i>excludeEnds</i> and <i>excludeTypes</i> options are ignored.</td>
     </tr>
+    <tr>
+        <th>fallbackRouter</th>
+        <td><i>(vertices, options, linkView) => Array&lt;g.Point&gt;</i></td>
+        <td>A function that is called when the routing fails. Use this in situations where you need to retry routing with more relaxed options e.g. no start/endDirections constraints. The default fallbackRouter is an orthogonal router.</td>
+    </tr>    
 </table>
 
 <p>Example:</p>

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -3463,6 +3463,7 @@ export namespace routers {
         startDirections?: dia.OrthogonalDirection[];
         endDirections?: dia.OrthogonalDirection[];
         isPointObstacle?: (point: dia.Point) => boolean;
+        fallbackRouter: (vertices: dia.Point[], opts?: ManhattanRouterArguments, linkView?: dia.LinkView) => dia.Point[];
     }
 
     interface OrthogonalRouterArguments {


### PR DESCRIPTION
## Description

The manhattan router has an undocumented fallbackRouter option that defaults to "orthogonal". This PR exposes the option in ManhattanRouterArguments so it can be used by consumers and adds documentation for it.

In our app, we found it useful to provide a fallbackRouter that retries manhattan with more relaxed options before falling back to orthogonal. E.g. first manhattan tries with restricted start/end directions, while the second one uses all possible start/end directions.

