### PR TITLE
feat(dia.CellView): add unset() attribute callback

### DIFF
--- a/examples/tree-of-life/src/index.ts
+++ b/examples/tree-of-life/src/index.ts
@@ -202,7 +202,7 @@ class Branch extends dia.Link {
     static attributes = {
         // The `organicStroke` attribute is used to set the `d` attribute of the `<path>` element.
         // It works similarly to the `connection` attribute of JointJS.
-        organicStroke: {
+        'organic-stroke': {
             set: function (
                 _value: any,
                 _refBBox: g.Rect,
@@ -231,7 +231,7 @@ class Branch extends dia.Link {
                 // Using the `getStroke` function from the `perfect-freehand` library,
                 // we get the points that represent the outline of the stroke.
                 const outlinePoints = getStroke(points, {
-                    size: attrs.organicStrokeSize || 20,
+                    size: attrs['organic-stroke-size'] || 20,
                     thinning: 0.5,
                     simulatePressure: false,
                     last: true,
@@ -241,10 +241,11 @@ class Branch extends dia.Link {
                 // The `d` attribute is set on the `node` element.
                 return { d };
             },
+            unset: 'd'
         },
         // Empty attributes definition to prevent the attribute from being set on the element.
         // They are only meant to be used in the `organicStroke` function.
-        organicStrokeSize: {},
+        'organic-stroke-size': {},
     };
 }
 

--- a/examples/tree-of-life/src/index.ts
+++ b/examples/tree-of-life/src/index.ts
@@ -203,15 +203,15 @@ class Branch extends dia.Link {
         // The `organicStroke` attribute is used to set the `d` attribute of the `<path>` element.
         // It works similarly to the `connection` attribute of JointJS.
         organicStroke: {
-            qualify: function () {
-                return this.model.isLink();
-            },
             set: function (
                 _value: any,
                 _refBBox: g.Rect,
                 _node: SVGElement,
                 attrs: attributes.NativeSVGAttributes
             ) {
+                if (!this.model.isLink()) {
+                    throw new Error('The `organicStroke` attribute can only be used with links.');
+                }
                 // The path of the link as returned by the `connector`.
                 const path = this.getConnection();
                 const segmentSubdivisions = this.getConnectionSubdivisions();

--- a/packages/joint-core/demo/custom-shapes/src/custom-shapes.mjs
+++ b/packages/joint-core/demo/custom-shapes/src/custom-shapes.mjs
@@ -24,7 +24,8 @@ joint.dia.attributes['line-style'] = {
         }[lineStyle] || 'none';
 
         return { 'stroke-dasharray': dasharray };
-    }
+    },
+    unset: 'stroke-dasharray'
 };
 
 joint.dia.attributes['fit-ref'] = {
@@ -49,7 +50,8 @@ joint.dia.attributes['fit-ref'] = {
                 };
         }
         return {};
-    }
+    },
+    unset: ['rx', 'ry', 'cx', 'cy', 'width', 'height', 'd']
 };
 
 var Circle = joint.dia.Element.define('custom.Circle', {

--- a/packages/joint-core/demo/puzzle/src/puzzle.js
+++ b/packages/joint-core/demo/puzzle/src/puzzle.js
@@ -14,8 +14,8 @@ joint.dia.Element.define('jigsaw.Piece', {
 } , {
     attributes: {
         tabs: { /* [topTab, rightTab, bottomTab, leftTab] */
-            qualify: Array.isArray,
             set: function(tabs, refBBox) {
+                if (!Array.isArray(tabs)) return;
                 var tabSize = this.model.prop('tabSize');
                 var points = [];
                 var refCenter = refBBox.center();
@@ -41,11 +41,12 @@ joint.dia.Element.define('jigsaw.Piece', {
                 return {
                     points: points.join(' ').replace(/@/g,' ')
                 };
-            }
+            },
+            unset: 'points'
         },
         image: { /* [imageId, rowIndex, columnIndex] */
-            qualify: Array.isArray,
             set: function(image) {
+                if (!Array.isArray(image)) return;
                 var paper = this.paper;
                 var model = this.model;
                 var width = model.prop('size/width');
@@ -71,7 +72,8 @@ joint.dia.Element.define('jigsaw.Piece', {
                 return {
                     fill: 'url(#' + id + ')'
                 };
-            }
+            },
+            unset: 'fill'
         }
     }
 });

--- a/packages/joint-core/demo/rough/src/rough.js
+++ b/packages/joint-core/demo/rough/src/rough.js
@@ -247,7 +247,8 @@
                     }
                     var sets = shape.sets;
                     return { d: r.opsToPath(sets[opt.fillSketch ? 0 : 1]) };
-                }
+                },
+                unset: 'd'
             },
             'pointer-shape': {
                 set: function(type, bbox) {
@@ -271,7 +272,8 @@
                             break;
                     }
                     return { d: vel.convertToPathData() };
-                }
+                },
+                unset: 'd'
             }
         }
     });
@@ -323,7 +325,8 @@
                         bowing: opt.bowing || 1
                     };
                     return { d: r.opsToPath(r.generator.path(this.getSerializedConnection(), rOpt).sets[0]) };
-                }
+                },
+                unset: 'd'
             }
         }
     });

--- a/packages/joint-core/demo/shapes/src/standard.js
+++ b/packages/joint-core/demo/shapes/src/standard.js
@@ -10,12 +10,11 @@ V.attributeNames['placeholderURL'] = 'placeholderURL';
 
 // Custom attribute for retrieving image placeholder with specific size
 dia.attributes.placeholderURL = {
-    qualify: function(url) {
-        return typeof url === 'string';
-    },
     set: function(url, refBBox) {
+        if (typeof url !== 'string') return;
         return { 'xlink:href': util.template(url)(refBBox.round().toJSON()) };
-    }
+    },
+    unset: 'xlink:href'
 };
 
 var CylinderTiltTool = elementTools.Control.extend({

--- a/packages/joint-core/docs/demo/shapes/shapes.standard.js
+++ b/packages/joint-core/docs/demo/shapes/shapes.standard.js
@@ -9,12 +9,11 @@ V.attributeNames['placeholderURL'] = 'placeholderURL';
 
 // Custom attribute for retrieving image placeholder with specific size
 dia.attributes.placeholderURL = {
-    qualify: function(url) {
-        return typeof url === 'string';
-    },
     set: function(url, refBBox) {
+        if (typeof url !== 'string') return;
         return { 'xlink:href': util.template(url)(refBBox.round().toJSON()) };
-    }
+    },
+    unset: 'xlink:href'
 };
 
 var graph = new dia.Graph({}, { cellNamespace: joint.shapes });

--- a/packages/joint-core/src/dia/attributes/connection.mjs
+++ b/packages/joint-core/src/dia/attributes/connection.mjs
@@ -25,6 +25,7 @@ const connectionAttributesNS = {
 
     'connection': {
         qualify: isLinkView,
+        unset: 'd',
         set: function({ stubs = 0 }) {
             let d;
             if (isFinite(stubs) && stubs !== 0) {

--- a/packages/joint-core/src/dia/attributes/connection.mjs
+++ b/packages/joint-core/src/dia/attributes/connection.mjs
@@ -50,21 +50,25 @@ const connectionAttributesNS = {
 
     'at-connection-length-keep-gradient': {
         qualify: isLinkView,
+        unset: 'transform',
         set: atConnectionWrapper('getTangentAtLength', { rotate: true })
     },
 
     'at-connection-length-ignore-gradient': {
         qualify: isLinkView,
+        unset: 'transform',
         set: atConnectionWrapper('getTangentAtLength', { rotate: false })
     },
 
     'at-connection-ratio-keep-gradient': {
         qualify: isLinkView,
+        unset: 'transform',
         set: atConnectionWrapper('getTangentAtRatio', { rotate: true })
     },
 
     'at-connection-ratio-ignore-gradient': {
         qualify: isLinkView,
+        unset: 'transform',
         set: atConnectionWrapper('getTangentAtRatio', { rotate: false })
     }
 

--- a/packages/joint-core/src/dia/attributes/defs.mjs
+++ b/packages/joint-core/src/dia/attributes/defs.mjs
@@ -33,6 +33,7 @@ const defsAttributesNS = {
 
     'source-marker': {
         qualify: isPlainObject,
+        unset: 'marker-start',
         set: function(marker, refBBox, node, attrs) {
             marker = assign(contextMarker(attrs), marker);
             return { 'marker-start': 'url(#' + this.paper.defineMarker(marker) + ')' };
@@ -41,6 +42,7 @@ const defsAttributesNS = {
 
     'target-marker': {
         qualify: isPlainObject,
+        unset: 'marker-end',
         set: function(marker, refBBox, node, attrs) {
             marker = assign(contextMarker(attrs), { 'transform': 'rotate(180)' }, marker);
             return { 'marker-end': 'url(#' + this.paper.defineMarker(marker) + ')' };
@@ -49,6 +51,7 @@ const defsAttributesNS = {
 
     'vertex-marker': {
         qualify: isPlainObject,
+        unset: 'marker-mid',
         set: function(marker, refBBox, node, attrs) {
             marker = assign(contextMarker(attrs), marker);
             return { 'marker-mid': 'url(#' + this.paper.defineMarker(marker) + ')' };

--- a/packages/joint-core/src/dia/attributes/index.mjs
+++ b/packages/joint-core/src/dia/attributes/index.mjs
@@ -49,6 +49,9 @@ const attributesNS = {
     },
 
     'html': {
+        unset: function(node) {
+            $(node).empty();
+        },
         set: function(html, refBBox, node) {
             $(node).html(html + '');
         }

--- a/packages/joint-core/src/dia/attributes/shape.mjs
+++ b/packages/joint-core/src/dia/attributes/shape.mjs
@@ -69,18 +69,22 @@ function pointsWrapper(opt) {
 const shapeAttributesNS = {
 
     'ref-d-reset-offset': {
+        unset: 'd',
         set: dWrapper({ resetOffset: true })
     },
 
     'ref-d-keep-offset': {
+        unset: 'd',
         set: dWrapper({ resetOffset: false })
     },
 
     'ref-points-reset-offset': {
+        unset: 'points',
         set: pointsWrapper({ resetOffset: true })
     },
 
     'ref-points-keep-offset': {
+        unset: 'points',
         set: pointsWrapper({ resetOffset: false })
     },
 };

--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -40,6 +40,9 @@ const textAttributesNS = {
             const textWrap = attrs['text-wrap'];
             return !textWrap || !isPlainObject(textWrap);
         },
+        unset: function(node) {
+            node.textContent = '';
+        },
         set: function(text, refBBox, node, attrs) {
             const cacheName = 'joint-text';
             const cache = $.data.get(node, cacheName);
@@ -170,6 +173,13 @@ const textAttributesNS = {
         qualify: function(title, node) {
             // HTMLElement title is specified via an attribute (i.e. not an element)
             return node instanceof SVGElement;
+        },
+        unset: function(node) {
+            $.data.remove(node, 'joint-title');
+            const titleNode = node.firstElementChild;
+            if (titleNode) {
+                titleNode.remove();
+            }
         },
         set: function(title, refBBox, node) {
             var cacheName = 'joint-title';

--- a/packages/joint-core/src/shapes/standard.mjs
+++ b/packages/joint-core/src/shapes/standard.mjs
@@ -530,7 +530,8 @@ export const Cylinder = Element.define('standard.Cylinder', {
                     'Z'
                 ];
                 return { d: data.join(' ') };
-            }
+            },
+            unset: 'd'
         }
     }
 });
@@ -611,6 +612,12 @@ export const TextBlock = Element.define('standard.TextBlock', {
                     var wrapAttrs = assign({ 'text-vertical-anchor': 'middle' }, style);
                     attributes['text-wrap'].set.call(this, wrapValue, refBBox, node, wrapAttrs);
                     return { fill: style.color || null };
+                }
+            },
+            unset: function(node) {
+                node.textContent = '';
+                if (node instanceof SVGElement) {
+                    return 'fill';
                 }
             },
             position: function(text, refBBox, node) {

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -604,6 +604,39 @@ QUnit.module('Attributes', function() {
             cell.attr('div/html', null);
             assert.notOk(divNode.firstChild);
         });
+
+        QUnit.test('unset transform & position callback', function(assert) {
+            joint.dia.attributes['test-transform-attribute'] = {
+                unset: 'transform',
+                set: function(value) {
+                    return { transform: `translate(${value},${value})` };
+                }
+            };
+            joint.dia.attributes['test-position-attribute'] = {
+                position(value) {
+                    return new g.Point(value, value);
+                }
+            };
+
+            // set transform attribute
+            cell.attr('body/testTransformAttribute', 7);
+            const bodyNode = cellView.findNode('body');
+            assert.ok(bodyNode.getAttribute('transform'));
+            assert.deepEqual(V(bodyNode).translate(), { tx: 7, ty: 7 });
+            // unset transform attribute
+            cell.attr('body/testTransformAttribute', null);
+            assert.notOk(bodyNode.getAttribute('transform'));
+            assert.deepEqual(V(bodyNode).translate(), { tx: 0, ty: 0 });
+            // position attribute and deleted transform
+            cell.attr('body/testPositionAttribute', 11);
+            assert.deepEqual(V(bodyNode).translate(), { tx: 11, ty: 11 });
+            // position and set transform attribute
+            cell.attr('body/testTransformAttribute', 13);
+            assert.deepEqual(V(bodyNode).translate(), { tx: 13 + 11, ty: 13 + 11 });
+
+            delete joint.dia.attributes['test-transform-attribute'];
+            delete joint.dia.attributes['test-position-attribute'];
+        });
     });
 
 

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -404,6 +404,209 @@ QUnit.module('Attributes', function() {
 
     });
 
+    QUnit.module('Unset Attributes', function(hooks) {
+
+        var paper, graph, cell, cellView;
+
+        hooks.beforeEach(function() {
+            graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            var fixtures = document.getElementById('qunit-fixture');
+            var paperEl = document.createElement('div');
+            fixtures.appendChild(paperEl);
+            paper = new joint.dia.Paper({ el: paperEl, model: graph, cellViewNamespace: joint.shapes });
+            cell = new joint.shapes.standard.Rectangle();
+            cell.addTo(graph);
+            cellView = cell.findView(paper);
+            // custom presentation attributes
+            joint.dia.attributes.test1 = { set: 'test2' };
+        });
+
+        hooks.afterEach(function() {
+            paper.remove();
+        });
+
+        QUnit.test('unset() callback', function(assert) {
+            const unsetSpy = sinon.spy();
+            joint.dia.attributes['test-attribute'] = {
+                unset: unsetSpy
+            };
+            cell.attr('body/fill', 'purple');
+            assert.ok(unsetSpy.notCalled);
+            cell.attr('body/testAttribute', 'test');
+            assert.ok(unsetSpy.notCalled);
+            cell.attr('body/testAttribute', null);
+            assert.ok(unsetSpy.calledOnce);
+            assert.ok(unsetSpy.calledWithExactly(
+                cellView.findNode('body'),
+                sinon.match({ 'test-attribute': null, fill: 'purple' }),
+                cellView
+            ));
+            delete joint.dia.attributes['test-attribute'];
+        });
+
+        QUnit.module('unset() single attribute', function() {
+            QUnit.test('string', function(assert) {
+                joint.dia.attributes['test-attribute'] = {
+                    set: 'a',
+                    unset: 'a'
+                };
+                cell.attr('body/testAttribute', 'value');
+                const bodyNode = cellView.findNode('body');
+                assert.equal(bodyNode.getAttribute('a'), 'value');
+                cell.attr('body/testAttribute', null);
+                assert.notOk(bodyNode.getAttribute('a'));
+                delete joint.dia.attributes['test-attribute'];
+            });
+            QUnit.test('function', function(assert) {
+                joint.dia.attributes['test-attribute'] = {
+                    set: function(value) {
+                        return { a: value };
+                    },
+                    unset: function() {
+                        return 'a';
+                    }
+                };
+                cell.attr('body/testAttribute', 'value');
+                const bodyNode = cellView.findNode('body');
+                assert.equal(bodyNode.getAttribute('a'), 'value');
+                cell.attr('body/testAttribute', null);
+                assert.notOk(bodyNode.getAttribute('a'));
+                delete joint.dia.attributes['test-attribute'];
+            });
+        });
+
+        QUnit.module('unset() multiple attributes', function() {
+            QUnit.test('string', function(assert) {
+                joint.dia.attributes['test-attribute'] = {
+                    set: function(value) {
+                        return { a: value, b: value };
+                    },
+                    unset: ['a', 'b']
+                };
+                cell.attr('body/testAttribute', 'value');
+                const bodyNode = cellView.findNode('body');
+                assert.equal(bodyNode.getAttribute('a'), 'value');
+                assert.equal(bodyNode.getAttribute('b'), 'value');
+                cell.attr('body/testAttribute', null);
+                assert.notOk(bodyNode.getAttribute('a'));
+                assert.notOk(bodyNode.getAttribute('b'));
+            });
+            QUnit.test('function', function(assert) {
+                joint.dia.attributes['test-attribute'] = {
+                    set: function(value) {
+                        return { a: value, b: value };
+                    },
+                    unset: function() {
+                        return ['a', 'b'];
+                    }
+                };
+                cell.attr('body/testAttribute', 'value');
+                const bodyNode = cellView.findNode('body');
+                assert.equal(bodyNode.getAttribute('a'), 'value');
+                assert.equal(bodyNode.getAttribute('b'), 'value');
+                cell.attr('body/testAttribute', null);
+                assert.notOk(bodyNode.getAttribute('a'));
+                assert.notOk(bodyNode.getAttribute('b'));
+                delete joint.dia.attributes['test-attribute'];
+            });
+        });
+
+        [{
+            attribute: 'no-def'
+        }, {
+            attribute: 'fill',
+            label: 'with-def',
+            value: 'blue',
+        }, {
+            attribute: 'test1',
+            label: 'alias',
+            svgAttribute: 'test2',
+        }, {
+            attribute: 'sourceMarker',
+            svgAttribute: 'marker-start',
+            value: { type: 'path', d: 'M 0 0 10 10' }
+        }, {
+            attribute: 'targetMarker',
+            svgAttribute: 'marker-end',
+            value: { type: 'path', d: 'M 0 0 10 10' }
+        }, {
+            attribute: 'vertexMarker',
+            svgAttribute: 'marker-mid',
+            value: { type: 'path', d: 'M 0 0 10 10' }
+        }, {
+            attribute: 'refD',
+            svgAttribute: 'd',
+            value: 'M 0 0 10 10',
+        }, {
+            attribute: 'refPoints',
+            svgAttribute: 'points',
+            value: '0,0 10,10',
+        }].forEach(function({
+            attribute,
+            label = attribute,
+            svgAttribute = attribute,
+            value = true
+        }) {
+            QUnit.test(`attribute: ${label}`, function(assert) {
+                const path = ['body', attribute];
+                const bodyNode = cellView.findNode('body');
+                // set
+                cell.attr(path, value);
+                assert.ok(bodyNode.getAttribute(svgAttribute));
+                // unset
+                cell.attr(path, null);
+                assert.notOk(bodyNode.getAttribute(svgAttribute));
+            });
+        });
+
+        [{
+            test1: null, // unset `test2`
+            test2: 'test3'
+        }, {
+            test2: 'test3',
+            test1: null, // unset `test2`
+        }].forEach(function(attributes, index) {
+            QUnit.test(`unset order: ${index + 1}`, function(assert) {
+                cell.attr('body', attributes);
+                const bodyNode = cellView.findNode('body');
+                assert.ok(bodyNode.getAttribute('test2'));
+            });
+        });
+
+        QUnit.test('attribute: title', function(assert) {
+            cell.attr('body/title', 'test');
+            const bodyNode = cellView.findNode('body');
+            assert.ok(bodyNode.querySelector('title'));
+            cell.attr('body/title', null);
+            assert.notOk(bodyNode.querySelector('title'));
+        });
+
+        QUnit.test('attribute: text', function(assert) {
+            cell.attr('label/text', 'test');
+            const textNode = cellView.findNode('label');
+            assert.ok(textNode.firstChild);
+            cell.attr('label/text', null);
+            assert.notOk(textNode.firstChild);
+            cell.attr('label/text', '');
+            assert.ok(textNode.firstChild);
+        });
+
+        QUnit.test('attribute: html', function(assert) {
+            cell.set('markup', joint.util.svg`
+                <foreignObject>
+                    <div xmlns="http://www.w3.org/1999/xhtml" @selector="div">test</div>
+                </foreignObject>
+            `);
+            const divNode = cellView.findNode('div');
+            assert.ok(divNode);
+            cell.attr('div/html', 'test');
+            assert.ok(divNode.firstChild);
+            cell.attr('div/html', null);
+            assert.notOk(divNode.firstChild);
+        });
+    });
+
+
     QUnit.module('Calc()', function(hooks) {
 
         var X = 13;

--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -198,3 +198,27 @@ rectangle.prop({ size: { width: 100 }});
 new joint.shapes.standard.Rectangle({
     position: { x: 100 },
 });
+
+class MyElement extends joint.dia.Element {
+
+    static attributes = {
+        'empty-attribute': {},
+        'set1-attribute': {
+            set: 'alias',
+            unset: 'alias'
+        },
+        'set2-attribute': {
+            set: () => ({ 'alias': 21 }),
+            unset: ['alias']
+        },
+        'set3-attribute': {
+            set: function() { return 21; },
+        },
+        'position-attribute': {
+            position: () => ({ x: 5, y: 7 })
+        },
+        'offset-attribute': {
+            offset: () => ({ x: 11, y: 13 })
+        },
+    };
+}

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -351,6 +351,7 @@ export namespace dia {
             this: V,
             attributeValue: any,
             refBBox: g.Rect,
+            node: Element,
             nodeAttributes: { [name: string]: any },
             cellView: V
         ) => { [key: string]: any } | string | number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -339,6 +339,46 @@ export namespace dia {
             ignoreDefault?: boolean | string[];
             ignoreEmptyAttributes?: boolean;
         }
+
+        type UnsetCallback<V> = (
+            this: V,
+            node: Element,
+            nodeAttributes: { [name: string]: any },
+            cellView: V
+        ) => string | Array<string> | null | void;
+
+        type SetCallback<V> = (
+            this: V,
+            attributeValue: any,
+            refBBox: g.Rect,
+            nodeAttributes: { [name: string]: any },
+            cellView: V
+        ) => { [key: string]: any } | string | number;
+
+        type PositionCallback<V> = (
+            this: V,
+            attributeValue: any,
+            refBBox: g.Rect,
+            node: Element,
+            nodeAttributes: { [name: string]: any },
+            cellView: V
+        ) => dia.Point | null | void;
+
+        type OffsetCallback<V> = (
+            this: V,
+            attributeValue: any,
+            nodeBBox: g.Rect,
+            node: Element,
+            nodeAttributes: { [name: string]: any },
+            cellView: V
+        ) => dia.Point | null | void;
+
+        interface SpecialAttribute<V = dia.CellView> {
+            set?: SetCallback<V> | string;
+            unset?: UnsetCallback<V> | string | Array<string>;
+            position?: PositionCallback<V>;
+            offset?: OffsetCallback<V>;
+        }
     }
 
     class Cell<A extends ObjectHash = Cell.Attributes, S extends mvc.ModelSetOptions = dia.ModelSetOptions> extends mvc.Model<A, S> {
@@ -510,7 +550,7 @@ export namespace dia {
         }
 
         interface ResizeOptions extends Cell.Options {
-            direction?: Direction
+            direction?: Direction;
         }
 
         interface BBoxOptions extends Cell.EmbeddableOptions {
@@ -578,6 +618,8 @@ export namespace dia {
         protected generatePortId(): string | number;
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Element>;
+
+        static attributes: { [attributeName: string]: Cell.SpecialAttribute<ElementView> };
     }
 
     // dia.Link
@@ -726,6 +768,8 @@ export namespace dia {
         translate(tx: number, ty: number, opt?: S): this;
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Link>;
+
+        static attributes: { [attributeName: string]: Cell.SpecialAttribute<LinkView> };
     }
 
     // dia.CellView

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -354,7 +354,7 @@ export namespace dia {
             node: Element,
             nodeAttributes: { [name: string]: any },
             cellView: V
-        ) => { [key: string]: any } | string | number;
+        ) => { [key: string]: any } | string | number | void;
 
         type PositionCallback<V> = (
             this: V,

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -373,7 +373,7 @@ export namespace dia {
             cellView: V
         ) => dia.Point | null | void;
 
-        interface SpecialAttribute<V = dia.CellView> {
+        interface PresentationAttributeDefinition<V = dia.CellView> {
             set?: SetCallback<V> | string;
             unset?: UnsetCallback<V> | string | Array<string>;
             position?: PositionCallback<V>;
@@ -619,7 +619,7 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Element>;
 
-        static attributes: { [attributeName: string]: Cell.SpecialAttribute<ElementView> };
+        static attributes: { [attributeName: string]: Cell.PresentationAttributeDefinition<ElementView> };
     }
 
     // dia.Link
@@ -769,7 +769,7 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Link>;
 
-        static attributes: { [attributeName: string]: Cell.SpecialAttribute<LinkView> };
+        static attributes: { [attributeName: string]: Cell.PresentationAttributeDefinition<LinkView> };
     }
 
     // dia.CellView


### PR DESCRIPTION
## Description

If you currently set `sourceMarker` and later try to remove it by setting it to `null`, `marker-start` SVG attribute will not be removed from the DOM. This is a mechanism to ensure that the actual presentation attributes can be removed if necessary.

This PR also defines TypeScript for defining custom special attributes and fixes various examples where special attributes were used.

### Documentation

The `unset` callback for presentation attributes is called when an attribute is set to `null`.
- If there is no `unset` callback defined, an attribute with the same name as attribute definition is removed.
- Otherwise, it can be a **string** (an attribute to be removed from the DOM element), an **array of strings**, or a function that returns the aforementioned string or array.
- The callback accepts `(node, attrs, cellView)`.

```ts
attributes: {
  'line-style': {
      set: function(lineStyle, refBBox, node, attrs) {
          const n = parseFloat(attrs['stroke-width']) || 1;
          const dasharray = {
              'dashed': `${4*n},${2*n}`,
              'dotted': `${n},${n}`,
          }[lineStyle] || 'none';
          return { 'stroke-dasharray': dasharray };
      },
      unset: 'stroke-dasharray'
  }
}
```
