### PR TITLE
fix(linkTools.Vertices): fix to fire mouseleave event when redundancy…

### DIFF
--- a/packages/joint-core/src/linkTools/Vertices.mjs
+++ b/packages/joint-core/src/linkTools/Vertices.mjs
@@ -189,7 +189,10 @@ export const Vertices = ToolView.extend({
     onHandleChanged: function(_handle, evt) {
         const { options, relatedView: linkView } = this;
         if (options.vertexAdding) this.updatePath();
-        if (!options.redundancyRemoval) return;
+        if (!options.redundancyRemoval) {
+            linkView.checkMouseleave(util.normalizeEvent(evt));
+            return;
+        }
         var verticesRemoved = linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
         if (verticesRemoved) this.render();
         this.blur();


### PR DESCRIPTION
## Description

A fix to trigger `link:mouseleave` event when the user stops dragging a vertex, the pointer is no longer over the vertex and `redundancyRemoval` option is disabled.
