### PR TITLE
fix(dia.Cell): remove setter from prototype in docs and types

### DIFF
--- a/packages/joint-core/docs/src/joint/api/dia/Cell/prototype/parent.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Cell/prototype/parent.html
@@ -4,6 +4,3 @@
 <p>If the cell is a part of an embedding, the <code>id</code> of the parent cell is returned as a string.</p>
 
 <p>If you need to be sure that a Cell is returned (and not its <code>id</code>), use the <code>cell.getParentCell</code> <a href="#dia.Cell.prototype.getParentCell">function</a> instead.</p>
-
-<pre class="docs-method-signature"><code>cell.parent(parentId [, opt])</code></pre>
-<p>Set the <code>parent</code> property of the cell to <code>parentId</code> provided.</p>

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -349,7 +349,6 @@ export namespace dia {
         toBack(opt?: Cell.ToFrontAndBackOptions): this;
 
         parent(): string;
-        parent(parentId: Cell.ID): this;
 
         getParentCell(): Cell | null;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Remove the `Cell.parent(id)` setter from type definitions and documentation.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

`Cell.parent(id)` method is not intended to be used as a way to embed cells. To eliminate the confusion it was decided to remove it from type definitions and documentation.

Related to #2107.

### Migration guide
In case you were using the `Cell.parent(cell)` as a solution to embed cells, use the `Cell.embed(cell)` instead.

#### Example usage:
```js
const parent = joint.shapes.standard.Rectangle();
const child = joint.shapes.standard.Rectangle();
parent.embed(child);
```
