### PR TITLE
feat(dia.Element): add getPortGroupNames()

### DIFF
--- a/examples/libavoid/src/avoid-router.js
+++ b/examples/libavoid/src/avoid-router.js
@@ -186,8 +186,7 @@ export class AvoidRouter {
         // specific sides of the element.
 
         // Add pins to each port of the element.
-        const portGroups = Object.keys(element.prop('ports/groups'));
-        portGroups.forEach((group) => {
+        element.getPortGroupNames().forEach((group) => {
             const portsPositions = element.getPortsPositions(group);
             const { width, height } = element.size();
             const rect = new g.Rect(0, 0, width, height);

--- a/packages/joint-core/docs/src/joint/api/dia/Element/prototype/getPortGroupNames.html
+++ b/packages/joint-core/docs/src/joint/api/dia/Element/prototype/getPortGroupNames.html
@@ -1,0 +1,5 @@
+<pre class="docs-method-signature"><code>element.getPortGroupNames()</code></pre>
+
+Returns an array of port group names of the element.
+It returns all port group names defined on the element regardless of whether the port group has any ports or not.
+

--- a/packages/joint-core/src/dia/ports.mjs
+++ b/packages/joint-core/src/dia/ports.mjs
@@ -280,6 +280,10 @@ export const elementPortPrototype = {
         }));
     },
 
+    getPortGroupNames: function() {
+        return Object.keys(this._portSettingsData.groups);
+    },
+
     /**
      * @param {string} groupName
      * @returns {Object<portId, {x: number, y: number, angle: number}>}

--- a/packages/joint-core/test/jointjs/elementPorts.js
+++ b/packages/joint-core/test/jointjs/elementPorts.js
@@ -2019,6 +2019,37 @@ QUnit.module('element ports', function() {
         });
     });
 
+    QUnit.module('getPortGroupNames', function() {
+
+        QUnit.test('return group names of all ports', function(assert) {
+
+                const shape = new joint.shapes.standard.Rectangle();
+
+                assert.deepEqual(shape.getPortGroupNames(), [], 'no groups');
+
+                shape.set({
+                    ports: {
+                        groups: {
+                            a: { position: 'left' },
+                            b: { position: 'right' }
+                        },
+                        items: [
+                            { id: 'one', group: 'a' },
+                            { id: 'two', group: 'b' },
+                            { id: 'three', group: 'b' },
+                            { id: 'four', group: 'b' }
+                        ]
+                    }
+                });
+
+                assert.deepEqual(shape.getPortGroupNames(), ['a', 'b'], 'group with ports');
+
+                shape.prop('ports/groups/c', { position: 'top' });
+
+                assert.deepEqual(shape.getPortGroupNames(), ['a', 'b', 'c'], 'group without ports');
+            });
+    });
+
     QUnit.module('portProp', function() {
 
         QUnit.test('set port properties', function(assert) {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -548,6 +548,8 @@ export namespace dia {
 
         getPortIndex(port: string | Element.Port): number;
 
+        getPortGroupNames(): string[];
+
         portProp(portId: string, path: dia.Path): any;
 
         portProp(portId: string, path: dia.Path, value?: any, opt?: S): Element;


### PR DESCRIPTION
## Description

Add a convenient method for those who want to iterate over all port groups.

```ts
element.getPortGroupNames().forEach(group => {
   const groupPortPositions = element.getPortsPositions(group);
  /* ... */ 
});
```
## Documentation

### element.getPortGroupNames()

Returns an array of port group names of the element.
It returns all port group names defined on the element regardless of whether the port group has any ports or not.


