### PR TITLE
fix(dia.Paper): don't leak animation frame request

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -417,6 +417,8 @@ export const Paper = View.extend({
     },
 
     _resetUpdates: function() {
+        if (this._updates && this._updates.id) cancelFrame(this._updates.id);
+
         return this._updates = {
             id: null,
             priorities: [{}, {}, {}],

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -1886,6 +1886,26 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 });
             });
 
+            QUnit.module('resetViews()', function() {
+                QUnit.test('does not leak animation frames', function(assert) {
+                    var done = assert.async();
+                    assert.expect(1);
+
+                    graph.resetCells([
+                        new joint.shapes.standard.Rectangle(),
+                    ]);
+                    paper.freeze();
+
+                    var spy = sinon.spy(paper, 'updateViewsAsync');
+                    requestAnimationFrame(function() {
+                        requestAnimationFrame(function() {
+                            assert.equal(spy.callCount, 0);
+                            done();
+                        });
+                    });
+                });
+            });
+
             QUnit.test('hasScheduledUpdates()', function(assert) {
                 var done = assert.async();
                 assert.expect(4);


### PR DESCRIPTION
## Description

This ensures that when `Paper.resetViews()` is called, any pending animation frame request is not leaked.

## Motivation and Context

When `resetViews()` calls `_resetUpdates()` it's possible that there's an animation frame request, but `_resetUpdates()` was not checking for this and cancelling any such request, potentially causing `updateViewsAsync()` to be called when it shouldn't be.

This can cause unexpected behavior if the paper was frozen, or cause an error to be thrown if the paper is removed (since `updateViewsAsync()` with throw in such a case).