### PR TITLE
chore(package.json): prevent publishing via NPM

### DIFF
--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -37,6 +37,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn run dist",
     "build": "grunt install",
     "test": "grunt test",

--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn run dist",
     "build": "tsc",
     "dist": "tsc"

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -32,6 +32,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn run dist",
     "dist": "rollup --config",
     "build": "rollup --config",

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn run dist",
     "build": "tsc",
     "dist": "tsc"

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn run dist",
     "build": "tsc",
     "dist": "tsc"


### PR DESCRIPTION
## Description

Add a `prepublishOnly` script to prevent publishing via NPM. `prepublishOnly` scripts are called by NPM before publish when `npm publish` is called. These scripts are ignored by Yarn, allowing us to call `yarn npm publish` as intended.

## Motivation and Context

Publishing via `npm publish` does not resolve `workspace:` protocols in `dependencies`, which leads to an error when our users try to install our packages.

Technically, this change is not necessary for `joint-core` (since it does not have any `workspace:` protocol dependencies), but I did it for it too for consistency.