### PR TITLE
fix(linkTools): fix pending batch for TargetArrowhead and SourceArrowead

### DIFF
--- a/packages/joint-core/src/linkTools/Arrowhead.mjs
+++ b/packages/joint-core/src/linkTools/Arrowhead.mjs
@@ -51,7 +51,8 @@ const Arrowhead = ToolView.extend({
         var paper = relatedView.paper;
         relatedView.model.startBatch('arrowhead-move', { ui: true, tool: this.cid });
         relatedView.startArrowheadMove(this.arrowheadType);
-        this.delegateDocumentEvents();
+        const data = evt.data || (evt.data = {});
+        this.delegateDocumentEvents(null, data);
         paper.undelegateEvents();
         this.focus();
         this.el.style.pointerEvents = 'none';

--- a/packages/joint-core/test/jointjs/dia/linkTools.js
+++ b/packages/joint-core/test/jointjs/dia/linkTools.js
@@ -341,6 +341,30 @@ QUnit.module('linkTools', function(hooks) {
 
             listener.stopListening();
         });
+
+        QUnit.test('data', function(assert) {
+
+            assert.expect(3);
+
+            const arrowhead = new joint.linkTools.TargetArrowhead();
+            linkView.addTools(new joint.dia.ToolsView({ tools: [arrowhead] }));
+            const listener = new joint.mvc.Listener();
+
+            listener.listenTo(paper, {
+                'link:pointerdown': (linkView, evt) => evt.data.test = true,
+                'link:pointermove': (linkView, evt) => assert.ok(evt.data.test),
+                'link:pointerup': (linkView, evt) => assert.ok(evt.data.test),
+            });
+
+            // Make sure the link is connected to a target element
+            assert.ok(link.getTargetCell());
+
+            simulate.mousedown({ el: arrowhead.el });
+            simulate.mousemove({ el: paper.el });
+            simulate.mouseup({ el: paper.el });
+
+            listener.stopListening();
+        });
     });
 
 });


### PR DESCRIPTION
## Description

This PR makes sure that all active batches are closed at the end of the drag arrowhead interaction.

https://github.com/clientIO/joint/pull/2625 fixed triggering of `pointerdown` event. This caused the `pointer` batch to be (correctly) triggered, but due to not passing event data to subsequent events (`pointermove` & `pointerup`), the `pointer` batch closure was never invoked.

Fixes [issue](https://github.com/clientIO/joint/issues/2719).
