### PR TITLE
fix(mvc.Dom): use getComputedStyle for static position check for position method

### DIFF
--- a/packages/joint-core/src/mvc/Dom/methods.mjs
+++ b/packages/joint-core/src/mvc/Dom/methods.mjs
@@ -337,8 +337,8 @@ export function position() {
         doc = el.ownerDocument;
         offsetParent = el.offsetParent || doc.documentElement;
         const isStaticallyPositioned = (el) => {
-            const { position } = el.style;
-            return !position || position === 'static';
+            const { position } = getComputedStyle(el);
+            return position === 'static';
         };
         while (offsetParent && offsetParent !== doc.documentElement && isStaticallyPositioned(offsetParent)) {
             offsetParent = offsetParent.offsetParent || doc.documentElement;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

This change updates the `position()` method to use the `getComputedStyle()` function to accurately retrieve the `position` property of the currently checked parent element. This ensures the proper handling of style inheritance and computed values.

## Motivation and Context

Fixes a bug introduced in #2852 by checking if the parent is statically positioned while retrieving the position in the `position()` method. This as a result led to incorrect positioning of the current view of the ui.Navigator plugin.
