### PR TITLE
fix(attributes): text-wrap takes external CSS into account

### DIFF
--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -123,12 +123,16 @@ const textAttributesNS = {
             if (text === undefined) text = attrs.text;
             if (text !== undefined) {
                 const breakTextFn = value.breakText || breakText;
+                const computedStyles = getComputedStyle(node);
+
                 wrappedText = breakTextFn('' + text, size, {
-                    'font-weight': attrs['font-weight'],
-                    'font-size': attrs['font-size'],
-                    'font-family': attrs['font-family'],
+                    'font-weight': computedStyles.fontWeight,
+                    'font-family': computedStyles.fontFamily,
+                    'text-transform': computedStyles.textTransform,
+                    'font-size': computedStyles.fontSize,
+                    'letter-spacing': computedStyles.letterSpacing,
+                    // The `line-height` attribute in SVG is JoinJS specific.
                     'lineHeight': attrs['line-height'],
-                    'letter-spacing': attrs['letter-spacing']
                 }, {
                     // Provide an existing SVG Document here
                     // instead of creating a temporary one over again.

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -104,6 +104,38 @@ QUnit.module('Attributes', function() {
                     return obj.width === refBBox.width - 11 && obj.height === refBBox.height - 13;
                 })));
 
+                // external css styles taken into account
+                spy.resetHistory();
+                const fontSize = '23px';
+                const fontFamily = 'Arial';
+                const fontWeight = '800';
+                const letterSpacing = '5px';
+                const textTransform = 'uppercase';
+                const stylesheet = V.createSVGStyle(`
+                    text {
+                        font-size: ${fontSize};
+                        font-family: ${fontFamily};
+                        font-weight: ${fontWeight};
+                        letter-spacing: ${letterSpacing};
+                        text-transform: ${textTransform};
+                    }
+                `);
+                paper.svg.prepend(stylesheet);
+                textWrap.set.call(cellView, { text: 'text', breakText: spy }, bbox, node, {});
+                assert.ok(spy.calledWith(
+                    sinon.match.string,
+                    sinon.match.object,
+                    sinon.match((obj) => {
+                        return (
+                            obj['font-size'] === fontSize &&
+                            obj['font-family'] === fontFamily &&
+                            obj['letter-spacing'] === letterSpacing &&
+                            obj['text-transform'] === textTransform &&
+                            obj['font-weight'] === fontWeight
+                        );
+                    })));
+                stylesheet.remove();
+
                 spy.restore();
             });
 


### PR DESCRIPTION
## Description

The `text-wrap` attribute takes external CSS and inherited styles into account when computing the line breaks (previously only explicit inline attributes were considered).

The `text-wrap` worked properly only when the font attributes were set explicitly.

```html
<text font-size="12">A text to wrap</text>
```

This PR adds support for external CSS: 

```html
<style>
  text { font-size: 12px; }
</style>

...

<text>A text to wrap</text>
```

_Note: Thanks to https://github.com/clientIO/joint/pull/2459, all font attributes are evaluated and set before `text-wrap`, so it is safe to use the `getComputedStyle()` method._

Fixes https://github.com/clientIO/joint/issues/2295.


