### PR TITLE
types(dai.Paper): fix dumpViews() and updateViews() signature

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1596,7 +1596,6 @@ export namespace dia {
             mountBatchSize?: number;
             unmountBatchSize?: number;
             viewport?: Paper.ViewportCallback;
-            progress?: Paper.ProgressCallback;
         }): void;
 
         checkViewport(opt?: {
@@ -1611,10 +1610,10 @@ export namespace dia {
         updateViews(opt?: {
             batchSize?: number;
             viewport?: Paper.ViewportCallback;
-            progress?: Paper.ProgressCallback;
         }): {
             updated: number;
             batches: number;
+            priority: number;
         };
 
         hasScheduledUpdates(): boolean;


### PR DESCRIPTION
## Description

Fix incorrect TS definition of a few paper methods.

- remove `progress` option from `dumpViews()`
- remove `progress` option from `updateViews()`
- add `priority` property to `updateViews()` return value

---

See https://github.com/clientIO/joint/discussions/2695.