### PR TITLE
fix(dia.LinkView): invalidate the root node cache when labels change

### DIFF
--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -768,6 +768,12 @@ export const CellView = View.extend({
         this.metrics = {};
     },
 
+    cleanNodeCache: function(node) {
+        const id = node.id;
+        if (!id) return;
+        delete this.metrics[id];
+    },
+
     nodeCache: function(magnet) {
 
         var metrics = this.metrics;

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -461,6 +461,13 @@ export const LinkView = CellView.extend({
 
         if (!this._V.labels) return this;
 
+        if (!this.paper.options.labelLayer) {
+            // If there is no label layer, the cache needs to be cleared
+            // of the root node because the labels are attached
+            // to it and could affect the bounding box.
+            this.cleanNodeCache(this.el);
+        }
+
         var model = this.model;
         var labels = model.get('labels') || [];
         var canLabelMove = this.can('labelMove');

--- a/packages/joint-core/test/jointjs/linkView.js
+++ b/packages/joint-core/test/jointjs/linkView.js
@@ -91,6 +91,26 @@ QUnit.module('linkView', function(hooks) {
             assert.equal(group[0], circleNode);
             assert.equal(group[1], rectNode);
         });
+
+        QUnit.test('change label position', function(assert) {
+
+            link.labels([{
+                position: { distance: 0.5, offset: 0 },
+                attrs: { rect: { x: -10, y: -10, width: 20, height: 20 }}
+            }]);
+
+            const Y = 3;
+
+            const linkBBoxBefore = linkView.getNodeBBox(linkView.el);
+            assert.deepEqual(linkBBoxBefore.toJSON(), { x: 100, y: 90, width: 100, height: 20 });
+
+            link.label(0, { position: { distance: 0.5, offset: Y }});
+
+            const linkBBoxAfter = linkView.getNodeBBox(linkView.el);
+            assert.deepEqual(linkBBoxAfter.toJSON(), { x: 100, y: 90 + Y, width: 100, height: 20 });
+
+            assert.notOk(linkBBoxBefore.equals(linkBBoxAfter));
+        });
     });
 
     QUnit.module('addLabel', function(hooks) {


### PR DESCRIPTION
## Description

After moving/changing labels, this invalidates the root node's cache (which keeps the node's bounding box). Changing the label position could affect the overall link bounding box.

**Before:**
<img width="384" alt="image" src="https://github.com/user-attachments/assets/8e76b950-0f82-4719-8bcc-6c7bb9c3e6b9">

**After:**
<img width="377" alt="image" src="https://github.com/user-attachments/assets/35dafe73-2931-4570-8f6d-0190195cdff2">

