### PR TITLE
docs(standard.InscribedImage): fix typo in code example

### DIFF
--- a/docs/src/joint/api/shapes/standard/InscribedImage.html
+++ b/docs/src/joint/api/shapes/standard/InscribedImage.html
@@ -35,7 +35,7 @@
     </tr>
 </table>
 
-<pre><code>var inscribedImage = new joint.shapes.standard.InscibedImage();
+<pre><code>const inscribedImage = new joint.shapes.standard.InscribedImage();
 inscribedImage.resize(150, 100);
 inscribedImage.position(225, 410);
 inscribedImage.attr('root/title', 'joint.shapes.standard.InscribedImage');


### PR DESCRIPTION
## Description

- Fix typo in `standard.InscribedImage` code example. 
