### PR TITLE
types(dia.Cell): allow partial attributes with prop() and constructor()

### DIFF
--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -194,7 +194,6 @@ joint.connectors.curve({ x: 0, y: 0 }, { x: 20, y: 20 }, [], {
 /* Partial attributes */
 
 rectangle.prop({ size: { width: 100 }});
-rectangle.prop({ size: { width: 100 }}, { rewrite: true });
 
 new joint.shapes.standard.Rectangle({
     position: { x: 100 },

--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -190,3 +190,12 @@ joint.connectors.curve({ x: 0, y: 0 }, { x: 20, y: 20 }, [], {
     targetDirection: joint.connectors.curve.TangentDirections.CLOSEST_POINT,
     direction: joint.connectors.curve.Directions.HORIZONTAL
 });
+
+/* Partial attributes */
+
+rectangle.prop({ size: { width: 100 }});
+rectangle.prop({ size: { width: 100 }}, { rewrite: true });
+
+new joint.shapes.standard.Rectangle({
+    position: { x: 100 },
+});

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -12,6 +12,16 @@ export namespace config {
 
 type NativeEvent = Event;
 
+type _DeepRequired<T> = {
+    [P in keyof T]-?: T[P] extends object ? _DeepRequired<T[P]> : T[P];
+};
+
+type _DeepPartial<T> = {
+	[P in keyof T]?: T[P] extends object ? _DeepPartial<T[P]> : T[P];
+};
+
+type DeepPartial<T> = _DeepPartial<_DeepRequired<T>>;
+
 export namespace dia {
 
     type Event = mvc.TriggeredEvent;
@@ -327,7 +337,7 @@ export namespace dia {
 
     class Cell<A extends ObjectHash = Cell.Attributes, S extends mvc.ModelSetOptions = dia.ModelSetOptions> extends mvc.Model<A, S> {
 
-        constructor(attributes?: A, opt?: Cell.ConstructorOptions);
+        constructor(attributes?: DeepPartial<A>, opt?: Cell.ConstructorOptions);
 
         id: Cell.ID;
         graph: Graph;
@@ -361,7 +371,7 @@ export namespace dia {
         isEmbedded(): boolean;
 
         prop(key: Path): any;
-        prop(object: Partial<A>, opt?: Cell.Options): this;
+        prop(object: DeepPartial<A>, opt?: Cell.Options): this;
         prop(key: Path, value: any, opt?: Cell.Options): this;
 
         removeProp(path: Path, opt?: Cell.Options): this;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

It was not possible to set partial attributes using `prop()` method or when constructing a new cell in *TypeScript*.

```ts
rectangle.prop({ size: { width: 100 }});

new joint.shapes.standard.Rectangle({
    position: { x: 100 },
});
```
