### PR TITLE
fix(vitest-plugin-mock-svg): mock getScreenCTM()

### DIFF
--- a/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
+++ b/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
@@ -59,6 +59,14 @@ Object.defineProperty(globalThis.SVGElement.prototype, 'getComputedTextLength', 
 });
 
 /**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getScreenCTM
+ */
+Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => SVGMatrix),
+});
+
+/**
  * @description used in `util.breakText()` method
  * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getBBox
  */

--- a/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
+++ b/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
@@ -60,6 +60,8 @@ Object.defineProperty(globalThis.SVGElement.prototype, 'getComputedTextLength', 
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getScreenCTM
+ * Note: JSDOM SVGGraphicsElement does not encompass all SVG elements that might be needed,
+ * whereas SVGElement provides broader compatibility.
  */
 Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
     writable: true,

--- a/packages/joint-vitest-plugin-mock-svg/test/react/src/App.tsx
+++ b/packages/joint-vitest-plugin-mock-svg/test/react/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
     });
     rect.findView(paper).addTools(toolsView);
     rect.findView(paper).vel.translateAndAutoOrient({ x: 10, y: 10, }, { x: 100, y: 100 }, paper.svg);
+    (rect.findView(paper).el as SVGGElement).getScreenCTM()!.inverse();
 
     return () => {
       paper.remove();


### PR DESCRIPTION
## Description

Add missing `getScreenCTM()` method to all `SVGGraphicsElements`.

The method is actually added to `SVGElement` protoype. It is because JSDOM `SVGGraphicsElement` does not encompass all SVG elements that might be needed, whereas `SVGElement` provides broader compatibility.