### PR TITLE
feat(dia.Paper):  add methods to find cell/element/link views in paper

### DIFF
--- a/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
+++ b/packages/joint-core/demo/archive/joint.dia.LegacyLinkView.js
@@ -2242,7 +2242,7 @@
             // checking view in close area of the pointer
 
             var r = snapLinks.radius || 50;
-            var viewsInArea = paper.findViewsInArea({ x: x - r, y: y - r, width: 2 * r, height: 2 * r });
+            var viewsInArea = paper.findElementViewsInArea({ x: x - r, y: y - r, width: 2 * r, height: 2 * r });
 
             var prevClosestView = data.closestView || null;
             var prevClosestMagnet = data.closestMagnet || null;

--- a/packages/joint-core/demo/chess/src/chess.js
+++ b/packages/joint-core/demo/chess/src/chess.js
@@ -290,7 +290,7 @@ const Board = joint.dia.Paper.extend({
 
     at: function(square) {
 
-        return this.model.findModelsFromPoint(this._mid(this._n2p(square)));
+        return this.model.findElementsAtPoint(this._mid(this._n2p(square)));
     },
 
     addPiece: function(piece, square) {

--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -16,7 +16,7 @@ import {
     merge,
     uniq
 } from '../util/index.mjs';
-import { Point, Rect } from '../g/index.mjs';
+import { Point, Rect, intersection } from '../g/index.mjs';
 import V from '../V/index.mjs';
 import $ from '../mvc/Dom/index.mjs';
 import { HighlighterView } from './HighlighterView.mjs';
@@ -1320,7 +1320,27 @@ export const CellView = View.extend({
     setInteractivity: function(value) {
 
         this.options.interactive = value;
+    },
+
+    isIntersecting: function(geometryShape, geometryData) {
+        return intersection.exists(geometryShape, this.getNodeBBox(this.el), geometryData);
+    },
+
+    isEnclosedIn: function(geometryRect) {
+        return geometryRect.containsRect(this.getNodeBBox(this.el));
+    },
+
+    isInArea: function(geometryRect, options = {}) {
+        if (options.strict) {
+            return this.isEnclosedIn(geometryRect);
+        }
+        return this.isIntersecting(geometryRect);
+    },
+
+    isAtPoint: function(point, options) {
+        return this.getNodeBBox(this.el).containsPoint(point, options);
     }
+
 }, {
 
     Flags,

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -404,9 +404,9 @@ export const ElementView = CellView.extend({
         if (isFunction(findParentBy)) {
             candidates = toArray(findParentBy.call(graph, this, evt, x, y));
         } else if (findParentBy === 'pointer') {
-            candidates = toArray(graph.findModelsFromPoint({ x, y }));
+            candidates = graph.findElementsAtPoint({ x, y });
         } else {
-            candidates = graph.findModelsUnderElement(model, { searchBy: findParentBy });
+            candidates = graph.findElementsUnderElement(model, { searchBy: findParentBy });
         }
 
         candidates = candidates.filter((el) => {

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -959,28 +959,105 @@ export const Graph = Model.extend({
         util.invoke(this.getConnectedLinks(model), 'remove', opt);
     },
 
-    // Find all elements at given point
-    findModelsFromPoint: function(p) {
-        return this.getElements().filter(el => el.getBBox({ rotate: true }).containsPoint(p));
+    // Find all cells at given point
+
+    findElementsAtPoint: function(point, opt) {
+        return this._filterAtPoint(this.getElements(), point, opt);
     },
 
-    // Find all elements in given area
-    findModelsInArea: function(rect, opt = {}) {
-        const r = new g.Rect(rect);
+    findLinksAtPoint: function(point, opt) {
+        return this._filterAtPoint(this.getLinks(), point, opt);
+    },
+
+    findCellsAtPoint: function(point, opt) {
+        return this._filterAtPoint(this.getCells(), point, opt);
+    },
+
+    _filterAtPoint: function(cells, point, opt = {}) {
+        return cells.filter(el => el.getBBox({ rotate: true }).containsPoint(point, opt));
+    },
+
+    // Find all cells in given area
+
+    findElementsInArea: function(area, opt = {}) {
+        return this._filterInArea(this.getElements(), area, opt);
+    },
+
+    findLinksInArea: function(area, opt = {}) {
+        return this._filterInArea(this.getLinks(), area, opt);
+    },
+
+    findCellsInArea: function(area, opt = {}) {
+        return this._filterInArea(this.getCells(), area, opt);
+    },
+
+    _filterInArea: function(cells, area, opt = {}) {
+        const r = new g.Rect(area);
         const { strict = false } = opt;
         const method = strict ? 'containsRect' : 'intersect';
-        return this.getElements().filter(el => r[method](el.getBBox({ rotate: true })));
+        return cells.filter(el => r[method](el.getBBox({ rotate: true })));
     },
 
-    // Find all elements under the given element.
-    findModelsUnderElement: function(element, opt = {}) {
-        const { searchBy = 'bbox' } = opt;
-        const bbox = element.getBBox().rotateAroundCenter(element.angle());
-        const elements = (searchBy === 'bbox')
-            ? this.findModelsInArea(bbox)
-            : this.findModelsFromPoint(util.getRectPoint(bbox, searchBy));
-        // don't account element itself or any of its descendants
-        return elements.filter(el => element.id !== el.id && !el.isEmbeddedIn(element));
+    // Find all cells under the given element.
+
+    findElementsUnderElement: function(element, opt) {
+        return this._filterCellsUnderElement(this.getElements(), element, opt);
+    },
+
+    findLinksUnderElement: function(element, opt) {
+        return this._filterCellsUnderElement(this.getLinks(), element, opt);
+    },
+
+    findCellsUnderElement: function(element, opt) {
+        return this._filterCellsUnderElement(this.getCells(), element, opt);
+    },
+
+    _isValidElementUnderElement: function(el1, el2) {
+        return el1.id !== el2.id && !el1.isEmbeddedIn(el2);
+    },
+
+    _isValidLinkUnderElement: function(link, el) {
+        return (
+            link.source().id !== el.id &&
+            link.target().id !== el.id &&
+            !link.isEmbeddedIn(el)
+        );
+    },
+
+    _validateCellsUnderElement: function(cells, element) {
+        return cells.filter(cell => {
+            return cell.isLink()
+                ? this._isValidLinkUnderElement(cell, element)
+                : this._isValidElementUnderElement(cell, element);
+        });
+    },
+
+    _getFindUnderElementGeometry: function(element, searchBy = 'bbox') {
+        const bbox = element.getBBox({ rotate: true });
+        return (searchBy !== 'bbox') ? util.getRectPoint(bbox, searchBy) : bbox;
+    },
+
+    _filterCellsUnderElement: function(cells, element, opt = {}) {
+        const geometry = this._getFindUnderElementGeometry(element, opt.searchBy);
+        const filteredCells = (geometry.type === g.types.Point)
+            ? this._filterAtPoint(cells, geometry)
+            : this._filterInArea(cells, geometry, opt);
+        return this._validateCellsUnderElement(filteredCells, element);
+    },
+
+    // @deprecated use `findElementsInArea` instead
+    findModelsInArea: function(area, opt) {
+        return this.findElementsInArea(area, opt);
+    },
+
+    // @deprecated use `findElementsAtPoint` instead
+    findModelsFromPoint: function(point) {
+        return this.findElementsAtPoint(point);
+    },
+
+    // @deprecated use `findModelsUnderElement` instead
+    findModelsUnderElement: function(element, opt) {
+        return this.findElementsUnderElement(element, opt);
     },
 
     // Return bounding box of all elements.

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -817,14 +817,14 @@ export const LinkView = CellView.extend({
         return connectionPoint.round(this.decimalsRounding);
     },
 
-    isIntersecting: function(geometryShape, options) {
+    isIntersecting: function(geometryShape, geometryData) {
         const connection = this.getConnection();
         if (!connection) return false;
         return intersection.exists(
-            connection,
             geometryShape,
+            connection,
+            geometryData,
             { segmentSubdivisions: this.getConnectionSubdivisions() },
-            options
         );
     },
 

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -73,6 +73,7 @@ export const LinkView = CellView.extend({
     initFlag: [Flags.RENDER, Flags.SOURCE, Flags.TARGET, Flags.TOOLS],
 
     UPDATE_PRIORITY: 1,
+    EPSILON: 1e-6,
 
     confirmUpdate: function(flags, opt) {
 
@@ -840,7 +841,7 @@ export const LinkView = CellView.extend({
         // There is currently no method to determine if a path contains a point.
         const area = new Rect(point);
         // Intersection with a zero-size area is not possible.
-        area.inflate(1e-6);
+        area.inflate(this.EPSILON);
         return this.isIntersecting(area);
     },
 

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -816,7 +816,7 @@ export const LinkView = CellView.extend({
         return connectionPoint.round(this.decimalsRounding);
     },
 
-    isConnectionIntersecting: function(geometryShape, options) {
+    isIntersecting: function(geometryShape, options) {
         const connection = this.getConnection();
         if (!connection) return false;
         return intersection.exists(
@@ -825,6 +825,23 @@ export const LinkView = CellView.extend({
             { segmentSubdivisions: this.getConnectionSubdivisions() },
             options
         );
+    },
+
+    isEnclosedIn: function(geometryRect) {
+        const connection = this.getConnection();
+        if (!connection) return false;
+        const bbox = connection.bbox();
+        if (!bbox) return false;
+        return geometryRect.containsRect(bbox);
+    },
+
+    isAtPoint: function(point /*, options */) {
+        // Note: `strict` option is not applicable for links.
+        // There is currently no method to determine if a path contains a point.
+        const area = new Rect(point);
+        // Intersection with a zero-size area is not possible.
+        area.inflate(1e-6);
+        return this.isIntersecting(area);
     },
 
     // combine default label position with built-in default label position
@@ -1834,7 +1851,10 @@ export const LinkView = CellView.extend({
         // checking view in close area of the pointer
 
         var r = snapLinks.radius || 50;
-        var viewsInArea = paper.findViewsInArea({ x: x - r, y: y - r, width: 2 * r, height: 2 * r });
+        var viewsInArea = paper.findElementViewsInArea(
+            { x: x - r, y: y - r, width: 2 * r, height: 2 * r },
+            snapLinks.findInAreaOptions
+        );
 
         var prevClosestView = data.closestView || null;
         var prevClosestMagnet = data.closestMagnet || null;

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -2,7 +2,7 @@ import { CellView } from './CellView.mjs';
 import { Link } from './Link.mjs';
 import V from '../V/index.mjs';
 import { addClassNamePrefix, merge, assign, isObject, isFunction, clone, isPercentage, result, isEqual } from '../util/index.mjs';
-import { Point, Line, Path, normalizeAngle, Rect, Polyline } from '../g/index.mjs';
+import { Point, Line, Path, normalizeAngle, Rect, Polyline, intersection } from '../g/index.mjs';
 import * as routers from '../routers/index.mjs';
 import * as connectors from '../connectors/index.mjs';
 import { env } from '../env/index.mjs';
@@ -814,6 +814,17 @@ export const LinkView = CellView.extend({
         connectionPoint = connectionPointFn.call(this, line, view, magnet, connectionPointDef.args || {}, endType, this);
         if (!connectionPoint) return anchor;
         return connectionPoint.round(this.decimalsRounding);
+    },
+
+    isConnectionIntersecting: function(geometryShape, options) {
+        const connection = this.getConnection();
+        if (!connection) return false;
+        return intersection.exists(
+            connection,
+            geometryShape,
+            { segmentSubdivisions: this.getConnectionSubdivisions() },
+            options
+        );
     },
 
     // combine default label position with built-in default label position

--- a/packages/joint-core/src/g/rect.mjs
+++ b/packages/joint-core/src/g/rect.mjs
@@ -155,7 +155,7 @@ Rect.prototype = {
     },
 
     // @return {bool} true if rectangle `r` is inside me.
-    containsRect: function(r, opt) {
+    containsRect: function(r) {
 
         var r0 = new Rect(this).normalize();
         var r1 = new Rect(r).normalize();
@@ -179,9 +179,7 @@ Rect.prototype = {
         h1 += y1;
         h0 += y0;
 
-        return opt && opt.strict
-            ? (x0 < x1 && w1 < w0 && y0 < y1 && h1 < h0)
-            : (x0 <= x1 && w1 <= w0 && y0 <= y1 && h1 <= h0);
+        return x0 <= x1 && w1 <= w0 && y0 <= y1 && h1 <= h0;
     },
 
     corner: function() {

--- a/packages/joint-core/src/g/rect.mjs
+++ b/packages/joint-core/src/g/rect.mjs
@@ -138,16 +138,24 @@ Rect.prototype = {
     },
 
     // @return {bool} true if point p is inside me.
-    containsPoint: function(p) {
-        
-        if (!(p instanceof Point)) {
-            p = new Point(p);
+    // @param {bool} strict If true, the point has to be strictly inside (not on the border).
+    containsPoint: function(p, opt) {
+        let x, y;
+        if (!p || (typeof p === 'string')) {
+            // Backwards compatibility: if the point is not provided,
+            // the point is considered to be the origin [0, 0].
+            ({ x, y } = new Point(p));
+        } else {
+            // Do not create a new Point object if the point is already a Point-like object.
+            ({ x = 0, y = 0 } = p);
         }
-        return p.x >= this.x && p.x <= this.x + this.width && p.y >= this.y && p.y <= this.y + this.height;
+        return opt && opt.strict
+            ? (x > this.x && x < this.x + this.width && y > this.y && y < this.y + this.height)
+            : x >= this.x && x <= this.x + this.width && y >= this.y && y <= this.y + this.height;
     },
 
     // @return {bool} true if rectangle `r` is inside me.
-    containsRect: function(r) {
+    containsRect: function(r, opt) {
 
         var r0 = new Rect(this).normalize();
         var r1 = new Rect(r).normalize();
@@ -171,7 +179,9 @@ Rect.prototype = {
         h1 += y1;
         h0 += y0;
 
-        return x0 <= x1 && w1 <= w0 && y0 <= y1 && h1 <= h0;
+        return opt && opt.strict
+            ? (x0 < x1 && w1 < w0 && y0 < y1 && h1 < h0)
+            : (x0 <= x1 && w1 <= w0 && y0 <= y1 && h1 <= h0);
     },
 
     corner: function() {

--- a/packages/joint-core/test/geometry/rect.js
+++ b/packages/joint-core/test/geometry/rect.js
@@ -226,23 +226,6 @@ QUnit.module('rect', function() {
             });
         });
 
-        QUnit.module('containsRect(rect, strict=true)', function() {
-
-            QUnit.test('returns TRUE when rect is strictly inside the other rect', function(assert) {
-
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(20, 20, 200, 200), { strict: true })), 'not inside when surround');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(40, 40, 100, 100), { strict: true })), 'not inside when overlap left and top');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 100, 40), { strict: true })), 'not inside when overlap left');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 100, 100), { strict: true })), 'not inside when overlap right and bottom');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 40, 100), { strict: true })), 'not inside when overlap bottom');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(75, 75, 0, 0), { strict: true })), 'not inside when argument rect has zero width/height');
-                assert.notOk((new g.Rect(50, 50, 0, 0).containsRect(new g.Rect(50, 50, 0, 0), { strict: true })), 'not inside when both rects have zero width/height');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(50, 50, 100, 100), { strict: true })), 'not inside when equal');
-                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(50, 60, 20, 20), { strict: true })), 'not inside when rect is not strictly inside');
-                assert.ok((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 80, 80), { strict: true })), 'inside');
-            });
-        });
-
         QUnit.module('corner()', function() {
 
         });

--- a/packages/joint-core/test/geometry/rect.js
+++ b/packages/joint-core/test/geometry/rect.js
@@ -161,7 +161,7 @@ QUnit.module('rect', function() {
         });
 
         QUnit.module('containsPoint(point)', function() {
-            
+
             QUnit.test('returns TRUE when a point is inside the rect', function(assert) {
                 assert.ok((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(75, 75))), 'inside for Point');
                 assert.ok((new g.Rect(50, 50, 50, 50).containsPoint({ x: 75, y: 75 })), 'inside for object');
@@ -176,13 +176,39 @@ QUnit.module('rect', function() {
                 assert.ok(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(100, 100)));
             });
 
-            QUnit.test('returns TRUE when a point is outside the rect', function(assert) {
+            QUnit.test('returns FALSE when a point is outside the rect', function(assert) {
                 assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(49, 75))), 'outside for Point');
                 assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint({ x: 101, y: 75 })), 'outside for object');
                 assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75@101')), 'outside for string coords separated by @');
                 assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75 49')), 'outside for string coords separated by space');
             });
         });
+
+
+        QUnit.module('containsPoint(point, strict=true)', function() {
+
+            QUnit.test('returns TRUE when a point is inside the rect', function(assert) {
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(75, 75), { strict: true })), 'inside for Point');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint({ x: 75, y: 75 }, { strict: true })), 'inside for object');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint('75@75', { strict: true })), 'inside for string coords separated by @');
+                assert.ok((new g.Rect(50, 50, 50, 50).containsPoint('75 75', { strict: true })), 'inside for string coords separated by space');
+            });
+
+            QUnit.test('returns FALSE when a point is a corner of the rect', function(assert) {
+                assert.notOk(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(50, 50), { strict: true }));
+                assert.notOk(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(50, 100), { strict: true }));
+                assert.notOk(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(100, 50), { strict: true }));
+                assert.notOk(new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(100, 100), { strict: true }));
+            });
+
+            QUnit.test('returns FALSE when a point is outside the rect', function(assert) {
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint(new g.Point(49, 75), { strict: true })), 'outside for Point');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint({ x: 101, y: 75 }, { strict: true })), 'outside for object');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75@101', { strict: true })), 'outside for string coords separated by @');
+                assert.notOk((new g.Rect(50, 50, 50, 50).containsPoint('75 49', { strict: true })), 'outside for string coords separated by space');
+            });
+        });
+
 
         QUnit.module('containsRect(rect)', function() {
 
@@ -197,6 +223,23 @@ QUnit.module('rect', function() {
                 assert.notOk((new g.Rect(50, 50, 0, 0)).containsRect(new g.Rect(50, 50, 0, 0)), 'not inside when both rects have zero width/height');
                 assert.ok((new g.Rect(50, 50, 100, 100)).containsRect(new g.Rect(60, 60, 80, 80)), 'inside');
                 assert.ok((new g.Rect(50, 50, 100, 100)).containsRect(new g.Rect(50, 50, 100, 100)), 'inside when equal');
+            });
+        });
+
+        QUnit.module('containsRect(rect, strict=true)', function() {
+
+            QUnit.test('returns TRUE when rect is strictly inside the other rect', function(assert) {
+
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(20, 20, 200, 200), { strict: true })), 'not inside when surround');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(40, 40, 100, 100), { strict: true })), 'not inside when overlap left and top');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 100, 40), { strict: true })), 'not inside when overlap left');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 100, 100), { strict: true })), 'not inside when overlap right and bottom');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 40, 100), { strict: true })), 'not inside when overlap bottom');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(75, 75, 0, 0), { strict: true })), 'not inside when argument rect has zero width/height');
+                assert.notOk((new g.Rect(50, 50, 0, 0).containsRect(new g.Rect(50, 50, 0, 0), { strict: true })), 'not inside when both rects have zero width/height');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(50, 50, 100, 100), { strict: true })), 'not inside when equal');
+                assert.notOk((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(50, 60, 20, 20), { strict: true })), 'not inside when rect is not strictly inside');
+                assert.ok((new g.Rect(50, 50, 100, 100).containsRect(new g.Rect(60, 60, 80, 80), { strict: true })), 'inside');
             });
         });
 

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -840,7 +840,7 @@ QUnit.module('graph', function(hooks) {
         });
     });
 
-    QUnit.module('graph.findModelsUnderElement()', function() {
+    QUnit.module('graph.findElementsUnderElement()', function() {
 
         QUnit.test('sanity', function(assert) {
 
@@ -854,20 +854,20 @@ QUnit.module('graph', function(hooks) {
 
             this.graph.addCells([rect, under, away]);
 
-            assert.deepEqual(this.graph.findModelsUnderElement(away), [], 'There are no models under the element.');
-            assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is a model under the element.');
+            assert.deepEqual(this.graph.findElementsUnderElement(away), [], 'There are no models under the element.');
+            assert.deepEqual(this.graph.findElementsUnderElement(rect), [under], 'There is a model under the element.');
 
             under.translate(50, 50);
 
-            assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'origin' }), [], 'There is no model under the element if searchBy origin option used.');
-            assert.deepEqual(this.graph.findModelsUnderElement(rect, { searchBy: 'corner' }), [under], 'There is a model under the element if searchBy corner options used.');
+            assert.deepEqual(this.graph.findElementsUnderElement(rect, { searchBy: 'origin' }), [], 'There is no model under the element if searchBy origin option used.');
+            assert.deepEqual(this.graph.findElementsUnderElement(rect, { searchBy: 'corner' }), [under], 'There is a model under the element if searchBy corner options used.');
 
             var embedded = rect.clone().addTo(this.graph);
             rect.embed(embedded);
 
-            assert.deepEqual(this.graph.findModelsUnderElement(rect), [under], 'There is 1 model under the element found and 1 embedded element is omitted.');
-            assert.deepEqual(this.graph.findModelsUnderElement(under), [rect, embedded], 'There are 2 models under the element. Parent and its embed.');
-            assert.deepEqual(this.graph.findModelsUnderElement(embedded), [rect, under], 'There are 2 models under the element. The element\'s parent and one other element.');
+            assert.deepEqual(this.graph.findElementsUnderElement(rect), [under], 'There is 1 model under the element found and 1 embedded element is omitted.');
+            assert.deepEqual(this.graph.findElementsUnderElement(under), [rect, embedded], 'There are 2 models under the element. Parent and its embed.');
+            assert.deepEqual(this.graph.findElementsUnderElement(embedded), [rect, under], 'There are 2 models under the element. The element\'s parent and one other element.');
         });
 
         QUnit.test('rotated elements', function(assert) {
@@ -876,14 +876,14 @@ QUnit.module('graph', function(hooks) {
             var rect1 = new joint.shapes.standard.Rectangle({ size: { width: 10, height: 100 }});
             var rect2 = rect1.clone().translate(30, 30);
             graph.addCells([rect1, rect2]);
-            assert.deepEqual(graph.findModelsUnderElement(rect1), []);
+            assert.deepEqual(graph.findElementsUnderElement(rect1), []);
             rect1.set('angle', 90);
-            assert.deepEqual(graph.findModelsUnderElement(rect1), [rect2]);
+            assert.deepEqual(graph.findElementsUnderElement(rect1), [rect2]);
             rect2.set('angle', 90);
             // there is no intersection when both elements are rotated
-            assert.deepEqual(graph.findModelsUnderElement(rect1), []);
+            assert.deepEqual(graph.findElementsUnderElement(rect1), []);
             rect1.set('angle', 0);
-            assert.deepEqual(graph.findModelsUnderElement(rect1), [rect2]);
+            assert.deepEqual(graph.findElementsUnderElement(rect1), [rect2]);
         });
     });
 
@@ -1118,7 +1118,7 @@ QUnit.module('graph', function(hooks) {
     });
 
 
-    QUnit.module('findModelsInArea(rect[, opt])', function(hooks) {
+    QUnit.module('findElementsInArea(rect[, opt])', function(hooks) {
 
         var cells;
 
@@ -1146,19 +1146,19 @@ QUnit.module('graph', function(hooks) {
 
             var modelsInArea;
 
-            modelsInArea = this.graph.findModelsInArea(new g.rect(0, 0, 10, 10));
+            modelsInArea = this.graph.findElementsInArea(new g.rect(0, 0, 10, 10));
 
             assert.equal(modelsInArea.length, 0, 'area with no elements in it');
 
-            modelsInArea = this.graph.findModelsInArea(new g.rect(0, 0, 25, 25));
+            modelsInArea = this.graph.findElementsInArea(new g.rect(0, 0, 25, 25));
 
             assert.equal(modelsInArea.length, 1, 'area with 1 element in it');
 
-            modelsInArea = this.graph.findModelsInArea(new g.rect(0, 0, 300, 300));
+            modelsInArea = this.graph.findElementsInArea(new g.rect(0, 0, 300, 300));
 
             assert.equal(modelsInArea.length, 3, 'area with 3 elements in it');
 
-            modelsInArea = this.graph.findModelsInArea(new g.rect(0, 0, 100, 100), { strict: true });
+            modelsInArea = this.graph.findElementsInArea(new g.rect(0, 0, 100, 100), { strict: true });
 
             assert.equal(modelsInArea.length, 1, '[opt.strict = TRUE] should require elements to be completely within rect');
         });
@@ -1167,7 +1167,7 @@ QUnit.module('graph', function(hooks) {
 
             var modelsInArea;
 
-            modelsInArea = this.graph.findModelsInArea({
+            modelsInArea = this.graph.findElementsInArea({
                 x: 0,
                 y: 0,
                 width: 10,
@@ -1475,7 +1475,7 @@ QUnit.module('graph', function(hooks) {
                     type: 'test.Element'
                 }
             });
-        
+
             const el = new El({
                 foo: {}
             });

--- a/packages/joint-core/types/geometry.d.ts
+++ b/packages/joint-core/types/geometry.d.ts
@@ -651,7 +651,7 @@ export namespace g {
 
         containsPoint(p: PlainPoint | string, opt?: StrictOpt): boolean;
 
-        containsRect(r: PlainRect, opt?: StrictOpt): boolean;
+        containsRect(r: PlainRect): boolean;
 
         corner(): Point;
 

--- a/packages/joint-core/types/geometry.d.ts
+++ b/packages/joint-core/types/geometry.d.ts
@@ -37,6 +37,11 @@ export namespace g {
         precision?: number;
     }
 
+    export interface StrictOpt {
+
+        strict?: boolean;
+    }
+
     export interface SubdivisionsOpt extends PrecisionOpt {
 
         subdivisions?: Curve[];
@@ -644,9 +649,9 @@ export namespace g {
 
         clone(): Rect;
 
-        containsPoint(p: PlainPoint | string): boolean;
+        containsPoint(p: PlainPoint | string, opt? StrictOpt): boolean;
 
-        containsRect(r: PlainRect): boolean;
+        containsRect(r: PlainRect, opt? StrictOpt): boolean;
 
         corner(): Point;
 

--- a/packages/joint-core/types/geometry.d.ts
+++ b/packages/joint-core/types/geometry.d.ts
@@ -649,9 +649,9 @@ export namespace g {
 
         clone(): Rect;
 
-        containsPoint(p: PlainPoint | string, opt? StrictOpt): boolean;
+        containsPoint(p: PlainPoint | string, opt?: StrictOpt): boolean;
 
-        containsRect(r: PlainRect, opt? StrictOpt): boolean;
+        containsRect(r: PlainRect, opt?: StrictOpt): boolean;
 
         corner(): Point;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -173,7 +173,7 @@ export namespace dia {
 
         type SearchByKey = 'bbox' | PositionName;
 
-        interface FindUnderElementOptions extends FindInAreaOptions {
+        interface FindUnderElementOptions extends FindInAreaOptions, FindAtPointOptions {
             searchBy?: SearchByKey;
         }
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -933,6 +933,14 @@ export namespace dia {
 
         isDefaultInteractionPrevented(evt: dia.Event): boolean;
 
+        isIntersecting(geometryShape: g.Shape, geometryData?: g.SegmentSubdivisionsOpt | null): boolean;
+
+        protected isEnclosedIn(area: g.Rect): boolean;
+
+        protected isInArea(area: g.Rect, options: g.StrictOpt): boolean;
+
+        protected isAtPoint(point: g.Point, options: g.StrictOpt): boolean;
+
         protected findBySelector(selector: string, root?: SVGElement): SVGElement[];
 
         protected removeHighlighters(): void;
@@ -1165,8 +1173,6 @@ export namespace dia {
 
         getVertexIndex(x: number, y: number): number;
         getVertexIndex(point: Point): number;
-
-        isIntersecting(geometryShape: g.Shape, geometryData?: g.SegmentSubdivisionsOpt | null): boolean;
 
         update(): this;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -163,6 +163,20 @@ export namespace dia {
             breadthFirst?: boolean;
         }
 
+        interface FindAtPointOptions extends Options {
+            strict?: boolean;
+        }
+
+        interface FindInAreaOptions extends Options {
+            strict?: boolean;
+        }
+
+        type SearchByKey = 'bbox' | PositionName;
+
+        interface FindUnderElementOptions extends FindInAreaOptions {
+            searchBy?: SearchByKey;
+        }
+
         class Cells extends mvc.Collection<Cell> {
             graph: Graph;
             cellNamespace: any;
@@ -245,11 +259,42 @@ export namespace dia {
 
         clear(opt?: { [key: string]: any }): this;
 
+        findElementsAtPoint(p: Point, opt?: Graph.FindAtPointOptions): Element[];
+
+        findElementsInArea(rect: BBox, opt?: Graph.FindInAreaOptions): Element[];
+
+        findElementsUnderElement(element: Element, opt?: Graph.FindUnderElementOptions): Element[];
+
+        findLinksAtPoint(p: Point, opt?: Graph.FindAtPointOptions): Link[];
+
+        findLinksInArea(rect: BBox, opt?: Graph.FindInAreaOptions): Link[];
+
+        findLinksUnderElement(element: Element, opt?: Graph.FindUnderElementOptions): Link[];
+
+        findCellsAtPoint(p: Point, opt?: Graph.FindAtPointOptions): Cell[];
+
+        findCellsInArea(rect: BBox, opt?: Graph.FindInAreaOptions): Cell[];
+
+        findCellsUnderElement(element: Element, opt?: Graph.FindUnderElementOptions): Cell[];
+
+        protected _getFindUnderElementGeometry(element: Element, searchBy: Graph.SearchByKey): g.Point | g.Rect;
+
+        protected _validateCellsUnderElement<T extends Cell[]>(cells: T, element: Element): T;
+
+        protected _isValidElementUnderElement(el1: Element, el2: Element): boolean;
+
+        protected _isValidLinkUnderElement(link: Link, element: Element): boolean;
+
+        protected _filterCellsUnderElement(cells: Cell[], element: Element, opt: Graph.FindUnderElementOptions): Cell[];
+
+        /** @deprecated use `findElementsAtPoint` instead */
         findModelsFromPoint(p: Point): Element[];
 
-        findModelsInArea(rect: BBox, opt?: { strict?: boolean }): Element[];
+        /** @deprecated use `findElementsInArea` instead */
+        findModelsInArea(rect: BBox, opt?: Graph.FindInAreaOptions): Element[];
 
-        findModelsUnderElement(element: Element, opt?: { searchBy?: 'bbox' | PositionName }): Element[];
+        /** @deprecated use `findElementsUnderElement` instead */
+        findModelsUnderElement(element: Element, opt?: Graph.FindUnderElementOptions): Element[];
 
         getBBox(): g.Rect | null;
 
@@ -1120,6 +1165,8 @@ export namespace dia {
 
         getVertexIndex(x: number, y: number): number;
         getVertexIndex(point: Point): number;
+
+        isConnectionIntersecting(geometryShape: g.Shape, options?: g.SegmentSubdivisionsOpt | null): boolean;
 
         update(): this;
 


### PR DESCRIPTION
- **feat(dia.Paper):**  add methods to find cell/element/link views in paper
  - add `findCellViewsAtPoint(), `findLinkViewsAtPoint()`, and `findElementViewsAtPoint()`
  - add `findCellViewsInArea(), `findLinkViewsInArea()`, and `findElementViewsInArea()`
  - deprecate `findViewsFromPoint()` and `findViewsInArea()
- **feat(dia.Graph):**  add methods to find cells/elements/links in graph
  - add `findCellsAtPoint()`, `findLinksAtPoint()`, and `findElementsAtPoint()`
  - add `findCellsInArea()`, `findLinksInArea()`, and `findElementsInArea()`
  - add `findCellsUnderElement()`, `findLinksUnderElement()`, `findElementsUnderElement()`
  - deprecate `findModelsFromPoint()` and `findModelsInArea()`
- **feat(dia.CellView):** add `isIntersecting()` method
- **feat(g.Rect):** add `strict` option to `containsPoint()`

---

This PR:
- adds convenience methods for searching for links in the paper based on their geometry.
- optimizes the performance of search for elements and links in the paper.
- allows us to further optimize the search by a more efficient data structure in the graph.
- It lays the foundation for the future implementation of `snap-to-link` feature (as opposed to existing `snap-to-elements`).
