### PR TITLE
fix(dia.LinkView): fix missing arrowheads in Safari

### DIFF
--- a/packages/joint-core/src/env/index.mjs
+++ b/packages/joint-core/src/env/index.mjs
@@ -9,6 +9,7 @@ export const env = {
                 /SVGForeignObject/.test(({}).toString.call(document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')));
         },
 
+        // works for iOS browsers too
         isSafari: function() {
             return /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
         }

--- a/packages/joint-core/src/env/index.mjs
+++ b/packages/joint-core/src/env/index.mjs
@@ -7,6 +7,10 @@ export const env = {
         svgforeignobject: function() {
             return !!document.createElementNS &&
                 /SVGForeignObject/.test(({}).toString.call(document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')));
+        },
+
+        isSafari: function() {
+            return /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
         }
     },
 


### PR DESCRIPTION
## Description

Safari has a bug where any change after the first render is not reflected in the DOM.
https://bugs.webkit.org/show_bug.cgi?id=268376

This a fix to workaround the issue.

Fixing https://github.com/clientIO/joint/issues/2328.
