### PR TITLE
fix(attributes.filter)!: fix filter attribute for links

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2916,11 +2916,7 @@ export const Paper = View.extend({
             // Set the filter area to be 3x the bounding box of the cell
             // and center the filter around the cell.
             var filterAttrs = assign({
-                filterUnits: 'objectBoundingBox',
-                x: -1,
-                y: -1,
-                width: 3,
-                height: 3
+                filterUnits: 'userSpaceOnUse',
             }, filter.attrs, {
                 id: filterId
             });

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2913,8 +2913,7 @@ export const Paper = View.extend({
                 throw new Error('Non-existing filter ' + name);
             }
 
-            // Set the filter area to be 3x the bounding box of the cell
-            // and center the filter around the cell.
+            // SVG <filter/> attributes
             var filterAttrs = assign({
                 filterUnits: 'userSpaceOnUse',
             }, filter.attrs, {


### PR DESCRIPTION
## Description

Change how the default filters are rendered (change the coordinate system of the filters from `objectBoundingBox` to `userSpaceOnUse`).

This fixes applying filters to shapes with `0` width or height (such as horizontal/vertical links).

### Migration guide

If you need your filter to look the same as in the previous version, you can add `attrs` object to your filter as shown below.

```js
element1.attr('body/filter', {
    // for backwards compatibility
    attrs: {
        filterUnits: 'objectBoundingBox',
        x: -1,
        y: -1,
        width: 3,
        height: 3
    },
    name: 'dropShadow',
    args: {
        dx: 2,
        dy: 2,
        blur: 3
    }
});
```