### PR TITLE
feat(mvc.$): update methods for better backwards compatibility

### DIFF
--- a/packages/joint-core/src/mvc/Dom/Dom.mjs
+++ b/packages/joint-core/src/mvc/Dom/Dom.mjs
@@ -519,7 +519,7 @@ $.event.dispatch = function(nativeEvent) {
     }
 
     return event.result;
-},
+};
 
 $.event.handlers = function(event, handlers) {
 

--- a/packages/joint-core/src/mvc/Dom/animations.mjs
+++ b/packages/joint-core/src/mvc/Dom/animations.mjs
@@ -1,0 +1,78 @@
+export function animate(properties, opt = {}) {
+    let {
+        duration = 400,
+        easing = 'ease-in-out',
+        delay = 0,
+        complete
+    } = opt;
+
+    const that = this;
+    const [node] = this;
+
+    let endEvent = 'transitionend';
+    let fired = false;
+
+    // Convert milliseconds to seconds for CSS
+    duration = duration / 1000;
+    delay = delay / 1000;
+
+    // Set up CSS values for transition or keyframe animation
+    var cssValues = {};
+    if (typeof properties === 'string') {
+        // Keyframe animation
+        cssValues['animation-name'] = properties;
+        cssValues['animation-duration'] = duration + 's';
+        cssValues['animation-delay'] = delay + 's';
+        cssValues['animation-timing-function'] = easing;
+        endEvent = 'animationend';
+    } else {
+        // CSS transitions
+        var transitionProperties = [];
+        for (var key in properties) {
+            if (properties.hasOwnProperty(key)) {
+                cssValues[key] = properties[key];
+                transitionProperties.push(key);
+            }
+        }
+
+        if (duration > 0) {
+            cssValues['transition-property'] = transitionProperties.join(', ');
+            cssValues['transition-duration'] = duration + 's';
+            cssValues['transition-delay'] = delay + 's';
+            cssValues['transition-timing-function'] = easing;
+        }
+    }
+
+    const wrappedCallback = function(event){
+        if (typeof event !== 'undefined') {
+            if (event.target !== event.currentTarget) return; // makes sure the event didn't bubble from "below"
+            event.target.removeEventListener(endEvent, wrappedCallback);
+        } else
+            node.removeEventListener(endEvent, wrappedCallback); // triggered by setTimeout
+
+        fired = true;
+        // $(this).css(cssReset);
+        complete && complete.call(node);
+    };
+    if (duration > 0){
+        node.addEventListener(endEvent, wrappedCallback);
+        // transitionEnd is not always firing on older Android phones
+        // so make sure it gets fired
+        setTimeout(function(){
+            if (fired) return;
+            wrappedCallback.call(that);
+        }, ((duration + delay) * 1000) + 25);
+    }
+
+    this.css(cssValues);
+
+    if (duration <= 0) setTimeout(function() {
+        for (var i = 0; i < that.length; i++) wrappedCallback.call(that[i]);
+    }, 0);
+
+    return this;
+}
+
+export function stop() {
+    // TBD
+}

--- a/packages/joint-core/src/mvc/Dom/events.mjs
+++ b/packages/joint-core/src/mvc/Dom/events.mjs
@@ -5,7 +5,9 @@ import $ from './Dom.mjs';
 
 // Special events
 
-export const special = Object.create(null);
+const special = Object.create(null);
+
+export default special;
 
 special.load = {
     // Prevent triggered image.load events from bubbling to window.load

--- a/packages/joint-core/src/mvc/Dom/index.mjs
+++ b/packages/joint-core/src/mvc/Dom/index.mjs
@@ -1,8 +1,10 @@
 import { default as $ } from './Dom.mjs';
 import * as methods from './methods.mjs';
+import * as props from './props.mjs';
 import { special } from './events.mjs';
 
 Object.assign($.fn, methods);
+Object.assign($.fn, props);
 Object.assign($.event.special, special);
 
 export default $;

--- a/packages/joint-core/src/mvc/Dom/index.mjs
+++ b/packages/joint-core/src/mvc/Dom/index.mjs
@@ -1,6 +1,6 @@
 import { default as $ } from './Dom.mjs';
 import * as methods from './methods.mjs';
-import * as props from './props.mjs';
+import { methods as props } from './props.mjs';
 import { special } from './events.mjs';
 
 Object.assign($.fn, methods);

--- a/packages/joint-core/src/mvc/Dom/index.mjs
+++ b/packages/joint-core/src/mvc/Dom/index.mjs
@@ -1,9 +1,11 @@
 import { default as $ } from './Dom.mjs';
 import * as methods from './methods.mjs';
-import { methods as props } from './props.mjs';
-import { special } from './events.mjs';
+import * as animations from './animations.mjs';
+import { default as props } from './props.mjs';
+import { default as special } from './events.mjs';
 
 Object.assign($.fn, methods);
+Object.assign($.fn, animations);
 Object.assign($.fn, props);
 Object.assign($.event.special, special);
 

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -200,6 +200,20 @@ export function hasClass() {
     return V.prototype.hasClass.apply({ node }, arguments);
 }
 
+// Traversing
+
+export function children(selector) {
+    const matches = [];
+    for(let i = 0; i < this.length; i++) {
+        const node = this[i];
+        let children = Array.from(node.children);
+        if (typeof selector === 'string') {
+            children = children.filter(child => child.matches(selector));
+        }
+        matches.push(...children);
+    }
+    return this.pushStack(matches);
+}
 
 // Events
 
@@ -242,4 +256,32 @@ export function off(types, selector, fn) {
         $.event.remove(this[i], types, fn, selector);
     }
     return this;
+}
+
+// Measurements
+
+export function width() {
+    const [el] = this;
+    if (el === window) return el.document.documentElement.clientWidth;
+    else if (!el) return undefined;
+    const styles = window.getComputedStyle(el);
+    const height = el.offsetWidth;
+    const borderTopWidth = parseFloat(styles.borderTopWidth);
+    const borderBottomWidth = parseFloat(styles.borderBottomWidth);
+    const paddingTop = parseFloat(styles.paddingTop);
+    const paddingBottom = parseFloat(styles.paddingBottom);
+    return height - borderBottomWidth - borderTopWidth - paddingTop - paddingBottom;
+}
+
+export function height() {
+    const [el] = this;
+    if (el === window) return el.document.documentElement.clientHeight;
+    if (!el) return undefined;
+    const styles = window.getComputedStyle(el);
+    const width = el.offsetHeight;
+    const borderLeftWidth = parseFloat(styles.borderLeftWidth);
+    const borderRightWidth = parseFloat(styles.borderRightWidth);
+    const paddingLeft = parseFloat(styles.paddingLeft);
+    const paddingRight = parseFloat(styles.paddingRight);
+    return width - borderLeftWidth - borderRightWidth - paddingLeft - paddingRight;
 }

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -48,7 +48,8 @@ export function clone() {
 export function html(html) {
     const [el] = this;
     if (!el) return null;
-    if (html === undefined) return el.innerHTML;
+    if (arguments.length === 0) return el.innerHTML;
+    if (html === undefined) return this; // do nothing
     cleanNodesData(dataPriv, el.getElementsByTagName('*'));
     if (typeof html === 'string' || typeof html === 'number') {
         el.innerHTML = html;

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -158,19 +158,25 @@ export function attr(name, value) {
 
 // Classes
 
-export function removeClass() {
-    for (let i = 0; i < this.length; i++) {
-        const node = this[i];
-        V.prototype.removeClass.apply({ node }, arguments);
+function setNodesClass(method, nodes, args) {
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        V.prototype[method].apply({ node }, args);
     }
+}
+
+export function removeClass() {
+    setNodesClass('removeClass', this, arguments);
     return this;
 }
 
 export function addClass() {
-    for (let i = 0; i < this.length; i++) {
-        const node = this[i];
-        V.prototype.addClass.apply({ node }, arguments);
-    }
+    setNodesClass('addClass', this, arguments);
+    return this;
+}
+
+export function toggleClass() {
+    setNodesClass('toggleClass', this, arguments);
     return this;
 }
 
@@ -180,14 +186,17 @@ export function hasClass() {
     return V.prototype.hasClass.apply({ node }, arguments);
 }
 
+
 // Events
 
 export function on(types, selector, data, fn) {
-    return $.event.on(this, types, selector, data, fn);
+    $.event.on(this, types, selector, data, fn);
+    return this;
 }
 
 export function one(types, selector, data, fn) {
-    return $.event.on(this, types, selector, data, fn, 1);
+    $.event.on(this, types, selector, data, fn, 1);
+    return this;
 }
 
 export function off(types, selector, fn) {
@@ -218,4 +227,5 @@ export function off(types, selector, fn) {
     for (let i = 0; i < this.length; i++) {
         $.event.remove(this[i], types, fn, selector);
     }
+    return this;
 }

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -190,50 +190,6 @@ export function attr(name, value) {
     return this;
 }
 
-// Properties
-
-export function prop(name, value) {
-    if (!name) throw new Error('no property provided');
-    if (arguments.length === 1) {
-        const [el] = this;
-        if (!el) return null;
-        return el[name];
-    } else {
-        for (let i = 0; i < this.length; i++) {
-            this[i][name] = value;
-        }
-    }
-    return this;
-}
-
-export function outerWidth(...args) {
-    return this.prop('offsetWidth', ...args);
-}
-
-export function outerHeight(...args) {
-    return this.prop('offsetHeight', ...args);
-}
-
-export function innerWidth(...args) {
-    return this.prop('clientWidth', ...args);
-}
-
-export function innerHeight(...args) {
-    return this.prop('clientHeight', ...args);
-}
-
-export function scrollLeft(...args) {
-    return this.prop('scrollLeft', ...args);
-}
-
-export function scrollTop(...args) {
-    return this.prop('scrollTop', ...args);
-}
-
-export function val(...args) {
-    return this.prop('...args', ...args);
-}
-
 export function data(name, value) {
     if (arguments.length < 2) {
         const [el] = this;

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -39,9 +39,9 @@ export function empty() {
 export function html(html) {
     const [el] = this;
     if (!el) return null;
-    if (!html) return el.innerHTML;
+    if (html === undefined) return el.innerHTML;
     cleanNodesData(dataPriv, el.getElementsByTagName('*'));
-    if (typeof string === 'string' || typeof string === 'number') {
+    if (typeof html === 'string' || typeof html === 'number') {
         el.innerHTML = html;
     } else {
         el.innerHTML = '';
@@ -151,6 +151,20 @@ export function attr(name, value) {
             for (let i = 0; i < this.length; i++) {
                 this[i].setAttribute(attr, attributes[attr]);
             }
+        }
+    }
+    return this;
+}
+
+export function prop(name, value) {
+    if (!name) throw new Error('no property provided');
+    if (value === undefined) {
+        const [el] = this;
+        if (!el) return null;
+        return el[name];
+    } else {
+        for (let i = 0; i < this.length; i++) {
+            this[i][name] = value;
         }
     }
     return this;

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -358,26 +358,27 @@ export function position() {
         // when a statically positioned element is identified
         doc = el.ownerDocument;
         offsetParent = el.offsetParent || doc.documentElement;
-        const parentOffsetElement = $(offsetParent);
-        const parentOffsetElementPosition = parentOffsetElement.css('position') || 'static';
+        const $parentOffset = $(offsetParent);
+        const parentOffsetElementPosition = $parentOffset.css('position') || 'static';
         while ( offsetParent && (offsetParent === doc.body || offsetParent === doc.documentElement) && parentOffsetElementPosition === 'static') {
             offsetParent = offsetParent.parentNode;
         }
         if (offsetParent && offsetParent !== el && offsetParent.nodeType === 1) {
             // Incorporate borders into its offset, since they are outside its content origin
-            const borderTopWidth = parseFloat(window.getComputedStyle(offsetParent).borderTopWidth) || 0;
-            const borderLeftWidth = parseFloat(window.getComputedStyle(offsetParent).borderLeftWidth) || 0;
-            parentOffset = parentOffsetElement.offset();
-            parentOffset.top += parseFloat(borderTopWidth);
-            parentOffset.left += parseFloat(borderLeftWidth);
+            const offsetParentStyles = window.getComputedStyle(offsetParent);
+            const borderTopWidth = parseFloat(offsetParentStyles.borderTopWidth) || 0;
+            const borderLeftWidth = parseFloat(offsetParentStyles.borderLeftWidth) || 0;
+            parentOffset = $parentOffset.offset();
+            parentOffset.top += borderTopWidth;
+            parentOffset.left += borderLeftWidth;
         }
     }
     const marginTop = parseFloat(window.getComputedStyle(el).marginTop) || 0;
     const marginLeft = parseFloat(window.getComputedStyle(el).marginLeft) || 0;
     // Subtract parent offsets and element margins
     return {
-        top: offset.top - parentOffset.top - parseFloat(marginTop),
-        left: offset.left - parentOffset.left - parseFloat(marginLeft)
+        top: offset.top - parentOffset.top - marginTop,
+        left: offset.left - parentOffset.left - marginLeft
     };
 }
 

--- a/packages/joint-core/src/mvc/Dom/props.mjs
+++ b/packages/joint-core/src/mvc/Dom/props.mjs
@@ -1,0 +1,35 @@
+function prop(name, value) {
+    if (!name) throw new Error('no property provided');
+    if (arguments.length === 1) {
+        const [el] = this;
+        if (!el) return null;
+        return el[name];
+    }
+    if (value === undefined) return this;
+    for (let i = 0; i < this.length; i++) {
+        this[i][name] = value;
+    }
+    return this;
+}
+
+const properties = {
+    outerWidth: 'offsetWidth',
+    outerHeight: 'offsetHeight',
+    innerWidth: 'clientWidth',
+    innerHeight: 'clientHeight',
+    scrollLeft: 'scrollLeft',
+    scrollTop: 'scrollTop',
+    val: 'value',
+};
+
+const methods = {
+    prop
+};
+
+Object.keys(properties).forEach(methodName => {
+    methods[methodName] = function(...args) {
+        return this.prop(properties[methodName], ...args);
+    };
+});
+
+export default methods;

--- a/packages/joint-core/src/mvc/Dom/props.mjs
+++ b/packages/joint-core/src/mvc/Dom/props.mjs
@@ -22,7 +22,7 @@ const properties = {
     val: 'value',
 };
 
-export const methods = {
+const methods = {
     prop
 };
 
@@ -32,3 +32,4 @@ Object.keys(properties).forEach(methodName => {
     };
 });
 
+export default methods;

--- a/packages/joint-core/src/mvc/Dom/props.mjs
+++ b/packages/joint-core/src/mvc/Dom/props.mjs
@@ -22,7 +22,7 @@ const properties = {
     val: 'value',
 };
 
-const methods = {
+export const methods = {
     prop
 };
 
@@ -32,4 +32,3 @@ Object.keys(properties).forEach(methodName => {
     };
 });
 
-export default methods;

--- a/packages/joint-core/test/jointjs/index.html
+++ b/packages/joint-core/test/jointjs/index.html
@@ -19,6 +19,7 @@
         <script src="./mvc.viewBase.js"></script>
         <script src="./mvc.collection.js"></script>
         <script src="./mvc.model.js"></script>
+        <script src="./mvc.Dom.js"></script>
         <script src="./core/util.js"></script>
         <script src="./dia/attributes.js"></script>
         <script src="./dia/Paper.js"></script>

--- a/packages/joint-core/test/jointjs/mvc.Dom.js
+++ b/packages/joint-core/test/jointjs/mvc.Dom.js
@@ -1,0 +1,18 @@
+'use strict';
+
+QUnit.module('joint.mvc.$', function(hooks) {
+
+    QUnit.test('$.fn.prop', function(assert) {
+        const el = document.createElement('div');
+        const $el = joint.mvc.$(el);
+        assert.equal($el.prop('role'), null);
+        el.role = 'test';
+        assert.equal($el.prop('role'), 'test');
+        assert.equal($el.prop('role', 'test2'), $el);
+        assert.equal($el.prop('role'), 'test2');
+        assert.equal($el.prop('role', undefined), $el);
+        assert.equal($el.prop('role'), 'test2');
+        assert.equal($el.prop('role', null), $el);
+        assert.equal($el.prop('role'), null);
+    });
+});

--- a/packages/joint-core/test/jointjs/mvc.Dom.js
+++ b/packages/joint-core/test/jointjs/mvc.Dom.js
@@ -15,4 +15,73 @@ QUnit.module('joint.mvc.$', function(hooks) {
         assert.equal($el.prop('role', null), $el);
         assert.equal($el.prop('role'), null);
     });
+
+    QUnit.module('$.fn.animate', function() {
+
+        QUnit.test('options.complete is called when duration is 0.1s', function(assert) {
+            const done = assert.async();
+            const el = document.createElement('div');
+            const $el = joint.mvc.$(el);
+            el.style.width = '0px';
+            $el.animate({ width: 100 }, {
+                duration: 100,
+                complete: () => {
+                    assert.equal(el.style.width, '100px');
+                    done();
+                }
+            });
+        });
+
+        QUnit.test('options.complete is called if duration is 0', function(assert) {
+            const done = assert.async();
+            const el = document.createElement('div');
+            const $el = joint.mvc.$(el);
+            el.style.width = '0px';
+            $el.animate({ width: 100 }, {
+                duration: 0,
+                complete: () => {
+                    assert.equal(el.style.width, '100px');
+                    done();
+                }
+            });
+        });
+
+        QUnit.test('options.complete is called if the animated properties already match', function(assert) {
+            const done = assert.async();
+            const el = document.createElement('div');
+            const $el = joint.mvc.$(el);
+            el.style.width = '100px';
+            $el.animate({ width: 100 }, {
+                duration: 100,
+                complete: () => {
+                    assert.equal(el.style.width, '100px');
+                    done();
+                }
+            });
+        });
+
+    });
+
+    QUnit.module('$.fn.stop', function() {
+
+        QUnit.test('stops animation', function(assert) {
+            assert.expect(1);
+            const done = assert.async();
+            const el = document.createElement('div');
+            const $el = joint.mvc.$(el);
+            el.style.width = '0px';
+            $el.animate({ width: 100 }, {
+                duration: 100,
+                complete: () => {
+                    assert.notOk(true);
+                }
+            });
+            $el.stop();
+            setTimeout(() => {
+                assert.equal(el.style.width, '0px');
+                done();
+            }, 200);
+        });
+    });
+
 });

--- a/packages/joint-core/test/utils.js
+++ b/packages/joint-core/test/utils.js
@@ -153,23 +153,6 @@ $.fn.index = function() {
     return Array.prototype.indexOf.call(el.parentNode.children, el);
 };
 
-$.fn.offset = function() {
-    const [el] = this;
-    const box = el.getBoundingClientRect();
-    return {
-        top: box.top + window.scrollY - document.documentElement.clientTop,
-        left: box.left + window.scrollX - document.documentElement.clientLeft
-    };
-};
-
-$.fn.children = function(selector) {
-    const [el] = this;
-    if (selector) {
-        return $(Array.from(el.children).filter(child => child.matches(selector)));
-    }
-    return $(el.children);
-};
-
 $.fn.parent = function() {
     const [el] = this;
     return $(el.parentNode);

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2777,6 +2777,13 @@ export namespace mvc {
     type $HTMLElement = $Element<HTMLElement>;
     type $SVGElement = $Element<SVGElement>;
 
+    interface $AnimationOptions {
+        duration?: number;
+        delay?: number;
+        easing?: string;
+        complete?: (this: Element) => void;
+    }
+
     interface Event {
         // Event
         bubbles: boolean | undefined;


### PR DESCRIPTION
## Description

Improve the `mvc.$.fn` methods not to introduce breaking change unnecessarily

- fix `html()` method typos
- return `this` to allow chaining
- add `toggleClass()`, `prop()`, `height()`, `width()`, `children()`, `clone()`
- add other property method wrappers such as `val()`, `scrollTop()`
- add `animation()` and `stop()`
- add `offset()` and `position()`
- add a few tests

