### PR TITLE
(WIP) refactor(@joint/layout-directed-graph): avoid indirect function calls in API

### DIFF
--- a/packages/joint-core/docs/src/joint/api/layout/DirectedGraph.html
+++ b/packages/joint-core/docs/src/joint/api/layout/DirectedGraph.html
@@ -145,14 +145,15 @@ yarn install</code></pre>
 <table>
     <tr><th>toGraphLib(graph, opt)</th>
         <td>Convert the provided JointJS <code>joint.dia.Graph</code> object to a Graphlib graph object.
-            <pre><code>import { DirectedGraph } from '@joint/layout-directed-graph';
+            <pre><code>import { dia, shapes } from '@joint/core';
+import { DirectedGraph } from '@joint/layout-directed-graph';
 import * as graphlib from '@dagrejs/graphlib';
 
-var graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+const graph = new dia.Graph({}, { cellNamespace: shapes });
 // ... populate the graph with elements connected with links
 
 // Get a Graphlib representation of the graph:
-var glGraph = DirectedGraph.toGraphLib(graph);
+const glGraph = DirectedGraph.toGraphLib(graph);
 
 // Use Graphlib algorithms:
 graphlib.alg.isAcyclic(glGraph); // true if the graph is acyclic</code></pre>
@@ -161,31 +162,48 @@ graphlib.alg.isAcyclic(glGraph); // true if the graph is acyclic</code></pre>
     <tr><th>fromGraphLib(glGraph, opt)</th>
         <td>Convert the provided Graphlib graph object to a JointJS <code>joint.dia.Graph</code> object.
             <br/><br/>
-            The <code>opt.importNode</code> and <code>opt.importEdge</code> callbacks are provided with a Graphlib node / edge object, and are expected to return a corresponding JointJS element / link object.
-            <pre><code>import { DirectedGraph } from '@joint/layout-directed-graph';
+            Custom <code>opt.importNode</code> and <code>opt.importEdge</code> callbacks need to be provided in order for this method to work as expected - to return a JointJS Graph matching the structure of the provided Graphlib graph (<code>glGraph</code>). The callbacks are provided with the following attributes:
+            <ul>
+                <li><code>nodeId</code> / <code>edgeObj</code> - a <a href="https://github.com/dagrejs/graphlib/wiki/API-Reference#node-and-edge-representation">Graphlib item ID</a>,</li>
+                <li><code>glGraph</code> - the original Graphlib graph object,</li>
+                <li><code>graph</code> - the JointJS Graph object to be populated (a newly created <code>joint.dia.Graph</code> by default),</li>
+                <li><code>opt</code> - the options object provided to <code>fromGraphLib()</code>.</li>
+            </ul>
+            You can implement your own logic inside the two callbacks to support your use case.
+            <br/><br/>
+            The example below illustrates how Graphlib node/edge labels can be used to store additional information for each item. These labels are accessed in the callbacks as <code>nodeData</code> / <code>edgeData</code>, and the information within is used to specify the position, size, and label text of the Element / Link being created. (Note: In Graphlib, edge source id / edge target id are specified via <code>nodeId</code> of the respective node; we need to set the <code>id</code> of generated Elements as <code>nodeId</code> so that the generated Links can connect the generated Elements.) The callbacks work by adding the generated Element / Link to the <code>graph</code> in the end (e.g. via the <code>graph.addCell()</code> function):
+            <pre><code>import { shapes } from '@joint/core';
+import { DirectedGraph } from '@joint/layout-directed-graph';
 import * as graphlib from 'graphlib';
 
 // Create a graph in Graphlib:
-var glGraph = new graphlib.Graph();
-glGraph.setNode(1);
-glGraph.setNode(2);
-glGraph.setNode(3);
-glGraph.setEdge(1, 2);
-glGraph.setEdge(2, 3);
+const glGraph = new graphlib.Graph();
+glGraph.setNode(1, { x: 50, y: 50, width: 100, height: 50, label: 'A' });
+glGraph.setNode(2, { x: 50, y: 150, width: 100, height: 50, label: 'B' });
+glGraph.setNode(3, { x: 50, y: 250, width: 100, height: 50, label: 'C' });
+glGraph.setEdge(1, 2, { label: 'Hello' });
+glGraph.setEdge(2, 3, { label: 'World!' });
 
 // Get a JointJS representation of the Graphlib graph:
-var graph = DirectedGraph.fromGraphLib(glGraph, {
-    importNode: function(node) {
-        return new joint.shapes.standard.Rectangle({
-            position: { x: node.x, y: node.y },
-            size: { width: node.width, height: node.height }
+const graph = DirectedGraph.fromGraphLib(glGraph, {
+    importNode: (nodeId, glGraph, graph, opt) => {
+        const nodeData = glGraph.node(nodeId);
+        const element = new shapes.standard.Rectangle({
+            id: nodeId,
+            position: { x: nodeData.x, y: nodeData.y },
+            size: { width: nodeData.width, height: nodeData.height },
+            attrs: { label: { text: nodeData.label }}
         });
+        graph.addCell(element);
     },
-    importEdge: function(edge) {
-        return new joint.shapes.standard.Link({
-            source: { id: edge.v },
-            target: { id: edge.w }
+    importEdge: (edgeObj, glGraph, graph, opt) => {
+        const edgeData = glGraph.edge(edgeObj);
+        const link =  new shapes.standard.Link({
+            source: { id: edgeObj.v },
+            target: { id: edgeObj.w },
+            labels: [{ attrs: { text: { text: edgeData.label }}}]
         });
+        graph.addCell(link);
     }
 });</code></pre>
         </td>

--- a/packages/joint-layout-directed-graph/DirectedGraph.d.ts
+++ b/packages/joint-layout-directed-graph/DirectedGraph.d.ts
@@ -46,5 +46,4 @@ export namespace DirectedGraph {
     export function toGraphLib(graph: dia.Graph, opt?: toGraphLibOptions): any;
 
     export function fromGraphLib(glGraph: any, opt?: { [key: string]: any }): dia.Graph;
-    export function fromGraphLib(this: dia.Graph, glGraph: any, opt?: { [key: string]: any }): dia.Graph;
 }

--- a/packages/joint-layout-directed-graph/DirectedGraph.d.ts
+++ b/packages/joint-layout-directed-graph/DirectedGraph.d.ts
@@ -41,9 +41,14 @@ export namespace DirectedGraph {
         [key: string]: any;
     }
 
+    interface fromGraphLibOptions {
+        graph?: dia.Graph;
+        [key: string]: any;
+    }
+
     export function layout(graph: dia.Graph | dia.Cell[], opt?: LayoutOptions): g.Rect;
 
     export function toGraphLib(graph: dia.Graph, opt?: toGraphLibOptions): any;
 
-    export function fromGraphLib(glGraph: any, opt?: { [key: string]: any }): dia.Graph;
+    export function fromGraphLib(glGraph: any, opt?: fromGraphLibOptions): dia.Graph;
 }

--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -173,6 +173,7 @@ export const DirectedGraph = {
         graph.startBatch('layout');
 
         DirectedGraph.fromGraphLib(glGraph, {
+            graph,
             importNode: opt.importNode,
             importEdge: opt.importEdge,
             setPosition: opt.setPosition,
@@ -217,7 +218,7 @@ export const DirectedGraph = {
 
         var importNode = opt.importNode || util.noop;
         var importEdge = opt.importEdge || util.noop;
-        var graph = new dia.Graph();
+        var graph = opt.graph || new dia.Graph();
 
         // Import all nodes.
         glGraph.nodes().forEach(function(node) {

--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -37,17 +37,17 @@ export const DirectedGraph = {
     /**
      * @private
      */
-    importElement: function(node, glGraph, graph, opt) {
+    importElement: function(nodeId, glGraph, graph, opt) {
 
-        var element = graph.getCell(node);
-        var glNode = glGraph.node(node);
+        const element = graph.getCell(nodeId);
+        const nodeData = glGraph.node(nodeId);
 
         if (opt.setPosition) {
-            opt.setPosition(element, glNode);
+            opt.setPosition(element, nodeData);
         } else {
             element.set('position', {
-                x: glNode.x - glNode.width / 2,
-                y: glNode.y - glNode.height / 2
+                x: nodeData.x - (nodeData.width / 2),
+                y: nodeData.y - (nodeData.height / 2)
             });
         }
     },
@@ -55,13 +55,13 @@ export const DirectedGraph = {
     /**
      * @private
      */
-    importLink: function(edge, glGraph, graph, opt) {
+    importLink: function(edgeObj, glGraph, graph, opt) {
 
         const SIMPLIFY_THRESHOLD = 0.001;
 
-        const link = graph.getCell(edge.name);
-        const glEdge = glGraph.edge(edge);
-        const points = glEdge.points || [];
+        const link = graph.getCell(edgeObj.name);
+        const edgeData = glGraph.edge(edgeObj);
+        const points = edgeData.points || [];
         const polyline = new g.Polyline(points);
 
         // check the `setLinkVertices` here for backwards compatibility
@@ -79,8 +79,8 @@ export const DirectedGraph = {
             }
         }
 
-        if (opt.setLabels && ('x' in glEdge) && ('y' in glEdge)) {
-            const labelPosition = { x: glEdge.x, y: glEdge.y };
+        if (opt.setLabels && ('x' in edgeData) && ('y' in edgeData)) {
+            const labelPosition = { x: edgeData.x, y: edgeData.y };
             if (util.isFunction(opt.setLabels)) {
                 opt.setLabels(link, labelPosition, points);
             } else {
@@ -134,7 +134,7 @@ export const DirectedGraph = {
             setNodeLabel: opt.exportElement,
             setEdgeLabel: opt.exportLink,
             setEdgeName: function(link) {
-                // Graphlib edges have no ids. We use edge name property
+                // Graphlib edges have no ids. We use `edgeObj.name` property
                 // to store and retrieve ids instead.
                 return link.id;
             }
@@ -221,14 +221,10 @@ export const DirectedGraph = {
         var graph = opt.graph || new dia.Graph();
 
         // Import all nodes.
-        glGraph.nodes().forEach(function(node) {
-            importNode(node, glGraph, graph, opt);
-        });
+        glGraph.nodes().forEach((nodeId) => importNode(nodeId, glGraph, graph, opt));
 
         // Import all edges.
-        glGraph.edges().forEach(function(edge) {
-            importEdge(edge, glGraph, graph, opt);
-        });
+        glGraph.edges().forEach((edgeObj) => importEdge(edgeObj, glGraph, graph, opt));
 
         return graph;
     },


### PR DESCRIPTION
## Description

The old API of DirectedGraph had to count with the possibility that the API is being called from the `dia.Graph` object. To be able to do that, it made use of `call` and `bind` methods. With the separation of DirectedGraph as a separate plugin, there is no longer any need for these complications.

Also fixes the docs of the `fromGraphLib()` function for the case where a new JointJS Graph is created from a Graphlib graph, and adds a test.