### PR TITLE
refactor(dia.Paper)!: change the default connection point to 'boundary'

### DIFF
--- a/packages/joint-core/demo/archive/petri-nets/src/pn.js
+++ b/packages/joint-core/demo/archive/petri-nets/src/pn.js
@@ -132,7 +132,6 @@ var paper = new joint.dia.Paper({
     cellViewNamespace: shapes,
     linkView: joint.dia.LegacyLinkView,
     defaultAnchor: { name: 'perpendicular' },
-    defaultConnectionPoint: { name: 'boundary' },
     model: graph
 });
 

--- a/packages/joint-core/demo/bandwidth/src/bandwidth.js
+++ b/packages/joint-core/demo/bandwidth/src/bandwidth.js
@@ -14,9 +14,6 @@ const paper = new dia.Paper({
     cellViewNamespace: shapes,
     async: true,
     background: { color:  '#F3F7F6' },
-    defaultConnectionPoint: {
-        name: 'boundary',
-    },
     restrictTranslate: (elementView) => {
         // Restrict the element movement along the line only
         const { height } = elementView.model.size();

--- a/packages/joint-core/demo/container/src/index.js
+++ b/packages/joint-core/demo/container/src/index.js
@@ -12,9 +12,6 @@
             color: '#F3F7F6'
         },
         interactive: { linkMove: false },
-        defaultConnectionPoint: {
-            name: 'boundary'
-        },
         viewport: function(view) {
             var element = view.model;
             // Hide any element or link which is embedded inside a collapsed parent (or parent of the parent).

--- a/packages/joint-core/demo/devs/src/shapes.devs.js
+++ b/packages/joint-core/demo/devs/src/shapes.devs.js
@@ -241,7 +241,6 @@ const paper = new dia.Paper({
     embeddingMode: true,
     clickThreshold: 5,
     cellViewNamespace: shapes,
-    defaultConnectionPoint: { name: 'boundary' },
     overflow: true,
     highlighting: {
         'default': {

--- a/packages/joint-core/demo/expand/index.js
+++ b/packages/joint-core/demo/expand/index.js
@@ -73,7 +73,6 @@ var paper = new joint.dia.ExpandPaper({
     model: graph,
     cellViewNamespace: joint.shapes,
     defaultLink: new appLink(),
-    defaultConnectionPoint: { name: 'boundary' },
     magnetThreshold: 'onleave',
     clickThreshold: 5,
     validateMagnet: function(cellView, magnet) {

--- a/packages/joint-core/demo/fsa/src/fsa.js
+++ b/packages/joint-core/demo/fsa/src/fsa.js
@@ -6,7 +6,6 @@ const paper = new joint.dia.Paper({
     height: 600,
     model: graph,
     cellViewNamespace: joint.shapes,
-    defaultConnectionPoint: { name: 'boundary' },
     defaultConnector: { name: 'smooth' },
     interactive: { linkMove: false },
     labelsLayer: true,

--- a/packages/joint-core/demo/graph.js
+++ b/packages/joint-core/demo/graph.js
@@ -103,7 +103,6 @@ var paper = new joint.dia.Paper({
     height: 600,
     model: graph,
     cellViewNamespace: joint.shapes,
-    defaultConnectionPoint: { name: 'boundary' }
 });
 
 //var a, aa, aaa, b, c, d, e, f, g, h, t, l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l12, l13, l14, l15, l16, l17;
@@ -149,7 +148,6 @@ var treePaper = new joint.dia.Paper({
     height: 600,
     model: treeGraph,
     cellViewNamespace: joint.shapes,
-    defaultConnectionPoint: { name: 'boundary' }
 });
 
 treePaper.on('cell:mouseover', info);

--- a/packages/joint-core/demo/performance/async.js
+++ b/packages/joint-core/demo/performance/async.js
@@ -54,7 +54,6 @@ var paper = new Paper({
     async: true,
     frozen: true,
     defaultAnchor: { name: 'modelCenter' },
-    defaultConnectionPoint: { name: 'boundary' },
     viewport: function(view, isInViewport) {
         if (leaveDraggedInViewport && view.cid === draggedCid) return true;
         if (leaveRenderedInViewport && isInViewport) return true;

--- a/packages/joint-core/demo/ports/dynamic.js
+++ b/packages/joint-core/demo/ports/dynamic.js
@@ -112,7 +112,6 @@ var paper = new joint.dia.Paper({
     snapLinks: true,
     defaultLink: new joint.shapes.standard.Link({ z: - 1 }),
     defaultConnector: { name: 'smooth' },
-    defaultConnectionPoint: { name: 'boundary' },
     markAvailable: true,
     validateConnection: function(vS, mS, vT, mT, end, lV) {
         if (!mT) return false;

--- a/packages/joint-core/demo/ports/ports2.js
+++ b/packages/joint-core/demo/ports/ports2.js
@@ -7,7 +7,6 @@ new joint.dia.Paper({
     gridSize: 1,
     model: graph,
     cellViewNamespace: joint.shapes,
-    defaultConnectionPoint: { name: 'boundary' }
 });
 
 var m1 = new joint.shapes.standard.Rectangle({

--- a/packages/joint-core/docs/src/joint/api/connectionPoints/intro.html
+++ b/packages/joint-core/docs/src/joint/api/connectionPoints/intro.html
@@ -22,7 +22,7 @@
     }
 });</code></pre>
 
-<p>The default connection point is <code>'bbox'</code>; this can be changed with the <code>defaultConnectionPoint</code> <a href="#dia.Paper.prototype.options.defaultConnectionPoint">paper option</a>. Example:</p>
+<p>The default connection point is <code>'boundary'</code>; this can be changed with the <code>defaultConnectionPoint</code> <a href="#dia.Paper.prototype.options.defaultConnectionPoint">paper option</a>. Example:</p>
 
 <pre><code>paper.options.defaultConnectionPoint = {
     name: 'boundary',

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -192,7 +192,7 @@ export const Paper = View.extend({
 
         defaultLinkAnchor: { name: 'connectionRatio' },
 
-        defaultConnectionPoint: { name: 'bbox' },
+        defaultConnectionPoint: { name: 'boundary' },
 
         /* CONNECTING */
 

--- a/packages/joint-core/test/jointjs/connectors.js
+++ b/packages/joint-core/test/jointjs/connectors.js
@@ -12,6 +12,7 @@ QUnit.module('connectors', function(hooks) {
             gridSize: 10,
             model: this.graph,
             cellViewNamespace: joint.shapes,
+            defaultConnectionPoint: { name: 'bbox' },
         });
     });
 

--- a/packages/joint-core/test/jointjs/routers.js
+++ b/packages/joint-core/test/jointjs/routers.js
@@ -11,6 +11,7 @@ QUnit.module('routers', function(hooks) {
             gridSize: 10,
             model: this.graph,
             cellViewNamespace: joint.shapes,
+            defaultConnectionPoint: { name: 'bbox' },
         });
     });
 

--- a/packages/joint-core/tutorials/js/ports-basic-groups.js
+++ b/packages/joint-core/tutorials/js/ports-basic-groups.js
@@ -2,16 +2,15 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    new joint.dia.Paper({ 
+    new joint.dia.Paper({
         el: document.getElementById('paper-basic-groups'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link(),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent linking between ports within one element
             if (cellViewS === cellViewT) return false;
@@ -34,7 +33,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -85,7 +84,7 @@
             body: {
                 fill: '#8ECAE6',
             },
-            label: { 
+            label: {
                 text: 'Model',
                 fontSize: 16,
                 y: -10
@@ -101,15 +100,15 @@
 
 
     model.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'out' }}
         }

--- a/packages/joint-core/tutorials/js/ports-basic.js
+++ b/packages/joint-core/tutorials/js/ports-basic.js
@@ -2,16 +2,15 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    new joint.dia.Paper({ 
+    new joint.dia.Paper({
         el: document.getElementById('paper-basic'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link(),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent linking between ports within one element
             if (cellViewS === cellViewT) return false;
@@ -28,17 +27,17 @@
                 selector: 'label'
             }]
         },
-        attrs: { 
-            portBody: { 
+        attrs: {
+            portBody: {
                 magnet: true,
                 width: 16,
                 height: 16,
                 x: -8,
                 y: -8,
                 fill:  '#03071E'
-            }, 
-            label: { 
-                text: 'port' 
+            },
+            label: {
+                text: 'port'
             }
         },
         markup: [{

--- a/packages/joint-core/tutorials/js/ports-layout.js
+++ b/packages/joint-core/tutorials/js/ports-layout.js
@@ -2,12 +2,12 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    var paper = new joint.dia.Paper({ 
+    var paper = new joint.dia.Paper({
         el: document.getElementById('paper-layout'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link({
@@ -17,7 +17,6 @@
                 }
             }
         }),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent loop linking
             return (magnetS !== magnetT);
@@ -40,7 +39,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -183,7 +182,7 @@
             body: {
                 fill: '#8ECAE6'
             },
-            label: { 
+            label: {
                 text: 'Model 2',
                 fontSize: 16,
                 y: -10
@@ -199,15 +198,15 @@
 
 
     model1.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in3' }}
         },
@@ -218,15 +217,15 @@
     ]);
 
     model2.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'out' }}
         }
@@ -238,7 +237,7 @@
     paper.on('link:mouseenter', (linkView) => {
         showLinkTools(linkView);
     });
-    
+
     paper.on('link:mouseleave', (linkView) => {
         linkView.removeTools();
     });

--- a/packages/joint-core/tutorials/js/ports-link-snapping.js
+++ b/packages/joint-core/tutorials/js/ports-link-snapping.js
@@ -2,12 +2,12 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    var paper = new joint.dia.Paper({ 
+    var paper = new joint.dia.Paper({
         el: document.getElementById('paper-link-snapping'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link({
@@ -17,7 +17,6 @@
                 }
             }
         }),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent loop linking
             return (magnetS !== magnetT);
@@ -42,7 +41,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -96,7 +95,7 @@
             body: {
                 fill: '#8ECAE6',
             },
-            label: { 
+            label: {
                 text: 'Model',
                 fontSize: 16,
                 y: -10
@@ -112,15 +111,15 @@
 
 
     model.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'out' }}
         }
@@ -134,7 +133,7 @@
     paper.on('link:mouseenter', (linkView) => {
         showLinkTools(linkView);
     });
-    
+
     paper.on('link:mouseleave', (linkView) => {
         linkView.removeTools();
     });

--- a/packages/joint-core/tutorials/js/ports-links.js
+++ b/packages/joint-core/tutorials/js/ports-links.js
@@ -2,12 +2,12 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    var paper = new joint.dia.Paper({ 
+    var paper = new joint.dia.Paper({
         el: document.getElementById('paper-links'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link({
@@ -17,7 +17,6 @@
                 }
             }
         }),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent loop linking
             return (magnetS !== magnetT);
@@ -40,7 +39,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -94,7 +93,7 @@
             body: {
                 fill: '#8ECAE6',
             },
-            label: { 
+            label: {
                 text: 'Model',
                 fontSize: 16,
                 y: -10
@@ -110,17 +109,17 @@
 
 
     model.addPorts([
-        { 
+        {
             group: 'in',
             id: 'in1',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             id: 'in2',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             id: 'out',
             attrs: { label: { text: 'out' }}
@@ -135,7 +134,7 @@
     paper.on('link:mouseenter', (linkView) => {
         showLinkTools(linkView);
     });
-    
+
     paper.on('link:mouseleave', (linkView) => {
         linkView.removeTools();
     });

--- a/packages/joint-core/tutorials/js/ports-mark-available.js
+++ b/packages/joint-core/tutorials/js/ports-mark-available.js
@@ -2,12 +2,12 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    var paper = new joint.dia.Paper({ 
+    var paper = new joint.dia.Paper({
         el: document.getElementById('paper-mark-available'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link({
@@ -17,7 +17,6 @@
                 }
             }
         }),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent linking from output ports to input ports within one element.
             if (cellViewS === cellViewT) return false;
@@ -49,7 +48,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -103,7 +102,7 @@
             body: {
                 fill: '#8ECAE6',
             },
-            label: { 
+            label: {
                 text: 'Model',
                 fontSize: 16,
                 y: -10
@@ -119,15 +118,15 @@
 
 
     model.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'out' }}
         }
@@ -141,7 +140,7 @@
     paper.on('link:mouseenter', (linkView) => {
         showLinkTools(linkView);
     });
-    
+
     paper.on('link:mouseleave', (linkView) => {
         linkView.removeTools();
     });

--- a/packages/joint-core/tutorials/js/ports-restrictions.js
+++ b/packages/joint-core/tutorials/js/ports-restrictions.js
@@ -2,12 +2,12 @@
 
     var namespace = joint.shapes;
     var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
-    var paper = new joint.dia.Paper({ 
+    var paper = new joint.dia.Paper({
         el: document.getElementById('paper-restrictions'),
         width: 650,
         height: 200,
         gridSize: 1,
-        model: graph, 
+        model: graph,
         cellViewNamespace: namespace,
         linkPinning: false, // Prevent link being dropped in blank paper area
         defaultLink: () => new joint.shapes.standard.Link({
@@ -17,7 +17,6 @@
                 }
             }
         }),
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, magnetS, cellViewT, magnetT, end, linkView) {
             // Prevent linking from output ports to input ports within one element
             if (cellViewS === cellViewT) return false;
@@ -47,7 +46,7 @@
         label: {
             position: {
                 name: 'left',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -101,7 +100,7 @@
             body: {
                 fill: '#8ECAE6',
             },
-            label: { 
+            label: {
                 text: 'Model',
                 fontSize: 16,
                 y: -10
@@ -117,15 +116,15 @@
 
 
     model.addPorts([
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in1' }}
         },
-        { 
+        {
             group: 'in',
             attrs: { label: { text: 'in2' }}
         },
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'out' }}
         }
@@ -139,7 +138,7 @@
     paper.on('link:mouseenter', (linkView) => {
         showLinkTools(linkView);
     });
-    
+
     paper.on('link:mouseleave', (linkView) => {
         linkView.removeTools();
     });

--- a/packages/joint-core/tutorials/js/testing-e2e-playwright.js
+++ b/packages/joint-core/tutorials/js/testing-e2e-playwright.js
@@ -15,7 +15,6 @@
         cellViewNamespace: namespace,
         defaultLink: new joint.shapes.standard.Link(),
         linkPinning: false,
-        defaultConnectionPoint: { name: 'boundary' },
         validateConnection: function(cellViewS, _magnetS, cellViewT, _magnetT, _end, _linkView) {
             return (cellViewS !== cellViewT);
         }
@@ -36,7 +35,7 @@
         label: {
             position: {
                 name: 'right',
-                args: { y: 6 } 
+                args: { y: 6 }
             },
             markup: [{
                 tagName: 'text',
@@ -69,7 +68,7 @@
     });
 
     rect.addPorts([
-        { 
+        {
             group: 'out',
             attrs: { label: { text: 'port' }}
         }
@@ -86,8 +85,8 @@
             fill: 'black',
             textWrap: {
                 width: -10,
-                height: '50%', 
-                ellipsis: true 
+                height: '50%',
+                ellipsis: true
             }
         }
     });
@@ -176,5 +175,5 @@
     input.addEventListener('input', (e) => {
         rect.attr('label/text', e.target.value);
     });
-    
+
 })();


### PR DESCRIPTION
## Description

Change the value of the `defaultConnectionPoint` option to `boundary` to make the diagrams more visually appealing by default.

### Migration guide

To use the `bbox` connection point set the `defaultConnectionPoint` paper option as shown below:
```js
new dia.Paper({
    /* ... */
    defaultConnectionPoint: { name: 'bbox' }
});
```