### PR TITLE
feat(dia.Paper): custom events on link label

### DIFF
--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2201,10 +2201,8 @@ export const Paper = View.extend({
                 view.preventDefaultInteraction(evt);
             }
 
-            const rootViewEl = view.el;
-
             // Custom event
-            const eventEvt = this.customEventTrigger(evt, rootViewEl);
+            const eventEvt = this.customEventTrigger(evt, view);
             if (eventEvt) {
             // `onevent` could have stopped propagation
                 if (eventEvt.isPropagationStopped()) return;
@@ -2548,7 +2546,7 @@ export const Paper = View.extend({
         if (this.guard(evt, view)) return;
 
         // Custom event
-        const eventEvt = this.customEventTrigger(evt, labelNode);
+        const eventEvt = this.customEventTrigger(evt, view, labelNode);
         if (eventEvt) {
             // `onevent` could have stopped propagation
             if (eventEvt.isPropagationStopped()) return;
@@ -3085,10 +3083,9 @@ export const Paper = View.extend({
         return id;
     },
 
-    customEventTrigger: function(evt, rootNode) {
+    customEventTrigger: function(evt, view, rootNode = view.el) {
 
         const eventNode = evt.target.closest('[event]');
-        const view = this.findView(rootNode);
 
         if (eventNode && rootNode !== eventNode && view.el.contains(eventNode)) {
             const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
@@ -3105,6 +3102,8 @@ export const Paper = View.extend({
 
             return eventEvt;
         }
+
+        return null;
     }
 
 }, {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2548,15 +2548,31 @@ export const Paper = View.extend({
     onlabel: function(evt) {
 
         var labelNode = evt.currentTarget;
+        const eventNode = evt.target.closest('[event]');
+
         var view = this.findView(labelNode);
-        if (view) {
+        if (!view) return;
 
-            evt = normalizeEvent(evt);
-            if (this.guard(evt, view)) return;
+        evt = normalizeEvent(evt);
+        if (this.guard(evt, view)) return;
 
-            var localPoint = this.snapToGrid(evt.clientX, evt.clientY);
-            view.onlabel(evt, localPoint.x, localPoint.y);
+        if (eventNode && labelNode !== eventNode && view.el.contains(eventNode)) {
+            const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
+                data: evt.data,
+                // Originally the event listener was attached to the event element.
+                currentTarget: eventNode
+            }));
+            this.onevent(eventEvt);
+            if (eventEvt.isDefaultPrevented()) {
+                evt.preventDefault();
+            }
+            // `onevent` can stop propagation
+            if (eventEvt.isPropagationStopped()) return;
+            evt.data = eventEvt.data;
         }
+
+        var localPoint = this.snapToGrid(evt.clientX, evt.clientY);
+        view.onlabel(evt, localPoint.x, localPoint.y);
     },
 
     getPointerArgs(evt) {

--- a/src/dia/Paper.mjs
+++ b/src/dia/Paper.mjs
@@ -2204,19 +2204,11 @@ export const Paper = View.extend({
             const rootViewEl = view.el;
 
             // Custom event
-            const eventNode = target.closest('[event]');
-            if (eventNode && rootViewEl !== eventNode && view.el.contains(eventNode)) {
-                const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
-                    data: evt.data,
-                    // Originally the event listener was attached to the event element.
-                    currentTarget: eventNode
-                }));
-                this.onevent(eventEvt);
-                if (eventEvt.isDefaultPrevented()) {
-                    evt.preventDefault();
-                }
-                // `onevent` can stop propagation
+            const eventEvt = this.customEventTrigger(evt, rootViewEl);
+            if (eventEvt) {
+            // `onevent` could have stopped propagation
                 if (eventEvt.isPropagationStopped()) return;
+
                 evt.data = eventEvt.data;
             }
 
@@ -2548,7 +2540,6 @@ export const Paper = View.extend({
     onlabel: function(evt) {
 
         var labelNode = evt.currentTarget;
-        const eventNode = evt.target.closest('[event]');
 
         var view = this.findView(labelNode);
         if (!view) return;
@@ -2556,18 +2547,12 @@ export const Paper = View.extend({
         evt = normalizeEvent(evt);
         if (this.guard(evt, view)) return;
 
-        if (eventNode && labelNode !== eventNode && view.el.contains(eventNode)) {
-            const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
-                data: evt.data,
-                // Originally the event listener was attached to the event element.
-                currentTarget: eventNode
-            }));
-            this.onevent(eventEvt);
-            if (eventEvt.isDefaultPrevented()) {
-                evt.preventDefault();
-            }
-            // `onevent` can stop propagation
+        // Custom event
+        const eventEvt = this.customEventTrigger(evt, labelNode);
+        if (eventEvt) {
+            // `onevent` could have stopped propagation
             if (eventEvt.isPropagationStopped()) return;
+
             evt.data = eventEvt.data;
         }
 
@@ -3098,6 +3083,28 @@ export const Paper = View.extend({
         markerContentVEl.appendTo(markerVEl);
         markerVEl.appendTo(defs);
         return id;
+    },
+
+    customEventTrigger: function(evt, rootNode) {
+
+        const eventNode = evt.target.closest('[event]');
+        const view = this.findView(rootNode);
+
+        if (eventNode && rootNode !== eventNode && view.el.contains(eventNode)) {
+            const eventEvt = normalizeEvent($.Event(evt.originalEvent, {
+                data: evt.data,
+                // Originally the event listener was attached to the event element.
+                currentTarget: eventNode
+            }));
+
+            this.onevent(eventEvt);
+
+            if (eventEvt.isDefaultPrevented()) {
+                evt.preventDefault();
+            }
+
+            return eventEvt;
+        }
     }
 
 }, {

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2940,4 +2940,54 @@ QUnit.module('paper', function(hooks) {
             });
         });
     });
+
+    QUnit.test('custom event with label link', function(assert) {
+
+        const event = 'link:label:pointerdown';
+
+        const link = new joint.shapes.standard.Link({
+            source: { x: 50, y: 50 },
+            target: { x: 300, y: 70 },
+            labels: [{
+                markup: [
+                    {
+                        tagName: 'rect',
+                        selector: 'labelBody'
+                    }, {
+                        tagName: 'text',
+                        selector: 'labelText'
+                    }
+                ],
+                attrs: {
+                    labelText: {
+                        text: 'Label',
+                        pointerEvents: 'none',
+                    },
+                    labelBody: {
+                        ref: 'text',
+                        width: 'calc(w)',
+                        height: 'calc(h)',
+                        fill: '#ffffff',
+                        stroke: 'black',
+                        event,
+                    }
+                },
+            }]
+        });
+
+        const { paper, graph } = this;
+
+        graph.addCell(link);
+
+        const spy = sinon.spy();
+        paper.on(event, spy);
+
+        const linkView = link.findView(paper);
+        const labelBody = linkView.el.querySelector('rect');
+
+        simulate.mousedown({ el: labelBody });
+
+        assert.equal(spy.callCount, 1);
+        assert.equal(spy.firstCall.args[0], linkView);
+    });
 });

--- a/test/jointjs/paper.js
+++ b/test/jointjs/paper.js
@@ -2980,14 +2980,21 @@ QUnit.module('paper', function(hooks) {
         graph.addCell(link);
 
         const spy = sinon.spy();
-        paper.on(event, spy);
+        paper.on('all', spy);
 
         const linkView = link.findView(paper);
         const labelBody = linkView.el.querySelector('rect');
 
-        simulate.mousedown({ el: labelBody });
+        simulate.mousedown({ el: labelBody, clientX: 10, clientY: 10 });
 
-        assert.equal(spy.callCount, 1);
-        assert.equal(spy.firstCall.args[0], linkView);
+        var localPoint = paper.snapToGrid(10, 10);
+        assert.ok(spy.calledThrice);
+        assert.ok(spy.calledWithExactly(
+            event,
+            linkView,
+            sinon.match.instanceOf($.Event),
+            localPoint.x,
+            localPoint.y
+        ));
     });
 });

--- a/types/joint.d.ts
+++ b/types/joint.d.ts
@@ -1757,6 +1757,8 @@ export namespace dia {
         protected insertView(cellView: CellView, isInitialInsert: boolean): void;
 
         protected detachView(cellView: CellView): void;
+
+        protected customEventTrigger(event: dia.Event, view: CellView, rootNode?: SVGElement): dia.Event | null;
     }
 
     namespace PaperLayer {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

In case a custom event is bound to the label of the link propagate it, so the appropriate listeners can react to it accordingly.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->
Related to the changes from #2110.

## Motivation and Context

Custom events that were declared on the label of a link like this:
```js
const link = new joint.shapes.standard.Link({
    source: { x: 50, y: 50 },
    target: { x: 300, y: 70 },
    labels: [{
        markup: [
            {
                tagName: 'rect',
                selector: 'labelBody'
            }, {
                tagName: 'text',
                selector: 'labelText'
            }
        ],
        attrs: {
            labelText: {
                text: 'Label',
                pointerEvents: 'none',
            },
            labelBody: {
                ref: 'text',
                width: 'calc(w)',
                height: 'calc(h)',
                fill: '#ffffff',
                stroke: 'black',
                event: 'link:label:pointerdown',
            }
        },
    }]
});
```
were not triggered after the `pointerdown` event was executed.