### PR TITLE
feat(highlighters.Opacity)!: add alphaValue option

### DIFF
--- a/packages/joint-core/css/layout.css
+++ b/packages/joint-core/css/layout.css
@@ -86,12 +86,6 @@ very thin.
 }
 /* Paper */
 
-/*  Highlighting  */
-.joint-highlight-opacity {
-    opacity: 0.3;
-}
-/*  Highlighting  */
-
 /*
 
 Vertex markers are `<circle>` elements that appear at connection vertex positions.

--- a/packages/joint-core/docs/src/joint/api/highlighters/opacity.html
+++ b/packages/joint-core/docs/src/joint/api/highlighters/opacity.html
@@ -1,8 +1,11 @@
 <p>Changes the opacity of an arbitrary cell view's SVG node.</p>
 
-<p>When a cell is highlighted with the opacity highlighter, the node determined by the selector is given the <code data-lang="css">.joint-highlight-opacity</code> class. To customize the look of this highlighted state, you can add custom CSS rules that affect this class name.</p>
-
-<p>This highlighter does not currently have any options.</p>
+<p>Available options:</p>
+<ul>
+    <li><b>alphaValue</b> - a value that represents the degree to which content behind an element is hidden. It's a number in the range 0.0 to 1.0, inclusive. The default is <code>0.3</code>.</li>
+</ul>
 
 <p>Example usage:</p>
-<pre><code>joint.highlighters.opacity.add(cellView, 'body', 'my-highlighter-id');</code></pre>
+<pre><code>joint.highlighters.opacity.add(cellView, 'body', 'my-highlighter-id', {
+  alphaValue: 0.4
+});</code></pre>

--- a/packages/joint-core/src/highlighters/opacity.mjs
+++ b/packages/joint-core/src/highlighters/opacity.mjs
@@ -1,5 +1,3 @@
-import * as util from '../util/index.mjs';
-import V from '../V/index.mjs';
 import { HighlighterView } from '../dia/HighlighterView.mjs';
 
 export const opacity = HighlighterView.extend({
@@ -7,14 +5,13 @@ export const opacity = HighlighterView.extend({
     UPDATABLE: false,
     MOUNTABLE: false,
 
-    opacityClassName: util.addClassNamePrefix('highlight-opacity'),
-
     highlight: function(_cellView, node) {
-        V(node).addClass(this.opacityClassName);
+        const { alphaValue = 0.3 } = this.options;
+        node.style.opacity = alphaValue;
     },
 
     unhighlight: function(_cellView, node) {
-        V(node).removeClass(this.opacityClassName);
+        node.style.opacity = '';
     }
 
 });

--- a/packages/joint-core/src/highlighters/stroke.mjs
+++ b/packages/joint-core/src/highlighters/stroke.mjs
@@ -8,6 +8,7 @@ export const stroke = HighlighterView.extend({
     className: 'highlight-stroke',
     attributes: {
         'pointer-events': 'none',
+        'vector-effect': 'non-scaling-stroke',
         'fill': 'none'
     },
 

--- a/packages/joint-core/src/highlighters/stroke.mjs
+++ b/packages/joint-core/src/highlighters/stroke.mjs
@@ -8,7 +8,6 @@ export const stroke = HighlighterView.extend({
     className: 'highlight-stroke',
     attributes: {
         'pointer-events': 'none',
-        'vector-effect': 'non-scaling-stroke',
         'fill': 'none'
     },
 

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -809,21 +809,22 @@ QUnit.module('HighlighterView', function(hooks) {
 
         QUnit.test('Highlight element by a selector', function(assert) {
 
-            var HighlighterView = joint.highlighters.opacity;
-            var id = 'highlighter-id';
-            var el = elementView.el.querySelector('[joint-selector="body"]');
+            const HighlighterView = joint.highlighters.opacity;
+            const id = 'highlighter-id';
+            const el = elementView.el.querySelector('[joint-selector="body"]');
+            const alphaValue = 0.67;
 
             assert.equal(getComputedStyle(el).opacity, 1);
 
             // Highlight
-            var highlighter = HighlighterView.add(elementView, 'body', id, { alphaValue: 0.67 });
+            const highlighter = HighlighterView.add(elementView, 'body', id, { alphaValue });
             assert.ok(highlighter instanceof HighlighterView);
-            assert.equal(getComputedStyle(el).opacity, 0.67);
+            assert.equal(getComputedStyle(el).opacity, alphaValue);
 
             // Render (Default will unhighlight and highlight)
             element.attr(['body', 'fill'], 'red', { dirty: true });
-            var el2 = elementView.el.querySelector('[joint-selector="body"]');
-            assert.equal(getComputedStyle(el2).opacity, 0.67);
+            const el2 = elementView.el.querySelector('[joint-selector="body"]');
+            assert.equal(getComputedStyle(el2).opacity, alphaValue);
 
             // Unhighlight
             joint.dia.HighlighterView.remove(elementView, id);

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -811,22 +811,23 @@ QUnit.module('HighlighterView', function(hooks) {
 
             var HighlighterView = joint.highlighters.opacity;
             var id = 'highlighter-id';
-            var el = elementView.vel.findOne('[joint-selector="body"]');
-            var className = 'joint-highlight-opacity';
+            var el = elementView.el.querySelector('[joint-selector="body"]');
+
+            assert.equal(getComputedStyle(el).opacity, 1);
 
             // Highlight
-            var highlighter = HighlighterView.add(elementView, 'body', id);
+            var highlighter = HighlighterView.add(elementView, 'body', id, { alphaValue: 0.67 });
             assert.ok(highlighter instanceof HighlighterView);
-            assert.ok(el.hasClass(className));
+            assert.equal(getComputedStyle(el).opacity, 0.67);
 
             // Render (Default will unhighlight and highlight)
             element.attr(['body', 'fill'], 'red', { dirty: true });
-            var el2 = elementView.vel.findOne('[joint-selector="body"]');
-            assert.ok(el2.hasClass(className));
+            var el2 = elementView.el.querySelector('[joint-selector="body"]');
+            assert.equal(getComputedStyle(el2).opacity, 0.67);
 
             // Unhighlight
             joint.dia.HighlighterView.remove(elementView, id);
-            assert.notOk(el.hasClass(className));
+            assert.equal(getComputedStyle(el2).opacity, 1);
         });
 
     });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1972,7 +1972,7 @@ export namespace highlighters {
     }
 
     interface OpacityHighlighterArguments extends HighlighterView.Options {
-
+        alphaValue?: number;
     }
 
     interface StrokeHighlighterArguments extends HighlighterView.Options {


### PR DESCRIPTION
## Description

Add `alphaValue` to `opacity` highlighter to control the value of transparency.

### Migration guide

Opacity no longer adds a CSS class to the node. It is set to `opacity` via the inline CSS style attribute. If `opacity` was set on a node via the inline attribute, the original value will be removed when the highlighter is removed.

If I add a highlighter to such a node, the `opacity` property will be removed along with the highlighter.
```svg
<rect style="opacity: 0.5"/>
```
In this case, everything works as before.
```svg
<rect opacity="0.5"/>
```

If you need to support the `opacity` in the inline style attribute, use `highlighter.addClass` instead.
```js
highlighters.addClass.add(cellView, selector, id, { className: 'highlight-opacity' });
```
```css
.highlight-opacity { opacity: 0.3 }
```


