### PR TITLE
Release v4.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,7 +29,7 @@
   * mvc.View - fix to allow setting `style` via options
   * util - add `objectDifference()` method
   * util - expose `calc()` expression API
-  * Geometry - add `strict` option to `containsPoint()` of Rect
+  * Geometry - add `strict` option to `containsPoint()` of `Rect`
 
   @joint/layout-directed-graph
   * layout.DirectedGraph - add `graph` option to `fromGraphLib()`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@
   * dia.ElementView - fix to prevent exception when position or size is not defined
   * dia.LinkView - update tools when labels change
   * dia.LinkView - fix to invalidate the root node cache when labels change
-  * dia.CellView - add `unset()` callback for special presentation attributes
+  * dia.CellView - expose special presentation attributes API
   * dia.CellView - add `isIntersecting()` method
   * dia.Graph - accept `toJSON()` options
   * dia.Graph - add `transferCellEmbeds()` and `transferCellConnectedLinks()` methods

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
   * mvc.View - fix to allow setting `style` via options
   * util - add `objectDifference()` method
   * util - expose `calc()` expression API
+  * util - expose `cloneCells()` method
   * Geometry - add `strict` option to `containsPoint()` of `Rect`
 
   @joint/layout-directed-graph

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-08-11-2024 (v4.1.0)
+27-11-2024 (v4.1.0)
 
   @joint/core
   * dia.Paper - add methods to find cell/element/link views in paper

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,39 @@
+08-11-2024 (v4.1.0)
+
+  @joint/core
+  * examples.link-labels-ts - add new example to show link labels functionality
+  * dia.Paper - add methods to find cell/element/link views in paper
+  * dia.ElementView - add `getTargetParentView()` method
+  * dia.ElementView - fix to prevent exception when position or size is not defined
+  * dia.LinkView - update tools when labels change
+  * dia.LinkView - fix to invalidate the root node cache when labels change
+  * dia.CellView - add `unset()` callback for special presentation attributes
+  * dia.CellView - add `isIntersecting()` method
+  * dia.Graph - accept `toJSON()` options
+  * dia.Graph - add `transferCellEmbeds()` and `transferCellConnectedLinks()` methods
+  * dia.Graph - add methods to find cells/elements/links in graph
+  * dia.Graph - fix to remove graph reference from cells after `resetCells()`
+  * dia.Element - add `getPortGroupNames()` method
+  * dia.Cell - add `ignoreDefaults` and `ignoreEmptyAttributes` options to `toJSON()`
+  * dia.Cell - add `reparent` option to `embed()`
+  * elementTools.Control - add pointer event to `setPosition()` and `resetPosition()` signature
+  * linkTools - add `Control` link tool
+  * linkTools - add `RotateLabel` link tool
+  * linkTools - fix pending batch for `TargetArrowhead` and `SourceArrowhead`
+  * linkTools.Vertices - add `vertexAdding.interactiveLinkNode` option
+  * linkTools.Button - allow `distance` to be defined via callback
+  * routers.RightAngle - fix various routing issues
+  * dia.HighlighterView - add static `getAll()` method
+  * dia.ToolsView - fix to prevent tool `update()` from being called before previous `render()` due to visibility
+  * dia.ToolView - add `visibility` option callback
+  * mvc.View - fix to allow setting `style` via options
+  * util - add `objectDifference()` method
+  * util - expose `calc()` expression API
+  * g.Rect - add `strict` option to `containsPoint()`
+
+  @joint/layout-directed-graph
+  * layout.DirectedGraph - add `graph` option to `fromGraphLib()`
+
 31-05-2024 (v4.0.4)
 
   @joint/core

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 08-11-2024 (v4.1.0)
 
   @joint/core
-  * examples.link-labels-ts - add new example to show link labels functionality
+  * examples.link-labels-ts - add new example to show link label tools functionality
   * dia.Paper - add methods to find cell/element/link views in paper
   * dia.ElementView - add `getTargetParentView()` method
   * dia.ElementView - fix to prevent exception when position or size is not defined
@@ -29,7 +29,7 @@
   * mvc.View - fix to allow setting `style` via options
   * util - add `objectDifference()` method
   * util - expose `calc()` expression API
-  * g.Rect - add `strict` option to `containsPoint()`
+  * Geometry - add `strict` option to `containsPoint()` of Rect
 
   @joint/layout-directed-graph
   * layout.DirectedGraph - add `graph` option to `fromGraphLib()`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 08-11-2024 (v4.1.0)
 
   @joint/core
-  * examples.link-labels-ts - add new example to show link label tools functionality
   * dia.Paper - add methods to find cell/element/link views in paper
   * dia.ElementView - add `getTargetParentView()` method
   * dia.ElementView - fix to prevent exception when position or size is not defined

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-decorators",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-dwdm",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/fta-js/package.json
+++ b/examples/fta-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-fta-js",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-isometric",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-directed-graph/package.json
+++ b/examples/layout-directed-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-directed-graph",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - Directed Graph Layout Demo",
   "main": "./index.js",
   "homepage": "https://jointjs.com",

--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-libavoid-js",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/link-labels-ts/package.json
+++ b/examples/link-labels-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-link-labels-ts",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-list",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-shapes-general",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-of-life",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "author": {
     "name": "client IO",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "sideEffects": false,
   "homepage": "https://jointjs.com",
   "author": {

--- a/packages/joint-core/demo/custom-shapes/package.json
+++ b/packages/joint-core/demo/custom-shapes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-custom-shapes",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - Custom Shapes Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/elk/package.json
+++ b/packages/joint-core/demo/elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-elk-graph",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - Eclipse Layout Kernel Graph Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/rough/package.json
+++ b/packages/joint-core/demo/rough/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-rough",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - RoughJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/tree-shake/package.json
+++ b/packages/joint-core/demo/tree-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-shake",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - Tree Shake Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/ts-demo/package.json
+++ b/packages/joint-core/demo/ts-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-ts",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - TypeScript Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/vuejs/package.json
+++ b/packages/joint-core/demo/vuejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-vuejs",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JointJS - VueJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/core",
   "title": "JointJS",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "JavaScript diagramming library",
   "sideEffects": false,
   "main": "./dist/joint.min.js",

--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/decorators",
   "title": "JointJS Decorators",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Decorators module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-directed-graph",
   "title": "JointJS LayoutDirectedGraph",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "LayoutDirectedGraph module for JointJS",
   "main": "dist/DirectedGraph.js",
   "module": "./DirectedGraph.mjs",

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general-tools",
   "title": "JointJS General Shapes Tools",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "General Shapes Tools module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general",
   "title": "JointJS General Shapes",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "General Shapes module for JointJS",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",


### PR DESCRIPTION
# CHANGELOG

## @joint/core
  * **dia.Paper** - add methods to find cell/element/link views in paper (ca06b4e5dd8221644441f41698cfd2bd1c36cd6b)
  * **dia.ElementView** - add `getTargetParentView()` method (0d29e703ae877815dc0092afb0418cbd2a5687e4)
  * **dia.ElementView** - fix to prevent exception when position or size is not defined (3bead1c4fc50e3e54f958589da0829b16fa8d467)
  * **dia.LinkView** - update tools when labels change (f5df2d1b6fad47aa55304c580cfd2f604c12ebf6)
  * **dia.LinkView** - fix to invalidate the root node cache when labels change (6d12e652bbf133b5e6f85b3b4889218258604610)
  * **dia.CellView** - expose special presentation attributes API (58df31d4c4c0ce198e36b10d591a004ea70f13fc)
  * **dia.CellView** - add `isIntersecting()` method (ca06b4e5dd8221644441f41698cfd2bd1c36cd6b)
  * **dia.Graph** - accept `toJSON()` options (bf753a1fb0421165b386b7e889553b985e8e6c7c)
  * **dia.Graph** - add `transferCellEmbeds()` and `transferCellConnectedLinks()` methods (b62479cc3cdd72e2cd4a65f182cdd2ce9b878345)
  * **dia.Graph** - add methods to find cells/elements/links in graph (ca06b4e5dd8221644441f41698cfd2bd1c36cd6b)
  * **dia.Graph** - fix to remove graph reference from cells after `resetCells()` (cb162d1e2aca8d7ab4678cbc385c977d7f29bd1f)
  * **dia.Element** - add `getPortGroupNames()` method (b1b7a45e14b3e1a72100a7e9ae106c6698dcbe25)
  * **dia.Cell** - add `ignoreDefaults` and `ignoreEmptyAttributes` options to `toJSON()` (bf753a1fb0421165b386b7e889553b985e8e6c7c)
  * **dia.Cell** - add `reparent` option to `embed()` (b62479cc3cdd72e2cd4a65f182cdd2ce9b878345)
  * **elementTools.Control** - add pointer event to `setPosition()` and `resetPosition()` signature (dd0db32aa059d35e62786b30225de77d5812154e)
  * **linkTools** - add `Control` link tool (f5df2d1b6fad47aa55304c580cfd2f604c12ebf6)
  * **linkTools** - add `RotateLabel` link tool (f5df2d1b6fad47aa55304c580cfd2f604c12ebf6)
  * **linkTools** - fix pending batch for `TargetArrowhead` and `SourceArrowhead` (e9c5141c65af18438397a2ca75e7fc01da9da268)
  * **linkTools.Vertices** - add `vertexAdding.interactiveLinkNode` option (97b25eb3253aedc5f50f0fc04586ebf2f25380e9)
  * **linkTools.Button** - allow `distance` to be defined via callback (5168a3ac7cf81a763af2521cf36a3747d2c4cc40)
  * **routers.RightAngle** - fix various routing issues (5de4a15befa2d48a674e1a81963ba280e6a820d2)
  * **dia.HighlighterView** - add static `getAll()` method (7746050a3e8a4bfac8d0b749be2b53bfcb6970f3)
  * **dia.ToolsView** - fix to prevent tool `update()` from being called before previous `render()` due to visibility (f5df2d1b6fad47aa55304c580cfd2f604c12ebf6)
  * **dia.ToolView** - add `visibility` option callback (37065749db2efd7640df881b06a1f25e954aabcf)
  * **mvc.View** - fix to allow setting `style` via options (db0708250e46074bdf9c0ad2943c36544a66c5c8)
  * **util** - add `objectDifference()` method (bf753a1fb0421165b386b7e889553b985e8e6c7c)
  * **util** - expose `calc()` expression API (f8429461c2f5004fe830a135113fd046ff273b7a)
  * **util** - expose `cloneCells()` method (27d92fdc71ca6be3cc3d5966a6e0ab58c97e957c)
  * **Geometry** - add `strict` option to `containsPoint()` of `Rect` (ca06b4e5dd8221644441f41698cfd2bd1c36cd6b)

## @joint/layout-directed-graph
  * **layout.DirectedGraph** - add `graph` option to `fromGraphLib()` (66ab6b7e270f2e450e990c84adebbc1f64e5d006)