### PR TITLE
refactor(linkTools, elementTools)!: change Remove tool name

### DIFF
--- a/packages/joint-core/src/linkTools/Button.mjs
+++ b/packages/joint-core/src/linkTools/Button.mjs
@@ -91,6 +91,7 @@ export const Button = ToolView.extend({
 });
 
 export const Remove = Button.extend({
+    name: 'remove',
     children: [{
         tagName: 'circle',
         selector: 'button',


### PR DESCRIPTION
## Description

As per documentation "The names of built-in link tools are kebab-case versions of their class names ".
This was not the case for the `linkTools.Remove` and `elementTools.Remove` buttons.

### Migration guide

You may have styled the `Remove` button using CSS in your app.

Before:
```css
.joint-tool[data-tool-name="button"] circle {
    fill: #333;
}
```

Now:
```css
.joint-tool[data-tool-name="remove"] circle {
    fill: #333;
}
```

