### PR TITLE
types(dia.Element): fix size() signature

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -504,6 +504,10 @@ export namespace dia {
             deep?: boolean;
         }
 
+        interface ResizeOptions extends Cell.Options {
+            direction?: Direction
+        }
+
         interface BBoxOptions extends Cell.EmbeddableOptions {
             rotate?: boolean;
         }
@@ -517,10 +521,10 @@ export namespace dia {
         position(x: number, y: number, opt?: Element.PositionOptions): this;
 
         size(): Size;
-        size(size: { width?: number, height?: number }, opt?: { direction?: Direction, [key: string]: any }): this;
-        size(width: number, height: number, opt?: { direction?: Direction, [key: string]: any }): this;
+        size(size: Partial<Size>, opt?: Element.ResizeOptions): this;
+        size(width: number, height: number, opt?: Element.ResizeOptions): this;
 
-        resize(width: number, height: number, opt?: { direction?: Direction, [key: string]: any }): this;
+        resize(width: number, height: number, opt?: Element.ResizeOptions): this;
 
         rotate(deg: number, absolute?: boolean, origin?: Point, opt?: { [key: string]: any }): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -517,7 +517,8 @@ export namespace dia {
         position(x: number, y: number, opt?: Element.PositionOptions): this;
 
         size(): Size;
-        size(width: number, height?: number, opt?: { direction?: Direction, [key: string]: any }): this;
+        size(size: { width?: number, height?: number }, opt?: { direction?: Direction, [key: string]: any }): this;
+        size(width: number, height: number, opt?: { direction?: Direction, [key: string]: any }): this;
 
         resize(width: number, height: number, opt?: { direction?: Direction, [key: string]: any }): this;
 


### PR DESCRIPTION
## Description

According to the source code, `dia.Element.size()` has the following three signatures:
- getter (no arguments) = `return this.get('size')`
- setter (two arguments, first argument is an object) = read `width` and `height` from first argument (if not present, get the missing value from the current `size` attribute), pass `width`, `height`, and second argument to `this.resize` as `width`, `height`, `opt`
- setter (three arguments) = `return this.resize(width, height, opt)`

## Documentation

### size()

```ts
element.size(): Size;
```

Return the current size of the element as an object with `width` and `height`.

```ts
element.size(
    size: Partial<Size>,
    opt?: Element.ResizeOptions
): this;
```

Change the size of the element with an object that specifies the new `width` and `height`. If a value is not provided for a property, the old value is kept.

You may specify resize options in the second parameter. See the `resize()` method for more information.

```ts
element.size(
    width: number,
    height: number,
    opt?: Element.ResizeOptions
): this;
```

Change the size of the element to the provided `width` and `height`.

You may specify resize options in the third parameter. See the `resize()` method for more information.