### PR TITLE
feat(dia.ElementView): add getTargetParentView() method

### DIFF
--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -540,6 +540,11 @@ export const ElementView = CellView.extend({
         }
     },
 
+    getTargetParentView: function(evt) {
+        const { candidateEmbedView = null } = this.eventData(evt);
+        return candidateEmbedView;
+    },
+
     getDelegatedView: function() {
 
         var view = this;

--- a/packages/joint-core/test/jointjs/embedding.js
+++ b/packages/joint-core/test/jointjs/embedding.js
@@ -396,4 +396,38 @@ QUnit.module('embedding', function(hooks) {
         }), 'All links were brought to front.');
     });
 
+    QUnit.test('getTargetParentView()', function(assert) {
+
+        let evt;
+
+        const r1 = new joint.shapes.standard.Rectangle({
+            position: { x: 100, y: 100 },
+            size: { width: 100, height: 100 }
+        });
+        const r2 = new joint.shapes.standard.Rectangle({
+            position: { x: 500, y: 500 },
+            size: { width: 100, height: 100 }
+        });
+
+        this.graph.addCells([r1, r2]);
+
+        const v1 = r1.findView(this.paper);
+        const v2 = r2.findView(this.paper);
+
+        evt = new $.Event({ target: v1.el });
+        assert.equal(v2.getTargetParentView(evt), null);
+        v2.pointerdown(evt, 500, 500);
+        v2.pointermove(evt, 600, 600);
+        assert.equal(v2.getTargetParentView(evt), null);
+        v2.pointerup(evt, 600, 600);
+        assert.equal(v2.getTargetParentView(evt), null);
+
+        evt = new $.Event({ target: v1.el });
+        v2.pointerdown(evt, 600, 600);
+        v2.pointermove(evt, 100, 100);
+        assert.equal(v2.getTargetParentView(evt), v1);
+        v2.pointerup(evt, 100, 100);
+        assert.equal(v2.getTargetParentView(evt), null);
+        assert.equal(r2.get('parent'), r1.id);
+    });
 });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -989,6 +989,8 @@ export namespace dia {
 
         getDelegatedView(): ElementView | null;
 
+        getTargetParentView(evt: dia.Event): CellView | null;
+
         findPortNode(portId: string | number): SVGElement | null;
         findPortNode(portId: string | number, selector: string): E | null;
 


### PR DESCRIPTION
## Description

```ts
dia.ElementView.prototype.getTargetParentView(evt: dia.Event): dia.CellView | null;
```

The method returns a cell view (if any) that would become the parent of the currently dragged element view if the dragging were to finish immediately.

## Usage

```ts
paper.on('element:pointermove', (elementView, evt) => {
    console.log(elementView.getTargetParentView(evt));
});

// It can also be used while the user is dragging an element from the stencil
stencil.on('element:drag', (cloneView, evt) => {
    console.log(cloneView.getTargetParentView(evt));
});
```