### PR TITLE
fix(mvc.Dom): remove event listeners on element removal;  fix(linkTools.Vertices): fix to fire mouseleave event when redundancyRemoval is disabled

### DIFF
--- a/packages/joint-core/src/linkTools/Vertices.mjs
+++ b/packages/joint-core/src/linkTools/Vertices.mjs
@@ -189,10 +189,7 @@ export const Vertices = ToolView.extend({
     onHandleChanged: function(_handle, evt) {
         const { options, relatedView: linkView } = this;
         if (options.vertexAdding) this.updatePath();
-        if (!options.redundancyRemoval) {
-            linkView.checkMouseleave(util.normalizeEvent(evt));
-            return;
-        }
+        if (!options.redundancyRemoval) return;
         var verticesRemoved = linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
         if (verticesRemoved) this.render();
         this.blur();

--- a/packages/joint-core/src/linkTools/Vertices.mjs
+++ b/packages/joint-core/src/linkTools/Vertices.mjs
@@ -189,7 +189,10 @@ export const Vertices = ToolView.extend({
     onHandleChanged: function(_handle, evt) {
         const { options, relatedView: linkView } = this;
         if (options.vertexAdding) this.updatePath();
-        if (!options.redundancyRemoval) return;
+        if (!options.redundancyRemoval) {
+            linkView.checkMouseleave(util.normalizeEvent(evt));
+            return;
+        }
         var verticesRemoved = linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
         if (verticesRemoved) this.render();
         this.blur();

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -1,14 +1,23 @@
 import { camelCase } from '../../util/utilHelpers.mjs';
 import $ from './Dom.mjs';
 import V from '../../V/index.mjs';
-import { dataPriv, cleanNodesData } from './vars.mjs';
+import { dataPriv } from './vars.mjs';
 
 // Manipulation
 
-function removeNodes(nodes, removeData) {
+function cleanNodesData(nodes) {
+    let i = nodes.length;
+    while (i--) cleanNodeData(nodes[i]);
+}
+
+function cleanNodeData(node) {
+    $.event.remove(node);
+    dataPriv.remove(node);
+}
+
+function removeNodes(nodes) {
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
-        removeData && dataPriv.remove(node);
         if (node.parentNode) {
             node.parentNode.removeChild(node);
         }
@@ -16,12 +25,17 @@ function removeNodes(nodes, removeData) {
 }
 
 export function remove() {
-    removeNodes(this, true);
+    for (let i = 0; i < this.length; i++) {
+        const node = this[i];
+        cleanNodeData(node);
+        cleanNodesData(node.getElementsByTagName('*'));
+    }
+    removeNodes(this);
     return this;
 }
 
 export function detach() {
-    removeNodes(this, false);
+    removeNodes(this);
     return this;
 }
 
@@ -29,7 +43,7 @@ export function empty() {
     for (let i = 0; i < this.length; i++) {
         const node = this[i];
         if (node.nodeType === 1) {
-            cleanNodesData(dataPriv, node.getElementsByTagName('*'));
+            cleanNodesData(node.getElementsByTagName('*'));
             // Remove any remaining nodes
             node.textContent = '';
         }

--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -1,7 +1,7 @@
 import { camelCase } from '../../util/utilHelpers.mjs';
 import $ from './Dom.mjs';
 import V from '../../V/index.mjs';
-import { dataPriv } from './vars.mjs';
+import { dataPriv, dataUser } from './vars.mjs';
 
 // Manipulation
 
@@ -13,6 +13,7 @@ function cleanNodesData(nodes) {
 function cleanNodeData(node) {
     $.event.remove(node);
     dataPriv.remove(node);
+    dataUser.remove(node);
 }
 
 function removeNodes(nodes) {

--- a/packages/joint-core/src/mvc/Dom/vars.mjs
+++ b/packages/joint-core/src/mvc/Dom/vars.mjs
@@ -3,10 +3,3 @@ import Data from '../Data.mjs';
 export const dataPriv = new Data();
 
 export const dataUser = new Data();
-
-export function cleanNodesData(data, nodes) {
-    let i = nodes.length;
-    while (i--) {
-        data.remove(nodes[i]);
-    }
-}


### PR DESCRIPTION
## Description

Make sure all the event listeners and data are removed from the DOM nodes if they are removed using `mvc.Dom`.
This PR just fixes behavior to match jQuery removal functionality.