### PR TITLE
feat(dia.Element): add filter and minRect options to fitToChildren() and fitParent()

### DIFF
--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -345,8 +345,12 @@ export const Element = Cell.extend({
         if (!graph) throw new Error('Element must be part of a graph.');
 
         // Get filtered element children.
-        let filterFn = (cell) => (cell.isElement());
-        if (typeof opt.filter === 'function') filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        let filterFn;
+        if (typeof opt.filter === 'function') {
+            filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        } else {
+            filterFn = (cell) => (cell.isElement());
+        }
         const childElements = this.getEmbeddedCells().filter(filterFn);
         if (childElements.length === 0) return this;
 
@@ -383,8 +387,12 @@ export const Element = Cell.extend({
         if (!parentElement || !parentElement.isElement()) return this;
 
         // Get filtered element children of parent element (i.e. this element + any sibling elements).
-        let filterFn = (cell) => (cell.isElement());
-        if (typeof opt.filter === 'function') filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        let filterFn;
+        if (typeof opt.filter === 'function') {
+            filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        } else {
+            filterFn = (cell) => (cell.isElement());
+        }
         const siblingElements = parentElement.getEmbeddedCells().filter(filterFn);
         if (siblingElements.length === 0) return this;
 

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -344,14 +344,8 @@ export const Element = Cell.extend({
         const { graph } = this;
         if (!graph) throw new Error('Element must be part of a graph.');
 
-        // Get filtered element children.
-        let filterFn;
-        if (typeof opt.filter === 'function') {
-            filterFn = (cell) => (cell.isElement() && opt.filter(cell));
-        } else {
-            filterFn = (cell) => (cell.isElement());
-        }
-        const childElements = this.getEmbeddedCells().filter(filterFn);
+        // Get element children, optionally filtered according to `opt.filter`.
+        const childElements = this._getFilteredChildren(opt.filter);
         if (childElements.length === 0) return this;
 
         this.startBatch('fit-embeds', opt);
@@ -386,14 +380,8 @@ export const Element = Cell.extend({
         const parentElement = this.getParentCell();
         if (!parentElement || !parentElement.isElement()) return this;
 
-        // Get filtered element children of parent element (i.e. this element + any sibling elements).
-        let filterFn;
-        if (typeof opt.filter === 'function') {
-            filterFn = (cell) => (cell.isElement() && opt.filter(cell));
-        } else {
-            filterFn = (cell) => (cell.isElement());
-        }
-        const siblingElements = parentElement.getEmbeddedCells().filter(filterFn);
+        // Get element children of parent element (i.e. this element + any sibling elements), optionally filtered according to `opt.filter`.
+        const siblingElements = parentElement._getFilteredChildren(opt.filter);
         if (siblingElements.length === 0) return this;
 
         this.startBatch('fit-parent', opt);
@@ -414,6 +402,16 @@ export const Element = Cell.extend({
         this.stopBatch('fit-parent');
 
         return this;
+    },
+
+    _getFilteredChildren: function(filter) {
+        let filterFn;
+        if (typeof filter === 'function') {
+            filterFn = (cell) => (cell.isElement() && filter(cell));
+        } else {
+            filterFn = (cell) => (cell.isElement());
+        }
+        return this.getEmbeddedCells().filter(filterFn);
     },
 
     // Assumption: This element is part of a graph.

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -344,7 +344,10 @@ export const Element = Cell.extend({
         const { graph } = this;
         if (!graph) throw new Error('Element must be part of a graph.');
 
-        const childElements = this.getEmbeddedCells().filter(cell => cell.isElement());
+        // Get filtered element children.
+        let filterFn = (cell) => (cell.isElement());
+        if (typeof opt.filter === 'function') filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        const childElements = this.getEmbeddedCells().filter(filterFn);
         if (childElements.length === 0) return this;
 
         this.startBatch('fit-embeds', opt);
@@ -357,7 +360,7 @@ export const Element = Cell.extend({
         }
 
         // Set new size and position of this element, based on:
-        // - union of bboxes of all children
+        // - union of bboxes of filtered element children
         // - inflated by given `opt.padding`
         this._fitToElements(Object.assign({ elements: childElements }, opt));
 
@@ -378,14 +381,16 @@ export const Element = Cell.extend({
         const parentElement = this.getParentCell();
         if (!parentElement || !parentElement.isElement()) return this;
 
-        // Get all children of parent element (i.e. this element + any sibling elements).
-        const siblingElements = parentElement.getEmbeddedCells().filter(cell => cell.isElement());
+        // Get filtered element children of parent element (i.e. this element + any sibling elements).
+        let filterFn = (cell) => (cell.isElement());
+        if (typeof opt.filter === 'function') filterFn = (cell) => (cell.isElement() && opt.filter(cell));
+        const siblingElements = parentElement.getEmbeddedCells().filter(filterFn);
         if (siblingElements.length === 0) return this;
 
         this.startBatch('fit-parent', opt);
 
         // Set new size and position of parent element, based on:
-        // - union of bboxes of all children of parent element (i.e. this element + any sibling elements)
+        // - union of bboxes of filtered element children of parent element (i.e. this element + any sibling elements)
         // - inflated by given `opt.padding`
         parentElement._fitToElements(Object.assign({ elements: siblingElements }, opt));
 
@@ -516,4 +521,3 @@ export const Element = Cell.extend({
 });
 
 assign(Element.prototype, elementPortPrototype);
-

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -346,7 +346,6 @@ export const Element = Cell.extend({
 
         // Get element children, optionally filtered according to `opt.filter`.
         const childElements = this._getFilteredChildren(opt.filter);
-        if (childElements.length === 0) return this;
 
         this.startBatch('fit-embeds', opt);
 
@@ -382,7 +381,6 @@ export const Element = Cell.extend({
 
         // Get element children of parent element (i.e. this element + any sibling elements), optionally filtered according to `opt.filter`.
         const siblingElements = parentElement._getFilteredChildren(opt.filter);
-        if (siblingElements.length === 0) return this;
 
         this.startBatch('fit-parent', opt);
 

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -364,6 +364,17 @@ export const Element = Cell.extend({
         // - inflated by given `opt.padding`
         this._fitToElements(Object.assign({ elements: childElements }, opt));
 
+        // Adjust size of this element to be at least `opt.minSize`:
+        const { width: minWidth, height: minHeight } = opt.minSize ?? {};
+        if (minWidth || minHeight) {
+            const { width, height } = this.getBBox();
+            const w = (minWidth && (width < minWidth)) ? minWidth : width;
+            const h = (minHeight && (height < minHeight)) ? minHeight : height;
+            parentElement.set({
+                size: { width: w, height: h }
+            }, opt);
+        }
+
         this.stopBatch('fit-embeds');
 
         return this;
@@ -393,6 +404,17 @@ export const Element = Cell.extend({
         // - union of bboxes of filtered element children of parent element (i.e. this element + any sibling elements)
         // - inflated by given `opt.padding`
         parentElement._fitToElements(Object.assign({ elements: siblingElements }, opt));
+
+        // Adjust size of parent element to be at least `opt.minSize`:
+        const { width: minWidth, height: minHeight } = opt.minSize ?? {};
+        if (minWidth || minHeight) {
+            const { width, height } = parentElement.getBBox();
+            const w = (minWidth && (width < minWidth)) ? minWidth : width;
+            const h = (minHeight && (height < minHeight)) ? minHeight : height;
+            parentElement.set({
+                size: { width: w, height: h }
+            }, opt);
+        }
 
         if (opt.deep) {
             // `opt.deep = true` means "fit all ancestors to their respective children".

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -370,7 +370,7 @@ export const Element = Cell.extend({
             const { width, height } = this.getBBox();
             const w = (minWidth && (width < minWidth)) ? minWidth : width;
             const h = (minHeight && (height < minHeight)) ? minHeight : height;
-            parentElement.set({
+            this.set({
                 size: { width: w, height: h }
             }, opt);
         }

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -344,8 +344,8 @@ export const Element = Cell.extend({
         const { graph } = this;
         if (!graph) throw new Error('Element must be part of a graph.');
 
-        // If there are no children, there is nothing for us to do.
-        // - note: we need to do this check before filtering with `opt.filter` because we don't want to apply `minRect` in this case.
+        // If this element has no children, there is nothing for us to do.
+        // - We need to do this check before filtering with `opt.filter` because we don't want to apply `minRect` in this case.
         const childElements = this.getEmbeddedCells().filter(cell => cell.isElement());
         if (childElements.length === 0) return this;
 
@@ -386,7 +386,7 @@ export const Element = Cell.extend({
         // If the current element is `opt.terminator`, it means that this element has already been processed as parent so we can exit now.
         if (opt.deep && opt.terminator && ((opt.terminator === this) || (opt.terminator === this.id))) return this;
 
-        // If there is no parent, there is nothing for us to do.
+        // If this element has no parent, there is nothing for us to do.
         const parentElement = this.getParentCell();
         if (!parentElement || !parentElement.isElement()) return this;
 

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -362,16 +362,14 @@ export const Element = Cell.extend({
         // Set new size and position of this element, based on:
         // - union of bboxes of filtered element children
         // - inflated by given `opt.padding`
+        // - containing at least `opt.minRect`
         this._fitToElements(Object.assign({ elements: childElements }, opt));
-
-        // Adjust size of this element to be at least `opt.minSize`:
-        const { width: minWidth, height: minHeight } = opt.minSize ?? {};
-        if (minWidth || minHeight) {
-            const { width, height } = this.getBBox();
-            const w = (minWidth && (width < minWidth)) ? minWidth : width;
-            const h = (minHeight && (height < minHeight)) ? minHeight : height;
+        if (opt.minRect) {
+            const minRect = new Rect(opt.minRect);
+            const adjustedBBox = this.getBBox().union(minRect);
             this.set({
-                size: { width: w, height: h }
+                position: { x: adjustedBBox.x, y: adjustedBBox.y },
+                size: { width: adjustedBBox.width, height: adjustedBBox.height }
             }, opt);
         }
 
@@ -403,16 +401,14 @@ export const Element = Cell.extend({
         // Set new size and position of parent element, based on:
         // - union of bboxes of filtered element children of parent element (i.e. this element + any sibling elements)
         // - inflated by given `opt.padding`
+        // - containing at least `opt.minRect`
         parentElement._fitToElements(Object.assign({ elements: siblingElements }, opt));
-
-        // Adjust size of parent element to be at least `opt.minSize`:
-        const { width: minWidth, height: minHeight } = opt.minSize ?? {};
-        if (minWidth || minHeight) {
-            const { width, height } = parentElement.getBBox();
-            const w = (minWidth && (width < minWidth)) ? minWidth : width;
-            const h = (minHeight && (height < minHeight)) ? minHeight : height;
+        if (opt.minRect) {
+            const minRect = new Rect(opt.minRect);
+            const adjustedBBox = parentElement.getBBox().union(minRect);
             parentElement.set({
-                size: { width: w, height: h }
+                position: { x: adjustedBBox.x, y: adjustedBBox.y },
+                size: { width: adjustedBBox.width, height: adjustedBBox.height }
             }, opt);
         }
 

--- a/packages/joint-core/test/jointjs/elements.js
+++ b/packages/joint-core/test/jointjs/elements.js
@@ -149,7 +149,13 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the ancestors only one level above.');
         });
 
-        QUnit.test('shallow + padding + minRect', function(assert) {
+        QUnit.test('shallow + padding + minRect (from `mainGroup`)', function(assert) {
+
+            this.mainGroup.fitParent({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect option is not applied when there is no parent.');
+        });
+
+        QUnit.test('shallow + padding + minRect (from `a`)', function(assert) {
 
             this.a.fitParent({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
@@ -171,6 +177,12 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option only applies to ancestors one level above.');
             assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above.');
             assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above (group2) and takes only filtered siblings into account (c).');
+        });
+
+        QUnit.test('shallow + filter + padding + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect option is applied for parent when all children are filtered out.');
         });
 
         QUnit.test('shallow + expandOnly', function(assert) {
@@ -225,7 +237,13 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Using padding does not expand second group.');
         });
 
-        QUnit.test('deep + padding + minRect', function(assert) {
+        QUnit.test('deep + padding + minRect (from `mainGroup`)', function(assert) {
+
+            this.mainGroup.fitParent({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: minRect option is not applied when there is no parent.');
+        });
+
+        QUnit.test('deep + padding + minRect (from `a`)', function(assert) {
 
             this.a.fitParent({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 622, 734), 'Deep: Using padding and minRect options is expanding the groups.');
@@ -324,6 +342,14 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (group2).');
             assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Using filter option takes only filtered siblings into account.');
             assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (c).');
+        });
+
+        QUnit.test('deep + filter + padding + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 211, 300), 'Deep: minRect option is taken into account for parent of parent when some children are filtered out.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: minRect option is not applied to sibling of parent which is not filtered out.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect option is applied for parent when all siblings are filtered out.');
         });
 
         QUnit.test('deep + expandOnly', function(assert) {
@@ -430,7 +456,13 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
         });
 
-        QUnit.test('shallow + padding + minRect', function(assert) {
+        QUnit.test('shallow + padding + minRect (from `a`)', function(assert) {
+
+            this.a.fitToChildren({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.a.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: minRect option is ignored when there are no children.');
+        });
+
+        QUnit.test('shallow + padding + minRect (from `mainGroup`)', function(assert) {
 
             this.mainGroup.fitToChildren({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 612, 312), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
@@ -452,6 +484,12 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option takes only filtered embeds one level deep into account.');
             assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account (a).');
             assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account.');
+        });
+
+        QUnit.test('shallow + filter + padding + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect option is applied when all children are filtered out.');
         });
 
         QUnit.test('shallow + expandOnly', function(assert) {
@@ -506,7 +544,13 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(495, 345, 120, 120), 'Deep: Using padding is expanding second group.');
         });
 
-        QUnit.test('deep + padding + minRect', function(assert) {
+        QUnit.test('deep + padding + minRect (from `a`)', function(assert) {
+
+            this.a.fitToChildren({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.a.getBBox(), new g.Rect(153, 153, 100, 100), 'Deep: minRect option is ignored when there are no children.');
+        });
+
+        QUnit.test('deep + padding + minRect (from `mainGroup`)', function(assert) {
 
             this.mainGroup.fitToChildren({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 635, 734), 'Deep: Using padding and minRect options is expanding the groups.');
@@ -528,6 +572,12 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option takes only filtered embeds into account.');
             assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account (a).');
             assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account.');
+        });
+
+        QUnit.test('deep + filter + padding + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect option is applied when all children are filtered out.');
         });
 
         QUnit.test('deep + expandOnly', function(assert) {

--- a/packages/joint-core/test/jointjs/elements.js
+++ b/packages/joint-core/test/jointjs/elements.js
@@ -149,40 +149,58 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the ancestors only one level above.');
         });
 
-        QUnit.test('shallow + padding + minRect (from `mainGroup`)', function(assert) {
+        QUnit.test('shallow + minRect (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitParent({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect option is not applied when there is no parent.');
+            this.mainGroup.fitParent({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect is not applied when there is no parent.');
         });
 
-        QUnit.test('shallow + padding + minRect (from `a`)', function(assert) {
+        QUnit.test('shallow + minRect (from `a`)', function(assert) {
 
-            this.a.fitParent({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
+            this.a.fitParent({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect is not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 254, 704), 'Shallow: minRect is applied to parent only (group1).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: minRect is not applied to sibling of parent.');
+        });
+
+        QUnit.test('shallow + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect is not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: minRect is not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 605, 455), 'Shallow: minRect is applied to parent only (group2).');
         });
 
         QUnit.test('shallow + filter (from `a`)', function(assert) {
 
-            this.a.fitParent({ filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option only applies to ancestors one level above.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above (group1) and takes only filtered siblings into account (a).');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above.');
+            this.a.fitParent({ filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(154, 604, 100, 100), 'Shallow: Only filtered siblings are taken into account (b).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to sibling of parent.');
         });
 
         QUnit.test('shallow + filter (from `c`)', function(assert) {
 
-            this.c.fitParent({ filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option only applies to ancestors one level above.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Shallow: Using filter option only applies to ancestors one level above (group2) and takes only filtered siblings into account (c).');
+            this.c.fitParent({ filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to element when all siblings are filtered out.');
         });
 
-        QUnit.test('shallow + filter + padding + minRect (from `c`)', function(assert) {
+        QUnit.test('shallow + filter + minRect (from `a`)', function(assert) {
 
-            this.c.fitParent({ filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect option is applied for parent when all children are filtered out.');
+            this.a.fitParent({ filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 254, 704), 'Shallow: minRect is applied to parent only (group1), only filtered siblings are taken into account (b).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to sibling of parent.');
+        });
+
+        QUnit.test('shallow + filter + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent of parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect is applied to parent only (group2) when all siblings are filtered out.');
         });
 
         QUnit.test('shallow + expandOnly', function(assert) {
@@ -237,18 +255,26 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Using padding does not expand second group.');
         });
 
-        QUnit.test('deep + padding + minRect (from `mainGroup`)', function(assert) {
+        QUnit.test('deep + minRect (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitParent({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: minRect option is not applied when there is no parent.');
+            this.mainGroup.fitParent({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: minRect is not applied when there is no parent.');
         });
 
-        QUnit.test('deep + padding + minRect (from `a`)', function(assert) {
+        QUnit.test('deep + minRect (from `a`)', function(assert) {
 
-            this.a.fitParent({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 622, 734), 'Deep: Using padding and minRect options is expanding the groups.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Deep: Using padding and minRect options is expanding first group.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Using padding and minRect options does not expand second group.');
+            this.a.fitParent({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 602, 704), 'Deep: Includes parent of parent (mainGroup), minRect is not applied.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 254, 704), 'Deep: minRect is applied to parent (group1).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: minRect is not applied to sibling of parent.');
+        });
+
+        QUnit.test('deep + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 605, 455), 'Deep: Includes parent of parent (mainGroup), minRect is not applied.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: minRect is not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 605, 455), 'Deep: minRect is applied to parent (group2).');
         });
 
         QUnit.test('deep + terminator', function(assert) {
@@ -330,26 +356,34 @@ QUnit.module('elements', function(hooks) {
 
         QUnit.test('deep + filter (from `a`)', function(assert) {
 
-            this.a.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (group2).');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (a).');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Using filter option takes only filtered siblings into account.');
+            this.a.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(154, 604, 100, 100), 'Deep: Includes parent of parent (mainGroup), only filtered siblings of parent are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(154, 604, 100, 100), 'Deep: Only filtered siblings are taken into account (b).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Not applied to sibling of parent.');
         });
 
         QUnit.test('deep + filter (from `c`)', function(assert) {
 
-            this.c.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (group2).');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Using filter option takes only filtered siblings into account.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Using filter option takes only filtered siblings into account (c).');
+            this.c.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Includes parent of parent (mainGroup), only filtered siblings of parent are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Not applied to element when all siblings are filtered out.');
         });
 
-        QUnit.test('deep + filter + padding + minRect (from `c`)', function(assert) {
+        QUnit.test('deep + filter + minRect (from `a`)', function(assert) {
 
-            this.c.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 211, 300), 'Deep: minRect option is taken into account for parent of parent when some children are filtered out.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: minRect option is not applied to sibling of parent which is not filtered out.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect option is applied for parent when all siblings are filtered out.');
+            this.a.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 254, 704), 'Deep: Includes parent of parent (mainGroup), only filtered siblings of parent are taken into account (group1), minRect is not applied.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 254, 704), 'Deep: minRect is applied to parent (group1), only filtered siblings are taken into account (b).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Not applied to sibling of parent.');
+        });
+
+        QUnit.test('deep + filter + minRect (from `c`)', function(assert) {
+
+            this.c.fitParent({ deep: true, filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Includes parent of parent (mainGroup), only filtered siblings of parent are taken into account (group1), minRect is not applied.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Not applied to sibling of parent.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect is applied to parent (group2) when all siblings are filtered out.');
         });
 
         QUnit.test('deep + expandOnly', function(assert) {
@@ -456,40 +490,58 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
         });
 
-        QUnit.test('shallow + padding + minRect (from `a`)', function(assert) {
+        QUnit.test('shallow + minRect (from `a`)', function(assert) {
 
-            this.a.fitToChildren({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.a.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: minRect option is ignored when there are no children.');
+            this.a.fitToChildren({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.a.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect is applied when there are no children.');
         });
 
-        QUnit.test('shallow + padding + minRect (from `mainGroup`)', function(assert) {
+        QUnit.test('shallow + minRect (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitToChildren({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 612, 312), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
+            this.mainGroup.fitToChildren({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 602, 302), 'Shallow: minRect is applied to element only (mainGroup).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: minRect is not applied to child.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: minRect is not applied to child.');
+        });
+
+        QUnit.test('shallow + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: minRect is not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: minRect is not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 605, 455), 'Shallow: minRect is applied to element only (group2).');
         });
 
         QUnit.test('shallow + filter (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitToChildren({ filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account (group2).');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account');
+            this.mainGroup.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Applied to element only (mainGroup), only filtered children are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Not applied to children of children.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to children of children.');
         });
 
-        QUnit.test('shallow + filter (from `group1`)', function(assert) {
+        QUnit.test('shallow + filter (from `group2`)', function(assert) {
 
-            this.group1.fitToChildren({ filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option takes only filtered embeds one level deep into account.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account (a).');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds one level deep into account.');
+            this.group1.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(154, 604, 100, 100), 'Shallow: Not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to element when all children are filtered out.');
         });
 
-        QUnit.test('shallow + filter + padding + minRect (from `group2`)', function(assert) {
+        QUnit.test('shallow + filter + minRect (from `mainGroup`)', function(assert) {
 
-            this.group2.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect option is applied when all children are filtered out.');
+            this.mainGroup.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 201, 300), 'Shallow: minRect is applied to element only (mainGroup), only filtered children are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Not applied to children of children.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Not applied to children of children.');
+        });
+
+        QUnit.test('shallow + filter + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Shallow: minRect is applied to element only (group2), when all children are filtered out.');
         });
 
         QUnit.test('shallow + expandOnly', function(assert) {
@@ -544,40 +596,58 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(495, 345, 120, 120), 'Deep: Using padding is expanding second group.');
         });
 
-        QUnit.test('deep + padding + minRect (from `a`)', function(assert) {
+        QUnit.test('deep + minRect (from `a`)', function(assert) {
 
-            this.a.fitToChildren({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.a.getBBox(), new g.Rect(153, 153, 100, 100), 'Deep: minRect option is ignored when there are no children.');
+            this.a.fitToChildren({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.a.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect is applied when there are no children.');
         });
 
-        QUnit.test('deep + padding + minRect (from `mainGroup`)', function(assert) {
+        QUnit.test('deep + minRect (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitToChildren({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 635, 734), 'Deep: Using padding and minRect options is expanding the groups.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Deep: Using padding and minRect options is expanding first group.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 615, 465), 'Deep: Using padding and minRect options is expanding second group.');
+            this.mainGroup.fitToChildren({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 605, 704), 'Deep: minRect is applied to element (mainGroup).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 101, 551), 'Deep: Includes child (group1), minRect is not applied.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Includes child (group2), minRect is not applied.');
+        });
+
+        QUnit.test('deep + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ deep: true, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: minRect is not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: minRect is not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 605, 455), 'Deep: minRect is applied to element (group2).');
         });
 
         QUnit.test('deep + filter (from `mainGroup`)', function(assert) {
 
-            this.mainGroup.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(505, 355, 100, 100), 'Deep: Using filter option takes only filtered embeds into account (group2 > c).');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account.');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(505, 355, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account (c)');
+            this.mainGroup.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(154, 604, 100, 100), 'Deep: Applied to element (mainGroup), only filtered children are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(154, 604, 100, 100), 'Deep: Includes filtered child (group1), only filtered children of child are taken into account (b).');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Not applied to filtered-out child.');
         });
 
-        QUnit.test('deep + filter (from `group1`)', function(assert) {
+        QUnit.test('deep + filter (from `group2`)', function(assert) {
 
-            this.group1.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') === true) });
-            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using filter option takes only filtered embeds into account.');
-            assert.deepEqual(this.group1.getBBox(), new g.Rect(153, 153, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account (a).');
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using filter option takes only filtered embeds into account.');
+            this.group2.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true) });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: Not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Not applied when all children are filtered out.');
         });
 
-        QUnit.test('deep + filter + padding + minRect (from `group2`)', function(assert) {
+        QUnit.test('deep + filter + minRect (from `mainGroup`)', function(assert) {
 
-            this.group2.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true), padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
-            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect option is applied when all children are filtered out.');
+            this.mainGroup.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 254, 704), 'Deep: minRect is applied to element (mainGroup), only filtered children are taken into account (group1).');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(154, 604, 100, 100), 'Deep: Includes filtered child (group1), only filtered children of filtered child are taken into account (b), minRect is not applied.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: minRect is not applied to filtered-out child.');
+        });
+
+        QUnit.test('deep + filter + minRect (from `group2`)', function(assert) {
+
+            this.group2.fitToChildren({ deep: true, filter: (cell) => (cell.prop('filter') !== true), minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Deep: Not applied to parent.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Deep: Not applied to sibling.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 200, 300), 'Deep: minRect is applied to element (group2) when all children are filtered out.');
         });
 
         QUnit.test('deep + expandOnly', function(assert) {

--- a/packages/joint-core/test/jointjs/elements.js
+++ b/packages/joint-core/test/jointjs/elements.js
@@ -139,12 +139,22 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Call takes ancestors only one level above into account.');
             assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Shallow: Call takes ancestors only one level above into account.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes ancestors only one level above into account.');
+        });
 
-            // padding:
+        QUnit.test('shallow + padding', function(assert) {
+
             this.a.fitParent({ padding: 10 });
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(50, 150, 500, 400), 'Shallow: Using padding options is expanding the ancestors only one level above.');
             assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Shallow: Using padding options is expanding the ancestors only one level above.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the ancestors only one level above.');
+        });
+
+        QUnit.test('shallow + padding + minRect', function(assert) {
+
+            this.a.fitParent({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(50, 150, 500, 400), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using padding and minRect options is expanding the ancestors only one level above.');
         });
 
         QUnit.test('shallow + filter (from `a`)', function(assert) {
@@ -205,12 +215,22 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 449, 551), 'Deep: Call takes all embedding ancestors into account.');
             assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: After the call the first group fits its embeds.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: After the call the second group is unchanged.');
+        });
 
-            // padding:
+        QUnit.test('deep + padding', function(assert) {
+
             this.a.fitParent({ deep: true, padding: 10 });
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 133, 479, 591), 'Deep: Using padding options is expanding the groups.');
             assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Deep: Using padding is expanding first group.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: Using padding does not expand second group.');
+        });
+
+        QUnit.test('deep + padding + minRect', function(assert) {
+
+            this.a.fitParent({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 622, 734), 'Deep: Using padding and minRect options is expanding the groups.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Deep: Using padding and minRect options is expanding first group.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Deep: Using padding and minRect options does not expand second group.');
         });
 
         QUnit.test('deep + terminator', function(assert) {
@@ -400,12 +420,22 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(101, 101, 501, 201), 'Shallow: Call takes embeds only one level deep into account.');
             assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Call takes embeds only one level deep into account.');
+        });
 
-            // padding:
+        QUnit.test('shallow + padding', function(assert) {
+
             this.mainGroup.fitToChildren({ padding: 10 });
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(91, 91, 521, 221), 'Shallow: Using padding options is expanding the groups only one level deep.');
             assert.deepEqual(this.group1.getBBox(), g.rect(101, 101, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Shallow: Using padding options is expanding the groups only one level deep.');
+        });
+
+        QUnit.test('shallow + padding + minRect', function(assert) {
+
+            this.mainGroup.fitToChildren({ padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(0, 0, 612, 312), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(101, 101, 100, 100), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(502, 202, 100, 100), 'Shallow: Using padding and minRect options is expanding the groups only one level deep.');
         });
 
         QUnit.test('shallow + filter (from `mainGroup`)', function(assert) {
@@ -466,12 +496,22 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(153, 153, 452, 551), 'Deep: Call takes all descendant embeds into account.');
             assert.deepEqual(this.group1.getBBox(), g.rect(153, 153, 101, 551), 'Deep: After the call the first group fits its embeds.');
             assert.deepEqual(this.group2.getBBox(), g.rect(505, 355, 100, 100), 'Deep: After the call the second group fits its embeds.');
+        });
 
-            // padding:
+        QUnit.test('deep + padding', function(assert) {
+
             this.mainGroup.fitToChildren({ deep: true, padding: 10 });
             assert.deepEqual(this.mainGroup.getBBox(), g.rect(133, 133, 492, 591), 'Deep: Using padding options is expanding the groups.');
             assert.deepEqual(this.group1.getBBox(), g.rect(143, 143, 121, 571), 'Deep: Using padding is expanding first group.');
             assert.deepEqual(this.group2.getBBox(), g.rect(495, 345, 120, 120), 'Deep: Using padding is expanding second group.');
+        });
+
+        QUnit.test('deep + padding + minRect', function(assert) {
+
+            this.mainGroup.fitToChildren({ deep: true, padding: 10, minRect: { x: 0, y: 0, width: 200, height: 300 } });
+            assert.deepEqual(this.mainGroup.getBBox(), new g.Rect(-10, -10, 635, 734), 'Deep: Using padding and minRect options is expanding the groups.');
+            assert.deepEqual(this.group1.getBBox(), new g.Rect(0, 0, 264, 714), 'Deep: Using padding and minRect options is expanding first group.');
+            assert.deepEqual(this.group2.getBBox(), new g.Rect(0, 0, 615, 465), 'Deep: Using padding and minRect options is expanding second group.');
         });
 
         QUnit.test('deep + filter (from `mainGroup`)', function(assert) {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -614,6 +614,7 @@ export namespace dia {
             filter?: (cell: Cell) => boolean;
             deep?: boolean;
             padding?: Padding;
+            minSize?: dia.Size;
             expandOnly?: boolean;
             shrinkOnly?: boolean;
         }

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -610,6 +610,18 @@ export namespace dia {
             direction?: Direction;
         }
 
+        interface FitToChildrenOptions {
+            filter?: (cell: Cell) => boolean;
+            deep?: boolean;
+            padding?: Padding;
+            expandOnly?: boolean;
+            shrinkOnly?: boolean;
+        }
+
+        interface FitParentOptions extends FitToChildrenOptions {
+            terminator?: Cell | Cell.ID;
+        }
+
         interface BBoxOptions extends Cell.EmbeddableOptions {
             rotate?: boolean;
         }
@@ -634,10 +646,10 @@ export namespace dia {
 
         scale(scaleX: number, scaleY: number, origin?: Point, opt?: { [key: string]: any }): this;
 
-        fitEmbeds(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean }): this;
-        fitToChildren(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean }): this;
+        fitEmbeds(opt?: Element.FitToChildrenOptions): this;
+        fitToChildren(opt?: Element.FitToChildrenOptions): this;
 
-        fitParent(opt?: { deep?: boolean, padding?: Padding, expandOnly?: boolean, shrinkOnly?: boolean, terminator?: Cell | Cell.ID }): this;
+        fitParent(opt?: Element.FitParentOptions): this;
 
         getBBox(opt?: Element.BBoxOptions): g.Rect;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -614,7 +614,7 @@ export namespace dia {
             filter?: (cell: Cell) => boolean;
             deep?: boolean;
             padding?: Padding;
-            minSize?: dia.Size;
+            minRect?: g.Rect;
             expandOnly?: boolean;
             shrinkOnly?: boolean;
         }


### PR DESCRIPTION
## Description

Provides two new options for `element.fitToChildren()` and `element.fitParent()` methods:
- `opt.filter` = provide a callback function that returns `true` when an element-type child should be included
- `opt.minRect` = provide an object with `x`, `y`, `width` and `height` which specifies a minimum rectangle that must be part of the bounding box after fitting (added via union with the fitting result)

Edge cases:
- `opt.padding` is not applied on top of `opt.minRect` because `opt.padding` only specifies padding that embedded elements must have from the bounding box after fitting and thus doesn't apply to empty space inside the minimal rectangle
- When used together with `opt.deep`, `opt.minRect` is only applied for the first iteration, but not for any other
  - If the element has no filtered children, then `fitToChildren()` applies `opt.minRect` to the element; this is not the case for further descendants.
  - If the element has no filtered siblings, then `fitParent()` applies `opt.minRect` to the parent; this is not the case for further ancestors.
- If there is no parent, then `fitParent()` exits early without considering `opt.minRect` (since there is nothing to apply it to).
- In all other cases where we previously exited early, `opt.minRect` is now applied instead as a last resort (if it is provided):
  - if there are no filtered elements
  - if `opt.expandOnly` and `opt.shrinkOnly` are used together
  - if `opt.shrinkOnly` is in use and all children are outside the element's bounding box

## Motivation and Context

The `filter` option gives you full control over what kinds of embedded elements should be included in fitting. This is useful when you implement additional control logic that affects the contents of parent elements (e.g. when some child elements become invisible).

The `minRect` option gives you an opportunity to specify a fallback minimal bounding box for fitting. This may be necessary when your container needs to show placeholder text, or in general, when your container resizes according to contents but must stay prominently visible when there is not enough content for it.

The following example combines the `filter` option with the `padding` and `minRect` options. The `minRect` option makes sure that the element in question (the container) has a minimal width and height so that it is always visible to users (even if it only contains one small element, or if all contained elements are filtered out), while the `padding` option ensures that the container provides enough visual space around elements when some are present:

```ts
fitToChildElements: function (flags) {
    const HEADER_HEIGHT = 30;
    const PADDING = 10;
    const MIN_WIDTH = 140;
    const MIN_HEIGHT = 100;
    const origin = this.getBBox().origin();
    this.fitToChildren(
        {
            filter: (child) => (!this.isChildFiltered(child)),
            padding: {
                top: HEADER_HEIGHT + PADDING,
                left: PADDING,
                right: PADDING,
                bottom: PADDING
            },
            minRect: { x: origin.x, y: origin.y, width: MIN_WIDTH, height: MIN_HEIGHT },
        },
        flags
      );
    }
```