### PR TITLE
fix(types): lower ts versions compatibility

### DIFF
--- a/packages/joint-core/types/index.d.ts
+++ b/packages/joint-core/types/index.d.ts
@@ -1,3 +1,53 @@
-export * from './geometry';
-export * from './vectorizer';
-export * from './joint';
+import { g } from './geometry';
+import {
+    V,
+    Vectorizer,
+    VElement
+} from './vectorizer';
+import {
+    version,
+    config,
+    dia,
+    highlighters,
+    shapes,
+    util,
+    env,
+    layout,
+    mvc,
+    routers,
+    connectors,
+    anchors,
+    linkAnchors,
+    connectionPoints,
+    connectionStrategies,
+    attributes,
+    setTheme,
+    elementTools,
+    linkTools
+} from './joint';
+
+export {
+    g,
+    V,
+    Vectorizer,
+    VElement,
+    version,
+    config,
+    dia,
+    highlighters,
+    shapes,
+    util,
+    env,
+    layout,
+    mvc,
+    routers,
+    connectors,
+    anchors,
+    linkAnchors,
+    connectionPoints,
+    connectionStrategies,
+    attributes,
+    setTheme,
+    elementTools,
+    linkTools
+};


### PR DESCRIPTION
### Description

Fixes joint-plus package types resolutions, when using Typescript version lower then 4.9