### PR TITLE
refactor: remove legacy unused linkView and interactivity options

### DIFF
--- a/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
+++ b/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
@@ -85,12 +85,9 @@
 
         options: {
 
-            shortLinkLength: 105,
             doubleLinkTools: false,
-            longLinkLength: 155,
             linkToolsOffset: 40,
-            doubleLinkToolsOffset: 65,
-            sampleInterval: 50
+            doubleLinkToolsOffset: 65
         },
 
         _labelCache: null,

--- a/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
+++ b/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
@@ -85,9 +85,11 @@
 
         options: {
 
+            shortLinkLength: 105,
             doubleLinkTools: false,
+            longLinkLength: 155,
             linkToolsOffset: 40,
-            doubleLinkToolsOffset: 65
+            doubleLinkToolsOffset: 65,
         },
 
         _labelCache: null,

--- a/packages/joint-core/demo/marey/src/marey.js
+++ b/packages/joint-core/demo/marey/src/marey.js
@@ -374,7 +374,7 @@ const paper = new dia.Paper({
     async: true,
     width: 'calc(100% - 20px)',
     height: 'calc(100% - 70px)',
-    interactive: { linkMove: false, vertexMove: true },
+    interactive: { linkMove: false },
     background: {
         color: BG_COLOR
     },

--- a/packages/joint-core/docs/demo/dia/Paper/interactive/labelMove.html
+++ b/packages/joint-core/docs/demo/dia/Paper/interactive/labelMove.html
@@ -35,11 +35,6 @@
             return {
                 linkMove: false,
                 labelMove: view.model.get('enabled'),
-                arrowheadMove: false,
-                vertexMove: false,
-                vertexAdd: false,
-                vertexRemove: false,
-                useLinkTools: false
             };
         },
         model: graph,

--- a/packages/joint-core/docs/demo/dia/Paper/interactive/labelMoveSnapLabels.html
+++ b/packages/joint-core/docs/demo/dia/Paper/interactive/labelMoveSnapLabels.html
@@ -36,11 +36,6 @@
             return {
                 linkMove: false,
                 labelMove: view.model.get('enabled'),
-                arrowheadMove: false,
-                vertexMove: false,
-                vertexAdd: false,
-                vertexRemove: false,
-                useLinkTools: false
             };
         },
         model: graph,

--- a/packages/joint-core/docs/demo/dia/Paper/interactive/linkMove.html
+++ b/packages/joint-core/docs/demo/dia/Paper/interactive/linkMove.html
@@ -35,11 +35,6 @@
             return {
                 linkMove: view.model.get('enabled'),
                 labelMove: false,
-                arrowheadMove: false,
-                vertexMove: false,
-                vertexAdd: false,
-                vertexRemove: false,
-                useLinkTools: false
             };
         },
         model: graph,

--- a/packages/joint-core/docs/src/joint/api/dia/LinkView/intro.html
+++ b/packages/joint-core/docs/src/joint/api/dia/LinkView/intro.html
@@ -8,41 +8,30 @@
 
 <p>To find the view associated with a specific link model, use the <code>paper.findViewByModel()</code> <a href="#dia.Paper.prototype.findViewByModel">method</a>:</p>
 
-<pre><code>var linkView = paper.findViewByModel(link);</code></pre>
+<pre><code>const linkView = paper.findViewByModel(link);
+// const linkView = link.findView(paper); // alternatively</code></pre>
+</code></pre>
 
 <h4>Custom LinkView</h4>
 
-<p>It is possible to use a custom default link view for all your links in a paper. This can be set up via the <code>linkView</code> option on the <a href="#dia.Paper.prototype.options">paper object</a>. Several options in <code>joint.dia.LinkView</code> may be overridden in a custom LinkView:</p>
+<p>It is possible to use a custom default link view for all your links in a paper. This can be set up via the <code>linkView</code> option on the <a href="#dia.Paper.prototype.options">paper object</a>.</p>
 
-<ul>
-  <li><b>shortLinkLength</b> - if link is shorter than the length specified, the size of link tools is scaled down by half. Defaults to <code>105</code>.</li>
-  <li><b>doubleLinkTools</b> - render link tools on both ends of the link (only if the link is longer than <code>longLinkLength</code>). Defaults to <code>false</code>.</li>
-  <li><b>longLinkLength</b> - if length is longer than the length specified and <code>doubleLinkTools: true</code>, render link tools on both ends of the link. Defaults to <code>155</code>.</li>
-  <li><b>linkToolsOffset</b> - the offset of link tools from the beginning of the link. Defaults to <code>40</code>.</li>
-  <li><b>doubleLinkToolsOffset</b> - the offset of duplicate link tools from the end of the link, if length is longer than <code>longLinkLength</code> and <code>doubleLinkTools: true</code>. Defaults to <code>65</code>.</li>
-</ul>
-
-<p>A custom LinkView type may also override default LinkView event handlers, or provide new ones. It may be necessary to modify the <code>interactive</code> <a href="#dia.Paper.prototype.options.interactive">paper option</a> to prevent interference from builtin event handlers (most notably <code>vertexAdd</code> which listens for pointerdown events).</p>
+<p>A custom LinkView type may also override default LinkView event handlers, or provide new ones. It may be necessary to modify the <code>interactive</code> <a href="#dia.Paper.prototype.options.interactive">paper option</a> to prevent interference from builtin event handlers.</p>
 
 <p>Example:</p>
 
-<pre><code>var CustomLinkView = joint.dia.LinkView.extend({
+<pre><code>const CustomLinkView = dia.LinkView.extend({
     // custom interactions:
     pointerdblclick: function(evt, x, y) {
         this.addVertex(x, y);
     },
+
     contextmenu: function(evt, x, y) {
         this.addLabel(x, y);
-    },
-
-    // custom options:
-    options: joint.util.defaults({
-        doubleLinkTools: true,
-    }, joint.dia.LinkView.prototype.options)
+    }
 });
 
-var paper = new joint.dia.Paper({
+const paper = new dia.Paper({
     //...
     linkView: CustomLinkView,
-    interactive: { vertexAdd: false } // disable default vertexAdd interaction
 });</code></pre>

--- a/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/addLabel.html
+++ b/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/addLabel.html
@@ -38,6 +38,5 @@
 
 var paper = new joint.dia.Paper({
     // ...
-    linkView: CustomLinkView,
-    interactive: { vertexAdd: false } // disable default vertexAdd interaction
+    linkView: CustomLinkView
 });</code></pre>

--- a/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/addVertex.html
+++ b/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/addVertex.html
@@ -13,6 +13,5 @@
 
 var paper = new joint.dia.Paper({
     // ...
-    linkView: CustomLinkView,
-    interactive: { vertexAdd: false } // disable default vertexAdd interaction
+    linkView: CustomLinkView
 });</code></pre>

--- a/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/getLabelPosition.html
+++ b/packages/joint-core/docs/src/joint/api/dia/LinkView/prototype/getLabelPosition.html
@@ -78,6 +78,5 @@
 
 var paper = new joint.dia.Paper({
     // ...
-    linkView: CustomLinkView,
-    interactive: { vertexAdd: false } // disable default vertexAdd interaction
+    linkView: CustomLinkView
 });</code></pre>

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -31,16 +31,6 @@ export const LinkView = CellView.extend({
         return classNames.join(' ');
     },
 
-    options: {
-
-        shortLinkLength: 105,
-        doubleLinkTools: false,
-        longLinkLength: 155,
-        linkToolsOffset: 40,
-        doubleLinkToolsOffset: 65,
-        sampleInterval: 50
-    },
-
     _labelCache: null,
     _labelSelectors: null,
     _V: null,

--- a/packages/joint-core/tutorials/js/link-labels-interaction-snap-labels.js
+++ b/packages/joint-core/tutorials/js/link-labels-interaction-snap-labels.js
@@ -16,12 +16,7 @@
         snapLabels: true,
         interactive: {
             linkMove: false,
-            labelMove: true,
-            arrowheadMove: false,
-            vertexMove: false,
-            vertexAdd: false,
-            vertexRemove: false,
-            useLinkTools: false,
+            labelMove: true
         }
     });
 

--- a/packages/joint-core/tutorials/js/link-labels-interaction.js
+++ b/packages/joint-core/tutorials/js/link-labels-interaction.js
@@ -15,12 +15,7 @@
         cellViewNamespace: namespace,
         interactive: {
             linkMove: false,
-            labelMove: true,
-            arrowheadMove: false,
-            vertexMove: false,
-            vertexAdd: false,
-            vertexRemove: false,
-            useLinkTools: false,
+            labelMove: true
         }
     });
 

--- a/packages/joint-core/tutorials/link-labels.html
+++ b/packages/joint-core/tutorials/link-labels.html
@@ -406,12 +406,7 @@ link.appendLabel({
     // ...
     interactive: {
         linkMove: false,
-        labelMove: true,
-        arrowheadMove: false,
-        vertexMove: false,
-        vertexAdd: false,
-        vertexRemove: false,
-        useLinkTools: false
+        labelMove: true
     }
 });</code></pre>
 
@@ -430,12 +425,7 @@ link.appendLabel({
     snapLabels: true,
     interactive: {
         linkMove: false,
-        labelMove: true,
-        arrowheadMove: false,
-        vertexMove: false,
-        vertexAdd: false,
-        vertexRemove: false,
-        useLinkTools: false
+        labelMove: true
     }
 });</code></pre>
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -983,13 +983,8 @@ export namespace dia {
         }
 
         interface InteractivityOptions {
-            vertexAdd?: boolean;
-            vertexMove?: boolean;
-            vertexRemove?: boolean;
-            arrowheadMove?: boolean;
             labelMove?: boolean;
             linkMove?: boolean;
-            useLinkTools?: boolean;
         }
 
         interface LabelOptions extends Cell.Options {
@@ -1005,12 +1000,6 @@ export namespace dia {
         }
 
         interface Options extends mvc.ViewOptions<Link, SVGElement> {
-            shortLinkLength?: number;
-            doubleLinkTools?: boolean;
-            longLinkLength?: number;
-            linkToolsOffset?: number;
-            doubleLinkToolsOffset?: number;
-            sampleInterval?: number;
             labelsLayer?: Paper.Layers | string | false;
         }
     }


### PR DESCRIPTION
## Description

Remove legacy references to options (`dia.LinkView` and `interactivity`) across lib. Finishes work started by #2446 