### PR TITLE
feat(dia.Cell)!: add mergeArrays options to constructor

### DIFF
--- a/packages/joint-core/docs/src/joint/api/dia/Cell/constructor.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Cell/constructor.html
@@ -1,0 +1,13 @@
+<pre class="docs-method-signature"><code>new Cell([attributes], [options])</code></pre>
+
+<p>When creating an instance of a cell, you can pass in the initial values of the attributes, which will be set on the model.</p>
+
+<p>If you pass a <code>{ mergeArrays: true }</code> as the options, all the arrays defined as class defaults will be merged instead of overridden.</p>
+
+<pre><code>const MyRect = joint.shapes.standard.Rectangle.define('Rect', { array: [1,2] });
+
+const rect1 = new MyRect({ array: [3] });
+console.log(rect1.get('array')); // [3] array was overridden
+
+const rect2 = new MyRect({ array: [3] }, { mergeArrays: true });
+console.log(rect2.get('array')); // [3,2] array was merged </code></pre>

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -36,6 +36,12 @@ import * as g from '../g/index.mjs';
 // Cell base model.
 // --------------------------
 
+const attributesMerger = function(a, b) {
+    if (Array.isArray(a)) {
+        return b;
+    }
+};
+
 export const Cell = Model.extend({
 
     // This is the same as mvc.Model with the only difference that is uses util.merge
@@ -55,7 +61,8 @@ export const Cell = Model.extend({
         if ((defaults = result(this, 'defaults'))) {
             //<custom code>
             // Replaced the call to _.defaults with util.merge.
-            attrs = merge({}, defaults, attrs);
+            const customizer = (options && options.mergeArrays === true) ? false : attributesMerger;
+            attrs = merge({}, defaults, attrs, customizer);
             //</custom code>
         }
         this.set(attrs, options);

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -112,6 +112,30 @@ QUnit.module('cell', function(hooks) {
         });
     });
 
+    QUnit.module('defaults', function() {
+
+        QUnit.test('arrays', function(assert) {
+
+            const Rect = joint.shapes.standard.Rectangle.define('Rect', {
+                array: [1,2]
+            });
+
+            const rect1 = new Rect({});
+            assert.deepEqual(rect1.get('array'), [1,2]);
+            const rect2 = new Rect({ array: [] });
+            assert.deepEqual(rect2.get('array'), []);
+            const rect3 = new Rect({ array: [3] });
+            assert.deepEqual(rect3.get('array'), [3]);
+
+            const rect4 = new Rect({}, { mergeArrays: true });
+            assert.deepEqual(rect4.get('array'), [1,2]);
+            const rect5 = new Rect({ array: [] }, { mergeArrays: true });
+            assert.deepEqual(rect5.get('array'), [1,2]);
+            const rect6 = new Rect({ array: [3] }, { mergeArrays: true });
+            assert.deepEqual(rect6.get('array'), [3,2]);
+        });
+    });
+
     QUnit.module('parent', function(hooks) {
 
         QUnit.test('parent', function(assert) {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -320,11 +320,15 @@ export namespace dia {
             timingFunction?: util.timing.TimingFunction;
             valueFunction?: util.interpolate.InterpolateFunction<any>;
         }
+
+        interface ConstructorOptions extends Graph.Options {
+            mergeArrays?: boolean;
+        }
     }
 
     class Cell<A extends ObjectHash = Cell.Attributes, S extends mvc.ModelSetOptions = dia.ModelSetOptions> extends mvc.Model<A, S> {
 
-        constructor(attributes?: A, opt?: Graph.Options);
+        constructor(attributes?: A, opt?: Cell.ConstructorOptions);
 
         id: Cell.ID;
         graph: Graph;


### PR DESCRIPTION
## Description

The class array default attributes are now overridden instead of merged. A new option to support previous behavior was added. 

The reason for this change is to make it easier to instantiate the class and define the initial attributes, which are arrays.

```js
const MyRect = joint.shapes.standard.Rectangle.define('Rect', { array: [1,2] });

const rect1 = new MyRect({ array: [3] });
console.log(rect1.get('array')); // [3] array was overridden

const rect2 = new MyRect({ array: [3] }, { mergeArrays: true });
console.log(rect2.get('array')); // [3,2] array was merged
```
