### PR TITLE
refactor: Use joint directly in typescript tests and in ts-demo

### DIFF
--- a/packages/joint-core/demo/.eslintrc.js
+++ b/packages/joint-core/demo/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
         'Vue': true,
         'd3': true
     },
-    'ignorePatterns': ['/ts-demo/vendor/**'],
     'overrides': [{
         'files': [
             'rough/src/rough.js',

--- a/packages/joint-core/demo/custom-embedding/README.md
+++ b/packages/joint-core/demo/custom-embedding/README.md
@@ -8,7 +8,6 @@ You need to build *JointJS* first. Navigate to the root folder and run:
 ```bash
 yarn install
 yarn run build
-yarn run build-bundles
 ```
 
 Then navigate to this directory and open `index.html` in your browser:

--- a/packages/joint-core/demo/custom-embedding/custom-embedding.js
+++ b/packages/joint-core/demo/custom-embedding/custom-embedding.js
@@ -99,5 +99,3 @@ new Parent({
         label: { text: 'Parent #2\n(custom embedding logic)\nThree embedded children\n–\nTry to move me!' }
     }
 }).position(620, 480).size(160, 100).addTo(graph).embed(r).embed(g).embed(b);
-
-

--- a/packages/joint-core/demo/custom-embedding/index.html
+++ b/packages/joint-core/demo/custom-embedding/index.html
@@ -16,7 +16,7 @@
     <body>
         <div id="paper"></div>
 
-        <script src="../../build/joint.webpack-bundle.js"></script>
+        <script src="../../build/joint.js"></script>
 
         <script src="./custom-embedding.js"></script>
     </body>

--- a/packages/joint-core/demo/ts-demo/.gitignore
+++ b/packages/joint-core/demo/ts-demo/.gitignore
@@ -1,4 +1,3 @@
-vendor/
 dist/
 node_modules/
 .pnp.*

--- a/packages/joint-core/demo/ts-demo/custom.ts
+++ b/packages/joint-core/demo/ts-demo/custom.ts
@@ -1,7 +1,7 @@
-import * as joint from './vendor/joint';
+import * as joint from '../../';
 
 // extend joint.shapes namespace
-declare module './vendor/joint' {
+declare module '../../' {
     namespace shapes {
         namespace app {
             class CustomRect extends joint.shapes.standard.Rectangle {
@@ -62,4 +62,3 @@ class CustomRectView extends joint.dia.ElementView {
         CustomRectView
     }
 });
-

--- a/packages/joint-core/demo/ts-demo/index.ts
+++ b/packages/joint-core/demo/ts-demo/index.ts
@@ -1,6 +1,6 @@
-import * as joint from './vendor/joint';
+import * as joint from '../../';
 import './custom';
-import { V, g } from './vendor/joint';
+import { V, g } from '../../';
 import { MyShape } from './shape';
 
 const { body } = document;

--- a/packages/joint-core/demo/ts-demo/shape.ts
+++ b/packages/joint-core/demo/ts-demo/shape.ts
@@ -1,4 +1,4 @@
-import { shapes, dia, util } from './vendor/joint';
+import { shapes, dia, util } from '../../';
 
 export class MyShape extends dia.Element {
 

--- a/packages/joint-core/grunt/config/aliases.js
+++ b/packages/joint-core/grunt/config/aliases.js
@@ -30,8 +30,7 @@ module.exports = function(grunt) {
         'build:joint': [
             'shell:rollup-joint',
             'shell:api-extractor-dts-bundle',
-            'newer:concat:types',
-            'newer:copy:appsLibs'
+            'newer:concat:types'
         ],
         'uglify:all':[
             'newer:uglify:deps',

--- a/packages/joint-core/grunt/config/copy.js
+++ b/packages/joint-core/grunt/config/copy.js
@@ -60,12 +60,6 @@ module.exports = function(grunt) {
                     dest: 'build/docs/css/prism.css'
                 }
             ]
-        },
-        appsLibs: {
-            files: [
-                { nonull: true, src: 'build/joint.d.ts', dest: 'demo/ts-demo/vendor/joint.d.ts' },
-                { nonull: true, src: 'build/joint.js', dest: 'demo/ts-demo/vendor/joint.js' },
-            ]
         }
     };
 };

--- a/packages/joint-core/test/jointjs-nodejs/index.js
+++ b/packages/joint-core/test/jointjs-nodejs/index.js
@@ -3,7 +3,7 @@
 require('should');
 
 // Test against the latest JointJS build file.
-var joint = require('../../');
+var joint = require('../../build/joint');
 
 describe('Sanity check', function() {
 

--- a/packages/joint-core/test/jointjs-nodejs/index.js
+++ b/packages/joint-core/test/jointjs-nodejs/index.js
@@ -3,7 +3,7 @@
 require('should');
 
 // Test against the latest JointJS build file.
-var joint = require('../../build/joint');
+var joint = require('../../');
 
 describe('Sanity check', function() {
 

--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -1,6 +1,6 @@
 type AssertExtends<A,B> = A extends B ? true : never;
 
-import * as joint from '../../build/joint';
+import * as joint from '../../';
 
 const graph = new joint.dia.Graph({ graphAttribute: true });
 

--- a/packages/joint-core/test/ts/mvc.listener.test.ts
+++ b/packages/joint-core/test/ts/mvc.listener.test.ts
@@ -1,4 +1,4 @@
-import { dia, shapes, mvc } from '../../build/joint';
+import { dia, shapes, mvc } from '../../';
 
 type Args = [
     { graph: dia.Graph },
@@ -37,7 +37,7 @@ listener.listenTo(graph, {
         const element1 = graph.getCell(cellMap.rect1.id) as dia.Element;
         const element2 = cellMap['rect1'] as dia.Element;
         element1.attr({ body: { fill: 'yellow' }});
-        element2.attr({ body: { fill: 'red' }}); 
+        element2.attr({ body: { fill: 'red' }});
     },
     'link:add': ({ graph }, cellMap, _linkView, _evt) => {
         const link1 = graph.getCell(cellMap.link1.id) as dia.Link;

--- a/packages/joint-core/test/ts/toolsView.test.ts
+++ b/packages/joint-core/test/ts/toolsView.test.ts
@@ -1,4 +1,4 @@
-import { dia, linkTools, elementTools } from '../../build/joint';
+import { dia, linkTools, elementTools } from '../../';
 
 class MyVertexHandle extends linkTools.Vertices.VertexHandle {
 }

--- a/packages/joint-core/test/ts/vectorizer.test.ts
+++ b/packages/joint-core/test/ts/vectorizer.test.ts
@@ -1,4 +1,4 @@
-import { V, Vectorizer } from '../../build/joint';
+import { V, Vectorizer } from '../../';
 
 //** V */
 


### PR DESCRIPTION
## Description

- typescript tests import joint from joint-core package (`../../`)
- demo/ts-demo imports joint from joint-core package (`../../`)
   - grunt logic to copy joint.js and joint.d.ts files into `demo/ts-demo/vendor/joint` is no longer necessary
- demo/custom-embedding uses `build/joint.js` instead of `build/joint.webpack-bundle.js` (there was no reason to use the webpack bundle and it was inconsistent with other demos)

## Motivation and Context

Thanks to #2473, it is no longer necessary to build jointjs in order to be able to use it in typescript code.