### PR TITLE
docs(tutorials): update CDN link in installation tutorial

### DIFF
--- a/packages/joint-core/tutorials/installation.html
+++ b/packages/joint-core/tutorials/installation.html
@@ -41,7 +41,7 @@
     &lt;div id="myholder"&gt;&lt;/div&gt;
 
     &lt;!-- dependencies --&gt;
-    &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/4.0.0/joint.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/@joint/core/4.0.0/joint.js"&gt;&lt;/script&gt;
 
     &lt;!-- code --&gt;
     &lt;script type="text/javascript"&gt;


### PR DESCRIPTION
## Description

- Update CDN link in `installation` tutorial. The CDN links are already updated in the `JointJS_Site` docs release PR. https://github.com/clientIO/JointJS_Site/pull/215