### PR TITLE
refactor(dia.ElementView): extract snap-to-grid logic into dedicated method

### DIFF
--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -804,17 +804,23 @@ export const ElementView = CellView.extend({
 
     // Drag Handlers
 
+    snapToGrid: function(evt, x, y) {
+        const grid = this.paper.options.gridSize;
+        return {
+            x: snapToGrid(x, grid),
+            y: snapToGrid(y, grid)
+        }
+    },
+
     drag: function(evt, x, y) {
 
         var paper = this.paper;
-        var grid = paper.options.gridSize;
         var element = this.model;
         var data = this.eventData(evt);
         var { pointerOffset, restrictedArea, embedding } = data;
 
         // Make sure the new element's position always snaps to the current grid
-        var elX = snapToGrid(x + pointerOffset.x, grid);
-        var elY = snapToGrid(y + pointerOffset.y, grid);
+        const { x: elX, y: elY } = this.snapToGrid(evt, x + pointerOffset.x, y + pointerOffset.y);
 
         element.position(elX, elY, { restrictedArea, deep: true, ui: true });
 

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -809,7 +809,7 @@ export const ElementView = CellView.extend({
         return {
             x: snapToGrid(x, grid),
             y: snapToGrid(y, grid)
-        }
+        };
     },
 
     drag: function(evt, x, y) {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1090,6 +1090,8 @@ export namespace dia {
 
         protected dragMagnetEnd(evt: dia.Event, x: number, y: number): void;
 
+        protected snapToGrid(evt: dia.Event, x: number, y: number): dia.Point;
+
         protected prepareEmbedding(data: any): void;
 
         protected processEmbedding(data: any, evt: dia.Event, x: number, y: number): void;


### PR DESCRIPTION
## Description

This change enables customization of the snap-to-grid behavior, allowing for:  
- Snapping to the element's center (or to any point)
- Using key modifiers to adjust snapping behavior

```ts
import { dia, g } from '@joint/core';

const paper = new dia.Paper({
    /* ... */
    elementView: jdia.ElementView.extend({
        snapToGrid: function(_evt, x, y) {
            const gridSize = this.paper.options.gridSize;
            const { width, height } = this.model.size();
            // snap to the center of the element to the grid
            const snapX = g.snapToGrid(x + width / 2, gridSize);
            const snapY = g.snapToGrid(y + height / 2, gridSize);
            return { x: snapX - width / 2, y: snapY - height / 2 };
        }
    })
});
```