### PR TITLE
refactor(dia.Paper)!: remove deprecated perpendicularLinks option

### DIFF
--- a/packages/joint-core/demo/archive/org/src/org.js
+++ b/packages/joint-core/demo/archive/org/src/org.js
@@ -48,7 +48,7 @@ var paper = new joint.dia.Paper({
     gridSize: 1,
     model: graph,
     cellViewNamespace: shapes,
-    perpendicularLinks: true,
+    defaultAnchor: { name: 'perpendicular' },
     restrictTranslate: true
 });
 

--- a/packages/joint-core/demo/links/src/pipes.js
+++ b/packages/joint-core/demo/links/src/pipes.js
@@ -137,7 +137,7 @@ window.paper = new joint.dia.Paper({
     height: 800,
     gridSize: 1,
     model: graph,
-    perpendicularLinks: true,
+    defaultAnchor: { name: 'perpendicular' },
     linkView: PatternLinkView.extend({
 
         drawPattern: function(ctx, from, to, width, gradient) {

--- a/packages/joint-core/demo/ports/ports.html
+++ b/packages/joint-core/demo/ports/ports.html
@@ -32,7 +32,7 @@
             width: 800,
             height: 400,
             gridSize: 1,
-            perpendicularLinks: false,
+            defaultAnchor: { name: 'perpendicular' },
             model: graph,
         });
     }

--- a/packages/joint-core/docs/demo/layout/Port/port.html
+++ b/packages/joint-core/docs/demo/layout/Port/port.html
@@ -35,7 +35,7 @@
             width: 800,
             height: 400,
             gridSize: 1,
-            perpendicularLinks: false,
+            defaultAnchor: { name: 'perpendicular' },
             model: graph,
         });
     }

--- a/packages/joint-core/docs/demo/layout/Port/portRotationComp.html
+++ b/packages/joint-core/docs/demo/layout/Port/portRotationComp.html
@@ -35,7 +35,7 @@
             width: 800,
             height: 450,
             gridSize: 1,
-            perpendicularLinks: false,
+            defaultAnchor: { name: 'perpendicular' },
             model: graph
         });
     }

--- a/packages/joint-core/docs/demo/layout/PortLabel/portLabel.html
+++ b/packages/joint-core/docs/demo/layout/PortLabel/portLabel.html
@@ -35,7 +35,7 @@
             width: 800,
             height: 400,
             gridSize: 1,
-            perpendicularLinks: false,
+            defaultAnchor: { name: 'perpendicular' },
             model: graph,
         });
     }

--- a/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/options/perpendicularLinks.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/options/perpendicularLinks.html
@@ -1,1 +1,0 @@
-<code>perpendicularLinks</code> - if <code>true</code>, links will tend to get perpendicular to their associated objects. Default is <code>false</code>

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -934,11 +934,9 @@ export const LinkView = CellView.extend({
             if (isConnection) {
                 anchorDef = paperOptions.defaultLinkAnchor;
             } else {
-                if (paperOptions.perpendicularLinks || this.options.perpendicular) {
+                if (this.options.perpendicular) {
                     // Backwards compatibility
-                    // If `perpendicularLinks` flag is set on the paper and there are vertices
-                    // on the link, then try to find a connection point that makes the link perpendicular
-                    // even though the link won't point to the center of the targeted object.
+                    // See `manhattan` router for more details
                     anchorDef = { name: 'perpendicular' };
                 } else {
                     anchorDef = paperOptions.defaultAnchor;

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -115,7 +115,6 @@ export const Paper = View.extend({
         // e.g. background: { color: 'lightblue', image: '/paper-background.png', repeat: 'flip-xy' }
         background: false,
 
-        perpendicularLinks: false,
         elementView: ElementView,
         linkView: LinkView,
         snapLabels: false, // false, true

--- a/packages/joint-core/test/jointjs/links.js
+++ b/packages/joint-core/test/jointjs/links.js
@@ -666,9 +666,9 @@ QUnit.module('links', function(hooks) {
         );
     });
 
-    QUnit.test('perpendicularLinks', function(assert) {
+    QUnit.test('perpendicular links', function(assert) {
 
-        this.paper.options.perpendicularLinks = true;
+        this.paper.options.defaultAnchor = { name: 'perpendicular' };
 
         var myrect = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1246,7 +1246,6 @@ export namespace dia {
             width?: Dimension;
             height?: Dimension;
             origin?: Point;
-            perpendicularLinks?: boolean;
             drawGrid?: boolean | GridOptions | GridOptions[];
             drawGridSize?: number | null;
             background?: BackgroundOptions;


### PR DESCRIPTION
## Description

- remove deprecated `dia.Paper.prototype.options.perpendicularLinks`.

### Migration guide

Instead of using `perpendicularLinks: true`, set the [defaultAnchor](https://resources.jointjs.com/docs/jointjs/v3.7/joint.html#dia.Paper.prototype.options.defaultAnchor) paper option to [perpendicular](https://resources.jointjs.com/docs/jointjs/v3.7/joint.html#anchors.perpendicular) connection point.

```js
paper.options.defaultAnchor = { name: 'perpendicular' };
```


