### PR TITLE
fix(dia.attributes): fix to take the inline font attributes into acco…

### DIFF
--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -127,6 +127,7 @@ const textAttributesNS = {
 
                 const breakTextFn = value.breakText || breakText;
                 const computedStyles = getComputedStyle(node);
+                const wrapFontAttributes = {};
                 // The font size attributes must be set on the node
                 // to get the correct text wrapping.
                 // TODO: set the native SVG attributes before special attributes
@@ -158,7 +159,11 @@ const textAttributesNS = {
                 wrappedText = '';
             }
             textAttributesNS.text.set.call(this, wrappedText, refBBox, node, attrs);
-        }
+        },
+        // We expose the font attributes list to allow
+        // the user to take other custom font attributes into account
+        // when wrapping the text.
+        FONT_ATTRIBUTES
     },
 
     'title': {

--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -7,6 +7,8 @@ function isTextInUse(_value, _node, attrs) {
     return (attrs.text !== undefined);
 }
 
+const FONT_ATTRIBUTES = ['font-weight', 'font-family', 'font-size', 'letter-spacing', 'text-transform'];
+
 const textAttributesNS = {
 
     'line-height': {
@@ -122,18 +124,33 @@ const textAttributesNS = {
             var text = value.text;
             if (text === undefined) text = attrs.text;
             if (text !== undefined) {
-                const breakTextFn = value.breakText || breakText;
-                const computedStyles = getComputedStyle(node);
 
-                wrappedText = breakTextFn('' + text, size, {
-                    'font-weight': computedStyles.fontWeight,
-                    'font-family': computedStyles.fontFamily,
-                    'text-transform': computedStyles.textTransform,
-                    'font-size': computedStyles.fontSize,
-                    'letter-spacing': computedStyles.letterSpacing,
-                    // The `line-height` attribute in SVG is JoinJS specific.
-                    'lineHeight': attrs['line-height'],
-                }, {
+                const breakTextFn = value.breakText || breakText;
+                const faCount = FONT_ATTRIBUTES.length;
+
+                // The font size attributes must be set on the node
+                // to get the correct text wrapping.
+                // TODO: set the native SVG attributes before special attributes
+                for (let i = 0; i < faCount; i++) {
+                    const name = FONT_ATTRIBUTES[i];
+                    if (name in attrs) {
+                        node.setAttribute(name, attrs[name]);
+                    }
+                }
+
+                // Get the computed styles of the node for all font attributes.
+                const computedStyles = getComputedStyle(node);
+                const wrapFontAttributes = {};
+                for (let i = 0; i < faCount; i++) {
+                    const name = FONT_ATTRIBUTES[i];
+                    wrapFontAttributes[name] = computedStyles[name];
+                }
+
+                // The `line-height` attribute in SVG is JoinJS specific.
+                // TODO: change the `lineHeight` to breakText option.
+                wrapFontAttributes.lineHeight = attrs['line-height'];
+
+                wrappedText = breakTextFn('' + text, size, wrapFontAttributes, {
                     // Provide an existing SVG Document here
                     // instead of creating a temporary one over again.
                     svgDocument: this.paper.svg,

--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -126,23 +126,17 @@ const textAttributesNS = {
             if (text !== undefined) {
 
                 const breakTextFn = value.breakText || breakText;
-                const faCount = FONT_ATTRIBUTES.length;
-
+                const computedStyles = getComputedStyle(node);
                 // The font size attributes must be set on the node
                 // to get the correct text wrapping.
                 // TODO: set the native SVG attributes before special attributes
-                for (let i = 0; i < faCount; i++) {
+                for (let i = 0; i < FONT_ATTRIBUTES.length; i++) {
                     const name = FONT_ATTRIBUTES[i];
                     if (name in attrs) {
                         node.setAttribute(name, attrs[name]);
                     }
-                }
-
-                // Get the computed styles of the node for all font attributes.
-                const computedStyles = getComputedStyle(node);
-                const wrapFontAttributes = {};
-                for (let i = 0; i < faCount; i++) {
-                    const name = FONT_ATTRIBUTES[i];
+                    // Note: computedStyles is a live object
+                    // i.e. the properties are evaluated when accessed.
                     wrapFontAttributes[name] = computedStyles[name];
                 }
 

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -104,8 +104,14 @@ QUnit.module('Attributes', function() {
                     return obj.width === refBBox.width - 11 && obj.height === refBBox.height - 13;
                 })));
 
-                // external css styles taken into account
-                spy.resetHistory();
+                spy.restore();
+            });
+
+            QUnit.test('takes external CSS into account', function(assert) {
+
+                const spy = sinon.spy(joint.util, 'breakText');
+
+                // no text
                 const fontSize = '23px';
                 const fontFamily = 'Arial';
                 const fontWeight = '800';
@@ -121,7 +127,21 @@ QUnit.module('Attributes', function() {
                     }
                 `);
                 paper.svg.prepend(stylesheet);
-                textWrap.set.call(cellView, { text: 'text', breakText: spy }, bbox, node, {});
+
+                const el = new joint.shapes.standard.Rectangle({
+                    attrs: {
+                        label: {
+                            text: 'text',
+                            textWrap: {
+                                breakText: spy
+                            }
+                        }
+                    }
+
+                });
+                el.addTo(graph);
+                paper.requireView(el);
+
                 assert.ok(spy.calledWith(
                     sinon.match.string,
                     sinon.match.object,
@@ -134,8 +154,8 @@ QUnit.module('Attributes', function() {
                             obj['font-weight'] === fontWeight
                         );
                     })));
-                stylesheet.remove();
 
+                stylesheet.remove();
                 spy.restore();
             });
 


### PR DESCRIPTION
## Description

Make sure all font attributes are set on the `<text/>` node before starting text wrapping.

See https://github.com/clientIO/joint/issues/2675.

Currently, the native attributes are set after the special attributes (except the `offset` attributes).
This is a safe fix for a patch release. We should investigate if the order can be switched without a breaking change.