### PR TITLE
type: various small fixes

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1074,6 +1074,8 @@ export namespace dia {
 
         removeRedundantLinearVertices(opt?: dia.ModelSetOptions): number;
 
+        startArrowheadMove(end: dia.LinkEnd, options?: any);
+
         protected updateRoute(): void;
 
         protected updatePath(): void;
@@ -4082,6 +4084,14 @@ export namespace elementTools {
         constructor(opt?: Button.Options);
 
         protected onPointerDown(evt: dia.Event): void;
+
+        protected position(): void;
+
+        protected getCellMatrix(): SVGMatrix;
+
+        protected getElementMatrix(): SVGMatrix;
+
+        protected getLinkMatrix(): SVGMatrix;
     }
 
     class Remove extends Button {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -3602,7 +3602,7 @@ export namespace anchors {
             endMagnet: SVGElement,
             anchorReference: g.Point | SVGElement,
             opt: AnchorArgumentsMap[K],
-            endType: string,
+            endType: dia.LinkEnd,
             linkView: dia.LinkView
         ): g.Point;
     }
@@ -3701,7 +3701,7 @@ export namespace connectionPoints {
             endView: dia.CellView,
             endMagnet: SVGElement,
             opt: ConnectionPointArgumentsMap[K],
-            endType: string,
+            endType: dia.LinkEnd,
             linkView: dia.LinkView
         ): g.Point;
     }

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1074,7 +1074,7 @@ export namespace dia {
 
         removeRedundantLinearVertices(opt?: dia.ModelSetOptions): number;
 
-        startArrowheadMove(end: dia.LinkEnd, options?: any);
+        startArrowheadMove(end: dia.LinkEnd, options?: any): unknown;
 
         protected updateRoute(): void;
 


### PR DESCRIPTION
## Description

- add protected methods for `elementTools.Button` to allow class extension
- properly specify the link end in `anchor` and `connectionPoint` function
- add public `startArrowheadMove()` to the `LinkView` class (until a proper API to initiate a link's dragging is implemented).