### PR TITLE
feat(elementTools.Control): add UI event to setPosition() and resetPosition() signature

### DIFF
--- a/packages/joint-core/src/elementTools/Control.mjs
+++ b/packages/joint-core/src/elementTools/Control.mjs
@@ -133,7 +133,7 @@ export const Control = ToolView.extend({
         const { clientX, clientY } = util.normalizeEvent(evt);
         const coords = paper.clientToLocalPoint(clientX, clientY);
         const relativeCoords = model.getRelativePointFromAbsolute(coords);
-        this.setPosition(relatedView, relativeCoords, this);
+        this.setPosition(relatedView, relativeCoords, evt);
         this.update();
     },
     onPointerUp: function(_evt) {
@@ -144,9 +144,9 @@ export const Control = ToolView.extend({
         this.toggleExtras(false);
         relatedView.model.stopBatch('control-move', { ui: true, tool: this.cid });
     },
-    onPointerDblClick: function() {
+    onPointerDblClick: function(evt) {
         const { relatedView } = this;
-        this.resetPosition(relatedView, this);
+        this.resetPosition(relatedView, evt);
         this.update();
     }
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -4223,8 +4223,8 @@ export namespace elementTools {
         constructor(opt?: T);
 
         protected getPosition(view: dia.ElementView): dia.Point;
-        protected setPosition(view: dia.ElementView, coordinates: g.Point): void;
-        protected resetPosition(view: dia.ElementView): void;
+        protected setPosition(view: dia.ElementView, coordinates: g.Point, evt: dia.Event): void;
+        protected resetPosition(view: dia.ElementView, evt: dia.Event): void;
 
         protected updateHandle(handleNode: SVGElement): void;
         protected updateExtras(extrasNode: SVGElement): void;


### PR DESCRIPTION
## Description

The current signature:
```ts
abstract class Control extends dia.ToolView {
    protected getPosition(view: dia.ElementView): dia.Point;
    protected setPosition(view: dia.ElementView, coordinates: g.Point): void;
    protected resetPosition(view: dia.ElementView): void;
}
```
Is changed to:

```ts
abstract class Control extends dia.ToolView {
    protected getPosition(view: dia.ElementView): dia.Point;
    protected setPosition(view: dia.ElementView, coordinates: g.Point, evt: dia.Event): void;
    protected resetPosition(view: dia.ElementView, evt: dia.Event): void;
}
```
This allows anyone to modify the behavior of the control tool based on a UI event.
_e.g. disable the resize tool from snapping to the grid when the user holds down the `Shift` key._