### PR TITLE
Release v4.0.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
   @joint/core
   * update HTML demo in alignment with v4
   * dia.LinkView - fix missing arrowheads in Safari
-  * dia.attributes - fix to take the inline font attributes into account
+  * dia.attributes - fix to take the inline font attributes into account in `textWrap`
 
 14-05-2024 (v4.0.3)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 31-05-2024 (v4.0.4)
 
+  @joint/core
   * update HTML demo in alignment with v4
   * dia.LinkView - fix missing arrowheads in Safari
   * dia.attributes - fix to take the inline font attributes into account

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+31-05-2024 (v4.0.4)
+
+  * update HTML demo in alignment with v4
+  * dia.LinkView - fix missing arrowheads in Safari
+  * dia.attributes - fix to take the inline font attributes into account
+
 14-05-2024 (v4.0.3)
 
   * examples.libavoid - add new demo to illustrate using libavoid-js for orthogonal routing

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-decorators",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-dwdm",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/fta-js/package.json
+++ b/examples/fta-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-fta-js",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-isometric",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-directed-graph/package.json
+++ b/examples/layout-directed-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-directed-graph",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - Directed Graph Layout Demo",
   "main": "./index.js",
   "homepage": "https://jointjs.com",

--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-libavoid-js",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-list",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-shapes-general",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-of-life",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "src/index.ts",
   "author": {
     "name": "client IO",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "sideEffects": false,
   "homepage": "https://jointjs.com",
   "author": {

--- a/packages/joint-core/demo/custom-shapes/package.json
+++ b/packages/joint-core/demo/custom-shapes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-custom-shapes",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - Custom Shapes Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/elk/package.json
+++ b/packages/joint-core/demo/elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-elk-graph",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - Eclipse Layout Kernel Graph Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/rough/package.json
+++ b/packages/joint-core/demo/rough/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-rough",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - RoughJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/tree-shake/package.json
+++ b/packages/joint-core/demo/tree-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-shake",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - Tree Shake Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/ts-demo/package.json
+++ b/packages/joint-core/demo/ts-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-ts",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - TypeScript Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/vuejs/package.json
+++ b/packages/joint-core/demo/vuejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-vuejs",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JointJS - VueJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/core",
   "title": "JointJS",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "JavaScript diagramming library",
   "sideEffects": false,
   "main": "./dist/joint.min.js",

--- a/packages/joint-core/tutorials/hello-world.html
+++ b/packages/joint-core/tutorials/hello-world.html
@@ -34,7 +34,7 @@
     &lt;div id="myholder"&gt;&lt;/div&gt;
 
     &lt;!-- dependencies --&gt;
-    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.3/dist/joint.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.4/dist/joint.js"&gt;&lt;/script&gt;
 
     &lt;!-- code --&gt;
     &lt;script type="text/javascript"&gt;

--- a/packages/joint-core/tutorials/installation.html
+++ b/packages/joint-core/tutorials/installation.html
@@ -41,7 +41,7 @@
     &lt;div id="myholder"&gt;&lt;/div&gt;
 
     &lt;!-- dependencies --&gt;
-    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.3/dist/joint.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.4/dist/joint.js"&gt;&lt;/script&gt;
 
     &lt;!-- code --&gt;
     &lt;script type="text/javascript"&gt;

--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/decorators",
   "title": "JointJS Decorators",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Decorators module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-directed-graph",
   "title": "JointJS LayoutDirectedGraph",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "LayoutDirectedGraph module for JointJS",
   "main": "dist/DirectedGraph.js",
   "module": "./DirectedGraph.mjs",

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general-tools",
   "title": "JointJS General Shapes Tools",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "General Shapes Tools module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general",
   "title": "JointJS General Shapes",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "General Shapes module for JointJS",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",


### PR DESCRIPTION
# CHANGELOG

## @joint/core
  * update **HTML demo** in alignment with `v4` (2f3282146344d5637f729dfde8385106bb4190a8)
  * **dia.LinkView** - fix missing arrowheads in Safari (bccc2ef5605a1a090f7dda0f999ec1757b3ca173)
  * **dia.attributes** - fix to take the inline font attributes into account in `textWrap`(66442ad55ea5b3a27509828f8e1204beec5d8f3c)
