### PR TITLE
chore(tutorials): include video in custom elements tutorial

### DIFF
--- a/packages/joint-core/tutorials/custom-elements.html
+++ b/packages/joint-core/tutorials/custom-elements.html
@@ -39,7 +39,23 @@
                 What is important for us is to realize that combining the basic SVG shapes, we can define any 2D shape
                 we need.</p>
 
-            <p>For that, we use a built-in JointJS function:</p>
+            <p>
+                If you like video, the following youtube content will show you how to create custom JointJS elements using SVG.
+                This tutorial will still provide you with a comprehensive guide to defining custom shapes, even if you
+                decide to watch the video or not.
+            </p>
+
+            <iframe
+                width="560"
+                height="315"
+                src="https://www.youtube.com/embed/aEEWPVCQ5rE?si=P6XSBtz6BLuBzJjM"
+                title="YouTube video player"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen>
+            </iframe>
+
+            <p>To define any custom element, we can use a built-in JointJS function:</p>
 
             <ul>
                 <li><a href="/docs/jointjs#dia.Cell.define" target="_blank"><code>Element.define(type [, defaultInstanceProperties, prototypeProperties, staticProperties])</code></a>


### PR DESCRIPTION
## Description

Sync `custom-element` tutorial with video inclusion.

- Include youtube video in `custom-element` tutorial. This means this tutorial is in sync with `JointJS_Site`
- Closes https://github.com/clientIO/joint/pull/2393