### PR TITLE
feat(dia.HighlighterView): enable positioning of highlighter based on opt.z

### DIFF
--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -128,11 +128,11 @@ export const HighlighterView = mvc.View.extend({
             // we need to insert the highlighter before the element on the index.
             // Otherwise, the highlighter will be appended as the last child.
             const toBeInserted = isNumber(z) && beforeChild;
-            const isElementAtTargetPosition = toBeInserted ?
+            const isElementAtTargetPosition = toBeInserted
                 // If the element is being inserted, check if it is not already at the correct position.
-                el === beforeChild :
+                ? el === beforeChild
                 // If the element is being appended, check if it is not already last child.
-                !el.nextElementSibling;
+                : !el.nextElementSibling;
 
             // If the element is already mounted and does not require repositioning, do nothing.
             if (el.parentNode && isElementAtTargetPosition) return;

--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -107,7 +107,7 @@ export const HighlighterView = mvc.View.extend({
             return;
         }
         const { vel: cellViewRoot, paper } = cellView;
-        const { layer: layerName } = options;
+        const { layer: layerName, prepend } = options;
         if (layerName) {
             let vGroup;
             if (detachedTransformGroup) {
@@ -119,10 +119,14 @@ export const HighlighterView = mvc.View.extend({
             this.transformGroup = vGroup;
             paper.getLayerView(layerName).insertSortedNode(vGroup.node, options.z);
         } else {
-            // TODO: prepend vs append
-            if (!el.parentNode || el.nextSibling) {
-                // Not appended yet or not the last child
-                cellViewRoot.append(el);
+            const adjacentSibling = prepend ? el.previousSibling : el.nextSibling;
+            if (!el.parentNode || adjacentSibling) {
+                // Not appended yet or not the first/last child
+                if (prepend) {
+                    cellViewRoot.prepend(el);
+                } else {
+                    cellViewRoot.append(el);
+                }
             }
         }
     },

--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -1,6 +1,6 @@
 import * as mvc from '../mvc/index.mjs';
 import V from '../V/index.mjs';
-import { isPlainObject, result } from '../util/util.mjs';
+import { isNumber, isPlainObject, result } from '../util/util.mjs';
 
 function toArray(obj) {
     if (!obj) return [];
@@ -106,8 +106,8 @@ export const HighlighterView = mvc.View.extend({
             this.transform();
             return;
         }
-        const { vel: cellViewRoot, paper } = cellView;
-        const { layer: layerName, prepend } = options;
+        const { paper } = cellView;
+        const { layer: layerName, z } = options;
         if (layerName) {
             let vGroup;
             if (detachedTransformGroup) {
@@ -117,16 +117,30 @@ export const HighlighterView = mvc.View.extend({
                 vGroup = V('g').addClass('highlight-transform').append(el);
             }
             this.transformGroup = vGroup;
-            paper.getLayerView(layerName).insertSortedNode(vGroup.node, options.z);
+            paper.getLayerView(layerName).insertSortedNode(vGroup.node, z);
         } else {
-            const adjacentSibling = prepend ? el.previousSibling : el.nextSibling;
-            if (!el.parentNode || adjacentSibling) {
-                // Not appended yet or not the first/last child
-                if (prepend) {
-                    cellViewRoot.prepend(el);
-                } else {
-                    cellViewRoot.append(el);
-                }
+            const children = cellView.el.children;
+
+            const index = Math.max(z, 0);
+            const beforeChild = children[index];
+
+            // If the provided `z` is a number and there is an element on the index,
+            // we need to insert the highlighter before the element on the index.
+            // Otherwise, the highlighter will be appended as the last child.
+            const toBeInserted = isNumber(z) && beforeChild;
+            const isElementAtTargetPosition = toBeInserted ?
+                // If the element is being inserted, check if it is not already at the correct position.
+                el === beforeChild :
+                // If the element is being appended, check if it is not already last child.
+                !el.nextElementSibling;
+
+            // If the element is already mounted and does not require repositioning, do nothing.
+            if (el.parentNode && isElementAtTargetPosition) return;
+
+            if (toBeInserted) {
+                cellView.el.insertBefore(el, beforeChild);
+            } else {
+                cellView.el.appendChild(el);
             }
         }
     },

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -279,6 +279,20 @@ QUnit.module('HighlighterView', function(hooks) {
 
             });
 
+            QUnit.test('prepend', function(assert) {
+
+                var highlighter;
+                var id = 'highlighter-id';
+
+                // Prepend = true
+                highlighter = joint.dia.HighlighterView.add(elementView, 'body', id, {
+                    prepend: true
+                });
+
+                assert.equal(elementView.el.firstChild, highlighter.el);
+
+            });
+
             QUnit.test('z', function(assert) {
                 var layer = joint.dia.Paper.Layers.FRONT;
                 var h1 = joint.dia.HighlighterView.add(elementView, 'body', 'highlighter-id-1', { layer: layer, z: 2 });

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -279,21 +279,22 @@ QUnit.module('HighlighterView', function(hooks) {
 
             });
 
-            QUnit.test('prepend', function(assert) {
+            QUnit.test('z - cell view', function(assert) {
 
-                var highlighter;
-                var id = 'highlighter-id';
-
-                // Prepend = true
-                highlighter = joint.dia.HighlighterView.add(elementView, 'body', id, {
-                    prepend: true
+                const h1 = joint.dia.HighlighterView.add(elementView, 'body', 'highlighter-id-1', {
+                    z: 0
                 });
 
-                assert.equal(elementView.el.firstChild, highlighter.el);
+                const h2 = joint.dia.HighlighterView.add(elementView, 'body', 'highlighter-id-2', {
+                    z: 1
+                });
+
+                assert.equal(elementView.el.children[0], h1.el);
+                assert.equal(elementView.el.children[1], h2.el);
 
             });
 
-            QUnit.test('z', function(assert) {
+            QUnit.test('z - paper layer', function(assert) {
                 var layer = joint.dia.Paper.Layers.FRONT;
                 var h1 = joint.dia.HighlighterView.add(elementView, 'body', 'highlighter-id-1', { layer: layer, z: 2 });
                 var h2 = joint.dia.HighlighterView.add(elementView, 'body', 'highlighter-id-2', { layer: layer, z: 3  });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2067,6 +2067,7 @@ export namespace dia {
 
         interface Options extends mvc.ViewOptions<undefined, SVGElement> {
             layer?: dia.Paper.Layers | string | null;
+            prepend?: boolean;
             z?: number;
         }
     }

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2067,7 +2067,6 @@ export namespace dia {
 
         interface Options extends mvc.ViewOptions<undefined, SVGElement> {
             layer?: dia.Paper.Layers | string | null;
-            prepend?: boolean;
             z?: number;
         }
     }


### PR DESCRIPTION
## Description

This change introduces the ability to set the stacking order (`z-index`) for highlighters within the stacking context of `dia.CellView`. The `opt.z` controls whether a highlighter is inserted before or after other elements in the DOM hierarchy.

## Documentation

Update *layer* and *z* sections of the documentation to reflect the changes.

https://docs.jointjs.com/api/dia/HighlighterView/#options
### layer

**layer** - the stacking context of the highlighter. Applicable for [mountable](#mountable) highlighters only.

<table><tbody><tr><td>null</td><td>Render the highlighter within the dia.CellView, with its position determined by the provided z value. By default, the highlighter is rendered above the cell.</td></tr><tr><td>back</td><td>Render the highlighter behind all the cells.</td></tr><tr><td>front</td><td>Render the highlighter in front of all the cells.</td></tr></tbody></table>

### z

**z** - determines the stacking order (z-index) of the highlighter within the specified [layer](#layer) or directly within [dia.CellView](../CellView/CellView.mdx).

- If `layer` is defined, the highlighter is inserted into the specified [layer](#layer) at the correct position based on `z`.
- If `layer` is <b>not</b> defined, `z` represents the index within [dia.CellView](../CellView/CellView.mdx). If `z` is a valid number and corresponds to an existing child index, the highlighter is inserted before that child (e.g., if `z: 0`, the highlighter will be inserted before the first child element of the [dia.CellView](../CellView/CellView.mdx) - effectively resulting in prepending it under everything else); otherwise, it is appended as the last child.

Applicable for [mountable](#mountable) highlighters only.


