### PR TITLE
chore(Travis): update node and ubuntu dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
+dist: focal
 node_js:
-  - 16
+  - 18
 
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
## Description

- Bump `node` to version 18
- Bump `ubuntu` distribution to `20.04`
https://docs.travis-ci.com/user/reference/focal/

The following error occurs when updating to `node` 18, but with a lower `ubuntu` dist

<img width="1056" alt="Screenshot 2023-10-17 at 11 10 49" src="https://github.com/clientIO/joint/assets/42288565/ea57d2df-7821-4b39-a165-8a6c17291821">

### Additional Links about node/ubuntu for future reference
https://github.com/nodejs/node/issues/42351
https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909
https://travis-ci.community/t/npm-err-spin-is-not-a-valid-npm-option/13797

