### PR TITLE
docs(tutorials): update installation instructions

### DIFF
--- a/packages/joint-core/tutorials/installation.html
+++ b/packages/joint-core/tutorials/installation.html
@@ -91,7 +91,7 @@
                 Assuming that you have <a href="https://www.npmjs.com/package/npm">NPM</a> installed on your system, run
                 the following command in the command line (Terminal/Command Prompt):
 
-            <pre><code>npm install --save jointjs</code></pre>
+            <pre><code>npm install @joint/core</code></pre>
 
             <p>You can then find all the required source files in their respective folders inside the generated
                 <code>node_modules</code> folder.


### PR DESCRIPTION
## Description

- Update package name in installation instructions to `@joint/core` in `installation` tutorial.

In the `changelog`, `hello-world` tutorial, and `installation` tutorial there is a CDN link of:
```js
<script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/4.0.0/joint.js"></script>
```
I am currently not sure what the link should be.

