### PR TITLE
feat(linkTools.Vertices): add vertexAdding interactiveLinkNode option

### DIFF
--- a/packages/joint-core/demo/links/src/links.js
+++ b/packages/joint-core/demo/links/src/links.js
@@ -782,7 +782,7 @@ paper.on('link:mouseenter', function(linkView) {
             break;
         case link6:
             tools = [
-                new joint.linkTools.Vertices(),
+                new joint.linkTools.Vertices({ vertexAdding: { interactiveLinkNode: 'outline' }}),
                 new CustomBoundary({ padding: 25 })
             ];
             break;

--- a/packages/joint-core/test/jointjs/dia/linkTools.js
+++ b/packages/joint-core/test/jointjs/dia/linkTools.js
@@ -343,4 +343,39 @@ QUnit.module('linkTools', function(hooks) {
         });
     });
 
+    QUnit.module('Vertices', function() {
+        QUnit.test('vertexAdding', function(assert) {
+            // vertexAdding = true
+            const vertices1 = new joint.linkTools.Vertices({
+                vertexAdding: true
+            });
+            linkView.addTools(new joint.dia.ToolsView({ tools: [vertices1] }));
+            assert.ok(vertices1.el.querySelector('.joint-vertices-path'));
+            assert.notOk(linkView.el.querySelector('.joint-vertices-path'));
+            linkView.removeTools();
+            // vertexAdding = false
+            const vertices2 = new joint.linkTools.Vertices({
+                vertexAdding: false
+            });
+            linkView.addTools(new joint.dia.ToolsView({ tools: [vertices2] }));
+            assert.notOk(vertices2.el.querySelector('.joint-vertices-path'));
+            assert.notOk(linkView.el.querySelector('.joint-vertices-path'));
+            linkView.removeTools();
+            // interactiveLinkNode selector
+            const selector = 'wrapper';
+            const vertices3 = new joint.linkTools.Vertices({
+                vertexAdding: { interactiveLinkNode: selector }
+            });
+            linkView.addTools(new joint.dia.ToolsView({ tools: [vertices3] }));
+            assert.notOk(vertices3.el.querySelector('.joint-vertices-path'));
+            assert.ok(linkView.el.querySelector('.joint-vertices-path'));
+            assert.ok(joint.mvc.$.event.has(linkView.findNode(selector)));
+            assert.ok(linkView.findNode(selector).classList.contains('joint-vertices-path'));
+            linkView.removeTools();
+            assert.notOk(linkView.el.querySelector('.joint-vertices-path'));
+            assert.notOk(linkView.findNode(selector).classList.contains('joint-vertices-path'));
+            assert.notOk(joint.mvc.$.event.has(linkView.findNode(selector)));
+        });
+    });
+
 });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -4212,11 +4212,15 @@ export namespace linkTools {
             protected onPointerClick(evt: dia.Event): void;
         }
 
+        interface VertexAddingOptions {
+            interactiveLineNode: string;
+        }
+
         interface Options extends dia.ToolView.Options {
             handleClass?: typeof VertexHandle;
             snapRadius?: number;
             redundancyRemoval?: boolean;
-            vertexAdding?: boolean;
+            vertexAdding?: boolean | Partial<VertexAddingOptions>;
             vertexRemoving?: boolean;
             vertexMoving?: boolean;
             stopPropagation?: boolean;


### PR DESCRIPTION
## Description

The current solution with the `linkTools.Vertices` and its extra path overlay has several disadvantages. For example, it was not possible to move labels and create vertices at the same time (because an invisible path was rendered above the link and the labels).

This PR allows you to choose an existing node from the link view to serve as an interactive hit area for creating vertices.

## Docs
https://docs.jointjs.com/api/linkTools/#vertices

#### vertexAdding
Can the user add new vertices (by clicking a segment of the link)?
|Value|Description|
|--|--|
|`false`| The user can not add new vertices. |
|`true`|  An invisible path is rendered above the link which creates vertices upon interaction with it.  |
| `{}` |  See `VertexAddingOptions` | 

### VertexAddingOptions

|Option|Description|
|--|--|
|`interactiveLinkNode: string;` | A `selector` of an existing link node, e.g. `"wrapper"`. When the node is interacted with, a vertex is created. |

The default is `true`.

```ts
const verticesTool = new linkTools.Vertices({ vertexAdding: { interactiveLinkNode: 'outline' }}),
```

---

Implements https://github.com/clientIO/joint/issues/2688.
Solves: https://github.com/clientIO/joint/discussions/2370