### PR TITLE
fix(dia.HighlighterView): prevent highlighting nodes outside cell view

### DIFF
--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -71,7 +71,7 @@ export const HighlighterView = mvc.View.extend({
             }
         } else if (nodeSelector) {
             el = V.toNode(nodeSelector);
-            if (!(el instanceof SVGElement)) el = null;
+            if (!(el instanceof SVGElement) || !cellView.el.contains(el)) el = null;
         }
         return el ? el : null;
     },

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -400,6 +400,9 @@ QUnit.module('HighlighterView', function(hooks) {
 
             var highlightSpy = sinon.spy(joint.dia.HighlighterView.prototype, 'highlight');
             var unhighlightSpy = sinon.spy(joint.dia.HighlighterView.prototype, 'unhighlight');
+            var invalidSpy = sinon.spy();
+
+            paper.on('cell:highlight:invalid', invalidSpy);
 
             var id = 'highlighter-id';
             var node = elementView.el.querySelector('[joint-selector="body"]');
@@ -412,8 +415,10 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(highlightSpy.calledOnceWithExactly(elementView, node));
             assert.ok(highlightSpy.calledOn(highlighter));
             assert.ok(unhighlightSpy.notCalled);
+            assert.ok(invalidSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             // Re-render (will not highlight the node, because
             // it's not in the DOM anymore)
@@ -425,16 +430,21 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(unhighlightSpy.calledOnce);
             assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node));
             assert.ok(unhighlightSpy.calledOn(highlighter));
+            assert.ok(invalidSpy.calledOnce);
+            assert.ok(invalidSpy.calledOnceWithExactly(elementView, id, highlighter));
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             // Unhighlight
             joint.dia.HighlighterView.remove(elementView, id);
             assert.equal(joint.dia.HighlighterView.get(elementView, id), null);
             assert.notOk(unhighlightSpy.called);
             assert.ok(highlightSpy.notCalled);
+            assert.ok(invalidSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             // Highlight
             var id2 = 'highlighter-id-2';
@@ -442,6 +452,7 @@ QUnit.module('HighlighterView', function(hooks) {
             var highlighter2 = joint.dia.HighlighterView.add(elementView, node3, id2);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             // Update (Default will unhighlight and highlight)
             element.attr(['body', 'fill'], 'blue', { dirty: false });
@@ -453,8 +464,10 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(unhighlightSpy.calledOnce);
             assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node3));
             assert.ok(unhighlightSpy.calledOn(highlighter2));
+            assert.ok(invalidSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             // Unhighlight
             joint.dia.HighlighterView.remove(elementView, id2);
@@ -463,8 +476,10 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node3));
             assert.ok(unhighlightSpy.calledOn(highlighter2));
             assert.ok(highlightSpy.notCalled);
+            assert.ok(invalidSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
+            invalidSpy.resetHistory();
 
             highlightSpy.restore();
             unhighlightSpy.restore();

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -415,13 +415,13 @@ QUnit.module('HighlighterView', function(hooks) {
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
 
-            // Update (Default will unhighlight and highlight)
+            // Re-render (will not highlight the node, because
+            // it's not in the DOM anymore)
             element.attr(['body', 'fill'], 'red', { dirty: true });
             var node2 = elementView.el.querySelector('[joint-selector="body"]');
+            assert.ok(!node.isConnected);
             assert.notEqual(node, node2);
-            assert.ok(highlightSpy.calledOnce);
-            assert.ok(highlightSpy.calledOnceWithExactly(elementView, node));
-            assert.ok(highlightSpy.calledOn(highlighter));
+            assert.notOk(highlightSpy.called);
             assert.ok(unhighlightSpy.calledOnce);
             assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node));
             assert.ok(unhighlightSpy.calledOn(highlighter));
@@ -431,9 +431,37 @@ QUnit.module('HighlighterView', function(hooks) {
             // Unhighlight
             joint.dia.HighlighterView.remove(elementView, id);
             assert.equal(joint.dia.HighlighterView.get(elementView, id), null);
+            assert.notOk(unhighlightSpy.called);
+            assert.ok(highlightSpy.notCalled);
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            // Highlight
+            var id2 = 'highlighter-id-2';
+            var node3 = elementView.el.querySelector('[joint-selector="label"]');
+            var highlighter2 = joint.dia.HighlighterView.add(elementView, node3, id2);
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            // Update (Default will unhighlight and highlight)
+            element.attr(['body', 'fill'], 'blue', { dirty: false });
+            var node4 = elementView.el.querySelector('[joint-selector="label"]');
+            assert.equal(node3, node4);
+            assert.ok(highlightSpy.calledOnce);
+            assert.ok(highlightSpy.calledOnceWithExactly(elementView, node3));
+            assert.ok(highlightSpy.calledOn(highlighter2));
             assert.ok(unhighlightSpy.calledOnce);
-            assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node));
-            assert.ok(unhighlightSpy.calledOn(highlighter));
+            assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node3));
+            assert.ok(unhighlightSpy.calledOn(highlighter2));
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            // Unhighlight
+            joint.dia.HighlighterView.remove(elementView, id2);
+            assert.equal(joint.dia.HighlighterView.get(elementView, id2), null);
+            assert.ok(unhighlightSpy.calledOnce);
+            assert.ok(unhighlightSpy.calledOnceWithExactly(elementView, node3));
+            assert.ok(unhighlightSpy.calledOn(highlighter2));
             assert.ok(highlightSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();
@@ -607,9 +635,9 @@ QUnit.module('HighlighterView', function(hooks) {
             unhighlightSpy.resetHistory();
 
             // Update (Default will unhighlight and highlight)
-            link.attr(['line', 'stroke'], 'red', { dirty: true });
+            link.attr(['line', 'stroke'], 'red', { dirty: false });
             var node2 = linkView.el.querySelector('[joint-selector="line"]');
-            assert.notEqual(node, node2);
+            assert.equal(node, node2);
             assert.ok(highlightSpy.calledOnce);
             assert.ok(highlightSpy.calledOnceWithExactly(linkView, node));
             assert.ok(highlightSpy.calledOn(highlighter));
@@ -625,6 +653,33 @@ QUnit.module('HighlighterView', function(hooks) {
             assert.ok(unhighlightSpy.calledOnce);
             assert.ok(unhighlightSpy.calledOnceWithExactly(linkView, node));
             assert.ok(unhighlightSpy.calledOn(highlighter));
+            assert.ok(highlightSpy.notCalled);
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            var id2 = 'highlighter-id-2';
+            var node3 = linkView.el.querySelector('[joint-selector="wrapper"]');
+            var highlighter2 = joint.dia.HighlighterView.add(linkView, node3, id2);
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            // Re-render (will not highlight the node, because
+            // it's not in the DOM anymore)
+            link.attr(['line', 'stroke'], 'blue', { dirty: true });
+            var node4 = linkView.el.querySelector('[joint-selector="wrapper"]');
+            assert.ok(!node3.isConnected);
+            assert.notEqual(node3, node4);
+            assert.notOk(highlightSpy.calledOnce);
+            assert.ok(unhighlightSpy.calledOnce);
+            assert.ok(unhighlightSpy.calledOnceWithExactly(linkView, node3));
+            assert.ok(unhighlightSpy.calledOn(highlighter2));
+            highlightSpy.resetHistory();
+            unhighlightSpy.resetHistory();
+
+            // Unhighlight
+            joint.dia.HighlighterView.remove(linkView, id2);
+            assert.equal(joint.dia.HighlighterView.get(linkView, id2), null);
+            assert.notOk(unhighlightSpy.called);
             assert.ok(highlightSpy.notCalled);
             highlightSpy.resetHistory();
             unhighlightSpy.resetHistory();


### PR DESCRIPTION
## Description

When a highlighter is used with an `SVGElement` as its [NodeSelector](https://docs.jointjs.com/api/dia/HighlighterView/#nodeselector), and that element is not part of the `CellView`, the node will not be highlighted. Instead, a `cell:highlighter:invalid` event is triggered—similar to what happens with a non-existent selector.

## Motivation and Context

When a port is highlighted using an `SVGElement` selector and its attributes are updated, we need to make the highlighter invalid. This is because ports are re-rendered on each update, and the original `SVGElement` is removed from the DOM. The problem manifest during link reconnection, when the use set port attributes on `link:connect` event.

**Note:** This issue does not occur when using a JSON-based selector.
