### PR TITLE
fix(dia.ToolsView): make sure tools are rendered before the first update

### DIFF
--- a/packages/joint-core/src/dia/ToolsView.mjs
+++ b/packages/joint-core/src/dia/ToolsView.mjs
@@ -121,7 +121,12 @@ export const ToolsView = mvc.View.extend({
     },
 
     show: function() {
-        return this.blurTool(null);
+        this.blurTool(null);
+        // If this the first time the tools are shown, make sure they are mounted
+        if (!this.isMounted()) {
+            this.mount();
+        }
+        return this;
     },
 
     onRemove: function() {

--- a/packages/joint-core/src/dia/ToolsView.mjs
+++ b/packages/joint-core/src/dia/ToolsView.mjs
@@ -52,15 +52,7 @@ export const ToolsView = mvc.View.extend({
             const tool = tools[i];
             tool.updateVisibility();
             if (!tool.isVisible()) continue;
-            if (!this.isRendered) {
-                // There is at least one visible tool
-                this.isRendered = Array(n).fill(false);
-            }
-            if (!this.isRendered[i]) {
-                // First update executes render()
-                tool.render();
-                this.isRendered[i] = true;
-            } else if (opt.tool !== tool.cid) {
+            if (this.ensureToolRendered(tools, i) && opt.tool !== tool.cid) {
                 tool.update();
             }
         }
@@ -77,6 +69,20 @@ export const ToolsView = mvc.View.extend({
             this.blurTool();
         }
         return this;
+    },
+
+    ensureToolRendered(tools, i) {
+        if (!this.isRendered) {
+            // There is at least one visible tool
+            this.isRendered = Array(tools.length).fill(false);
+        }
+        if (!this.isRendered[i]) {
+            // First update executes render()
+            tools[i].render();
+            this.isRendered[i] = true;
+            return false;
+        }
+        return true;
     },
 
     focusTool: function(focusedTool) {
@@ -103,7 +109,7 @@ export const ToolsView = mvc.View.extend({
                 tool.show();
                 // Check if the tool is conditionally visible too
                 if (tool.isVisible()) {
-                    tool.update();
+                    this.ensureToolRendered(tools, i) && tool.update();
                 }
             }
         }

--- a/packages/joint-core/test/jointjs/dia/linkTools.js
+++ b/packages/joint-core/test/jointjs/dia/linkTools.js
@@ -206,8 +206,10 @@ QUnit.module('linkTools', function(hooks) {
             linkView.hideTools();
             paper.unfreeze();
             assert.notOk(toolsView.isRendered);
+            assert.notOk(toolsView.el.isConnected);
             linkView.showTools();
             assert.ok(toolsView.isRendered);
+            assert.ok(toolsView.el.isConnected);
         });
     });
 

--- a/packages/joint-core/test/jointjs/dia/linkTools.js
+++ b/packages/joint-core/test/jointjs/dia/linkTools.js
@@ -196,6 +196,19 @@ QUnit.module('linkTools', function(hooks) {
                 button2UpdateSpy.restore();
             });
         });
+
+
+        QUnit.test('show()', function(assert) {
+            paper.freeze();
+            const remove = new joint.linkTools.Vertices();
+            const toolsView = new joint.dia.ToolsView({ tools: [remove] });
+            linkView.addTools(toolsView);
+            linkView.hideTools();
+            paper.unfreeze();
+            assert.notOk(toolsView.isRendered);
+            linkView.showTools();
+            assert.ok(toolsView.isRendered);
+        });
     });
 
     QUnit.module('RotateLabel', function() {


### PR DESCRIPTION
## Description

PR ensures that `update()` of tools is called after they are rendered.

```ts
paper.freeze();
const remove = new joint.linkTools.Vertices();
const toolsView = new joint.dia.ToolsView({ tools: [remove] });
linkView.addTools(toolsView);
linkView.hideTools();
paper.unfreeze();
// ASSERT: the tools are not rendered yet
linkView.showTools();
// ASSERT: tools are now rendered (previously an update was called without the tools being correctly rendered)