### PR TITLE
fix(Vectorizer): fix normalizePathData() to support zero-length arc to curve

### DIFF
--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -2293,7 +2293,7 @@ const V = (function() {
 
                 var k = ((large_arc_flag == sweep_flag) ? -1 : 1) * sqrt(abs(((rx2 * ry2) - (rx2 * y * y) - (ry2 * x * x)) / ((rx2 * y * y) + (ry2 * x * x))));
                 if (!Number.isFinite(k)) {
-                    // Straight line
+                    // Arc is a single point
                     return [x1, y1, x2, y2, x2, y2];
                 }
 

--- a/packages/joint-core/test/vectorizer/vectorizer.js
+++ b/packages/joint-core/test/vectorizer/vectorizer.js
@@ -1486,7 +1486,7 @@ QUnit.module('vectorizer', function(hooks) {
             assert.equal(V.normalizePathData('A 3 0 0 0 1 10 15'), 'M 0 0 L 10 15'); // 0 y radius
             assert.equal(V.normalizePathData('A 0 0 0 0 1 10 15'), 'M 0 0 L 10 15'); // 0 x and y radii
 
-            assert.equal(V.normalizePathData('M 3 7 A 7 7 0 0 1 3 7'), 'M 3 7 C 3 7 3 7 3 7'); // straight line
+            assert.equal(V.normalizePathData('M 3 7 A 7 7 0 0 1 3 7'), 'M 3 7 C 3 7 3 7 3 7'); // arc corresponding to a single point
 
             // Make sure this does not throw an error because of recursion in a2c() exceeding the maximum stack size
             V.normalizePathData('M 0 0 A 1 1 0 1 0 -1 -1');


### PR DESCRIPTION
## Description

A zero-length arc `A` was converted to an invalid curve command `C` (containing `NaN` values).

After this change, such arcs are converted to a point-like curve.

Fixes https://github.com/clientIO/joint/issues/2465.

