### PR TITLE
types(dia.Paper): allow disabling allowNewOrigin option

### DIFF
--- a/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Paper/prototype/getFitToContentArea.html
@@ -6,9 +6,9 @@
 <ul>
     <li><code>opt.gridWidth</code> and <code>opt.gridHeight</code> – snap the resulting width and height of the paper to a grid defined by these dimensions.</li>
     <li><code>opt.padding</code> – additional padding around the resulting paper. It may be specified as a number, in which case it represents the padding width on all sides of the paper. It may be an object of the form <code>{ top?: [number], right?: [number], bottom?: [number], left?: [number], vertical?: [number], horizontal?: [number] }</code>.</li>
-    <li><code>opt.allowNewOrigin</code> – should the origin of the resulting paper be adjusted to match the origin of the paper content? In addition to no value being set, three values are recognized by this option: <code>'positive'</code>,&nbsp;<code>'negative'</code>,&nbsp;<code>'any'</code>.
+    <li><code>opt.allowNewOrigin</code> – should the origin of the resulting paper be adjusted to match the origin of the paper content? In addition to a falsy value being set, three values are recognized by this option: <code>'positive'</code>,&nbsp;<code>'negative'</code>,&nbsp;<code>'any'</code>.
       <ul>
-        <li>By default, the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the original point (0,0).</li>
+        <li><code>false</code> - by default, the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the original point (0,0).</li>
         <li><code>'positive'</code> – the method only recognizes the content at positive coordinates and puts the origin of resulting paper at the origin of the content. (Still, if the content starts at negative coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
         <li><code>'negative'</code> – the method only recognizes the content at negative coordinates and puts the origin of resulting paper at the origin of the content. (However, if the content starts at positive coordinates in an axis, the resulting paper's origin will be assigned <code>0</code> in that axis.)</li>
         <li><code>'any'</code> – the method recognizes all of the paper content. The origin of the resulting paper will be at the origin of the content.</li>

--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -102,6 +102,8 @@ const paper = new joint.dia.Paper({
     findParentBy: (_elementView, _evt, x, y) => graph.findModelsFromPoint({ x, y })
 });
 
+paper.fitToContent({ padding: { top: 10  }, allowNewOrigin: false });
+
 const cellView = graph.getCells[0].findView(paper);
 cellView.vel.addClass('test-class');
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1313,7 +1313,7 @@ export namespace dia {
             gridWidth?: number;
             gridHeight?: number;
             padding?: Padding;
-            allowNewOrigin?: 'negative' | 'positive' | 'any';
+            allowNewOrigin?: false | 'negative' | 'positive' | 'any';
             allowNegativeBottomRight?: boolean;
             minWidth?: number;
             minHeight?: number;


### PR DESCRIPTION
## Description

It's currently not possible to override the `allowNewOrigin` to its default. This PR makes it possible to pass `false` for the paper origin to remain at `0,0` in *TypeScript*.

Note that this has always been possible in *JavaScript*, and this PR just changes the types and updates the documentation to make it clear.

```ts
// before
paper.getFitToContentArea({ allowNewOrigin: 'negative' | 'positive' | 'any'  })

// after
paper.getFitToContentArea({ allowNewOrigin: false | 'negative' | 'positive' | 'any'  })
```

The problem was evident in the paper scroller.
```js
const scroller = new ui.PaperScroller({
   /* ... */
   contentOptions: {
      allowNewOrigin: false // the paper scroller default for `allowNewOrigin` is `positive`
   }
})
```