### PR TITLE
fix(joint-layout-directed-graph): Accept 0 value for nodesep, edgesep, ranksep

### DIFF
--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -143,11 +143,11 @@ export const DirectedGraph = {
         // Alignment for rank nodes. Can be UL, UR, DL, or DR
         if (opt.align) glLabel.align = opt.align;
         // Number of pixels that separate nodes horizontally in the layout.
-        if (opt.nodeSep != null) glLabel.nodesep = opt.nodeSep;
+        if (util.isNumber(opt.nodeSep)) glLabel.nodesep = opt.nodeSep;
         // Number of pixels that separate edges horizontally in the layout.
-        if (opt.edgeSep != null) glLabel.edgesep = opt.edgeSep;
+        if (util.isNumber(opt.edgeSep)) glLabel.edgesep = opt.edgeSep;
         // Number of pixels between each rank in the layout.
-        if (opt.rankSep != null) glLabel.ranksep = opt.rankSep;
+        if (util.isNumber(opt.rankSep)) glLabel.ranksep = opt.rankSep;
         // Type of algorithm to assign a rank to each node in the input graph.
         // Possible values: network-simplex, tight-tree or longest-path
         if (opt.ranker) glLabel.ranker = opt.ranker;

--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -143,11 +143,11 @@ export const DirectedGraph = {
         // Alignment for rank nodes. Can be UL, UR, DL, or DR
         if (opt.align) glLabel.align = opt.align;
         // Number of pixels that separate nodes horizontally in the layout.
-        if (opt.nodeSep) glLabel.nodesep = opt.nodeSep;
+        if (opt.nodeSep != null) glLabel.nodesep = opt.nodeSep;
         // Number of pixels that separate edges horizontally in the layout.
-        if (opt.edgeSep) glLabel.edgesep = opt.edgeSep;
+        if (opt.edgeSep != null) glLabel.edgesep = opt.edgeSep;
         // Number of pixels between each rank in the layout.
-        if (opt.rankSep) glLabel.ranksep = opt.rankSep;
+        if (opt.rankSep != null) glLabel.ranksep = opt.rankSep;
         // Type of algorithm to assign a rank to each node in the input graph.
         // Possible values: network-simplex, tight-tree or longest-path
         if (opt.ranker) glLabel.ranker = opt.ranker;

--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -134,8 +134,8 @@ export const DirectedGraph = {
         });
 
         var glLabel = {};
-        var marginX = opt.marginX || 0;
-        var marginY = opt.marginY || 0;
+        var marginX = (util.isNumber(opt.marginX)) ? opt.marginX : 0;
+        var marginY = (util.isNumber(opt.marginY)) ? opt.marginY : 0;
 
         // Dagre layout accepts options as lower case.
         // Direction for rank nodes. Can be TB, BT, LR, or RL
@@ -152,9 +152,9 @@ export const DirectedGraph = {
         // Possible values: network-simplex, tight-tree or longest-path
         if (opt.ranker) glLabel.ranker = opt.ranker;
         // Number of pixels to use as a margin around the left and right of the graph.
-        if (marginX) glLabel.marginx = marginX;
+        glLabel.marginx = marginX;
         // Number of pixels to use as a margin around the top and bottom of the graph.
-        if (marginY) glLabel.marginy = marginY;
+        glLabel.marginy = marginY;
 
         // Set the option object for the graph label.
         glGraph.setGraph(glLabel);


### PR DESCRIPTION
## Description

Fixes #2894 by checking that provided value is a number. Uses dagre defaults otherwise.

Also applies the same check to the `marginx` and `marginy` values. Uses `0` otherwise (dagre default).
