### PR TITLE
fix(dia.Paper)!: fix `paper:pinch` dispatched event type

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2467,7 +2467,7 @@ export const Paper = View.extend({
         if (evt.ctrlKey && pinchHandlers && pinchHandlers.length > 0) {
             // This is a pinch gesture, it's safe to assume that we must call .preventDefault()
             originalEvent.preventDefault();
-            this._mw_evt_buffer.event = originalEvent;
+            this._mw_evt_buffer.event = evt;
             this._mw_evt_buffer.deltas.push(deltaY);
             this._processMouseWheelEvtBuf();
         } else {


### PR DESCRIPTION
## Description

For consistency, all events fired on paper are passed native events wrapped in the `mvc.$.Event` wrapper.

Before:
```js
paper.on('paper:pinch', (evt) => console.log('this is a native event', evt));
```

Now:
```js
paper.on('paper:pinch', (evt) => console.log('this is a native event', evt.originalEvent));
```


