### PR TITLE
feat(dia.Graph): add transferCellEmbeds() and transferCellConnectedLinks()

### DIFF
--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -339,12 +339,22 @@ export const Cell = Model.extend({
         return this.set('parent', parent, opt);
     },
 
-    embed: function(cell, opt) {
+    embed: function(cell, opt = {}) {
         const cells = Array.isArray(cell) ? cell : [cell];
         if (!this.canEmbed(cells)) {
             throw new Error('Recursive embedding not allowed.');
         }
-        if (cells.some(c => c.isEmbedded() && this.id !== c.parent())) {
+        if (opt.reparent) {
+            const parents = uniq(cells.map(c => c.getParentCell()));
+
+            // Unembed cells from their current parents.
+            parents.forEach((parent) => {
+                // Cell doesn't have to be embedded.
+                if (!parent) return;
+                parent._unembedCells(cells, opt);
+            });
+
+        } else if (cells.some(c => c.isEmbedded() && this.id !== c.parent())) {
             throw new Error('Embedding of already embedded cells is not allowed.');
         }
         this._embedCells(cells, opt);

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -351,6 +351,9 @@ export const Cell = Model.extend({
             parents.forEach((parent) => {
                 // Cell doesn't have to be embedded.
                 if (!parent) return;
+
+                // Pass all the `cells` since the `dia.Cell._unembedCells` method can handle cases
+                // where not all elements of `cells` are embedded in the same parent.
                 parent._unembedCells(cells, opt);
             });
 

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -398,6 +398,8 @@ export const Graph = Model.extend({
 
     transferCellHierarchy: function(sourceCell, targetCell) {
 
+        this.startBatch('transfer-hierarchy');
+
         // Embed children of the source cell in the target cell.
         const children = sourceCell.getEmbeddedCells();
         if (children.length > 0) {
@@ -412,10 +414,14 @@ export const Graph = Model.extend({
             parent.embed(targetCell);
         }
 
+        this.stopBatch('transfer-hierarchy');
+
         return this;
     },
 
     transferCellLinks: function(sourceCell, targetCell) {
+
+        this.startBatch('transfer-links');
 
         // Reconnect all the links connected to the old cell to the new cell.
         const connectedLinks = this.getConnectedLinks(sourceCell);
@@ -429,6 +435,8 @@ export const Graph = Model.extend({
                 link.prop(['target', 'id'], targetCell.id);
             }
         });
+
+        this.stopBatch('transfer-links');
 
         return this;
     },

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -396,6 +396,41 @@ export const Graph = Model.extend({
         this.get('cells').remove(cell, { silent: true });
     },
 
+    transferCellHierarchy: function(sourceCell, targetCell) {
+
+        // Embed children of the source cell in the target cell.
+        const children = sourceCell.getEmbeddedCells();
+        if (children.length > 0) {
+            sourceCell.unembed(children);
+            targetCell.embed(children);
+        }
+
+        // Embed the target cell in the parent of the source cell, if any.
+        const parent = sourceCell.getParentCell();
+        if (parent) {
+            parent.unembed(sourceCell);
+            parent.embed(targetCell);
+        }
+
+        return this;
+    },
+
+    transferCellLinks: function(sourceCell, targetCell) {
+
+        // Reconnect all the links connected to the old cell to the new cell.
+        const connectedLinks = this.getConnectedLinks(sourceCell);
+        connectedLinks.forEach((link) => {
+
+            if (link.getSourceCell() === sourceCell) {
+                link.prop(['source', 'id'], targetCell.id);
+            } else {
+                link.prop(['target', 'id'], targetCell.id);
+            }
+        });
+
+        return this;
+    },
+
     // Get a cell by `id`.
     getCell: function(id) {
 

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -396,49 +396,39 @@ export const Graph = Model.extend({
         this.get('cells').remove(cell, { silent: true });
     },
 
-    transferCellHierarchy: function(sourceCell, targetCell) {
+    transferCellEmbeds: function(sourceCell, targetCell, opt = {}) {
 
-        this.startBatch('transfer-hierarchy');
+        const batchName = 'transfer-embeds';
+        this.startBatch(batchName);
+
+        opt.reparent = true;
 
         // Embed children of the source cell in the target cell.
-        const children = sourceCell.getEmbeddedCells();
-        if (children.length > 0) {
-            sourceCell.unembed(children);
-            targetCell.embed(children);
-        }
+        const children = sourceCell.getEmbeddedCells(opt);
+        targetCell.embed(children, opt);
 
-        // Embed the target cell in the parent of the source cell, if any.
-        const parent = sourceCell.getParentCell();
-        if (parent) {
-            parent.unembed(sourceCell);
-            parent.embed(targetCell);
-        }
-
-        this.stopBatch('transfer-hierarchy');
-
-        return this;
+        this.stopBatch(batchName);
     },
 
-    transferCellLinks: function(sourceCell, targetCell) {
+    transferCellConnectedLinks: function(sourceCell, targetCell, opt = {}) {
 
-        this.startBatch('transfer-links');
+        const batchName = 'transfer-connected-links';
+        this.startBatch(batchName);
 
         // Reconnect all the links connected to the old cell to the new cell.
-        const connectedLinks = this.getConnectedLinks(sourceCell);
+        const connectedLinks = this.getConnectedLinks(sourceCell, opt);
         connectedLinks.forEach((link) => {
 
             if (link.getSourceCell() === sourceCell) {
-                link.prop(['source', 'id'], targetCell.id);
+                link.prop(['source', 'id'], targetCell.id, opt);
             }
 
             if (link.getTargetCell() === sourceCell) {
-                link.prop(['target', 'id'], targetCell.id);
+                link.prop(['target', 'id'], targetCell.id, opt);
             }
         });
 
-        this.stopBatch('transfer-links');
-
-        return this;
+        this.stopBatch(batchName);
     },
 
     // Get a cell by `id`.

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -423,7 +423,9 @@ export const Graph = Model.extend({
 
             if (link.getSourceCell() === sourceCell) {
                 link.prop(['source', 'id'], targetCell.id);
-            } else {
+            }
+
+            if (link.getTargetCell() === sourceCell) {
                 link.prop(['target', 'id'], targetCell.id);
             }
         });

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -401,11 +401,9 @@ export const Graph = Model.extend({
         const batchName = 'transfer-embeds';
         this.startBatch(batchName);
 
-        opt.reparent = true;
-
         // Embed children of the source cell in the target cell.
-        const children = sourceCell.getEmbeddedCells(opt);
-        targetCell.embed(children, opt);
+        const children = sourceCell.getEmbeddedCells();
+        targetCell.embed(children, { ...opt, reparent: true });
 
         this.stopBatch(batchName);
     },

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -256,6 +256,36 @@ QUnit.module('cell', function(hooks) {
 
             assert.raises(() => { cell3.embed(cell2); }, /Embedding of already embedded cells is not allowed/, 'throws exception on embedding of embedded cell');
         });
+
+        QUnit.test('opt.reparent = true', function(assert) {
+
+            const cell1 = new joint.shapes.standard.Rectangle({
+                position: { x: 20, y: 20 },
+                size: { width: 60, height: 60 }
+            });
+            const cell2 = new joint.shapes.standard.Rectangle({
+                position: { x: 20, y: 20 },
+                size: { width: 60, height: 60 }
+            });
+            const cell3 = new joint.shapes.standard.Rectangle({
+                position: { x: 20, y: 20 },
+                size: { width: 60, height: 60 }
+            });
+            const cell4 = new joint.shapes.standard.Rectangle({
+                position: { x: 20, y: 20 },
+                size: { width: 60, height: 60 }
+            });
+
+            this.graph.addCells([cell1, cell2, cell3, cell4]);
+
+            cell1.embed(cell2);
+            cell3.embed([cell2, cell4], { reparent: true });
+
+            assert.equal(cell1.getEmbeddedCells().length, 0);
+            assert.equal(cell2.parent(), cell3.id);
+            assert.equal(cell3.getEmbeddedCells()[0].id, cell2.id);
+            assert.equal(cell3.getEmbeddedCells()[1].id, cell4.id);
+        });
     });
 
     QUnit.module('remove attributes', function(hooks) {

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1669,5 +1669,18 @@ QUnit.module('graph', function(hooks) {
             assert.equal(link1.source().id, replacementLink.id);
             assert.equal(link2.target().id, replacementLink.id);
         });
+
+        QUnit.test('should work with loop links', function(assert) {
+
+            const originalElement = new joint.shapes.standard.Rectangle();
+            const link = new joint.shapes.standard.Link({ source: { id: originalElement.id }, target: { id: originalElement.id }});
+            const replacementElement = new joint.shapes.standard.Rectangle();
+
+            this.graph.addCells([originalElement, link]);
+            this.graph.transferCellLinks(originalElement, replacementElement);
+
+            assert.equal(link.source().id, replacementElement.id);
+            assert.equal(link.target().id, replacementElement.id);
+        });
     });
 });

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1546,4 +1546,128 @@ QUnit.module('graph', function(hooks) {
             assert.notOk(graph.hasActiveBatch());
         });
     });
+
+    QUnit.module('graph.transferCellHierarchy()', function() {
+
+        QUnit.test('should transfer hierarchy of elements', function(assert) {
+
+            const topLevelElement = new joint.shapes.standard.Rectangle();
+            const originalElement = new joint.shapes.standard.Rectangle();
+            const child = new joint.shapes.standard.Rectangle();
+            const replacementElement = new joint.shapes.standard.Rectangle();
+
+            topLevelElement.embed(originalElement);
+            originalElement.embed(child);
+
+            this.graph.addCells([topLevelElement, originalElement, child, replacementElement]);
+            this.graph.transferCellHierarchy(originalElement, replacementElement);
+
+            assert.equal(replacementElement.getParentCell(), topLevelElement);
+            assert.equal(replacementElement.getEmbeddedCells()[0], child);
+        });
+
+        QUnit.test('should transfer hierarchy of links', function(assert) {
+
+            const parent = new joint.shapes.standard.Rectangle();
+            const originalLink = new joint.shapes.standard.Link();
+            const replacementLink = new joint.shapes.standard.Link();
+
+            parent.embed(originalLink);
+
+            this.graph.addCells([parent, originalLink, replacementLink]);
+            this.graph.transferCellHierarchy(originalLink, replacementLink);
+
+            assert.equal(replacementLink.getParentCell(), parent);
+        });
+
+        QUnit.test('should work when transferring hierarchy from a link to an element', function(assert) {
+
+            const parent = new joint.shapes.standard.Rectangle();
+            const link = new joint.shapes.standard.Link();
+            const element = new joint.shapes.standard.Rectangle();
+
+            parent.embed(link);
+
+            this.graph.addCells([parent, link, element]);
+            this.graph.transferCellHierarchy(link, element);
+
+            assert.equal(element.getParentCell(), parent);
+        });
+
+        QUnit.test('should work when transferring hierarchy from an element to a link', function(assert) {
+
+            const parent = new joint.shapes.standard.Rectangle();
+            const link = new joint.shapes.standard.Link();
+            const child = new joint.shapes.standard.Rectangle();
+            const element = new joint.shapes.standard.Rectangle();
+
+            element.embed(child);
+            parent.embed(element);
+
+            this.graph.addCells([parent, link, child, element]);
+            this.graph.transferCellHierarchy(element, link);
+
+            assert.equal(link.getParentCell(), parent);
+            assert.equal(link.getEmbeddedCells()[0], child);
+        });
+    });
+
+    QUnit.module('graph.transferCellLinks()', function() {
+
+        QUnit.test('should transfer links of an element', function(assert) {
+
+            const originalElement = new joint.shapes.standard.Rectangle();
+            const link1 = new joint.shapes.standard.Link({ source: { id: originalElement.id }});
+            const link2 = new joint.shapes.standard.Link({ target: { id: originalElement.id }});
+            const replacementElement = new joint.shapes.standard.Rectangle();
+
+            this.graph.addCells([originalElement, link1, link2]);
+            this.graph.transferCellLinks(originalElement, replacementElement);
+
+            assert.equal(link1.source().id, replacementElement.id);
+            assert.equal(link2.target().id, replacementElement.id);
+        });
+
+        QUnit.test('should transfer links of a link', function(assert) {
+
+            const originalLink = new joint.shapes.standard.Link();
+            const link1 = new joint.shapes.standard.Link({ source: { id: originalLink.id }});
+            const link2 = new joint.shapes.standard.Link({ target: { id: originalLink.id }});
+            const replacementLink = new joint.shapes.standard.Link();
+
+            this.graph.addCells([originalLink, link1, link2]);
+            this.graph.transferCellLinks(originalLink, replacementLink);
+
+            assert.equal(link1.source().id, replacementLink.id);
+            assert.equal(link2.target().id, replacementLink.id);
+        });
+
+        QUnit.test('should work when transferring links from a link to an element', function(assert) {
+
+            const originalLink = new joint.shapes.standard.Link();
+            const link1 = new joint.shapes.standard.Link({ source: { id: originalLink.id }});
+            const link2 = new joint.shapes.standard.Link({ target: { id: originalLink.id }});
+            const element = new joint.shapes.standard.Rectangle();
+
+            this.graph.addCells([originalLink, link1, link2, element]);
+            this.graph.transferCellLinks(originalLink, element);
+
+            assert.equal(link1.source().id, element.id);
+            assert.equal(link2.target().id, element.id);
+        });
+
+        QUnit.test('should work when transferring links from an element to a link', function(assert) {
+
+            const originalElement = new joint.shapes.standard.Rectangle();
+            const link1 = new joint.shapes.standard.Link({ source: { id: originalElement.id }});
+            const link2 = new joint.shapes.standard.Link({ target: { id: originalElement.id }});
+            const replacementLink = new joint.shapes.standard.Link();
+
+            this.graph.addCells([originalElement, link1, link2, replacementLink]);
+            this.graph.transferCellLinks(originalElement, replacementLink);
+
+            assert.equal(link1.source().id, replacementLink.id);
+            assert.equal(link2.target().id, replacementLink.id);
+        });
+    });
 });

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -1547,72 +1547,40 @@ QUnit.module('graph', function(hooks) {
         });
     });
 
-    QUnit.module('graph.transferCellHierarchy()', function() {
+    QUnit.module('graph.transferCellEmbeds()', function() {
 
-        QUnit.test('should transfer hierarchy of elements', function(assert) {
+        QUnit.test('should transfer embeds from one element to another', function(assert) {
 
-            const topLevelElement = new joint.shapes.standard.Rectangle();
             const originalElement = new joint.shapes.standard.Rectangle();
             const child = new joint.shapes.standard.Rectangle();
             const replacementElement = new joint.shapes.standard.Rectangle();
 
-            topLevelElement.embed(originalElement);
             originalElement.embed(child);
 
-            this.graph.addCells([topLevelElement, originalElement, child, replacementElement]);
-            this.graph.transferCellHierarchy(originalElement, replacementElement);
+            this.graph.addCells([originalElement, child, replacementElement]);
+            this.graph.transferCellEmbeds(originalElement, replacementElement);
 
-            assert.equal(replacementElement.getParentCell(), topLevelElement);
             assert.equal(replacementElement.getEmbeddedCells()[0], child);
+            assert.equal(originalElement.getEmbeddedCells().length, 0);
         });
 
-        QUnit.test('should transfer hierarchy of links', function(assert) {
+        QUnit.test('should transfer embeds from an element to a link', function(assert) {
 
-            const parent = new joint.shapes.standard.Rectangle();
-            const originalLink = new joint.shapes.standard.Link();
-            const replacementLink = new joint.shapes.standard.Link();
-
-            parent.embed(originalLink);
-
-            this.graph.addCells([parent, originalLink, replacementLink]);
-            this.graph.transferCellHierarchy(originalLink, replacementLink);
-
-            assert.equal(replacementLink.getParentCell(), parent);
-        });
-
-        QUnit.test('should work when transferring hierarchy from a link to an element', function(assert) {
-
-            const parent = new joint.shapes.standard.Rectangle();
-            const link = new joint.shapes.standard.Link();
-            const element = new joint.shapes.standard.Rectangle();
-
-            parent.embed(link);
-
-            this.graph.addCells([parent, link, element]);
-            this.graph.transferCellHierarchy(link, element);
-
-            assert.equal(element.getParentCell(), parent);
-        });
-
-        QUnit.test('should work when transferring hierarchy from an element to a link', function(assert) {
-
-            const parent = new joint.shapes.standard.Rectangle();
             const link = new joint.shapes.standard.Link();
             const child = new joint.shapes.standard.Rectangle();
             const element = new joint.shapes.standard.Rectangle();
 
             element.embed(child);
-            parent.embed(element);
 
-            this.graph.addCells([parent, link, child, element]);
-            this.graph.transferCellHierarchy(element, link);
+            this.graph.addCells([link, child, element]);
+            this.graph.transferCellEmbeds(element, link);
 
-            assert.equal(link.getParentCell(), parent);
             assert.equal(link.getEmbeddedCells()[0], child);
+            assert.equal(element.getEmbeddedCells().length, 0);
         });
     });
 
-    QUnit.module('graph.transferCellLinks()', function() {
+    QUnit.module('graph.transferCellConnectedLinks()', function() {
 
         QUnit.test('should transfer links of an element', function(assert) {
 
@@ -1621,8 +1589,8 @@ QUnit.module('graph', function(hooks) {
             const link2 = new joint.shapes.standard.Link({ target: { id: originalElement.id }});
             const replacementElement = new joint.shapes.standard.Rectangle();
 
-            this.graph.addCells([originalElement, link1, link2]);
-            this.graph.transferCellLinks(originalElement, replacementElement);
+            this.graph.addCells([originalElement, link1, link2, replacementElement]);
+            this.graph.transferCellConnectedLinks(originalElement, replacementElement);
 
             assert.equal(link1.source().id, replacementElement.id);
             assert.equal(link2.target().id, replacementElement.id);
@@ -1635,8 +1603,8 @@ QUnit.module('graph', function(hooks) {
             const link2 = new joint.shapes.standard.Link({ target: { id: originalLink.id }});
             const replacementLink = new joint.shapes.standard.Link();
 
-            this.graph.addCells([originalLink, link1, link2]);
-            this.graph.transferCellLinks(originalLink, replacementLink);
+            this.graph.addCells([originalLink, link1, link2, replacementLink]);
+            this.graph.transferCellConnectedLinks(originalLink, replacementLink);
 
             assert.equal(link1.source().id, replacementLink.id);
             assert.equal(link2.target().id, replacementLink.id);
@@ -1650,7 +1618,7 @@ QUnit.module('graph', function(hooks) {
             const element = new joint.shapes.standard.Rectangle();
 
             this.graph.addCells([originalLink, link1, link2, element]);
-            this.graph.transferCellLinks(originalLink, element);
+            this.graph.transferCellConnectedLinks(originalLink, element);
 
             assert.equal(link1.source().id, element.id);
             assert.equal(link2.target().id, element.id);
@@ -1664,7 +1632,7 @@ QUnit.module('graph', function(hooks) {
             const replacementLink = new joint.shapes.standard.Link();
 
             this.graph.addCells([originalElement, link1, link2, replacementLink]);
-            this.graph.transferCellLinks(originalElement, replacementLink);
+            this.graph.transferCellConnectedLinks(originalElement, replacementLink);
 
             assert.equal(link1.source().id, replacementLink.id);
             assert.equal(link2.target().id, replacementLink.id);
@@ -1676,8 +1644,8 @@ QUnit.module('graph', function(hooks) {
             const link = new joint.shapes.standard.Link({ source: { id: originalElement.id }, target: { id: originalElement.id }});
             const replacementElement = new joint.shapes.standard.Rectangle();
 
-            this.graph.addCells([originalElement, link]);
-            this.graph.transferCellLinks(originalElement, replacementElement);
+            this.graph.addCells([originalElement, link, replacementElement]);
+            this.graph.transferCellConnectedLinks(originalElement, replacementElement);
 
             assert.equal(link.source().id, replacementElement.id);
             assert.equal(link.target().id, replacementElement.id);

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -311,6 +311,10 @@ export namespace dia {
             [key: string]: any;
         }
 
+        interface EmbedOptions extends Options {
+            reparent?: boolean;
+        }
+
         interface EmbeddableOptions<T = boolean> extends Options {
             deep?: T;
         }
@@ -443,7 +447,7 @@ export namespace dia {
 
         stopTransitions(path?: string, delim?: string): this;
 
-        embed(cell: Cell | Cell[], opt?: Graph.Options): this;
+        embed(cell: Cell | Cell[], opt?: Cell.EmbedOptions): this;
 
         unembed(cell: Cell | Cell[], opt?: Graph.Options): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -263,7 +263,7 @@ export namespace dia {
 
         removeCells(cells: Cell[], opt?: Cell.DisconnectableOptions): this;
 
-        transferCellEmbeds(sourceCell: Cell, targetCell: Cell, opt?: { [key: string]: any }): void;
+        transferCellEmbeds(sourceCell: Cell, targetCell: Cell, opt?: S): void;
 
         transferCellConnectedLinks(sourceCell: Cell, targetCell: Cell, opt?: Graph.ConnectionOptions): void;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -263,9 +263,9 @@ export namespace dia {
 
         removeCells(cells: Cell[], opt?: Cell.DisconnectableOptions): this;
 
-        transferCellHierarchy(sourceCell: Cell, targetCell: Cell): this;
+        transferCellEmbeds(sourceCell: Cell, targetCell: Cell, opt?: { [key: string]: any }): void;
 
-        transferCellLinks(sourceCell: Cell, targetCell: Cell): this;
+        transferCellConnectedLinks(sourceCell: Cell, targetCell: Cell, opt?: { [key: string]: any }): void;
 
         resize(width: number, height: number, opt?: S): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -263,6 +263,10 @@ export namespace dia {
 
         removeCells(cells: Cell[], opt?: Cell.DisconnectableOptions): this;
 
+        transferCellHierarchy(sourceCell: Cell, targetCell: Cell): this;
+
+        transferCellLinks(sourceCell: Cell, targetCell: Cell): this;
+
         resize(width: number, height: number, opt?: S): this;
 
         resizeCells(width: number, height: number, cells: Cell[], opt?: S): this;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -265,7 +265,7 @@ export namespace dia {
 
         transferCellEmbeds(sourceCell: Cell, targetCell: Cell, opt?: { [key: string]: any }): void;
 
-        transferCellConnectedLinks(sourceCell: Cell, targetCell: Cell, opt?: { [key: string]: any }): void;
+        transferCellConnectedLinks(sourceCell: Cell, targetCell: Cell, opt?: Graph.ConnectionOptions): void;
 
         resize(width: number, height: number, opt?: S): this;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Add `graph.transferCellEmbeds()` and `graph.transferCellConnectedLinks()`.
Change the `dia.Cell.embed` method to accept `opt.reparent`.

## Documentation

### transferCellEmbeds()

```ts
graph.transferCellEmbeds(sourceCell, targetCell [, opt]);
```

Transfer embedded cells of `sourceCell` to `targetCell`.

### transferCellConnectedLinks()

```ts
graph.transferCellConnectedLinks(sourceCell, targetCell [, opt]);
```

Transfer all the links connected to `sourceCell` to `targetCell`.

### embed()

...

The `opt.reparent` option can be set to `true` to transfer the embedded cells from their current parent to the new parent.