### PR TITLE
feat(anchors): adds useModelGeometry option for relevant built-in anchors

### DIFF
--- a/examples/anchors-ts/.gitignore
+++ b/examples/anchors-ts/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+node_modules/

--- a/examples/anchors-ts/README.md
+++ b/examples/anchors-ts/README.md
@@ -1,0 +1,24 @@
+# JointJS Link Label Tools
+
+The example shows different tools for editing labels.
+
+## Setup
+
+Use Yarn to run this demo.
+
+You need to build *JointJS* first. Navigate to the root folder and run:
+```bash
+yarn install
+yarn run build
+```
+
+Navigate to this directory, then run:
+```bash
+yarn start
+```
+
+## License
+
+The *JointJS* library is licensed under the [Mozilla Public License 2.0](https://github.com/clientIO/joint/blob/master/LICENSE).
+
+Copyright © 2013-2024 client IO

--- a/examples/anchors-ts/index.html
+++ b/examples/anchors-ts/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" style="height:100%;">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="The JointJS Link Label Rotation demo serves as a template to help bring your idea to life in no time."/>
+    <title>Link Labels Typescript | JointJS</title>
+  </head>
+  <body style="height:100%;display:flex;justify-content:center;align-items:center;margin:0;overflow-y:hidden;">
+    <div id="paper"></div>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/examples/anchors-ts/index.html
+++ b/examples/anchors-ts/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="description" content="The JointJS Link Label Rotation demo serves as a template to help bring your idea to life in no time."/>
-    <title>Link Labels Typescript | JointJS</title>
+    <meta name="description" content="The JointJS link anchors demo serves as a template to help bring your idea to life in no time."/>
+    <title>Anchors Typescript | JointJS</title>
   </head>
   <body style="height:100%;display:flex;justify-content:center;align-items:center;margin:0;overflow-y:hidden;">
     <div id="paper"></div>

--- a/examples/anchors-ts/package.json
+++ b/examples/anchors-ts/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@joint/demo-anchors-ts",
+  "version": "4.1.1",
+  "main": "src/index.ts",
+  "homepage": "https://jointjs.com",
+  "author": {
+    "name": "client IO",
+    "url": "https://client.io"
+  },
+  "license": "MPL-2.0",
+  "private": true,
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "@joint/core": "workspace:^"
+  },
+  "devDependencies": {
+    "css-loader": "3.5.3",
+    "style-loader": "1.2.1",
+    "ts-loader": "^9.2.5",
+    "typescript": "^5.7.3",
+    "webpack": "^5.61.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.1"
+  },
+  "volta": {
+    "node": "16.18.1",
+    "npm": "8.19.2",
+    "yarn": "3.4.1"
+  }
+}

--- a/examples/anchors-ts/src/index.ts
+++ b/examples/anchors-ts/src/index.ts
@@ -19,6 +19,9 @@ const paper = new dia.Paper({
     cellViewNamespace: cellNamespace,
     gridSize: 10,
     async: true,
+    defaultConnectionPoint: {
+        name: 'anchor'
+    }
 });
 
 const el1 = new customShapes.Shape1({
@@ -30,10 +33,16 @@ const el1 = new customShapes.Shape1({
         width: 250,
         height: 120
     },
+    angle: 45,
     attrs: {
         extra: {
             y: 'calc(h)',
         }
+    },
+    ports: {
+        items: [{
+            id: 'port',
+        }]
     }
 });
 const el2 = new customShapes.Shape1({
@@ -45,24 +54,28 @@ const el2 = new customShapes.Shape1({
         width: 180,
         height: 350
     },
+    angle: 30
 });
 
 const l1 = new shapes.standard.Link({
     source: {
         id: el1.id,
+        port: 'port',
         anchor: {
-            name: 'midSide',
+            name: 'center',
             args: {
-                useModelGeometry: true
+                useModelGeometry: true,
+                rotate: true
             }
         }
     },
     target: {
         id: el2.id,
         anchor: {
-            name: 'perpendicular',
+            name: 'midSide',
             args: {
-                useModelGeometry: true
+                useModelGeometry: true,
+                rotate: true
             }
         }
     },

--- a/examples/anchors-ts/src/index.ts
+++ b/examples/anchors-ts/src/index.ts
@@ -30,6 +30,11 @@ const el1 = new customShapes.Shape1({
         width: 250,
         height: 120
     },
+    attrs: {
+        extra: {
+            y: 'calc(h)',
+        }
+    }
 });
 const el2 = new customShapes.Shape1({
     position: {
@@ -46,17 +51,23 @@ const l1 = new shapes.standard.Link({
     source: {
         id: el1.id,
         anchor: {
-            name: 'bottomLeft'
+            name: 'midSide',
+            args: {
+                useModelGeometry: true
+            }
         }
     },
     target: {
         id: el2.id,
         anchor: {
-            name: 'topRight',
+            name: 'perpendicular',
             args: {
                 useModelGeometry: true
             }
         }
+    },
+    router: {
+        name: 'rightAngle'
     },
     attrs: {
         line: {

--- a/examples/anchors-ts/src/index.ts
+++ b/examples/anchors-ts/src/index.ts
@@ -1,0 +1,68 @@
+import { dia, shapes } from '@joint/core';
+import * as customShapes from './shapes';
+
+const cellNamespace = {
+    ...shapes,
+    custom: customShapes
+}
+
+const graph = new dia.Graph({}, {
+    cellNamespace: cellNamespace
+});
+
+const paper = new dia.Paper({
+    el: document.getElementById('paper'),
+    width: 1000,
+    height: 1000,
+    overflow: true,
+    model: graph,
+    cellViewNamespace: cellNamespace,
+    gridSize: 10,
+    async: true,
+});
+
+const el1 = new customShapes.Shape1({
+    position: {
+        x: 100,
+        y: 270
+    },
+    size: {
+        width: 250,
+        height: 120
+    },
+});
+const el2 = new customShapes.Shape1({
+    position: {
+        x: 600,
+        y: 170
+    },
+    size: {
+        width: 180,
+        height: 350
+    },
+});
+
+const l1 = new shapes.standard.Link({
+    source: {
+        id: el1.id,
+        anchor: {
+            name: 'bottomLeft'
+        }
+    },
+    target: {
+        id: el2.id,
+        anchor: {
+            name: 'topRight',
+            args: {
+                useModelGeometry: true
+            }
+        }
+    },
+    attrs: {
+        line: {
+            strokeWidth: 3
+        }
+    }
+});
+
+graph.addCells([el1, el2, l1]);

--- a/examples/anchors-ts/src/shapes.ts
+++ b/examples/anchors-ts/src/shapes.ts
@@ -1,0 +1,36 @@
+import { dia, util } from '@joint/core';
+
+export class Shape1 extends dia.Element {
+    markup: string | dia.MarkupJSON = util.svg`
+        <rect @selector="body"></rect>
+        <rect @selector="extra"></rect>
+    `;
+
+    defaults() {
+        return util.defaultsDeep({
+            type: 'custom.Shape1',
+            size: {
+                width: 100,
+                height: 40
+            },
+            attrs: {
+                body: {
+                    strokeWidth: 2,
+                    stroke: 'black',
+                    fill: 'white',
+                    width: 'calc(w)',
+                    height: 'calc(h)'
+                },
+                extra: {
+                    x: 'calc(w/2)',
+                    y: -30,
+                    width: 40,
+                    height: 40,
+                    strokeWidth: 2,
+                    stroke: 'black',
+                    fill: 'white'
+                }
+            }
+        }, super.defaults);
+    }
+}

--- a/examples/anchors-ts/tsconfig.json
+++ b/examples/anchors-ts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "nodenext",
+        "module": "NodeNext",
+        "target": "es6",
+        "noImplicitAny": false,
+        "sourceMap": false,
+        "outDir": "./build"
+    }
+}

--- a/examples/anchors-ts/webpack.config.js
+++ b/examples/anchors-ts/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+
+module.exports = {
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js']
+    },
+    entry: './src/index.ts',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+        publicPath: '/dist/'
+    },
+    mode: 'development',
+    module: {
+        rules: [
+            { test: /\.ts$/, loader: 'ts-loader' },
+            {
+                test: /\.css$/,
+                sideEffects: true,
+                use: ['style-loader', 'css-loader'],
+            }
+        ]
+    },
+    devServer: {
+        static: {
+            directory: __dirname,
+        },
+        compress: true
+    },
+};

--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -6,8 +6,13 @@ function bboxWrapper(method) {
 
     return function(view, magnet, ref, opt) {
 
-        var rotate = !!opt.rotate;
-        var bbox = (rotate) ? view.getNodeUnrotatedBBox(magnet) : view.getNodeBBox(magnet);
+        const rotate = !!opt.rotate;
+        let bbox;
+        if (opt.useModelGeometry) {
+            bbox = view.model.getBBox();
+        } else {
+            bbox = (rotate) ? view.getNodeUnrotatedBBox(magnet) : view.getNodeBBox(magnet);
+        }
         var anchor = bbox[method]();
 
         var dx = opt.dx;
@@ -43,7 +48,7 @@ function bboxWrapper(method) {
 function _perpendicular(view, magnet, refPoint, opt) {
 
     var angle = view.model.angle();
-    var bbox = view.getNodeBBox(magnet);
+    var bbox = opt.useModelGeometry ? view.model.getBBox() : view.getNodeBBox(magnet);
     var anchor = bbox.center();
     var topLeft = bbox.origin();
     var bottomRight = bbox.corner();
@@ -69,11 +74,11 @@ function _midSide(view, magnet, refPoint, opt) {
     var rotate = !!opt.rotate;
     var bbox, angle, center;
     if (rotate) {
-        bbox = view.getNodeUnrotatedBBox(magnet);
+        bbox = opt.useModelGeometry ? view.model.getBBox() : view.getNodeUnrotatedBBox(magnet);
         center = view.model.getBBox().center();
         angle = view.model.angle();
     } else {
-        bbox = view.getNodeBBox(magnet);
+        bbox = opt.useModelGeometry ? view.model.getBBox() : view.getNodeBBox(magnet);
     }
 
     var padding = opt.padding;

--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -5,6 +5,11 @@ import { resolveRef } from '../linkAnchors/index.mjs';
 function bboxWrapper(method) {
 
     return function(view, magnet, ref, opt) {
+        // use model geometry only if the view is the same as the magnet
+        // allows magnetSelector and ports to work as expected
+        if (view.el !== magnet) {
+            opt.useModelGeometry = false;
+        }
 
         const rotate = !!opt.rotate;
         let bbox;
@@ -46,9 +51,14 @@ function bboxWrapper(method) {
 }
 
 function _perpendicular(view, magnet, refPoint, opt) {
+    // use model geometry only if the view is the same as the magnet
+    // allows magnetSelector and ports to work as expected
+    if (view.el !== magnet) {
+        opt.useModelGeometry = false;
+    }
 
     var angle = view.model.angle();
-    var bbox = opt.useModelGeometry ? view.model.getBBox() : view.getNodeBBox(magnet);
+    var bbox = opt.useModelGeometry ? view.model.getBBox().rotateAroundCenter(angle) : view.getNodeBBox(magnet);
     var anchor = bbox.center();
     var topLeft = bbox.origin();
     var bottomRight = bbox.corner();
@@ -70,6 +80,11 @@ function _perpendicular(view, magnet, refPoint, opt) {
 }
 
 function _midSide(view, magnet, refPoint, opt) {
+    // use model geometry only if the view is the same as the magnet
+    // allows magnetSelector and ports to work as expected
+    if (view.el !== magnet) {
+        opt.useModelGeometry = false;
+    }
 
     var rotate = !!opt.rotate;
     var bbox, angle, center;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -3782,7 +3782,11 @@ export namespace connectors {
 
 export namespace anchors {
 
-    interface RotateAnchorArguments {
+    interface ElementAnchorArguments {
+        useModelGeometry?: boolean;
+    }
+
+    interface RotateAnchorArguments extends ElementAnchorArguments {
         rotate?: boolean;
     }
 
@@ -3791,7 +3795,7 @@ export namespace anchors {
         dy?: number | string;
     }
 
-    interface PaddingAnchorArguments {
+    interface PaddingAnchorArguments extends ElementAnchorArguments {
         padding?: number;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Adds `useModelGeometry` attribute for relevant built-in anchors to allow using model bbox instead of view bbox for calculations.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

For example, when using ports together with built-in anchors there is a collision because shape's view contains ports which are usually rendered outside of the model bbox rectangle.

### Screenshots (if appropriate):
