### PR TITLE
fix(examples): webpack css import fix, package.json cleanup, small chores

### DIFF
--- a/examples/decorators/.gitignore
+++ b/examples/decorators/.gitignore
@@ -1,10 +1,3 @@
-src/*.js
+build/
 dist/
 node_modules/
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/examples/decorators/index.html
+++ b/examples/decorators/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS Decorators demo serves as a template to help bring your idea to life in no time.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS Decorators demo serves as a template to help bring your idea to life in no time."/>
     <title>Decorators | JointJS</title>
-    <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
   </head>
   <body>
     <div id="paper"></div>

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -31,6 +31,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/decorators/src/index.ts
+++ b/examples/decorators/src/index.ts
@@ -1,6 +1,8 @@
 import { g, dia, shapes } from 'jointjs';
 import { Model, View, On, SVGAttribute, Function } from '@joint/decorators';
 
+import 'jointjs/dist/joint.css';
+
 const shapeNamespace = {
     ...shapes,
 }

--- a/examples/decorators/webpack.config.js
+++ b/examples/decorators/webpack.config.js
@@ -14,10 +14,11 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts$/, loader: 'ts-loader' },
             { test: /\.svg$/, loader: 'raw-loader' },
             {
                 test: /\.css$/,
+                sideEffects: true,
                 use: [
                     'style-loader',
                     'css-loader'

--- a/examples/dwdm/.gitignore
+++ b/examples/dwdm/.gitignore
@@ -1,10 +1,3 @@
-src/*.js
+build/
 dist/
 node_modules/
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/examples/dwdm/index.html
+++ b/examples/dwdm/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS DWDM demo serves as a template to help bring your idea to life in no time.">
-    <title>Dense wavelength-division multiplexing | JointJS</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS DWDM demo serves as a template to help bring your idea to life in no time."/>
+    <title>Dense Wavelength-Division Multiplexing | JointJS</title>
   </head>
   <body>
     <div id="paper"></div>

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -20,10 +20,6 @@
     "jointjs": "workspace:^"
   },
   "devDependencies": {
-    "@types/dagre": "~0.7.47",
-    "@types/graphlib": "~2.1.8",
-    "@types/jquery": "~3.5.13",
-    "@types/lodash": "~4.14.178",
     "css-loader": "^3.6.0",
     "style-loader": "^1.3.0",
     "ts-loader": "^9.2.5",
@@ -33,6 +29,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/dwdm/tsconfig.json
+++ b/examples/dwdm/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": false,
-        "sourceMap": false
+        "sourceMap": false,
+        "outDir": "./build"
     }
 }

--- a/examples/dwdm/webpack.config.js
+++ b/examples/dwdm/webpack.config.js
@@ -14,10 +14,11 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts$/, loader: 'ts-loader' },
             { test: /\.svg$/, loader: 'raw-loader' },
             {
                 test: /\.css$/,
+                sideEffects: true,
                 use: [
                     'style-loader',
                     'css-loader'

--- a/examples/isometric/.gitignore
+++ b/examples/isometric/.gitignore
@@ -1,9 +1,3 @@
+build/
 dist/
 node_modules/
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/examples/isometric/index.html
+++ b/examples/isometric/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS Isometric demo serves as a template to help bring your idea to life in no time.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS Isometric demo serves as a template to help bring your idea to life in no time."/>
     <title>Isometric Diagram | JointJS</title>
   </head>
   <body>

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -31,6 +31,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/isometric/src/index.ts
+++ b/examples/isometric/src/index.ts
@@ -174,4 +174,3 @@ paper.on('blank:pointermove', (evt) => {
 paper.on('blank:pointerup', () => {
     paper.el.style.cursor = 'grab';
 });
-

--- a/examples/isometric/tsconfig.json
+++ b/examples/isometric/tsconfig.json
@@ -5,5 +5,6 @@
         "noImplicitAny": false,
         "sourceMap": false,
         "experimentalDecorators": true,
+        "outDir": "./build"
     }
 }

--- a/examples/isometric/webpack.config.js
+++ b/examples/isometric/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts$/, loader: 'ts-loader' },
             { test: /\.svg$/, loader: 'raw-loader' },
             {
                 test: /\.css$/,

--- a/examples/list/.gitignore
+++ b/examples/list/.gitignore
@@ -1,10 +1,3 @@
-src/*.js
+build/
 dist/
 node_modules/
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/examples/list/index.html
+++ b/examples/list/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html style="height:100%;">
+<html lang="en" style="height:100%;">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS List Items demo serves as a template to help bring your idea to life in no time.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS List Items demo serves as a template to help bring your idea to life in no time."/>
     <title>List Items | JointJS</title>
-    <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
   </head>
   <body style="height:100%;display:flex;justify-content:center;align-items:center;margin:0;overflow-y:hidden;">
     <div id="paper"></div>

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -20,6 +20,8 @@
     "jointjs": "workspace:^"
   },
   "devDependencies": {
+    "css-loader": "3.5.3",
+    "style-loader": "1.2.1",
     "ts-loader": "^9.2.5",
     "typescript": "^4.4.3",
     "webpack": "^5.61.0",
@@ -27,6 +29,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/list/src/index.ts
+++ b/examples/list/src/index.ts
@@ -1,5 +1,7 @@
 import { dia, shapes, g, linkTools, util } from 'jointjs';
 
+import 'jointjs/dist/joint.css';
+
 const GRID_SIZE = 8;
 const PADDING_S = GRID_SIZE;
 const PADDING_L = GRID_SIZE * 2;

--- a/examples/list/tsconfig.json
+++ b/examples/list/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": false,
-        "sourceMap": false
+        "sourceMap": false,
+        "outDir": "./build"
     }
 }

--- a/examples/list/webpack.config.js
+++ b/examples/list/webpack.config.js
@@ -13,7 +13,12 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' }
+            { test: /\.ts$/, loader: 'ts-loader' },
+            {
+                test: /\.css$/,
+                sideEffects: true,
+                use: ['style-loader', 'css-loader'],
+            }
         ]
     },
     devServer: {

--- a/examples/shapes-general/.gitignore
+++ b/examples/shapes-general/.gitignore
@@ -1,10 +1,3 @@
-src/*.js
+build/
 dist/
 node_modules/
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/examples/shapes-general/index.html
+++ b/examples/shapes-general/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS General Shapes demo serves as a template to help bring your idea to life in no time.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS General Shapes demo serves as a template to help bring your idea to life in no time."/>
     <title>General Shapes | JointJS</title>
-    <link rel="stylesheet" type="text/css" href="node_modules/jointjs/dist/joint.css" />
   </head>
   <body>
     <div id="paper"></div>

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -32,6 +32,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/shapes-general/src/index.ts
+++ b/examples/shapes-general/src/index.ts
@@ -31,6 +31,8 @@ import {
     CardOffsetControl,
 } from '@joint/shapes-general-tools';
 
+import 'jointjs/dist/joint.css';
+
 const namespace = {
     LinkedProcess,
     Input,

--- a/examples/shapes-general/webpack.config.js
+++ b/examples/shapes-general/webpack.config.js
@@ -14,10 +14,11 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts$/, loader: 'ts-loader' },
             { test: /\.svg$/, loader: 'raw-loader' },
             {
                 test: /\.css$/,
+                sideEffects: true,
                 use: [
                     'style-loader',
                     'css-loader'

--- a/examples/tree-of-life/.gitignore
+++ b/examples/tree-of-life/.gitignore
@@ -1,3 +1,3 @@
-package-lock.json
-src/*.js
+build/
 dist/
+node_modules/

--- a/examples/tree-of-life/index.html
+++ b/examples/tree-of-life/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html style="height:100%;">
+<html lang="en" style="height:100%;">
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The JointJS Tree of life demo serves as a template to help bring your idea to life in no time.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS Tree of Life demo serves as a template to help bring your idea to life in no time."/>
     <title>The Tree of Life | JointJS</title>
   </head>
   <body>

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -29,6 +29,8 @@
     "webpack-dev-server": "^4.2.1"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
   }
 }

--- a/examples/tree-of-life/tsconfig.json
+++ b/examples/tree-of-life/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": false,
-        "sourceMap": false
+        "sourceMap": false,
+        "outDir": "./build"
     }
 }

--- a/examples/tree-of-life/webpack.config.js
+++ b/examples/tree-of-life/webpack.config.js
@@ -13,9 +13,10 @@ module.exports = {
     mode: 'development',
     module: {
         rules: [
-            { test: /\.ts?$/, loader: 'ts-loader' },
+            { test: /\.ts$/, loader: 'ts-loader' },
             {
                 test: /\.css$/,
+                sideEffects: true,
                 use: [
                     'style-loader',
                     'css-loader'

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,10 +123,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@joint/demo-dwdm@workspace:examples/dwdm"
   dependencies:
-    "@types/dagre": ~0.7.47
-    "@types/graphlib": ~2.1.8
-    "@types/jquery": ~3.5.13
-    "@types/lodash": ~4.14.178
     css-loader: ^3.6.0
     jointjs: "workspace:^"
     style-loader: ^1.3.0
@@ -159,7 +155,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@joint/demo-list@workspace:examples/list"
   dependencies:
+    css-loader: 3.5.3
     jointjs: "workspace:^"
+    style-loader: 1.2.1
     ts-loader: ^9.2.5
     typescript: ^4.4.3
     webpack: ^5.61.0
@@ -418,13 +416,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dagre@npm:~0.7.47":
-  version: 0.7.48
-  resolution: "@types/dagre@npm:0.7.48"
-  checksum: 9d06fc08219056db7c55041bf2099cea24fe824d8c8741ae11c365c7464502d8c65273153446a5546b4a92bc0833802ac1c6bddb708bfcaa75af3963e7fc84aa
-  languageName: node
-  linkType: hard
-
 "@types/dagre@npm:~0.7.50":
   version: 0.7.52
   resolution: "@types/dagre@npm:0.7.52"
@@ -497,13 +488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graphlib@npm:~2.1.8":
-  version: 2.1.8
-  resolution: "@types/graphlib@npm:2.1.8"
-  checksum: ca0285c30e76626c7d63942057e21d45a6c85a4f1b7add5ed892b6a02bad12ce3c7e927c7d56fbb7daf3ff286eae2dcc8e0f475a6c6104b99ae49b888d2fa883
-  languageName: node
-  linkType: hard
-
 "@types/graphlib@npm:~2.1.9":
   version: 2.1.11
   resolution: "@types/graphlib@npm:2.1.11"
@@ -527,15 +511,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jquery@npm:~3.5.13":
-  version: 3.5.16
-  resolution: "@types/jquery@npm:3.5.16"
-  dependencies:
-    "@types/sizzle": "*"
-  checksum: 13c995f15d1c2f1d322103dc1cb0a22b95eecc3e7546f00279b8731aea21d7ec04550af40e609ee48e755d4e11bf61c25b4aa9f53df3bcbec4b8fe8e81471732
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8":
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
@@ -547,13 +522,6 @@ __metadata:
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
   checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:~4.14.178":
-  version: 4.14.191
-  resolution: "@types/lodash@npm:4.14.191"
-  checksum: ba0d5434e10690869f32d5ea49095250157cae502f10d57de0a723fd72229ce6c6a4979576f0f13e0aa9fbe3ce2457bfb9fa7d4ec3d6daba56730a51906d1491
   languageName: node
   linkType: hard
 
@@ -640,13 +608,6 @@ __metadata:
     "@types/mime": "*"
     "@types/node": "*"
   checksum: 15c261dbfc57890f7cc17c04d5b22b418dfa0330c912b46c5d8ae2064da5d6f844ef7f41b63c7f4bbf07675e97ebe6ac804b032635ec742ae45d6f1274259b3e
-  languageName: node
-  linkType: hard
-
-"@types/sizzle@npm:*":
-  version: 2.3.3
-  resolution: "@types/sizzle@npm:2.3.3"
-  checksum: 586a9fb1f6ff3e325e0f2cc1596a460615f0bc8a28f6e276ac9b509401039dd242fa8b34496d3a30c52f5b495873922d09a9e76c50c2ab2bcc70ba3fb9c4e160
   languageName: node
   linkType: hard
 
@@ -3166,6 +3127,29 @@ __metadata:
     semver: ^5.4.1
     xml2js: ^0.4.19
   checksum: 79659760f01c7db01e2ef8394329397782c91c556ff6102e2dd3b6a87ddfb7bddaf6a26fa000fafa00e9217e3e11e48ad3fc0fadeaa6a6d761eb525fffeb79a0
+  languageName: node
+  linkType: hard
+
+"css-loader@npm:3.5.3":
+  version: 3.5.3
+  resolution: "css-loader@npm:3.5.3"
+  dependencies:
+    camelcase: ^5.3.1
+    cssesc: ^3.0.0
+    icss-utils: ^4.1.1
+    loader-utils: ^1.2.3
+    normalize-path: ^3.0.0
+    postcss: ^7.0.27
+    postcss-modules-extract-imports: ^2.0.0
+    postcss-modules-local-by-default: ^3.0.2
+    postcss-modules-scope: ^2.2.0
+    postcss-modules-values: ^3.0.0
+    postcss-value-parser: ^4.0.3
+    schema-utils: ^2.6.6
+    semver: ^6.3.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: e5fa1707d77fcb30bacf4fc4fd7b41c7f95051c7e62767a93df36cf3e4b942f761b61ef61cfd84abc071fe0a17e135b684a10f75a321696b9627f85aef5a1092
   languageName: node
   linkType: hard
 
@@ -9199,14 +9183,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.0.3, postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
   languageName: node
   linkType: hard
 
-"postcss@npm:^7.0.14, postcss@npm:^7.0.32, postcss@npm:^7.0.5, postcss@npm:^7.0.6":
+"postcss@npm:^7.0.14, postcss@npm:^7.0.27, postcss@npm:^7.0.32, postcss@npm:^7.0.5, postcss@npm:^7.0.6":
   version: 7.0.39
   resolution: "postcss@npm:7.0.39"
   dependencies:
@@ -10309,7 +10293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^2.7.0":
+"schema-utils@npm:^2.6.6, schema-utils@npm:^2.7.0":
   version: 2.7.1
   resolution: "schema-utils@npm:2.7.1"
   dependencies:
@@ -11302,6 +11286,18 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
+"style-loader@npm:1.2.1":
+  version: 1.2.1
+  resolution: "style-loader@npm:1.2.1"
+  dependencies:
+    loader-utils: ^2.0.0
+    schema-utils: ^2.6.6
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: cd30484665c9b7a32e9505fafa7494ce2ea868eb9cdaa4c7c7da78ff1990cc18795e90545377004420e827ce82ace5a21c44212fa3844bbdc1debe58523ead7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- use `sideEffects: true` in webpack to enable css import inside javascript
- cleanup all package.json files - remove references to dagre, graphlib, jquery, lodash
- cleanup all .gitignore files - remove references to yarn
- provide `"outDir": "./build"` in all tsconfig.json files
- add explicit volta specification to all package.json files
- index.html harmonization across examples
- webpack rules harmonization across examples
