### PR TITLE
feat(dia.HighlighterView): add static getAll() method

### DIFF
--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -278,18 +278,22 @@ export const HighlighterView = mvc.View.extend({
         });
     },
 
-    removeAll(paper, id = null) {
+    getAll(paper, id = null) {
+        const views = [];
         const { _views } = this;
-
         for (let cid in _views) {
             for (let hid in _views[cid]) {
                 const view = _views[cid][hid];
-
                 if (view.cellView.paper === paper && view instanceof this && (id === null || hid === id)) {
-                    view.remove();
+                    views.push(view);
                 }
             }
         }
+        return views;
+    },
+
+    removeAll(paper, id = null) {
+        this.getAll(paper, id).forEach(view => view.remove());
     },
 
     update(cellView, id = null, dirty = false) {

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -143,6 +143,8 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.equal(joint.dia.HighlighterView.get(elementView, highlighterId2), null);
             assert.ok(joint.dia.HighlighterView.get(elementView2, highlighterId1));
             assert.equal(joint.dia.HighlighterView.get(elementView3, highlighterId1), null);
+
+            paper2.remove();
         });
 
         QUnit.test('removeAll(paper, id)', function(assert) {
@@ -171,6 +173,74 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(joint.dia.HighlighterView.get(elementView, highlighterId2));
             assert.ok(joint.dia.HighlighterView.get(elementView2, highlighterId1));
             assert.equal(joint.dia.HighlighterView.get(elementView3, highlighterId1), null);
+
+            paper2.remove();
+        });
+    });
+
+    QUnit.module('static getAll()', function() {
+
+        QUnit.test('getAll(paper)', function(assert) {
+
+            const highlighterId1 = 'highlighter-id-1';
+            const highlighterId2 = 'highlighter-id-2';
+
+            const graph2 = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            const paper2 = new joint.dia.Paper({ model: graph2, cellViewNamespace: joint.shapes });
+            const element2 = element.clone();
+            const elementDifferentGraph = element.clone();
+
+            element2.addTo(graph);
+            elementDifferentGraph.addTo(graph2);
+
+            const elementView2 = element2.findView(paper);
+            const elementViewDifferentGraph = elementDifferentGraph.findView(paper2);
+
+            const h1 = joint.dia.HighlighterView.add(elementView, 'body', highlighterId1);
+            const h2 = joint.dia.HighlighterView.add(elementView, 'body', highlighterId2);
+            const h3 = joint.dia.HighlighterView.add(elementView2, 'body', highlighterId1);
+            const h4 = joint.dia.HighlighterView.add(elementViewDifferentGraph, 'body', highlighterId1);
+
+            const highlighters = joint.dia.HighlighterView.getAll(paper);
+            assert.equal(highlighters.length, 3);
+            assert.ok(highlighters.includes(h1));
+            assert.ok(highlighters.includes(h2));
+            assert.ok(highlighters.includes(h3));
+            assert.notOk(highlighters.includes(h4));
+
+            paper2.remove();
+        });
+
+        QUnit.test('getAll(paper, id)', function(assert) {
+
+            const highlighterId1 = 'highlighter-id-1';
+            const highlighterId2 = 'highlighter-id-2';
+
+            const graph2 = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            const paper2 = new joint.dia.Paper({ model: graph2, cellViewNamespace: joint.shapes });
+
+            const element2 = element.clone();
+            const elementDifferentGraph = element.clone();
+
+            element2.addTo(graph);
+            elementDifferentGraph.addTo(graph2);
+
+            const elementView2 = element2.findView(paper);
+            const elementViewDifferentGraph = elementDifferentGraph.findView(paper2);
+
+            const h1 = joint.dia.HighlighterView.add(elementView, 'body', highlighterId1);
+            const h2 = joint.dia.HighlighterView.add(elementView, 'body', highlighterId2);
+            const h3 = joint.dia.HighlighterView.add(elementView2, 'body', highlighterId1);
+            const h4 = joint.dia.HighlighterView.add(elementViewDifferentGraph, 'body', highlighterId1);
+
+            const highlighters = joint.dia.HighlighterView.getAll(paper, highlighterId1);
+            assert.equal(highlighters.length, 2);
+            assert.ok(highlighters.includes(h1));
+            assert.notOk(highlighters.includes(h2));
+            assert.ok(highlighters.includes(h3));
+            assert.notOk(highlighters.includes(h4));
+
+            paper2.remove();
         });
     });
 


### PR DESCRIPTION
## Description

A new static method added to `dia.HighlighterView` as there was no way to get all the highlighters of a certain type and ID from the paper.

## Documentation

https://docs.jointjs.com/api/dia/HighlighterView/

### `static getAll(paper, id?)`

Get an array of all highlighters on the `paper`, which are instances of this class. If an `id` is provided, get only the highlighters with given `id` on the `paper`.