### PR TITLE
feat(dia.Cell): new toJSON options

### DIFF
--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -43,6 +43,23 @@ const attributesMerger = function(a, b) {
     }
 };
 
+function removeEmptyAttributes(obj) {
+
+    for (const key in obj) {
+
+        const objValue = obj[key];
+        const isRealObject = isObject(objValue) && !Array.isArray(objValue);
+
+        if (isRealObject) {
+            removeEmptyAttributes(objValue);
+        }
+
+        if (isEmpty(objValue) && isRealObject) {
+            delete obj[key];
+        }
+    }
+}
+
 export const Cell = Model.extend({
 
     // This is the same as mvc.Model with the only difference that is uses util.merge
@@ -81,23 +98,6 @@ export const Cell = Model.extend({
         const { ignoreDefaults, ignoreEmptyAttributes = false } = opt || {};
         const defaults = result(this.constructor.prototype, 'defaults');
 
-        function removeEmptyAttributes(obj) {
-
-            for (const key in obj) {
-
-                const objValue = obj[key];
-                const isRealObject = isObject(objValue) && !Array.isArray(objValue);
-
-                if (isRealObject) {
-                    removeEmptyAttributes(objValue);
-                }
-
-                if (isEmpty(objValue) && isRealObject) {
-                    delete obj[key];
-                }
-            }
-        }
-
         if (ignoreDefaults === false) {
             // Return all attributes without omitting the defaults
             const finalAttributes = cloneDeep(this.attributes);
@@ -125,7 +125,7 @@ export const Cell = Model.extend({
         }
 
         // Omit `type` attribute from the defaults since it should be always present
-        const finalAttributes = objectDifference(attributes, omit(defaultAttributes, 'type'), ignoreEmptyAttributes, 4);
+        const finalAttributes = objectDifference(attributes, omit(defaultAttributes, 'id', 'type'), ignoreEmptyAttributes, 4);
 
         return finalAttributes;
     },

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -45,16 +45,15 @@ const attributesMerger = function(a, b) {
 
 function removeEmptyAttributes(obj) {
 
+    // Remove toplevel empty attributes
     for (const key in obj) {
 
         const objValue = obj[key];
         const isRealObject = isObject(objValue) && !Array.isArray(objValue);
 
-        if (isRealObject) {
-            removeEmptyAttributes(objValue);
-        }
+        if (!isRealObject) continue;
 
-        if (isEmpty(objValue) && isRealObject) {
+        if (isEmpty(objValue)) {
             delete obj[key];
         }
     }
@@ -124,8 +123,12 @@ export const Cell = Model.extend({
             });
         }
 
-        // Omit `type` attribute from the defaults since it should be always present
-        const finalAttributes = objectDifference(attributes, omit(defaultAttributes, 'id', 'type'), ignoreEmptyAttributes, 4);
+        // Omit `id` and `type` attribute from the defaults since it should be always present
+        const finalAttributes = objectDifference(attributes, omit(defaultAttributes, 'id', 'type'), { maxDepth: 4 });
+
+        if (ignoreEmptyAttributes) {
+            removeEmptyAttributes(finalAttributes);
+        }
 
         return finalAttributes;
     },

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -208,12 +208,12 @@ export const Graph = Model.extend({
         return (this._in && this._in[node]) || {};
     },
 
-    toJSON: function(opt) {
+    toJSON: function(opt = {}) {
 
         // JointJS does not recursively call `toJSON()` on attributes that are themselves models/collections.
         // It just clones the attributes. Therefore, we must call `toJSON()` on the cells collection explicitly.
         var json = Model.prototype.toJSON.apply(this, arguments);
-        json.cells = this.get('cells').toJSON(opt);
+        json.cells = this.get('cells').toJSON(opt.cellAttributes);
         return json;
     },
 

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -208,12 +208,12 @@ export const Graph = Model.extend({
         return (this._in && this._in[node]) || {};
     },
 
-    toJSON: function() {
+    toJSON: function(opt) {
 
         // JointJS does not recursively call `toJSON()` on attributes that are themselves models/collections.
         // It just clones the attributes. Therefore, we must call `toJSON()` on the cells collection explicitly.
         var json = Model.prototype.toJSON.apply(this, arguments);
-        json.cells = this.get('cells').toJSON();
+        json.cells = this.get('cells').toJSON(opt);
         return json;
     },
 

--- a/packages/joint-core/src/util/util.mjs
+++ b/packages/joint-core/src/util/util.mjs
@@ -1708,6 +1708,47 @@ export const toggleFullScreen = function(el) {
     }
 };
 
+
+// Util function used for purposes of `dia.Cell.toJSON()` method
+export function objectDifference(object, base, ignoreEmptyObjects = false, depth = Number.POSITIVE_INFINITY) {
+
+    function findDifference(obj, baseObj, currentDepth) {
+
+        if (currentDepth === depth) {
+            return {};
+        }
+
+        const diff = {};
+
+        Object.keys(obj).forEach((key) => {
+
+            const objValue = obj[key];
+            const baseValue = baseObj[key];
+
+            if (!Array.isArray(objValue) && !Array.isArray(baseValue) && isObject(objValue) && isObject(baseValue)) {
+
+                const nestedDepth = currentDepth + 1;
+                const nestedDiff = findDifference(objValue, baseValue, nestedDepth);
+
+                if (Object.keys(nestedDiff).length > 0) {
+                    diff[key] = nestedDiff;
+                } else if ((currentDepth === 0 || nestedDepth === depth) && !ignoreEmptyObjects) {
+                    // If we are at the root level or at the maximum depth and the nested object is empty,
+                    // we still want to include it in the diff object if `ignoreEmptyObjects` is set to true
+                    diff[key] = {};
+                }
+
+            } else if (!isEqual(objValue, baseValue)) {
+                diff[key] = objValue;
+            }
+        });
+
+        return diff;
+    }
+
+    return findDifference(object, base, 0);
+}
+
 export {
     isBoolean,
     isObject,

--- a/packages/joint-core/src/util/util.mjs
+++ b/packages/joint-core/src/util/util.mjs
@@ -1708,45 +1708,43 @@ export const toggleFullScreen = function(el) {
     }
 };
 
+function findDifference(obj, baseObj, currentDepth, maxDepth) {
 
-// Util function used for purposes of `dia.Cell.toJSON()` method
-export function objectDifference(object, base, ignoreEmptyObjects = false, depth = Number.POSITIVE_INFINITY) {
-
-    function findDifference(obj, baseObj, currentDepth) {
-
-        if (currentDepth === depth) {
-            return {};
-        }
-
-        const diff = {};
-
-        Object.keys(obj).forEach((key) => {
-
-            const objValue = obj[key];
-            const baseValue = baseObj[key];
-
-            if (!Array.isArray(objValue) && !Array.isArray(baseValue) && isObject(objValue) && isObject(baseValue)) {
-
-                const nestedDepth = currentDepth + 1;
-                const nestedDiff = findDifference(objValue, baseValue, nestedDepth);
-
-                if (Object.keys(nestedDiff).length > 0) {
-                    diff[key] = nestedDiff;
-                } else if ((currentDepth === 0 || nestedDepth === depth) && !ignoreEmptyObjects) {
-                    // If we are at the root level or at the maximum depth and the nested object is empty,
-                    // we still want to include it in the diff object if `ignoreEmptyObjects` is set to true
-                    diff[key] = {};
-                }
-
-            } else if (!isEqual(objValue, baseValue)) {
-                diff[key] = objValue;
-            }
-        });
-
-        return diff;
+    if (currentDepth === maxDepth) {
+        return {};
     }
 
-    return findDifference(object, base, 0);
+    const diff = {};
+
+    Object.keys(obj).forEach((key) => {
+
+        const objValue = obj[key];
+        const baseValue = baseObj[key];
+
+        if (!Array.isArray(objValue) && !Array.isArray(baseValue) && isObject(objValue) && isObject(baseValue)) {
+
+            const nestedDepth = currentDepth + 1;
+            const nestedDiff = findDifference(objValue, baseValue, nestedDepth, maxDepth);
+
+            if (Object.keys(nestedDiff).length > 0) {
+                diff[key] = nestedDiff;
+            } else if ((currentDepth === 0 || nestedDepth === maxDepth)) {
+                diff[key] = {};
+            }
+
+        } else if (!isEqual(objValue, baseValue)) {
+            diff[key] = objValue;
+        }
+    });
+
+    return diff;
+}
+
+export function objectDifference(object, base, opt) {
+
+    const { maxDepth = Number.POSITIVE_INFINITY } = opt || {};
+
+    return findDifference(object, base, 0, maxDepth);
 }
 
 export {

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -689,9 +689,7 @@ QUnit.module('cell', function(hooks) {
             });
         
             const el = new El({
-                foo: {
-                    bar: {}
-                }
+                foo: {}
             });
 
             const expected = joint.util.cloneDeep(el.attributes);

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -671,6 +671,66 @@ QUnit.module('cell', function(hooks) {
 
             assert.deepEqual(el.toJSON(), { id: 'el1', attrs: { test2: { prop2: true }}});
         });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = false', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            assert.deepEqual(rect.toJSON({ ignoreDefaults: false }), {
+                id: rect.id,
+                ...joint.shapes.standard.Rectangle.prototype.defaults,
+            });
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = false, `opt.ignoreEmptyAttributes` = true', function(assert) {
+            const El = joint.dia.Element.extend({
+                defaults: {
+                    type: 'test.Element'
+                }
+            });
+        
+            const el = new El({
+                foo: {
+                    bar: {}
+                }
+            });
+
+            const expected = joint.util.cloneDeep(el.attributes);
+            delete expected.foo;
+
+            assert.deepEqual(el.toJSON({ ignoreDefaults: false, ignoreEmptyAttributes: true }), expected);
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = true', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            assert.deepEqual(rect.toJSON({ ignoreDefaults: true }), {
+                type: joint.shapes.standard.Rectangle.prototype.defaults.type,
+                id: rect.id,
+                size: {},
+                position: {},
+                attrs: {}
+            });
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = true, `opt.ignoreEmptyAttributes` = true', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            assert.deepEqual(rect.toJSON({ ignoreDefaults: true, ignoreEmptyAttributes: true }), {
+                type: joint.shapes.standard.Rectangle.prototype.defaults.type,
+                id: rect.id
+            });
+        });
+
+        QUnit.test('`opt.ignoreDefaults` should accept an array of keys to differentiate', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            assert.deepEqual(rect.toJSON({ ignoreDefaults: ['attrs', 'size'] }), {
+                id: rect.id,
+                ...joint.shapes.standard.Rectangle.prototype.defaults,
+                attrs: {},
+                size: {}
+            });
+        });
     });
 
     QUnit.module('relative vs absolute points', function() {

--- a/packages/joint-core/test/jointjs/core/util.js
+++ b/packages/joint-core/test/jointjs/core/util.js
@@ -1729,29 +1729,6 @@ QUnit.module('util', function(hooks) {
             assert.deepEqual(actual, expected);
         });
 
-        QUnit.test('should accept the `ignoreEmptyObjects` argument', function(assert) {
-            const expected = { foo: 'bar' };
-            const actual = joint.util.objectDifference(
-                {
-                    foo: 'bar',
-                    baz: {
-                        x: 10,
-                        y: 10
-                    }
-                },
-                {
-                    foo: '',
-                    baz: {
-                        x: 10,
-                        y: 10
-                    }
-                },
-                true
-            );
-
-            assert.deepEqual(actual, expected);
-        });
-
         QUnit.test('should use arrays from the first object', function(assert) {
             const expected = { foo: [1, 2, 3] };
             const actual = joint.util.objectDifference(
@@ -1766,7 +1743,7 @@ QUnit.module('util', function(hooks) {
             assert.deepEqual(actual, expected);
         });
 
-        QUnit.test('should respect the `depth` argument', function(assert) {
+        QUnit.test('should respect the `opt.maxDepth` argument', function(assert) {
             const expected = {
                 foo: {
                     bar: {}
@@ -1800,8 +1777,7 @@ QUnit.module('util', function(hooks) {
                         }
                     }
                 },
-                false,
-                2
+                { maxDepth: 2 }
             );
 
             assert.deepEqual(actual, expected);
@@ -1819,7 +1795,7 @@ QUnit.module('util', function(hooks) {
                 }
             };
 
-            const actual = joint.util.objectDifference(object1, object2, false, 2);
+            const actual = joint.util.objectDifference(object1, object2, { maxDepth: 2 });
 
             assert.deepEqual(actual, expected);
         });

--- a/packages/joint-core/test/jointjs/core/util.js
+++ b/packages/joint-core/test/jointjs/core/util.js
@@ -1599,4 +1599,230 @@ QUnit.module('util', function(hooks) {
         });
     });
 
+    QUnit.module('objectDifference', function(assert) {
+
+        QUnit.test('should return the difference of values', function(assert) {
+            const expected = { b: 2 };
+            const actual = joint.util.objectDifference({ a: 1, b: 2 }, { a: 1, c: 3 });
+
+            assert.deepEqual(actual, expected);
+        });
+    
+        QUnit.test('should return the difference of multiple values', function(assert) {
+            const expected = { b: 2, c: 3 };
+            const actual = joint.util.objectDifference({ a: 1, b: 2, c: 3 }, { a: 1 });
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should return the difference of nested values', function(assert) {
+            const expected = {
+                a: {
+                    b: {
+                        c: {
+                            d: 4
+                        }
+                    }
+                }
+            };
+            const actual = joint.util.objectDifference(
+                {
+                    a: {
+                        b: {
+                            c: {
+                                d: 4
+                            }
+                        }
+                    }
+                }, 
+                {
+                    a: {
+                        b: {
+                            c: {
+                                d: 5
+                            }
+                        }
+                    }
+                }
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should return the difference of multiple nested values', function(assert) {
+            const expected = {
+                a: {
+                    b: {
+                        c: {
+                            d: 4
+                        }
+                    }
+                },
+                foo: {
+                    bar: {
+                        baz: 5
+                    }
+                },
+                x: 'y'
+            };
+
+            const actual = joint.util.objectDifference(
+                {
+                    a: {
+                        b: {
+                            c: {
+                                d: 4
+                            }
+                        }
+                    },
+                    foo: {
+                        bar: {
+                            baz: 5
+                        }
+                    },
+                    x: 'y'
+                }, 
+                {
+                    a: {
+                        b: {
+                            c: {
+                                d: 5
+                            }
+                        }
+                    },
+                    foo: {
+                        bar: {
+                            baz: 6
+                        }
+                    },
+                    x: 'z'
+                }
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should take into account the keys of the first object', function(assert) {
+            const expected = { foo: 'bar' };
+            const actual = joint.util.objectDifference({ foo: 'bar' }, { a: 1, c: 3 });
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should return an empty object when the toplevel properties are the same', function(assert) {
+            const expected = { foo: {}};
+            const actual = joint.util.objectDifference(
+                {
+                    foo: {
+                        x: 10,
+                        y: 10
+                    }
+                },
+                {
+                    foo: {
+                        x: 10,
+                        y: 10
+                    }
+                }
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should accept the `ignoreEmptyObjects` argument', function(assert) {
+            const expected = { foo: 'bar' };
+            const actual = joint.util.objectDifference(
+                {
+                    foo: 'bar',
+                    baz: {
+                        x: 10,
+                        y: 10
+                    }
+                },
+                {
+                    foo: '',
+                    baz: {
+                        x: 10,
+                        y: 10
+                    }
+                },
+                true
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should use arrays from the first object', function(assert) {
+            const expected = { foo: [1, 2, 3] };
+            const actual = joint.util.objectDifference(
+                {
+                    foo: [1, 2, 3]
+                },
+                {
+                    foo: [1, 2, 4]
+                }
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should respect the `depth` argument', function(assert) {
+            const expected = {
+                foo: {
+                    bar: {}
+                },
+                x: {
+                    y: {}
+                }
+            };
+            const actual = joint.util.objectDifference(
+                {
+                    foo: {
+                        bar: {
+                            baz: 5
+                        }
+                    },
+                    x: {
+                        y: {
+                            z: 5
+                        }
+                    }
+                },
+                {
+                    foo: {
+                        bar: {
+                            test: 5
+                        }
+                    },
+                    x: {
+                        y: {
+                            test: 5
+                        }
+                    }
+                },
+                false,
+                2
+            );
+
+            assert.deepEqual(actual, expected);
+        });
+
+        QUnit.test('should not throw `Maximum call stack size exceeded`', function(assert) {
+            const object1 = {};
+            const object2 = {};
+            object1.foo = object2;
+            object2.foo = object1;
+
+            const expected = {
+                foo: {
+                    foo: {}
+                }
+            };
+
+            const actual = joint.util.objectDifference(object1, object2, false, 2);
+
+            assert.deepEqual(actual, expected);
+        });
+    });
+
 });

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1477,9 +1477,7 @@ QUnit.module('graph', function(hooks) {
             });
         
             const el = new El({
-                foo: {
-                    bar: {}
-                }
+                foo: {}
             });
 
             this.graph.resetCells([el]);

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1461,7 +1461,7 @@ QUnit.module('graph', function(hooks) {
             const rect = new joint.shapes.standard.Rectangle();
 
             this.graph.resetCells([rect]);
-            const json = this.graph.toJSON({ ignoreDefaults: false });
+            const json = this.graph.toJSON({ cellAttributes: { ignoreDefaults: false }});
 
             assert.deepEqual(json.cells[0], {
                 id: rect.id,
@@ -1481,7 +1481,7 @@ QUnit.module('graph', function(hooks) {
             });
 
             this.graph.resetCells([el]);
-            const json = this.graph.toJSON({ ignoreDefaults: false, ignoreEmptyAttributes: true });
+            const json = this.graph.toJSON({ cellAttributes: { ignoreDefaults: false, ignoreEmptyAttributes: true }});
 
             const expected = joint.util.cloneDeep(el.attributes);
             delete expected.foo;
@@ -1493,7 +1493,7 @@ QUnit.module('graph', function(hooks) {
             const rect = new joint.shapes.standard.Rectangle();
 
             this.graph.resetCells([rect]);
-            const json = this.graph.toJSON({ ignoreDefaults: true });
+            const json = this.graph.toJSON({ cellAttributes: { ignoreDefaults: true }});
 
             assert.deepEqual(json.cells[0], {
                 type: joint.shapes.standard.Rectangle.prototype.defaults.type,
@@ -1508,7 +1508,7 @@ QUnit.module('graph', function(hooks) {
             const rect = new joint.shapes.standard.Rectangle();
 
             this.graph.resetCells([rect]);
-            const json = this.graph.toJSON({ ignoreDefaults: true, ignoreEmptyAttributes: true });
+            const json = this.graph.toJSON({ cellAttributes: { ignoreDefaults: true, ignoreEmptyAttributes: true }});
 
             assert.deepEqual(json.cells[0], {
                 type: joint.shapes.standard.Rectangle.prototype.defaults.type,
@@ -1520,7 +1520,7 @@ QUnit.module('graph', function(hooks) {
             const rect = new joint.shapes.standard.Rectangle();
 
             this.graph.resetCells([rect]);
-            const json = this.graph.toJSON({ ignoreDefaults: ['attrs', 'size'] });
+            const json = this.graph.toJSON({ cellAttributes: { ignoreDefaults: ['attrs', 'size'] }});
 
             assert.deepEqual(json.cells[0], {
                 id: rect.id,

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1456,6 +1456,81 @@ QUnit.module('graph', function(hooks) {
             assert.ok(_.isArray(json.cells));
             assert.equal(json.cells.length, 3);
         });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = false', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            this.graph.resetCells([rect]);
+            const json = this.graph.toJSON({ ignoreDefaults: false });
+
+            assert.deepEqual(json.cells[0], {
+                id: rect.id,
+                ...joint.shapes.standard.Rectangle.prototype.defaults,
+            });
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = false, `opt.ignoreEmptyAttributes` = true', function(assert) {
+            const El = joint.dia.Element.extend({
+                defaults: {
+                    type: 'test.Element'
+                }
+            });
+        
+            const el = new El({
+                foo: {
+                    bar: {}
+                }
+            });
+
+            this.graph.resetCells([el]);
+            const json = this.graph.toJSON({ ignoreDefaults: false, ignoreEmptyAttributes: true });
+
+            const expected = joint.util.cloneDeep(el.attributes);
+            delete expected.foo;
+
+            assert.deepEqual(json.cells[0], expected);
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = true', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            this.graph.resetCells([rect]);
+            const json = this.graph.toJSON({ ignoreDefaults: true });
+
+            assert.deepEqual(json.cells[0], {
+                type: joint.shapes.standard.Rectangle.prototype.defaults.type,
+                id: rect.id,
+                size: {},
+                position: {},
+                attrs: {}
+            });
+        });
+
+        QUnit.test('should take in account `opt.ignoreDefaults` = true, `opt.ignoreEmptyAttributes` = true', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            this.graph.resetCells([rect]);
+            const json = this.graph.toJSON({ ignoreDefaults: true, ignoreEmptyAttributes: true });
+
+            assert.deepEqual(json.cells[0], {
+                type: joint.shapes.standard.Rectangle.prototype.defaults.type,
+                id: rect.id
+            });
+        });
+
+        QUnit.test('`opt.ignoreDefaults` should accept an array of keys to differentiate', function(assert) {
+            const rect = new joint.shapes.standard.Rectangle();
+
+            this.graph.resetCells([rect]);
+            const json = this.graph.toJSON({ ignoreDefaults: ['attrs', 'size'] });
+
+            assert.deepEqual(json.cells[0], {
+                id: rect.id,
+                ...joint.shapes.standard.Rectangle.prototype.defaults,
+                attrs: {},
+                size: {}
+            });
+        });
     });
 
     QUnit.module('graph.hasActiveBatch()', function() {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -239,7 +239,7 @@ export namespace dia {
 
         getCommonAncestor(...cells: Cell[]): Element | undefined;
 
-        toJSON(opt?: { ignoreDefaults: boolean | string[], ignoreEmptyAttributes: boolean }): any;
+        toJSON(opt?: dia.Cell.ExportOptions): any;
 
         fromJSON(json: any, opt?: S): this;
 
@@ -334,6 +334,11 @@ export namespace dia {
         interface ConstructorOptions extends Graph.Options {
             mergeArrays?: boolean;
         }
+
+        interface ExportOptions {
+            ignoreDefault?: boolean | string[];
+            ignoreEmptyAttributes?: boolean;
+        }
     }
 
     class Cell<A extends ObjectHash = Cell.Attributes, S extends mvc.ModelSetOptions = dia.ModelSetOptions> extends mvc.Model<A, S> {
@@ -351,7 +356,7 @@ export namespace dia {
 
         protected stopScheduledTransitions(path?: string, delim?: string): void;
 
-        toJSON(opt?: { ignoreDefaults: boolean | string[], ignoreEmptyAttributes: boolean }): Cell.JSON<any, A>;
+        toJSON(opt?: dia.Cell.ExportOptions): Cell.JSON<any, A>;
 
         remove(opt?: Cell.DisconnectableOptions): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2454,6 +2454,8 @@ export namespace util {
 
     export function toggleFullScreen(el?: Element): void;
 
+    export function objectDifference(object: object, base: object, opt?: { maxDepth?: number }): object;
+
     interface DOMJSONDocument {
         fragment: DocumentFragment;
         selectors: { [key: string]: Element };

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -239,7 +239,7 @@ export namespace dia {
 
         getCommonAncestor(...cells: Cell[]): Element | undefined;
 
-        toJSON(): any;
+        toJSON(opt?: { ignoreDefaults: boolean | string[], ignoreEmptyAttributes: boolean }): any;
 
         fromJSON(json: any, opt?: S): this;
 
@@ -351,7 +351,7 @@ export namespace dia {
 
         protected stopScheduledTransitions(path?: string, delim?: string): void;
 
-        toJSON(): Cell.JSON<any, A>;
+        toJSON(opt?: { ignoreDefaults: boolean | string[], ignoreEmptyAttributes: boolean }): Cell.JSON<any, A>;
 
         remove(opt?: Cell.DisconnectableOptions): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -239,7 +239,7 @@ export namespace dia {
 
         getCommonAncestor(...cells: Cell[]): Element | undefined;
 
-        toJSON(opt?: dia.Cell.ExportOptions): any;
+        toJSON(opt?: { cellAttributes?: dia.Cell.ExportOptions }): any;
 
         fromJSON(json: any, opt?: S): this;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

This PR includes changes to the `dia.Cell.toJSON()`, now accepting two new options.
- `opt.ignoreDefaults` (_default_ `['attrs']`) - accepts an array of attribute names to be compared to the defaults, additionally setting this option to `false` will result in returning all of the attributes without comparing them, while setting it to `true` results in a comparison of all the attributes with defaults
- `opt.ignoreEmptyAttributes` (_default_ `false`) - determines if the result should include empty attributes

These two options are also applicable to `dia.Graph.toJSON()` method.

This PR also includes a new `util.objectDifference` function used to determine the difference between two provided objects.

## Documentation
https://docs.jointjs.com/api/dia/Cell/#tojson

### `toJSON()`

```ts
cell.toJSON([opt])
```

Return a copy of the cell's attributes for JSON serialization. This can be used for persistance or serialization. Note that this method doesn't return a JSON string but rather an object that can be then serialized to JSON with `JSON.stringify()`.

By default, `opt.ignoreDefaults` is set to `['attrs']`. This setting ensures that only non-default attributes in the attrs object are returned, as it compares the attrs object to its defaults. To include all attributes of `dia.Cell` without filtering out defaults, set `opt.ignoreDefaults` to `false`. Alternatively, setting `opt.ignoreDefaults` to `true` will compare all attributes to their defaults, returning only those that differ. You can also provide an array of strings for `opt.ignoreDefaults`, specifying a list of attributes to compare against their defaults.

Additionally, `opt.ignoreEmptyAttributes` defaults to `false`, which may include empty objects in the JSON output. To exclude empty objects, set `opt.ignoreEmptyAttributes` to `true`.

```ts
const rectangle = new shapes.standard.Rectangle();

rectangle.toJSON();
// {
//     "type": "standard.Rectangle",
//     "attrs": {},
//     "position": {
//         "x": 0,
//         "y": 0
//     },
//     "size": {
//         "width": 1,
//         "height": 1
//     },
//     "angle": 0,
//     "id": "..."
// }

rectangle.toJSON({ ignoreDefaults: true });
// {
//     "type": "standard.Rectangle",
//     "attrs": {},
//     "position": {},
//     "size": {},
//     "id": "..."
// }

rectangle.toJSON({ ignoreDefaults: true, ignoreEmptyAttributes: true });
// {
//     "type": "standard.Rectangle",
//     "id": "..."
// }

rectangle.toJSON({ ignoreDefaults: ['attrs', 'size'] });
// {
//     "type": "standard.Rectangle",
//     "attrs": {},
//     "position": {
//         "x": 0,
//         "y": 0
//     },
//     "size": {},
//     "angle": 0,
//     "id": "..."
// }
```
---
https://docs.jointjs.com/api/dia/Graph/#tojson

### toJSON()

```ts
graph.toJSON([opt])
```

This method accepts an optional `opt` object, the `opt.cellAttributes` accepts same options as the [dia.Cell.toJSON()](../Cell/Cell.mdx#tojson) method, which will impact the result of the `toJSON()` method.


---
https://docs.jointjs.com/api/util/

### objectDifference()

```ts
util.objectDifference(object, base, [opt])
```

Return an object that represents the difference between `object` and `base`.

<table>
    <tbody>
        <tr>
            <th>object</th>
            <td>Object</td>
            <td>The object to compare</td>
        </tr>
        <tr>
            <th>base</th>
            <td>Object</td>
            <td>The object to compare with</td>
        </tr>
        <tr>
            <th>[opt.maxDepth]</th>
            <td>number</td>
            <td>The maximum depth to compare</td>
        </tr>
    </tbody>
</table>
