### PR TITLE
fix(mvc.$): add missing filter() method, fix html() to accept numbers

### DIFF
--- a/packages/joint-core/src/mvc/Dom/Dom.mjs
+++ b/packages/joint-core/src/mvc/Dom/Dom.mjs
@@ -210,8 +210,11 @@ $.event = {
     special: Object.create(null),
 };
 
-$.event.has = function(elem) {
-    return dataPriv.has(elem, 'events');
+$.event.has = function(elem, eventType) {
+    const events = dataPriv.get(elem, 'events');
+    if (!events) return false;
+    if (!eventType) return true;
+    return Array.isArray(events[eventType]) && events[eventType].length > 0;
 };
 
 $.event.on = function(elem, types, selector, data, fn, one) {

--- a/packages/joint-core/src/mvc/Dom/Dom.mjs
+++ b/packages/joint-core/src/mvc/Dom/Dom.mjs
@@ -121,6 +121,16 @@ $.fn.addBack = function() {
     return this.add(this.prevObject);
 };
 
+$.fn.filter = function(selector) {
+    const matches = [];
+    for (let i = 0; i < this.length; i++) {
+        const node = this[i];
+        if (!node.matches(selector)) continue;
+        matches.push(node);
+    }
+    return this.pushStack(matches);
+};
+
 // A simple way to check for HTML strings
 // Prioritize #id over <tag> to avoid XSS via location.hash (trac-9521)
 // Strict HTML recognition (trac-11290: must start with <)

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -4,9 +4,9 @@ import { dataPriv, cleanNodesData } from './vars.mjs';
 
 // Manipulation
 
-function _remove(removeData) {
-    for (let i = 0; i < this.length; i++) {
-        const node = this[i];
+function removeNodes(nodes, removeData) {
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
         removeData && dataPriv.remove(node);
         if (node.parentNode) {
             node.parentNode.removeChild(node);
@@ -15,11 +15,13 @@ function _remove(removeData) {
 }
 
 export function remove() {
-    _remove(true);
+    removeNodes(this, true);
+    return this;
 }
 
 export function detach() {
-    _remove(false);
+    removeNodes(this, false);
+    return this;
 }
 
 export function empty() {

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -4,14 +4,22 @@ import { dataPriv, cleanNodesData } from './vars.mjs';
 
 // Manipulation
 
-export function remove() {
+function _remove(removeData) {
     for (let i = 0; i < this.length; i++) {
         const node = this[i];
-        dataPriv.remove(node);
+        removeData && dataPriv.remove(node);
         if (node.parentNode) {
             node.parentNode.removeChild(node);
         }
     }
+}
+
+export function remove() {
+    _remove(true);
+}
+
+export function detach() {
+    _remove(false);
 }
 
 export function empty() {

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -31,7 +31,7 @@ export function html(html) {
     if (!el) return null;
     if (!html) return el.innerHTML;
     cleanNodesData(dataPriv, el.getElementsByTagName('*'));
-    if (typeof string === 'string') {
+    if (typeof string === 'string' || typeof string === 'number') {
         el.innerHTML = html;
     } else {
         el.innerHTML = '';

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -752,13 +752,13 @@ export namespace dia {
 
         presentationAttributes(): CellView.PresentationAttributes;
 
-        highlight(el?: $SVGElement, opt?: { [key: string]: any }): this;
+        highlight(el?: mvc.$SVGElement, opt?: { [key: string]: any }): this;
 
-        unhighlight(el?: $SVGElement, opt?: { [key: string]: any }): this;
+        unhighlight(el?: mvc.$SVGElement, opt?: { [key: string]: any }): this;
 
         can(feature: string): boolean;
 
-        findMagnet(el: $SVGElement): SVGElement | undefined;
+        findMagnet(el: mvc.$SVGElement): SVGElement | undefined;
 
         findNode(selector: string): Element | null;
 
@@ -1496,7 +1496,7 @@ export namespace dia {
 
         getContentBBox(opt?: { useModelGeometry: boolean }): g.Rect;
 
-        findView<T extends ElementView | LinkView>(element: $SVGElement): T;
+        findView<T extends ElementView | LinkView>(element: mvc.$SVGElement): T;
 
         findViewByModel<T extends ElementView | LinkView>(model: Cell | Cell.ID): T;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2427,7 +2427,7 @@ export namespace util {
     export function getElementBBox(el: Element): dia.BBox;
 
     export function sortElements(
-        elements: $Element,
+        elements: mvc.$Element,
         comparator: (a: Element, b: Element) => number
     ): Element[];
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -10,9 +10,6 @@ export namespace config {
 
 type NativeEvent = Event;
 
-/* A JQuery-like object */
-type Dom = any;
-
 export namespace dia {
 
     type Event = mvc.TriggeredEvent;
@@ -755,13 +752,13 @@ export namespace dia {
 
         presentationAttributes(): CellView.PresentationAttributes;
 
-        highlight(el?: SVGElement | Dom | string, opt?: { [key: string]: any }): this;
+        highlight(el?: $SVGElement, opt?: { [key: string]: any }): this;
 
-        unhighlight(el?: SVGElement | Dom | string, opt?: { [key: string]: any }): this;
+        unhighlight(el?: $SVGElement, opt?: { [key: string]: any }): this;
 
         can(feature: string): boolean;
 
-        findMagnet(el: SVGElement | Dom | string): SVGElement | undefined;
+        findMagnet(el: $SVGElement): SVGElement | undefined;
 
         findNode(selector: string): Element | null;
 
@@ -821,7 +818,7 @@ export namespace dia {
 
         isDefaultInteractionPrevented(evt: dia.Event): boolean;
 
-        protected findBySelector(selector: string, root?: SVGElement | Dom | string): SVGElement[];
+        protected findBySelector(selector: string, root?: SVGElement): SVGElement[];
 
         protected removeHighlighters(): void;
 
@@ -1499,7 +1496,7 @@ export namespace dia {
 
         getContentBBox(opt?: { useModelGeometry: boolean }): g.Rect;
 
-        findView<T extends ElementView | LinkView>(element: string | Dom | SVGElement): T;
+        findView<T extends ElementView | LinkView>(element: $SVGElement): T;
 
         findViewByModel<T extends ElementView | LinkView>(model: Cell | Cell.ID): T;
 
@@ -2430,7 +2427,7 @@ export namespace util {
     export function getElementBBox(el: Element): dia.BBox;
 
     export function sortElements(
-        elements: Element[] | string | Dom,
+        elements: $Element,
         comparator: (a: Element, b: Element) => number
     ): Element[];
 
@@ -2772,6 +2769,13 @@ export namespace layout {
 // mvc
 
 export namespace mvc {
+
+    type Dom = unknown;
+    // The following types represent the DOM elements that can be passed to the
+    // $() function.
+    type $Element<T extends Element = Element> = string | T | T[] | Dom;
+    type $HTMLElement = $Element<HTMLElement>;
+    type $SVGElement = $Element<SVGElement>;
 
     interface Event {
         // Event
@@ -3156,7 +3160,7 @@ export namespace mvc {
         model?: TModel | undefined;
         // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
         collection?: Collection<any> | undefined; // was: Collection<TModel>;
-        el?: TElement | Dom | string | undefined;
+        el?: $Element<TElement> | string | undefined;
         id?: string | undefined;
         attributes?: Record<string, any> | undefined;
         className?: string | undefined;
@@ -3192,7 +3196,7 @@ export namespace mvc {
         // A conditional type used here to prevent `TS2532: Object is possibly 'undefined'`
         model: TModel extends Model ? TModel : undefined;
         collection: Collection<any>;
-        setElement(element: TElement | Dom): this;
+        setElement(element: $Element<TElement>): this;
         id?: string | undefined;
         cid: string;
         className?: string | undefined;
@@ -3212,7 +3216,7 @@ export namespace mvc {
         undelegate(eventName: string, selector?: string, listener?: ViewBaseEventListener): this;
 
         protected _removeElement(): void;
-        protected _setElement(el: TElement | Dom): void;
+        protected _setElement(el: $Element<TElement>): void;
         protected _createElement(tagName: string): void;
         protected _ensureElement(): void;
         protected _setAttributes(attributes: Record<string, any>): void;


### PR DESCRIPTION
## Description

- add missing `filter()` method used by `util.seAttributesBySelector()`
- `$el.html(number)`  converts the number to a string and sets the element content
- add `detach()` method as an alternative to `remove()` which does not remove the attached  events
- `$.event.has` now accepts the second attribute (type of the event)
- introduce the `$Element` type, which represents DOM elements that can be passed to the `$()` function. Many functions still use `$` internally, and this type describes what types are accepted

