### PR TITLE
refactor(dia.Paper)!: add SVG grid layer

### DIFF
--- a/packages/joint-core/demo/paper/src/paper.js
+++ b/packages/joint-core/demo/paper/src/paper.js
@@ -367,8 +367,7 @@ $h.on('input change', function() {
     paper.setDimensions(parseInt($w.val(), 10), parseInt(this.value, 10));
 });
 $grid.on('input change', function() {
-    paper.options.gridSize = this.value;
-    paper.drawGrid();
+    paper.setGridSize(this.value);
 });
 $('.range').on('input change', function() {
     $(this).next().text(this.value);
@@ -548,7 +547,6 @@ var gridTypes = {
 var renderer = _inputRenderer(gridTypes, function(gridOpt) {
 
     paper.setGrid(gridOpt);
-    paper.drawGrid();
 });
 
 var $gridTypesOpt = $('.grid-types-opt');

--- a/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/clearGrid.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/clearGrid.html
@@ -1,3 +1,0 @@
-
-<pre class="docs-method-signature"><code>paper.clearGrid()</code></pre>
-<p>Hide the current grid.</p>

--- a/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/drawGrid.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/drawGrid.html
@@ -1,7 +1,0 @@
-
-<pre class="docs-method-signature"><code>paper.drawGrid([opt])</code></pre>
-<p>Draw visual grid lines on the paper. Possible options:</p>
-<ul>
-    <li><b>color</b> - the color of the grid line (hex, RGB, etc).</li>
-    <li><b>thickness</b> - the thickness of the grid line (pixels).</li>
-</ul>

--- a/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/setGrid.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/setGrid.html
@@ -1,7 +1,7 @@
 <pre class="docs-method-signature"><code>paper.setGrid(gridOption)</code></pre>
-<p>Set the type of visual grid on the paper. Note, you still have to call <code>paper.drawGrid()</code> afterwards to draw the grid.</p>
+<p>Set the type of visual grid on the paper. If a falsy value is provided, the grid is removed.</p>
 
-<pre><code>paper.setGrid(); // default pattern (dot) with default settings
+<pre><code>paper.setGrid(); // removes the grid visual
 paper.setGrid(true); // default pattern (dot) with default settings
 
 paper.setGrid('mesh'); // pre-defined pattern with default settings

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1807,7 +1807,7 @@ export const Paper = View.extend({
         }
 
         const { options } = this;
-        const { origin, drawGrid } = options;
+        const { origin } = options;
 
         // setter
         tx || (tx = 0);

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2667,7 +2667,7 @@ export const Paper = View.extend({
             root: V('svg', { width: '100%', height: '100%' }, V('defs')),
             patterns: {},
             add: function(id, vel) {
-                V(this.root.node.childNodes[0]).append(vel);
+                this.root.children()[0].append(vel);
                 this.patterns[id] = vel;
                 this.root.append(V('rect', { width: '100%', height: '100%', fill: 'url(#' + id + ')' }));
             },

--- a/packages/joint-core/src/dia/PaperLayer.mjs
+++ b/packages/joint-core/src/dia/PaperLayer.mjs
@@ -2,6 +2,7 @@ import { View } from '../mvc/index.mjs';
 import { addClassNamePrefix } from '../util/util.mjs';
 
 export const LayersNames = {
+    GRID: 'grid',
     CELLS: 'cells',
     BACK: 'back',
     FRONT: 'front',

--- a/packages/joint-core/src/dia/layers/GridLayer.mjs
+++ b/packages/joint-core/src/dia/layers/GridLayer.mjs
@@ -1,0 +1,176 @@
+import { PaperLayer } from '../PaperLayer.mjs';
+import {
+    isFunction,
+    isString,
+    defaults,
+    omit,
+    assign,
+    merge,
+} from '../../util/index.mjs';
+import V from '../../V/index.mjs';
+
+export const GridLayer = PaperLayer.extend({
+
+    style: {
+        'pointer-events': 'none'
+    },
+
+    _gridCache: null,
+    _gridSettings: null,
+
+    init() {
+        PaperLayer.prototype.init.apply(this, arguments);
+        const { options: { paper }} = this;
+        this._gridCache = null;
+        this._gridSettings = [];
+        this.listenTo(paper, 'scale translate resize', this.updateGrid);
+    },
+
+    setGrid(drawGrid) {
+        this._gridSettings = this.getGridSettings(drawGrid);
+        this.renderGrid();
+    },
+
+    getGridSettings(drawGrid) {
+        const gridSettings = [];
+        if (drawGrid) {
+            const optionsList = Array.isArray(drawGrid) ? drawGrid : [drawGrid || {}];
+            optionsList.forEach((item) => {
+                gridSettings.push(...this._resolveDrawGridOption(item));
+            });
+        }
+        return gridSettings;
+    },
+
+    removeGrid() {
+        const { _gridCache: grid } = this;
+        if (!grid) return;
+        grid.root.remove();
+        this._gridCache = null;
+    },
+
+    renderGrid() {
+
+        const { options: { paper }} = this;
+        const { _gridSettings: gridSettings } = this;
+
+        this.removeGrid();
+
+        if (gridSettings.length === 0) return;
+
+        const gridSize = paper.options.drawGridSize || paper.options.gridSize;
+        if (gridSize <= 1) {
+            return;
+        }
+
+        const refs = this._getGridRefs();
+
+        gridSettings.forEach((gridLayerSetting, index) => {
+
+            const id = 'pattern_' + index;
+            const options = merge({}, gridLayerSetting);
+            const { scaleFactor = 1 } = options;
+            options.width = gridSize * scaleFactor || 1;
+            options.height = gridSize * scaleFactor || 1;
+
+            let vPattern;
+            if (!refs.exist(id)) {
+                vPattern = V('pattern', { id: id, patternUnits: 'userSpaceOnUse' }, V(options.markup));
+                refs.add(id, vPattern);
+            } else {
+                vPattern = refs.get(id);
+            }
+
+            if (isFunction(options.render)) {
+                options.render(vPattern.node.firstChild, options, paper);
+            }
+            vPattern.attr({
+                width: options.width,
+                height: options.height
+            });
+        });
+
+        refs.root.appendTo(this.el);
+        this.updateGrid();
+    },
+
+    updateGrid() {
+
+        const { _gridCache: grid, _gridSettings: gridSettings, options: { paper }} = this;
+        if (!grid) return;
+        const { root: vSvg, patterns } = grid;
+        const { x, y, width, height } = paper.getArea();
+        vSvg.attr({ x, y, width, height });
+        for (const patternId in patterns) {
+            const vPattern = patterns[patternId];
+            vPattern.attr({ x: -x, y: -y });
+        }
+        gridSettings.forEach((options, index) => {
+            if (isFunction(options.update)) {
+                const vPattern = patterns['pattern_' + index];
+                options.update(vPattern.node.firstChild, options, paper);
+            }
+        });
+    },
+
+    _getGridRefs() {
+        let { _gridCache: grid } = this;
+        if (grid) return grid;
+        const defsVEl = V('defs');
+        const svgVEl = V('svg', { width: '100%', height: '100%' }, [defsVEl]);
+        grid = this._gridCache = {
+            root: svgVEl,
+            patterns: {},
+            add: function(id, patternVEl) {
+                const rectVEl = V('rect', { width: '100%', height: '100%', fill: `url(#${id})` });
+                defsVEl.append(patternVEl);
+                svgVEl.append(rectVEl);
+                this.patterns[id] = patternVEl;
+            },
+            get: function(id) {
+                return this.patterns[id];
+            },
+            exist: function(id) {
+                return this.patterns[id] !== undefined;
+            }
+        };
+        return grid;
+    },
+
+    _resolveDrawGridOption(opt) {
+
+        var namespace = this.options.patterns;
+        if (isString(opt) && Array.isArray(namespace[opt])) {
+            return namespace[opt].map(function(item) {
+                return assign({}, item);
+            });
+        }
+
+        var options = opt || { args: [{}] };
+        var isArray = Array.isArray(options);
+        var name = options.name;
+
+        if (!isArray && !name && !options.markup) {
+            name = 'dot';
+        }
+
+        if (name && Array.isArray(namespace[name])) {
+            var pattern = namespace[name].map(function(item) {
+                return assign({}, item);
+            });
+
+            var args = Array.isArray(options.args) ? options.args : [options.args || {}];
+
+            defaults(args[0], omit(opt, 'args'));
+            for (var i = 0; i < args.length; i++) {
+                if (pattern[i]) {
+                    assign(pattern[i], args[i]);
+                }
+            }
+            return pattern;
+        }
+
+        return isArray ? options : [options];
+    },
+
+});

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -1337,7 +1337,11 @@ QUnit.module('paper', function(hooks) {
 
     QUnit.module('draw grid options', function(hooks) {
 
-        var getGridVel = function(paper) {
+        const getGridSettings = function(paper) {
+            return paper.getLayerView(joint.dia.Paper.Layers.GRID)._gridSettings;
+        };
+
+        const getGridVel = function(paper) {
             return V(paper.getLayerNode(joint.dia.Paper.Layers.GRID).firstChild);
         };
 
@@ -1383,7 +1387,7 @@ QUnit.module('paper', function(hooks) {
                     gridSize: 1,
                     drawGridSize: 17
                 });
-                const drawGridSpy = sinon.spy(paper, 'renderGrid');
+                const drawGridSpy = sinon.spy(paper.getLayerView(joint.dia.Paper.Layers.GRID), 'renderGrid');
                 paper.setGridSize(5);
                 assert.ok(drawGridSpy.notCalled);
                 drawGridSpy.restore();
@@ -1616,8 +1620,9 @@ QUnit.module('paper', function(hooks) {
 
                 var check = function(message) {
 
-                    assert.equal(paper._gridSettings.length, 2);
-                    var firstLayer = paper._gridSettings[0];
+                    const gridSettings = getGridSettings(paper);
+                    assert.equal(gridSettings.length, 2);
+                    var firstLayer = gridSettings[0];
 
                     assert.equal(firstLayer.color, 'red', message + ': color');
                     assert.equal(firstLayer.thickness, 11, message + ': thickness');
@@ -1629,7 +1634,7 @@ QUnit.module('paper', function(hooks) {
                 check('args: {}');
 
                 paper.setGrid(drawGridTestFixtures[1]);
-                var secondLayer = paper._gridSettings[1];
+                var secondLayer = getGridSettings(paper)[1];
                 var message = 'args: [{}] - second layer';
                 assert.equal(secondLayer.color, 'black', message + ': color');
                 assert.equal(secondLayer.thickness, 55, message + ': thickness');
@@ -1644,13 +1649,13 @@ QUnit.module('paper', function(hooks) {
             QUnit.test('render default', function(assert){
 
                 paper.setGrid({ color: 'red', thickness: 11 });
-                assert.propEqual(paper._gridSettings[0], {
+                assert.propEqual(getGridSettings(paper)[0], {
                     color: 'red',
                     thickness: 11,
                     markup: 'rect',
                     render: {}
                 }, 'update default');
-                assert.ok(_.isFunction(paper._gridSettings[0].render));
+                assert.ok(_.isFunction(getGridSettings(paper)[0].render));
             });
 
             QUnit.test('create custom', function(assert) {
@@ -1662,16 +1667,16 @@ QUnit.module('paper', function(hooks) {
                 ];
 
                 paper.setGrid(drawGridTestFixtures[0]);
-                assert.deepEqual(paper._gridSettings[0], { markup: 'rect', update: 'fnc' }, 'custom markup and update');
+                assert.deepEqual(getGridSettings(paper)[0], { markup: 'rect', update: 'fnc' }, 'custom markup and update');
 
                 paper.setGrid(drawGridTestFixtures[1]);
-                assert.ok(_.isArray(paper._gridSettings));
-                assert.deepEqual(paper._gridSettings[0], { markup: 'rect', update: 'fnc' }, 'custom markup and update - first layer');
-                assert.deepEqual(paper._gridSettings[1], { markup: 'rect2', update: 'fnc2' }, 'custom markup and update- second layer');
+                assert.ok(_.isArray(getGridSettings(paper)));
+                assert.deepEqual(getGridSettings(paper)[0], { markup: 'rect', update: 'fnc' }, 'custom markup and update - first layer');
+                assert.deepEqual(getGridSettings(paper)[1], { markup: 'rect2', update: 'fnc2' }, 'custom markup and update- second layer');
 
                 paper.setGrid(drawGridTestFixtures[2]);
-                assert.ok(_.isArray(paper._gridSettings));
-                assert.deepEqual(paper._gridSettings[0], { markup: '<circle/>' }, 'custom grid - minimal setup');
+                assert.ok(_.isArray(getGridSettings(paper)));
+                assert.deepEqual(getGridSettings(paper)[0], { markup: '<circle/>' }, 'custom grid - minimal setup');
             });
 
             QUnit.test('initialize gridSettings', function(assert) {
@@ -1679,14 +1684,14 @@ QUnit.module('paper', function(hooks) {
                 var dotDefault = joint.dia.Paper.gridPatterns.dot[0];
 
                 paper.setGrid({ markup: '<rect/>' });
-                assert.deepEqual(paper._gridSettings[0], { markup: '<rect/>' }, 'markup only');
+                assert.deepEqual(getGridSettings(paper)[0], { markup: '<rect/>' }, 'markup only');
 
                 paper.setGrid({ update: 'custom' });
-                assert.propEqual(_.omit(paper._gridSettings[0], 'update'), _.omit(dotDefault, 'update'), 'override update function');
-                assert.equal(paper._gridSettings[0].update, 'custom');
+                assert.propEqual(_.omit(getGridSettings(paper)[0], 'update'), _.omit(dotDefault, 'update'), 'override update function');
+                assert.equal(getGridSettings(paper)[0].update, 'custom');
 
                 paper.setGrid('dot');
-                assert.propEqual(paper._gridSettings[0], dotDefault, 'update');
+                assert.propEqual(getGridSettings(paper)[0], dotDefault, 'update');
 
                 paper.setGrid([{ color: 'red' }, { color: 'black' }]);
             });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1518,19 +1518,11 @@ export namespace dia {
 
         drawBackground(opt?: Paper.BackgroundOptions): this;
 
-        drawGrid(opt?: Paper.GridOptions | Paper.GridOptions[]): this;
-
-        clearGrid(): this;
-
         getDefaultLink(cellView: CellView, magnet: SVGElement): Link;
 
         getModelById(id: Cell.ID | Cell): Cell;
 
         setDimensions(width: Paper.Dimension, height: Paper.Dimension): void;
-
-        setGrid(opt?: boolean | string | Paper.GridOptions | Paper.GridOptions[]): this;
-
-        setGridSize(gridSize: number): this;
 
         setInteractivity(value: any): void;
 
@@ -1545,6 +1537,16 @@ export namespace dia {
         update(): this;
 
         getPointerArgs(evt: dia.Event): [dia.Event, number, number];
+
+        // grid
+
+        protected renderGrid(): this;
+
+        protected removeGrid(): this;
+
+        setGrid(opt?: null | boolean | string | Paper.GridOptions | Paper.GridOptions[]): this;
+
+        setGridSize(gridSize: number): this;
 
         // tools
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1187,6 +1187,7 @@ export namespace dia {
             BACK = 'back',
             FRONT = 'front',
             TOOLS = 'tools',
+            GRID = 'grid',
         }
 
         type UpdateStats = {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1541,10 +1541,6 @@ export namespace dia {
 
         // grid
 
-        protected renderGrid(): this;
-
-        protected removeGrid(): this;
-
         setGrid(opt?: null | boolean | string | Paper.GridOptions | Paper.GridOptions[]): this;
 
         setGridSize(gridSize: number): this;


### PR DESCRIPTION
## Description

The grid is now rendered as an SVG document inside the paper layer.
- Paper transformations are applied to it in the same way as to cells, i.e. the grid does not need to be completely redrawn when the paper is transformed (unlike the previous solution with HTMLDivElement CSS background).
- The grid can now also be easily exported as SVG/PNG.

### Migration guide

API change. Drop `drawGrid()` and `clearGrid()` methods.

Before:
```js
// show the grid
paper.setGrid('mesh');
paper.drawGrid();

// remove the grid
paper.clearGrid();

// change color of grid
const paper = new dia.Paper({ drawGrid: { name: 'dots', color: 'red' }});
paper.drawGrid({ color: 'blue' });

// paper.options.drawGrid value
const paper = new dia.Paper({ drawGrid: { name: 'dots' }});
paper.drawGrid({ name: 'mesh; }); // paper.options.drawGrid === { name: 'dots' }

```

Now:
```js
// show the gird
paper.setGrid('mesh');

// remove the grid
paper.setGrid(null);

// change color of grid
const paper = new dia.Paper({ drawGrid: { name: 'dots', color: 'red' }});
paper.setGrid({ name: 'dots', color: 'blue' });

// paper.options.drawGrid value
const paper = new dia.Paper({ drawGrid: { name: 'dots' }});
paper.setGrid({ name: 'mesh; }); // paper.options.drawGrid === { name: 'mesh' }
```

Unless you somehow rely on the structure of a paper SVG document, this change shouldn't affect you in any way. The paper is missing `<div class="joint-paper-grid"/>` and instead has a new layer `<g class="joint-grid-layout" />`.



