### PR TITLE
types(dia.CellView): improve the findNode return type specificity

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -763,9 +763,9 @@ export namespace dia {
 
         findMagnet(el: SVGElement | Dom | string): SVGElement | undefined;
 
-        findNode(selector: string): Element | null;
+        findNode(selector: string): SVGElement | HTMLElement | null;
 
-        findNodes(groupSelector: string): Element[];
+        findNodes(groupSelector: string): Array<SVGElement | HTMLElement>;
 
         findProxyNode(el: SVGElement | null, type: string): SVGElement;
 

--- a/packages/joint-shapes-general-tools/src/RadiusControl.ts
+++ b/packages/joint-shapes-general-tools/src/RadiusControl.ts
@@ -83,7 +83,7 @@ export interface RadiusControlOptions extends elementTools.Control.Options {
     protected updateExtras(extrasNode: SVGElement): void {
         const { relatedView, options } = this;
         const { selector, padding = 0 } = options;
-        const magnet = relatedView.findNode(selector) as unknown as SVGElement;
+        const magnet = relatedView.findNode(selector) as SVGElement;
         if (!magnet) return;
         const { model } = relatedView;
         const angle = model.angle();


### PR DESCRIPTION
## Description

Improve the return type of the `findNode()` method to avoid the use of `as unknown`.