### PR TITLE
fix(layout.DirectedGraph): better error message when dagre fails to connect to container

### DIFF
--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -160,7 +160,16 @@ export const DirectedGraph = {
         glGraph.setGraph(glLabel);
 
         // Executes the layout.
-        dagreUtil.layout(glGraph, { debugTiming: !!opt.debugTiming });
+        try {
+            dagreUtil.layout(glGraph, { debugTiming: !!opt.debugTiming });
+        } catch (err) {
+            if (err instanceof TypeError) {
+                // see https://github.com/clientIO/joint/issues/455
+                throw new Error('DirectedGraph: It is not possible to connect a child to a container.');
+            } else {
+                throw err;
+            }
+        }
 
         // Wrap all graph changes into a batch.
         graph.startBatch('layout');


### PR DESCRIPTION
## Description

Provides a better error message when Dagre fails due to trying to connect a child to a container.

See https://github.com/clientIO/joint/issues/455 for more information and workarounds.