### PR TITLE
types(layout.DirectedGraph): capitalize interface names

### DIFF
--- a/packages/joint-layout-directed-graph/DirectedGraph.d.ts
+++ b/packages/joint-layout-directed-graph/DirectedGraph.d.ts
@@ -43,21 +43,27 @@ export namespace DirectedGraph {
         exportLink?: (link: dia.Link) => Edge;
     }
 
-    interface toGraphLibOptions extends ExportOptions {
+    interface ToGraphLibOptions extends ExportOptions {
         [key: string]: any;
     }
 
-    interface fromGraphLibOptions extends ImportOptions {
+    interface FromGraphLibOptions extends ImportOptions {
         graph?: dia.Graph;
         [key: string]: any;
     }
 
     export function layout(graph: dia.Graph | dia.Cell[], opt?: LayoutOptions): g.Rect;
 
-    export function toGraphLib(graph: dia.Graph, opt?: toGraphLibOptions): any;
+    export function toGraphLib(graph: dia.Graph, opt?: ToGraphLibOptions): any;
 
-    export function fromGraphLib(glGraph: any, opt?: fromGraphLibOptions): dia.Graph;
+    export function fromGraphLib(glGraph: any, opt?: FromGraphLibOptions): dia.Graph;
 
     // @deprecated pass the `graph` option instead
     export function fromGraphLib(this: dia.Graph, glGraph: any, opt?: { [key: string]: any }): dia.Graph;
+
+    // @deprecated use `FromGraphLibOptions` instead
+    type fromGraphLibOptions = FromGraphLibOptions;
+
+    // @deprecated use `ToGraphLibOptions` instead
+    type toGraphLibOptions = ToGraphLibOptions;
 }


### PR DESCRIPTION
## Description

Rename `toGraphLibOptions` and `fromGraphLibOptions` to `ToGraphLibOptions` and `FromGraphLibOptions` (all interfaces in _JointJS_ start with a capital letter).

Deprecate the old names (keep them for backwards compatibility).
