### PR TITLE
docs: update tutorial CDN links

### DIFF
--- a/packages/joint-core/tutorials/hello-world.html
+++ b/packages/joint-core/tutorials/hello-world.html
@@ -34,7 +34,7 @@
     &lt;div id="myholder"&gt;&lt;/div&gt;
 
     &lt;!-- dependencies --&gt;
-    &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/@joint/core/4.0.0/joint.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.1/dist/joint.js"&gt;&lt;/script&gt;
 
     &lt;!-- code --&gt;
     &lt;script type="text/javascript"&gt;

--- a/packages/joint-core/tutorials/installation.html
+++ b/packages/joint-core/tutorials/installation.html
@@ -41,7 +41,7 @@
     &lt;div id="myholder"&gt;&lt;/div&gt;
 
     &lt;!-- dependencies --&gt;
-    &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/@joint/core/4.0.0/joint.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.1/dist/joint.js"&gt;&lt;/script&gt;
 
     &lt;!-- code --&gt;
     &lt;script type="text/javascript"&gt;


### PR DESCRIPTION
## Description

Update tutorial CDN links to `jsdelivr`, because package has not been added to `cdnjs` yet.
https://www.jsdelivr.com/package/npm/@joint/core
