### PR TITLE
docs: fix highlighter example

### DIFF
--- a/packages/joint-core/docs/demo/highlighters/js/mask.js
+++ b/packages/joint-core/docs/demo/highlighters/js/mask.js
@@ -67,7 +67,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     pointerEvents: 'none'
                 },
                 labelBody: {
-                    ref: 'text',
+                    ref: 'labelText',
                     fill: '#ffffff',
                     stroke: 'black',
                     strokeWidth: 2,


### PR DESCRIPTION
## Description

Fix a failing example in the documentation for highlighters (invalid `ref` attribute value).
