### PR TITLE
fix(@joint/layout-directed-graph): refine top-level cluster filtering

### DIFF
--- a/packages/joint-layout-directed-graph/DirectedGraph.mjs
+++ b/packages/joint-layout-directed-graph/DirectedGraph.mjs
@@ -174,9 +174,9 @@ export const DirectedGraph = {
 
         if (opt.resizeClusters) {
             // Resize and reposition cluster elements
-            // Filter out top-level clusters and map them to cells
+            // Filter out top-level clusters (nodes without a parent and with children) and map them to cells
             const topLevelClusters = glGraph.nodes()
-                .filter(v => !glGraph.parent(v))
+                .filter(v => !glGraph.parent(v) && glGraph.children(v).length > 0)
                 .map(graph.getCell.bind(graph));
 
             // Since the `opt.deep` is set to `true`, the `fitToChildren` method is applied in reverse-depth

--- a/packages/joint-layout-directed-graph/test/index.js
+++ b/packages/joint-layout-directed-graph/test/index.js
@@ -354,5 +354,33 @@ QUnit.module('DirectedGraph', function(hooks) {
                 nextExpectedSize.height += padding * 2;
             }
         });
+
+        QUnit.test('should not resize clusters if `glGraph` does not hold reference to their children', function(assert) {
+
+            const containerSize = {
+                width: 500,
+                height: 500
+            };
+
+            const container1 = new joint.shapes.standard.Rectangle({ size: containerSize });
+            const container2 = new joint.shapes.standard.Rectangle({ size: containerSize });
+
+            const rect1 = new joint.shapes.standard.Rectangle({ size: { width: 60, height: 60 }});
+            const rect2 = new joint.shapes.standard.Rectangle({ size: { width: 120, height: 120 }});
+
+            container1.embed(rect1);
+            container2.embed(rect2);
+
+            graph.resetCells([container1, container2, rect1, rect2]);
+
+            // Do not pass the children to the layout function
+            DirectedGraph.layout([container1, container2], {
+                resizeClusters: true
+            });
+
+            // Size remains unchanged
+            assert.deepEqual(container1.size(), containerSize);
+            assert.deepEqual(container2.size(), containerSize);
+        });
     });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

The changes ensure that only the top-level clusters get resized if the glGraph has references to their children.

Added test for the scenario where the layout function is called with container elements without their children - the expected result is not resizing the containers, since the call to the function was made without the children.

## Motivation and Context

PR #2886 introduced a bug in the filtering logic for clusters to be resized. The original condition, `glGraph.children(v).length > 0`, accounted for special cases where no children were provided for layouting. However, the current implementation does not handle these cases correctly.
