### PR TITLE
fix(mvc.View): set style via options

### DIFF
--- a/packages/joint-core/src/mvc/ViewBase.mjs
+++ b/packages/joint-core/src/mvc/ViewBase.mjs
@@ -35,7 +35,8 @@ export var ViewBase = function(options) {
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
 // List of view options to be set as properties.
-var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
+// TODO: `style` attribute is not supported in ViewBase class yet, but only in View class that extends ViewBase.
+var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events', 'style'];
 
 // Set up all inheritable **ViewBase** properties and methods.
 assign(ViewBase.prototype, Events, {

--- a/packages/joint-core/test/jointjs/mvc.view.js
+++ b/packages/joint-core/test/jointjs/mvc.view.js
@@ -266,4 +266,23 @@ QUnit.module('joint.mvc.View', function(hooks) {
             view.remove();
         });
     });
+
+    QUnit.module('style', function() {
+
+        QUnit.test('as class property', function(assert) {
+            assert.expect(1);
+            var View = joint.mvc.View.extend({
+                style: {
+                    'color': 'red'
+                }
+            });
+            assert.strictEqual(new View().el.style.color, 'red');
+        });
+
+        QUnit.test('as option', function(assert) {
+            assert.expect(1);
+            var View = joint.mvc.View.extend();
+            assert.strictEqual(new View({ style: { 'color': 'red' }}).el.style.color, 'red');
+        });
+    });
 });


### PR DESCRIPTION
## Description

Allow `style` attribute to be set via options.

All other properties can be set either as a class property or as a constructor option.

```ts
// Already supported
(new mvc.View.extend({ style: { color: 'red' }})).el.style.color === 'red';
```

```ts
// Supported after this PR
(new mvc.View({ style: { color: 'red' }})).el.style.color === 'red'
```

## Documentation

The documentation missing not only the `style` property but also `events` and `constructor()`.
https://docs.jointjs.com/api/mvc/View/#properties

### style

A hash of CSS properties that will be set as inline style on the view's el (`color: red;`, etc.), or a function that returns such a hash.

### constructor()

There are several special options that, if passed, will be attached directly to the view: `model`, `collection`, `el`, `id`, `className`, `tagName`, `attributes`, `style` and `events`. If the view defines an initialize function, it will be called when the view is first created. If you'd like to create a view that references an element already in the DOM, pass in the element as an option: `new View({el: existingElement})`

```ts
var doc = documents.first();

new DocumentRow({
  model: doc,
  id: "document-row-" + doc.id
});
```

### events

The events hash (or method) can be used to specify a set of DOM events that will be bound to methods on your View through `delegateEvents`.

JointJS will automatically attach the event listeners at instantiation time, right before invoking `initialize`.

```ts
var ENTER_KEY = 13;
var InputView = Backbone.View.extend({

  tagName: 'input',

  events: {
    "keydown" : "keyAction",
  },

  render: function() { ... },

  keyAction: function(e) {
    if (e.which === ENTER_KEY) {
      this.collection.add({text: this.$el.val()});
    }
  }
});
```

