### PR TITLE
types(util): make debounce options optional

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2635,7 +2635,7 @@ export namespace util {
 
     export function toArray(value: any): any[];
 
-    export function debounce<T extends Function>(func: T, wait?: number, options?: { leading: boolean, maxWait: number, trailing: boolean }): T & Cancelable;
+    export function debounce<T extends Function>(func: T, wait?: number, options?: { leading?: boolean, maxWait?: number, trailing?: boolean }): T & Cancelable;
 
     export function groupBy(collection: Collection, iteratee?: IterateeFunction<any>): object;
 


### PR DESCRIPTION
## Description

The individual options in `debounce` methods should not be mandatory.
```ts
util.debounce(fn, 100, { leading: true }); // `maxWait` and `trailing` are optional
```

