### PR TITLE
chore(dist): do not distribute joint.core.js + joint.core.min.js

### DIFF
--- a/packages/joint-core/grunt/config/aliases.js
+++ b/packages/joint-core/grunt/config/aliases.js
@@ -37,7 +37,6 @@ module.exports = function(grunt) {
             'newer:uglify:geometry',
             'newer:uglify:vectorizer',
             'newer:uglify:joint',
-            'newer:uglify:jointCore',
             'newer:uglify:jointNoWrap',
             'newer:uglify:plugins'
         ],

--- a/packages/joint-core/grunt/config/copy.js
+++ b/packages/joint-core/grunt/config/copy.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
                 cwd: 'build/',
                 src: [
                     '*',
+                    '!joint.core.js',
                     '!api-extractor',
                     '!docs',
                     '!min',

--- a/packages/joint-core/grunt/config/shell.js
+++ b/packages/joint-core/grunt/config/shell.js
@@ -2,9 +2,6 @@ module.exports = {
     'rollup-joint': {
         command: 'rollup -c --config-joint'
     },
-    'rollup-libs-esm': {
-        command: 'rollup -c --config-libs-esm'
-    },
     'rollup-dist': {
         command: 'rollup -c --config-dist'
     },

--- a/packages/joint-core/grunt/config/uglify.js
+++ b/packages/joint-core/grunt/config/uglify.js
@@ -22,10 +22,6 @@ module.exports = function() {
             src: modules.joint.umd,
             dest: 'build/joint.min.js'
         },
-        jointCore: {
-            src: modules.jointCore.umd,
-            dest: 'build/joint.core.min.js'
-        },
         jointNoWrap: {
             src: modules.joint.iife,
             dest: 'build/joint.nowrap.min.js'

--- a/packages/joint-core/grunt/resources/core.js
+++ b/packages/joint-core/grunt/resources/core.js
@@ -1,8 +1,0 @@
-const modules = require('../resources/esm');
-
-module.exports = {
-
-    js: [
-        modules.jointCore.iife,
-    ]
-};

--- a/packages/joint-core/grunt/resources/esm.js
+++ b/packages/joint-core/grunt/resources/esm.js
@@ -13,7 +13,7 @@ module.exports = {
         iife: 'build/joint.nowrap.js',  // joint + plugins + vectorizer + geometry. browser-only version
         noDependencies: 'build/joint.nodeps.js' // joint + plugins (for unit testing)
     },
-    jointCore: {
+    jointCore: { // without shapes - not exported to dist - see grunt/config/copy.js
         src: 'wrappers/joint.core.wrapper.mjs',
         umd: 'build/joint.core.js', // joint + vectorizer + geometry. universal module
     },

--- a/packages/joint-core/joint.mjs
+++ b/packages/joint-core/joint.mjs
@@ -1,4 +1,3 @@
-import * as layout from './src/layout/index.mjs';
 import * as shapes from './src/shapes/index.mjs';
 
 // joint core
@@ -7,6 +6,7 @@ export {
     config,
     env,
     anchors,
+    layout,
     linkAnchors,
     connectionPoints,
     connectionStrategies,
@@ -24,4 +24,4 @@ export {
     g
 } from './src/core.mjs';
 
-export { layout, shapes };
+export { shapes };

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -6,6 +6,7 @@
   "sideEffects": false,
   "main": "./dist/joint.min.js",
   "module": "joint.mjs",
+  "style": "./dist/joint.min.css",
   "types": "./types/index.d.ts",
   "homepage": "https://jointjs.com",
   "author": {
@@ -55,6 +56,7 @@
     "build-docs": "grunt build:docs"
   },
   "files": [
+    "css/",
     "dist/",
     "src/",
     "types/*.d.ts",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -57,6 +57,7 @@
   "files": [
     "dist/",
     "src/",
+    "!src/core.mjs",
     "types/*.d.ts",
     "./index.js",
     "./joint.mjs",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -6,7 +6,6 @@
   "sideEffects": false,
   "main": "./dist/joint.min.js",
   "module": "joint.mjs",
-  "style": "./dist/joint.min.css",
   "types": "./types/index.d.ts",
   "homepage": "https://jointjs.com",
   "author": {
@@ -56,7 +55,6 @@
     "build-docs": "grunt build:docs"
   },
   "files": [
-    "css/",
     "dist/",
     "src/",
     "types/*.d.ts",

--- a/packages/joint-core/rollup.config.js
+++ b/packages/joint-core/rollup.config.js
@@ -5,15 +5,12 @@ const JOINT = [
     modules.joint
 ];
 
-const LIBS_ESM = [
-];
-
 const DIST = [
     modules.version,
     modules.jointCore,
     modules.geometry,
     modules.vectorizer,
-].concat(modules.jointPlugins).concat(LIBS_ESM);
+].concat(modules.jointPlugins);
 
 const TEST_BUNDLE = [
     modules.jointNoDependencies
@@ -24,11 +21,6 @@ export default commandLineArgs => {
     // rollup -c --config-joint
     if (commandLineArgs['config-joint']) {
         return JOINT;
-    }
-
-    // rollup -c --config-libs-esm
-    if (commandLineArgs['config-libs-esm']) {
-        return LIBS_ESM;
     }
 
     // rollup -c --config-dist
@@ -43,7 +35,6 @@ export default commandLineArgs => {
 
     // all
     return JOINT
-        .concat(LIBS_ESM)
         .concat(DIST)
         .concat(TEST_BUNDLE);
 };

--- a/packages/joint-core/test/jointjs/require.js
+++ b/packages/joint-core/test/jointjs/require.js
@@ -16,8 +16,6 @@ require(['qunit'], function(QUnit) {
     QUnit.module('RequireJS');
 
     var buildFiles = [
-        'build/joint.core',
-        'build/joint.core.min',
         'build/joint',
         'build/joint.min'
     ];


### PR DESCRIPTION
## Description

Removes `joint.core.js` and `joint.core.min.js` from `dist/`, and the associated logic