### PR TITLE
refactor(mvc.Listener): drop Vectorizer dependency

### DIFF
--- a/packages/joint-core/src/mvc/Listener.mjs
+++ b/packages/joint-core/src/mvc/Listener.mjs
@@ -1,4 +1,3 @@
-import V from '../V/index.mjs';
 import { Events } from './Events.mjs';
 
 export class Listener {
@@ -9,7 +8,7 @@ export class Listener {
     listenTo(object, evt, ...args) {
         const { callbackArguments } = this;
         // signature 1 - (object, eventHashMap, context)
-        if (V.isObject(evt)) {
+        if (evt && typeof evt === 'object') {
             const [context = null] = args;
             Object.entries(evt).forEach(([eventName, cb]) => {
                 if (typeof cb !== 'function') return;


### PR DESCRIPTION
## Description

Due to its dependency on `Vectorizer`, the `mvc.Listener` cannot be initialized in environments without access to the DOM (e.g. [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)). This PR removes that dependency.