### PR TITLE
types: fix untyped model when using ElementView/LinkView

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -919,7 +919,7 @@ export namespace dia {
 
         setInteractivity(value: boolean | ElementView.InteractivityOptions): void;
 
-        getDelegatedView(): ElementView<E> | null;
+        getDelegatedView(): ElementView | null;
 
         findPortNode(portId: string | number): SVGElement | null;
         findPortNode(portId: string | number, selector: string): E | null;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -913,18 +913,18 @@ export namespace dia {
         }
     }
 
-    class ElementView extends CellViewGeneric<Element> {
+    class ElementView<E extends Element = Element> extends CellViewGeneric<E> {
 
-        update(element?: Element, renderingOnlyAttrs?: { [key: string]: any }): void;
+        update(element?: E, renderingOnlyAttrs?: { [key: string]: any }): void;
 
         setInteractivity(value: boolean | ElementView.InteractivityOptions): void;
 
-        getDelegatedView(): ElementView | null;
+        getDelegatedView(): ElementView<E> | null;
 
         findPortNode(portId: string | number): SVGElement | null;
-        findPortNode(portId: string | number, selector: string): Element | null;
+        findPortNode(portId: string | number, selector: string): E | null;
 
-        findPortNodes(portId: string | number, groupSelector: string): Element[];
+        findPortNodes(portId: string | number, groupSelector: string): E[];
 
         protected renderMarkup(): void;
 
@@ -999,14 +999,14 @@ export namespace dia {
 
         }
 
-        interface Options extends mvc.ViewOptions<Link, SVGElement> {
+        interface Options<L extends Link = Link> extends mvc.ViewOptions<L, SVGElement> {
             labelsLayer?: Paper.Layers | string | false;
         }
     }
 
-    class LinkView extends CellViewGeneric<Link> {
+    class LinkView<L extends Link = Link> extends CellViewGeneric<L> {
 
-        options: LinkView.Options;
+        options: LinkView.Options<L>;
         sourceAnchor: g.Point;
         targetAnchor: g.Point;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description
Instead of passing a generic `Element`/`Link` type to `CellViewGeneric` this provides an optional generic to pass the model type. It would be used like the following:

```typescript
interface CustomElementAttributes extends dia.Element.Attributes {
  custom_attribute: string,
}

class CustomElement extends dia.Element<CustomElementAttributes> {
  // ...
}

class CustomElementView extends dia.ElementView<CustomElement> {
  // ...
}
```

Default behaviour is the current behaviour. The change is fully backwards compatible.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context
- this.model.get(...) is checked against attributes of the model
  - return value is typed instead of `any`
  - language server knows about possible keys
- No longer throws errors ("... implicitely has any type") when used with typescript
  - Removes manual overhead of hard coding types back in after using `get()`
