### PR TITLE
refactor(dia.Link)!: remove legacy attributes from the default label d…

### DIFF
--- a/packages/joint-core/docs/src/joint/api/dia/Link/intro.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Link/intro.html
@@ -334,8 +334,8 @@ var link = new CustomLink({
             ry: 3,
             x: 'calc(x)',
             y: 'calc(y)',
-            width: 'calc(width)',
-            height: 'calc(height)'
+            width: 'calc(w)',
+            height: 'calc(h)'
         }
     },
     // built-in default position:

--- a/packages/joint-core/docs/src/joint/api/dia/Link/intro.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Link/intro.html
@@ -324,7 +324,7 @@ var link = new CustomLink({
             fill: '#000000',
             fontSize: 14,
             textAnchor: 'middle',
-            yAlignment: 'middle',
+            textVerticalAnchor: 'middle',
             pointerEvents: 'none'
         },
         rect: {
@@ -332,10 +332,10 @@ var link = new CustomLink({
             fill: '#ffffff',
             rx: 3,
             ry: 3,
-            refWidth: 1,
-            refHeight: 1,
-            refX: 0,
-            refY: 0
+            x: 'calc(x)',
+            y: 'calc(y)',
+            width: 'calc(width)',
+            height: 'calc(height)'
         }
     },
     // built-in default position:

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -95,8 +95,8 @@ export const Link = Cell.extend({
                     ry: 3,
                     x: 'calc(x)',
                     y: 'calc(y)',
-                    width: 'calc(width)',
-                    height: 'calc(height)'
+                    width: 'calc(w)',
+                    height: 'calc(h)'
                 }
             },
             // builtin default position:

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -85,7 +85,7 @@ export const Link = Cell.extend({
                     fill: '#000000',
                     fontSize: 14,
                     textAnchor: 'middle',
-                    yAlignment: 'middle',
+                    textVerticalAnchor: 'middle',
                     pointerEvents: 'none'
                 },
                 rect: {
@@ -93,10 +93,10 @@ export const Link = Cell.extend({
                     fill: '#ffffff',
                     rx: 3,
                     ry: 3,
-                    refWidth: 1,
-                    refHeight: 1,
-                    refX: 0,
-                    refY: 0
+                    x: 'calc(x)',
+                    y: 'calc(y)',
+                    width: 'calc(width)',
+                    height: 'calc(height)'
                 }
             },
             // builtin default position:


### PR DESCRIPTION
## Description

Replace legacy attributes in the default label definition:

`yAlignment` -> `textVerticalAnchor`
`refX` -> `x`
`refY` ->`y`
`refWidth` -> `width`
`refHeight` -> `height`

### Migration guide

If you were changing any of the label legacy attributes (left-side) in your application, you should change it to its new form (right-side).


