### PR TITLE
feat(Vectorizer)!: support camel case attributes, add attributeNames static property

### DIFF
--- a/packages/joint-core/demo/flowchart/index.js
+++ b/packages/joint-core/demo/flowchart/index.js
@@ -277,8 +277,8 @@ paper.on('cell:mouseenter', (cellView, evt) => {
         padding,
         layer: dia.Paper.Layers.FRONT,
         attrs: {
-            'stroke-width': 1.5,
-            'stroke-linejoin': 'round',
+            strokeWidth: 1.5,
+            strokeLinejoin: 'round',
         }
     });
     frame.el.classList.add('jj-frame');

--- a/packages/joint-core/demo/links/src/custom-links.js
+++ b/packages/joint-core/demo/links/src/custom-links.js
@@ -58,11 +58,11 @@ var link1 = new joint.dia.Link({
             pointerEvents: 'none',
             strokeLinejoin: 'round',
             targetMarker: {
-                'type': 'path',
-                'fill': '#fe854f',
-                'stroke': 'black',
-                'stroke-width': 1,
-                'd': 'M 10 -3 10 -10 -2 0 10 10 10 3'
+                type: 'path',
+                fill: '#fe854f',
+                stroke: 'black',
+                strokeWidth: 1,
+                d: 'M 10 -3 10 -10 -2 0 10 10 10 3'
             }
         },
         p3: {
@@ -71,10 +71,10 @@ var link1 = new joint.dia.Link({
             fill: 'none',
             stroke: 'black',
             targetMarker: {
-                'type': 'path',
-                'fill': 'black',
-                'stroke': 'black',
-                'd': 'M 10 10 -2 0 10 -10'
+                type: 'path',
+                fill: 'black',
+                stroke: 'black',
+                d: 'M 10 10 -2 0 10 -10'
             }
         },
         sign: {

--- a/packages/joint-core/demo/links/src/links.js
+++ b/packages/joint-core/demo/links/src/links.js
@@ -24,14 +24,14 @@ var link1 = new joint.shapes.standard.Link({
         line: {
             stroke: '#222138',
             sourceMarker: {
-                'fill': '#31d0c6',
-                'stroke': 'none',
-                'd': 'M 5 -10 L -15 0 L 5 10 Z'
+                fill: '#31d0c6',
+                stroke: 'none',
+                d: 'M 5 -10 L -15 0 L 5 10 Z'
             },
             targetMarker: {
-                'fill': '#fe854f',
-                'stroke': 'none',
-                'd': 'M 5 -10 L -15 0 L 5 10 Z'
+                fill: '#fe854f',
+                stroke: 'none',
+                d: 'M 5 -10 L -15 0 L 5 10 Z'
             }
         }
     }
@@ -46,12 +46,12 @@ var link2 = new joint.shapes.standard.Link({
             strokeWidth: 4,
             sourceMarker: {
                 // if no fill or stroke specified, marker inherits the line color
-                'd': 'M 0 -5 L -10 0 L 0 5 Z'
+                d: 'M 0 -5 L -10 0 L 0 5 Z'
             },
             targetMarker: {
                 // the marker can be an arbitrary SVGElement
-                'type': 'circle',
-                'r': 5
+                type: 'circle',
+                r: 5
             }
         }
     }
@@ -78,14 +78,14 @@ var link3 = new joint.shapes.standard.Link({
             strokeWidth: 3,
             strokeDasharray: '5 2',
             sourceMarker: {
-                'stroke': '#31d0c6',
-                'fill': '#31d0c6',
-                'd': normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
+                stroke: '#31d0c6',
+                fill: '#31d0c6',
+                d: normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
             },
             targetMarker: {
-                'stroke': '#31d0c6',
-                'fill': '#31d0c6',
-                'd': normalizeMarker('M4.834,4.834L4.833,4.833c-5.889,5.892-5.89,15.443,0.001,21.334s15.44,5.888,21.33-0.002c5.891-5.891,5.893-15.44,0.002-21.33C20.275-1.056,10.725-1.056,4.834,4.834zM25.459,5.542c0.833,0.836,1.523,1.757,2.104,2.726l-4.08,4.08c-0.418-1.062-1.053-2.06-1.912-2.918c-0.859-0.859-1.857-1.494-2.92-1.913l4.08-4.08C23.7,4.018,24.622,4.709,25.459,5.542zM10.139,20.862c-2.958-2.968-2.959-7.758-0.001-10.725c2.966-2.957,7.756-2.957,10.725,0c2.954,2.965,2.955,7.757-0.001,10.724C17.896,23.819,13.104,23.817,10.139,20.862zM5.542,25.459c-0.833-0.837-1.524-1.759-2.105-2.728l4.081-4.081c0.418,1.063,1.055,2.06,1.914,2.919c0.858,0.859,1.855,1.494,2.917,1.913l-4.081,4.081C7.299,26.982,6.379,26.292,5.542,25.459zM8.268,3.435l4.082,4.082C11.288,7.935,10.29,8.571,9.43,9.43c-0.858,0.859-1.494,1.855-1.912,2.918L3.436,8.267c0.58-0.969,1.271-1.89,2.105-2.727C6.377,4.707,7.299,4.016,8.268,3.435zM22.732,27.563l-4.082-4.082c1.062-0.418,2.061-1.053,2.919-1.912c0.859-0.859,1.495-1.857,1.913-2.92l4.082,4.082c-0.58,0.969-1.271,1.891-2.105,2.728C24.623,26.292,23.701,26.983,22.732,27.563z', 10)
+                stroke: '#31d0c6',
+                fill: '#31d0c6',
+                d: normalizeMarker('M4.834,4.834L4.833,4.833c-5.889,5.892-5.89,15.443,0.001,21.334s15.44,5.888,21.33-0.002c5.891-5.891,5.893-15.44,0.002-21.33C20.275-1.056,10.725-1.056,4.834,4.834zM25.459,5.542c0.833,0.836,1.523,1.757,2.104,2.726l-4.08,4.08c-0.418-1.062-1.053-2.06-1.912-2.918c-0.859-0.859-1.857-1.494-2.92-1.913l4.08-4.08C23.7,4.018,24.622,4.709,25.459,5.542zM10.139,20.862c-2.958-2.968-2.959-7.758-0.001-10.725c2.966-2.957,7.756-2.957,10.725,0c2.954,2.965,2.955,7.757-0.001,10.724C17.896,23.819,13.104,23.817,10.139,20.862zM5.542,25.459c-0.833-0.837-1.524-1.759-2.105-2.728l4.081-4.081c0.418,1.063,1.055,2.06,1.914,2.919c0.858,0.859,1.855,1.494,2.917,1.913l-4.081,4.081C7.299,26.982,6.379,26.292,5.542,25.459zM8.268,3.435l4.082,4.082C11.288,7.935,10.29,8.571,9.43,9.43c-0.858,0.859-1.494,1.855-1.912,2.918L3.436,8.267c0.58-0.969,1.271-1.89,2.105-2.727C6.377,4.707,7.299,4.016,8.268,3.435zM22.732,27.563l-4.082-4.082c1.062-0.418,2.061-1.053,2.919-1.912c0.859-0.859,1.495-1.857,1.913-2.92l4.082,4.082c-0.58,0.969-1.271,1.891-2.105,2.728C24.623,26.292,23.701,26.983,22.732,27.563z', 10)
             }
         }
     }
@@ -100,20 +100,20 @@ var link4 = new joint.shapes.standard.Link({
             stroke: '#3c4260',
             strokeWidth: 2,
             sourceMarker: {
-                'fill': '#4b4a67',
-                'stroke': '#4b4a67',
-                'd': normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
+                fill: '#4b4a67',
+                stroke: '#4b4a67',
+                d: normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
             },
             targetMarker: {
-                'fill': '#4b4a67',
-                'stroke': '#4b4a67',
-                'd': normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
+                fill: '#4b4a67',
+                stroke: '#4b4a67',
+                d: normalizeMarker('M5.5,15.499,15.8,21.447,15.8,15.846,25.5,21.447,25.5,9.552,15.8,15.152,15.8,9.552z')
             },
             vertexMarker: {
-                'type': 'circle',
-                'r': 5,
-                'stroke-width': 2,
-                'fill': 'white'
+                type: 'circle',
+                r: 5,
+                strokeWidth: 2,
+                fill: 'white'
             }
         }
     }
@@ -129,14 +129,14 @@ var link5 = new joint.shapes.standard.Link({
             stroke: '#7c68fc',
             strokeWidth: 3,
             sourceMarker: {
-                'stroke': '#7c68fc',
-                'fill': '#7c68fc',
-                'd': normalizeMarker('M24.316,5.318,9.833,13.682,9.833,5.5,5.5,5.5,5.5,25.5,9.833,25.5,9.833,17.318,24.316,25.682z')
+                stroke: '#7c68fc',
+                fill: '#7c68fc',
+                d: normalizeMarker('M24.316,5.318,9.833,13.682,9.833,5.5,5.5,5.5,5.5,25.5,9.833,25.5,9.833,17.318,24.316,25.682z')
             },
             targetMarker: {
-                'stroke': '#feb663',
-                'fill': '#feb663',
-                'd': normalizeMarker('M14.615,4.928c0.487-0.986,1.284-0.986,1.771,0l2.249,4.554c0.486,0.986,1.775,1.923,2.864,2.081l5.024,0.73c1.089,0.158,1.335,0.916,0.547,1.684l-3.636,3.544c-0.788,0.769-1.28,2.283-1.095,3.368l0.859,5.004c0.186,1.085-0.459,1.553-1.433,1.041l-4.495-2.363c-0.974-0.512-2.567-0.512-3.541,0l-4.495,2.363c-0.974,0.512-1.618,0.044-1.432-1.041l0.858-5.004c0.186-1.085-0.307-2.6-1.094-3.368L3.93,13.977c-0.788-0.768-0.542-1.525,0.547-1.684l5.026-0.73c1.088-0.158,2.377-1.095,2.864-2.081L14.615,4.928z')
+                stroke: '#feb663',
+                fill: '#feb663',
+                d: normalizeMarker('M14.615,4.928c0.487-0.986,1.284-0.986,1.771,0l2.249,4.554c0.486,0.986,1.775,1.923,2.864,2.081l5.024,0.73c1.089,0.158,1.335,0.916,0.547,1.684l-3.636,3.544c-0.788,0.769-1.28,2.283-1.095,3.368l0.859,5.004c0.186,1.085-0.459,1.553-1.433,1.041l-4.495-2.363c-0.974-0.512-2.567-0.512-3.541,0l-4.495,2.363c-0.974,0.512-1.618,0.044-1.432-1.041l0.858-5.004c0.186-1.085-0.307-2.6-1.094-3.368L3.93,13.977c-0.788-0.768-0.542-1.525,0.547-1.684l5.026-0.73c1.088-0.158,2.377-1.095,2.864-2.081L14.615,4.928z')
             }
         }
     }
@@ -166,7 +166,7 @@ var link7 = new joint.shapes.standard.Link({
     attrs: {
         line: {
             targetMarker: {
-                'd': 'M 0 -5 L -10 0 L 0 5 Z'
+                d: 'M 0 -5 L -10 0 L 0 5 Z'
             }
         }
     },
@@ -320,11 +320,11 @@ var link9 = new joint.dia.Link({
             pointerEvents: 'none',
             strokeLinejoin: 'round',
             targetMarker: {
-                'type': 'path',
-                'fill': '#fe854f',
-                'stroke': 'black',
-                'stroke-width': 1,
-                'd': 'M 10 -3 10 -10 -2 0 10 10 10 3'
+                type: 'path',
+                fill: '#fe854f',
+                stroke: 'black',
+                strokeWidth: 1,
+                d: 'M 10 -3 10 -10 -2 0 10 10 10 3'
             }
         },
         sign: {
@@ -381,9 +381,9 @@ var link10 = new joint.shapes.standard.Link({
     attrs: {
         line: {
             sourceMarker: {
-                'd': 'M 0 0 15 0',
-                'stroke': 'white',
-                'stroke-width': 3
+                d: 'M 0 0 15 0',
+                stroke: 'white',
+                strokeWidth: 3
             }
         }
     }
@@ -430,20 +430,20 @@ var link11 = new joint.dia.Link({
             strokeWidth: 2,
             strokeLinejoin: 'round',
             sourceMarker: {
-                'type': 'circle',
-                'r': 5,
-                'cx': 5,
-                'fill': 'white',
-                'stroke': 'black',
-                'stroke-width': 2
+                type: 'circle',
+                r: 5,
+                cx: 5,
+                fill: 'white',
+                stroke: 'black',
+                strokeWidth: 2
             },
             targetMarker: {
-                'type': 'circle',
-                'r': 5,
-                'cx': 5,
-                'fill': 'white',
-                'stroke': 'black',
-                'stroke-width': 2
+                type: 'circle',
+                r: 5,
+                cx: 5,
+                fill: 'white',
+                stroke: 'black',
+                strokeWidth: 2
             }
         },
         endReferenceBody: {
@@ -522,20 +522,20 @@ var link12 = new joint.dia.Link({
             strokeWidth: 2,
             strokeLinejoin: 'round',
             sourceMarker: {
-                'type': 'circle',
-                'r': 5,
-                'cx': 5,
-                'fill': 'white',
-                'stroke': 'black',
-                'stroke-width': 2
+                type: 'circle',
+                r: 5,
+                cx: 5,
+                fill: 'white',
+                stroke: 'black',
+                strokeWidth: 2
             },
             targetMarker: {
-                'type': 'circle',
-                'r': 5,
-                'cx': 5,
-                'fill': 'white',
-                'stroke': 'black',
-                'stroke-width': 2
+                type: 'circle',
+                r: 5,
+                cx: 5,
+                fill: 'white',
+                stroke: 'black',
+                strokeWidth: 2
             }
         },
         crossing: {
@@ -564,12 +564,12 @@ var link13 = new joint.shapes.standard.Link({
             strokeWidth: 3,
             strokeDasharray: '3,1',
             sourceMarker: {
-                'd': 'M 0 -10 0 10',
-                'stroke-width': 3
+                d: 'M 0 -10 0 10',
+                strokeWidth: 3
             },
             targetMarker: {
-                'd': 'M 0 -10 0 10',
-                'stroke-width': 3
+                d: 'M 0 -10 0 10',
+                strokeWidth: 3
             }
         }
     }
@@ -613,20 +613,20 @@ var link14 = new joint.dia.Link({
             strokeDashoffset: 20,
             strokeWidth: 5,
             sourceMarker: {
-                'type': 'circle',
-                'r': 10,
-                'cx': 5,
-                'fill': '#fe854f',
-                'stroke': '#222138',
-                'stroke-width': 5
+                type: 'circle',
+                r: 10,
+                cx: 5,
+                fill: '#fe854f',
+                stroke: '#222138',
+                strokeWidth: 5
             },
             targetMarker: {
-                'type': 'circle',
-                'r': 10,
-                'cx': 5,
-                'fill': '#7c68fc',
-                'stroke': '#222138',
-                'stroke-width': 5
+                type: 'circle',
+                r: 10,
+                cx: 5,
+                fill: '#7c68fc',
+                stroke: '#222138',
+                strokeWidth: 5
             }
         }
     }
@@ -640,40 +640,40 @@ graph.resetCells([el1, link1, link2, link3, link4, link5, link6, link7, link8, l
 var RectangleSourceArrowhead = joint.linkTools.SourceArrowhead.extend({
     tagName: 'rect',
     attributes: {
-        'x': -15,
-        'y': -15,
-        'width': 30,
-        'height': 30,
-        'fill': 'black',
-        'fill-opacity': 0.3,
-        'stroke': 'black',
-        'stroke-width': 2,
-        'cursor': 'move',
-        'class': 'target-arrowhead'
+        x: -15,
+        y: -15,
+        width: 30,
+        height: 30,
+        fill: 'black',
+        fillOpacity: 0.3,
+        stroke: 'black',
+        strokeWidth: 2,
+        cursor: 'move',
+        class: 'target-arrowhead'
     }
 });
 
 var CircleTargetArrowhead = joint.linkTools.TargetArrowhead.extend({
     tagName: 'circle',
     attributes: {
-        'r': 20,
-        'fill': 'black',
-        'fill-opacity': 0.3,
-        'stroke': 'black',
-        'stroke-width': 2,
-        'cursor': 'move',
-        'class': 'target-arrowhead'
+        r: 20,
+        fill: 'black',
+        fillOpacity: 0.3,
+        stroke: 'black',
+        strokeWidth: 2,
+        cursor: 'move',
+        class: 'target-arrowhead'
     }
 });
 
 var CustomBoundary = joint.linkTools.Boundary.extend({
     attributes: {
-        'fill': '#7c68fc',
-        'fill-opacity': 0.2,
-        'stroke': '#33334F',
-        'stroke-width': .5,
-        'stroke-dasharray': '5, 5',
-        'pointer-events': 'none'
+        fill: '#7c68fc',
+        fillOpacity: 0.2,
+        stroke: '#33334F',
+        strokeWidth: .5,
+        strokeDasharray: '5, 5',
+        pointerEvents: 'none'
     },
 });
 
@@ -698,23 +698,23 @@ paper.on('link:mouseenter', function(linkView) {
                         tagName: 'circle',
                         selector: 'button',
                         attributes: {
-                            'r': 7,
-                            'stroke': '#fe854f',
-                            'stroke-width': 3,
-                            'fill': 'white',
-                            'cursor': 'pointer'
+                            r: 7,
+                            stroke: '#fe854f',
+                            strokeWidth: 3,
+                            fill: 'white',
+                            cursor: 'pointer'
                         }
                     }, {
                         tagName: 'text',
                         textContent: 'B',
                         selector: 'icon',
                         attributes: {
-                            'fill': '#fe854f',
-                            'font-size': 10,
-                            'text-anchor': 'middle',
-                            'font-weight': 'bold',
-                            'pointer-events': 'none',
-                            'y': '0.3em'
+                            fill: '#fe854f',
+                            fontSize: 10,
+                            textAnchor: 'middle',
+                            fontWeight: 'bold',
+                            pointerEvents: 'none',
+                            y: '0.3em'
                         }
                     }],
                     distance: -30,
@@ -731,23 +731,23 @@ paper.on('link:mouseenter', function(linkView) {
                         tagName: 'circle',
                         selector: 'button',
                         attributes: {
-                            'r': 7,
-                            'stroke': '#fe854f',
-                            'stroke-width': 3,
-                            'fill': 'white',
-                            'cursor': 'pointer'
+                            r: 7,
+                            stroke: '#fe854f',
+                            strokeWidth: 3,
+                            fill: 'white',
+                            cursor: 'pointer'
                         }
                     }, {
                         tagName: 'text',
                         textContent: 'A',
                         selector: 'icon',
                         attributes: {
-                            'fill': '#fe854f',
-                            'font-size': 10,
-                            'text-anchor': 'middle',
-                            'font-weight': 'bold',
-                            'pointer-events': 'none',
-                            'y': '0.3em'
+                            fill: '#fe854f',
+                            fontSize: 10,
+                            textAnchor: 'middle',
+                            fontWeight: 'bold',
+                            pointerEvents: 'none',
+                            y: '0.3em'
                         }
                     }],
                     distance: -50,

--- a/packages/joint-core/docs/src/vectorizer/api/V/attributeNames.html
+++ b/packages/joint-core/docs/src/vectorizer/api/V/attributeNames.html
@@ -1,0 +1,19 @@
+
+<pre class="docs-method-signature"><code>V.attributeNames</code></pre>
+<p>A map of attribute names. It maps JavaScript attribute names to the SVG attributes names.</p>
+
+<pre><code>// SVG dash-case attributes
+V.attributeNames['stroke-width'] // `stroke-width'
+V.attributeNames['strokeWidth'] // `stroke-width'
+
+// SVG came-case attributes
+V.attributeNames['pathLength'] // `pathLength` as defined in SVG
+
+// Custom attributes are always dash-case
+V.attributeNames['myAttribute'] // `my-attribute`
+V('g').attr('myAttribute', 'myValue') // &lt;g my-attribute="myValue"&gt;&lt;/g&gt;</code></pre>
+
+<p>It is possible to add custom attribute names to the map. For example:</p>
+
+<pre><code>V.attributeNames['myAttribute'] = 'myAttribute';
+V('g').attr('myAttribute', 'myValue') // &lt;g myAttribute="myValue"&gt;&lt;/g&gt;</code></pre>

--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -1460,18 +1460,17 @@ const V = (function() {
         }
     });
 
-    // Note: The `attributeNames` and `supportCamelCaseAttributes` properties are not enumerable
-    // in this version to avoid breaking changes. They will be made enumerable in the next major version.
-
     // Dictionary of attribute names
     Object.defineProperty(V, 'attributeNames', {
+        enumerable: true,
         value: attributeNames,
         writable: false,
     });
 
     // Should camel case attributes be supported?
     Object.defineProperty(V, 'supportCamelCaseAttributes', {
-        value: false,
+        enumerable: true,
+        value: true,
         writable: true,
     });
 

--- a/packages/joint-core/src/highlighters/mask.mjs
+++ b/packages/joint-core/src/highlighters/mask.mjs
@@ -147,8 +147,8 @@ export const mask = HighlighterView.extend({
 
         const { VISIBLE, INVISIBLE, options } = this;
         const { padding, attrs } = options;
-
-        const strokeWidth = ('stroke-width' in attrs) ? attrs['stroke-width'] : 1;
+        // support both `strokeWidth` and `stroke-width` attribute names
+        const strokeWidth = parseFloat(V('g').attr(attrs).attr('stroke-width'));
         const hasNodeFill = vNode.attr('fill') !== 'none';
         let magnetStrokeWidth = parseFloat(vNode.attr('stroke-width'));
         if (isNaN(magnetStrokeWidth)) magnetStrokeWidth = 1;

--- a/packages/joint-core/test/vectorizer/vectorizer.js
+++ b/packages/joint-core/test/vectorizer/vectorizer.js
@@ -143,6 +143,30 @@ QUnit.module('vectorizer', function(hooks) {
         assert.notOk(V.isSVGGraphicsElement(svgLinearGradient));
     });
 
+    QUnit.test('V.attributeNames', function(assert) {
+        // kebab-case
+        assert.equal(V.attributeNames['stroke-width'], 'stroke-width');
+        assert.equal(V.attributeNames['strokeWidth'], 'stroke-width');
+        assert.equal(V.attributeNames['stroke'], 'stroke');
+        // camel-case
+        assert.equal(V.attributeNames['pathLength'], 'pathLength');
+        // custom
+        assert.equal(V.attributeNames['custom-attribute'], 'custom-attribute');
+        assert.equal(V.attributeNames['customAttribute'], 'custom-attribute');
+        const g1 = V('g').attr('customAttribute', 'value');
+        assert.equal(g1.attr('customAttribute'), 'value');
+        assert.equal(g1.node.getAttribute('custom-attribute'), 'value');
+        assert.equal(g1.node.getAttribute('customAttribute'), null);
+        // custom override
+        V.attributeNames['customAttribute'] = 'customAttribute';
+        assert.equal(V.attributeNames['custom-attribute'], 'custom-attribute');
+        assert.equal(V.attributeNames['customAttribute'], 'customAttribute');
+        const g2 = V('g').attr('customAttribute', 'value');
+        assert.equal(g2.attr('customAttribute'), 'value');
+        assert.equal(g2.node.getAttribute('customAttribute'), 'value');
+        assert.equal(g2.node.getAttribute('custom-attribute'), null);
+    });
+
     QUnit.test('index()', function(assert) {
 
         // svg container

--- a/packages/joint-core/tutorials/custom-links.html
+++ b/packages/joint-core/tutorials/custom-links.html
@@ -256,11 +256,7 @@ graph.getLinks()[0].appendLabel({
                 not JointJS attrs.
                 This means that JointJS special attributes are not recognized (since <code>markup.attributes</code> are not
                 supposed to change, they would not be able to reflect possible changes in referenced subelements or in the
-                size/position of model bbox).
-                Additionally, this means that there is no JointJS kebab-case translation of attribute names; thus, using
-                quotes around all attribute names is encouraged in this context, to communicate these restrictions to
-                programmers (i.e. <code>'fill'</code>, not <code>fill</code>; <code>'pointer-events'</code>, not
-                <code>pointerEvents</code>).</p>
+                size/position of model bbox).</p>
 
             <h3 id="default-attributes">Default Attributes</h3>
 

--- a/packages/joint-core/types/vectorizer.d.ts
+++ b/packages/joint-core/types/vectorizer.d.ts
@@ -318,4 +318,8 @@ interface VStatic {
     toNode(el: SVGElement | VElement | SVGElement[]): SVGElement;
 
     prototype: VElement;
+
+    attributeNames: { [key: string]: string };
+
+    supportCamelCaseAttributes: boolean;
 }


### PR DESCRIPTION
## Description

The PR enables the camel case attribute support by default and makes the `attributeNames` property public.
The `supportCamelCaseAttributes` property remains private.

Before:
```js
V('g').attr('myAttribute', 'value') // <g myAttribute="value"/>
```

Now:
```js
V('g').attr('myAttribute', 'value') // <g my-attribute="value"/>
```

Allows you to use camel case attribute names anywhere in JointJS. e.g `targetMarker`, `mvc.View.prototype.attributes`

### Migration guide

If you need any attribute to stay camel cased, you have to define it through `attributeNames` property.

```js
V.attributeNames['myAttribute'] = 'myAttribute';
V('g').attr('myAttribute', 'value') // <g myAttribute="value"/>
```


