### PR TITLE
refactor(dia.Link)!: remove smooth and manhattan attributes

### DIFF
--- a/packages/joint-core/demo/archive/fsa/src/fsa.js
+++ b/packages/joint-core/demo/archive/fsa/src/fsa.js
@@ -60,7 +60,6 @@ const EndState = joint.dia.Element.define('fsa.EndState', {
 
 const Arrow = joint.dia.Link.define('fsa.Arrow', {
     attrs: { '.marker-target': { d: 'M 10 0 L 0 5 L 10 10 z' }},
-    smooth: true
 });
 
 const shapes = {

--- a/packages/joint-core/demo/links/src/links.js
+++ b/packages/joint-core/demo/links/src/links.js
@@ -123,7 +123,7 @@ var link5 = new joint.shapes.standard.Link({
     source: { x: 440, y: 100 },
     target: { x: 740, y: 100 },
     vertices: [{ x: 400, y: 140 }, { x: 550, y: 100 }, { x: 600, y: 140 }],
-    smooth: true,
+    connector: { name: 'smooth' },
     attrs: {
         line: {
             stroke: '#7c68fc',
@@ -242,7 +242,7 @@ var link8 = new joint.shapes.standard.ShadowLink({
     source: { x: 10, y: 280 },
     target: { x: 440, y: 280 },
     vertices: [{ x: 150, y: 350 }, { x: 300, y: 280 }],
-    smooth: true,
+    connector: { name: 'smooth' },
     markup: [{
         tagName: 'path',
         selector: 'shadow',

--- a/packages/joint-core/docs/demo/layout/DirectedGraph/js/index.js
+++ b/packages/joint-core/docs/demo/layout/DirectedGraph/js/index.js
@@ -61,7 +61,7 @@
         return new joint.shapes.standard.Link({
             source: { id: parentElementLabel },
             target: { id: childElementLabel },
-            smooth: true,
+            connector: { name: 'smooth' },
             attrs: {
                 line: {
                     targetMarker: {

--- a/packages/joint-core/docs/src/joint/api/connectors/smooth.html
+++ b/packages/joint-core/docs/src/joint/api/connectors/smooth.html
@@ -3,8 +3,3 @@
 <p>Example:</p>
 
 <pre><code>link.connector('smooth');</code></pre>
-
-<p>(<i>Deprecated</i>) For the purposes of backwards compatibility, the <code>'smooth'</code> connector may also be enabled by setting the <code>link.smooth</code> property to <code>true</code>.</p>
-
-<pre><code>// deprecated
-link.set('smooth', true)</code></pre>

--- a/packages/joint-core/docs/src/joint/api/dia/Link/events.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Link/events.html
@@ -3,8 +3,8 @@
     <li><code>change:source</code> - triggered when the link changes its source</li>
     <li><code>change:target</code> - triggered when the link changes its target</li>
     <li><code>change:attrs</code> - triggered when the link changes its attributes</li>
-    <li><code>change:smooth</code> - (deprecated) triggered when the link toggled interpolation </li>
-    <li><code>change:manhattan</code> - (deprecated) triggered when the link toggled orthogonal routing</li>
+    <li><code>change:connector</code> - triggered when the link changes its connector </li>
+    <li><code>change:router</code> - triggered when the link changes its router</li>
     <li><code>change:vertices</code> - triggered when the link changes its vertices array </li>
     <li><code>change:z</code> - triggered when the link is moved in the z-level (<a href="#dia.Link.prototype.toFront">toFront</a> and <a href="#dia.Link.prototype.toBack">toBack</a>)</li>
     <li><code>transition:start</code> - triggered when a transition starts.</li>

--- a/packages/joint-core/docs/src/joint/api/dia/Link/prototype/connector.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Link/prototype/connector.html
@@ -1,8 +1,6 @@
 <pre class="docs-method-signature"><code>link.connector()</code></pre>
 <p>Return a shallow copy of the <code>connector</code> property of the link.</p>
 
-<p>For backwards compatibility, if there is no connector, the function also checks whether the legacy <code>smooth</code> property is set on the link and returns <code>{ name: smooth }</code> if it is.</p>
-
 <pre class="docs-method-signature"><code>link.connector(connector [, opt])</code></pre>
 <p>Set the <code>connector</code> of the link.</p>
 

--- a/packages/joint-core/docs/src/joint/api/dia/Link/prototype/router.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Link/prototype/router.html
@@ -1,8 +1,6 @@
 <pre class="docs-method-signature"><code>link.router()</code></pre>
 <p>Return a shallow copy of the <code>router</code> property of the link.</p>
 
-<p>For backwards compatibility, if there is no router, the function also checks whether the legacy <code>manhattan</code> property is set on the link and returns <code>{ name: orthogonal }</code> if it is.</p>
-
 <pre class="docs-method-signature"><code>link.router(router [, opt])</code></pre>
 <p>Set the <code>router</code> of the link.</p>
 

--- a/packages/joint-core/docs/src/joint/api/routers/orthogonal.html
+++ b/packages/joint-core/docs/src/joint/api/routers/orthogonal.html
@@ -13,8 +13,3 @@
 <pre><code>link.router('orthogonal', {
     padding: 10
 });</code></pre>
-
-<p>(<i>Deprecated</i>) For the purposes of backwards compatibility, the <code>'orthogonal'</code> router can also be enabled by setting the <code>link.manhattan</code> property to <code>true</code>. Note that the meaning of <q>manhattan</q> in JointJS has changed over time.</p>
-
-<pre><code>// deprecated
-link.set('manhattan', true);</code></pre>

--- a/packages/joint-core/src/connectors/jumpover.mjs
+++ b/packages/joint-core/src/connectors/jumpover.mjs
@@ -428,7 +428,7 @@ export const jumpover = function(sourcePoint, targetPoint, route, opt) { // esli
                 if (overlapIndex > -1 && thisLine.containsPoint(linkLinesToTest[overlapIndex].end)) {
                     // Remove the next segment because there will never be a jump
                     linkLinesToTest.splice(overlapIndex + 1, 1);
-                } 
+                }
                 const lineIntersections = findLineIntersections(thisLine, linkLinesToTest);
                 res.push.apply(res, lineIntersections);
             }

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -215,7 +215,6 @@ export const Link = Cell.extend({
         if (name === undefined) {
             var router = this.get('router');
             if (!router) {
-                if (this.get('manhattan')) return { name: 'orthogonal' }; // backwards compatibility
                 return null;
             }
             if (typeof router === 'object') return clone(router);
@@ -236,7 +235,6 @@ export const Link = Cell.extend({
         if (name === undefined) {
             var connector = this.get('connector');
             if (!connector) {
-                if (this.get('smooth')) return { name: 'smooth' }; // backwards compatibility
                 return null;
             }
             if (typeof connector === 'object') return clone(connector);

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -80,8 +80,6 @@ export const LinkView = CellView.extend({
         attrs: [Flags.UPDATE],
         router: [Flags.UPDATE],
         connector: [Flags.CONNECTOR],
-        smooth: [Flags.UPDATE],
-        manhattan: [Flags.UPDATE],
         toolMarkup: [Flags.LEGACY_TOOLS],
         labels: [Flags.LABELS],
         labelMarkup: [Flags.LABELS],

--- a/packages/joint-core/test/jointjs/routers.js
+++ b/packages/joint-core/test/jointjs/routers.js
@@ -87,7 +87,7 @@ QUnit.module('routers', function(hooks) {
         var l1 = new joint.dia.Link({
             source: { id: r1.id },
             target: { id: r2.id },
-            manhattan: true,
+            router: { name: 'orthogonal' },
             vertices: [{ x: 150, y: 200 }]
         });
 
@@ -106,7 +106,7 @@ QUnit.module('routers', function(hooks) {
         var l2 = new joint.dia.Link({
             source: { id: r3.id },
             target: { id: r4.id },
-            manhattan: true
+            router: { name: 'orthogonal' },
         });
 
         this.graph.addCells([r3, r4, l2]);
@@ -124,7 +124,7 @@ QUnit.module('routers', function(hooks) {
         var l3 = new joint.dia.Link({
             source: { id: r5.id },
             target: { id: r6.id },
-            manhattan: true,
+            router: { name: 'orthogonal' },
             vertices: [{ x: 150, y: 200 }]
         });
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -582,9 +582,7 @@ export namespace dia {
             target?: EndJSON;
             labels?: Label[];
             vertices?: Point[];
-            manhattan?: boolean;
             router?: routers.Router | routers.RouterJSON;
-            smooth?: boolean;
             connector?: connectors.Connector | connectors.ConnectorJSON;
         }
 


### PR DESCRIPTION
## Description

- removing the deprecated `smooth` attribute (syntactic sugar for the `smooth` connector).
- removing the obsolete `manhattan` attribute (syntactic sugar for `orthogonal` router).

### Migration guide

Before:
```js
link.set('smooth', true);
link.set('manhattan', true);
```

Now:
```js
link.connector('smooth'); // or link.set('connector', { name: 'smooth' });
link.router('orthogonal'); // or link.set('router', { name: 'orthogonal' });
```
