### PR TITLE
feat(anchors): support for calc expressions in dx,dy options

### DIFF
--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -50,10 +50,16 @@ function bboxWrapper(method) {
 
         let dx = opt.dx;
         if (dx) {
-            const dxPercentage = util.isPercentage(dx);
-            dx = parseFloat(dx);
+            const isDxPercentage = util.isPercentage(dx);
+            if (!isDxPercentage && util.isCalcExpression(dx)) {
+                // calc expression
+                dx = Number(util.evalCalcExpression(dx, bbox));
+            } else {
+                // percentage or a number
+                dx = parseFloat(dx);
+            }
             if (isFinite(dx)) {
-                if (dxPercentage) {
+                if (isDxPercentage) {
                     dx /= 100;
                     dx *= bbox.width;
                 }
@@ -63,10 +69,16 @@ function bboxWrapper(method) {
 
         let dy = opt.dy;
         if (dy) {
-            const dyPercentage = util.isPercentage(dy);
-            dy = parseFloat(dy);
+            const isDyPercentage = util.isPercentage(dy);
+            if (!isDyPercentage && util.isCalcExpression(dy)) {
+                // calc expression
+                dy = Number(util.evalCalcExpression(dy, bbox));
+            } else {
+                // percentage or a number
+                dy = parseFloat(dy);
+            }
             if (isFinite(dy)) {
-                if (dyPercentage) {
+                if (isDyPercentage) {
                     dy /= 100;
                     dy *= bbox.height;
                 }

--- a/packages/joint-core/test/jointjs/dia/anchors.js
+++ b/packages/joint-core/test/jointjs/dia/anchors.js
@@ -245,6 +245,79 @@ QUnit.module('anchors', function(hooks) {
                 );
             });
 
+            QUnit.module(`${name}: dx,dy`, function() {
+
+                QUnit.test('number', function(assert) {
+                    const dx = 23;
+                    const dy = -47;
+                    const anchor = {
+                        name,
+                        args: {
+                            useModelGeometry: true,
+                            dx,
+                            dy
+                        }
+                    };
+
+                    link.prop(['source', 'anchor'], anchor, { rewrite: true });
+
+                    const expectedPoint = link.getSourceElement().getBBox()[method]().offset(dx, dy).round();
+
+                    assert.ok(
+                        expectedPoint.equals(linkView.sourceAnchor)
+                    );
+
+                });
+
+                QUnit.test('percentage', function(assert) {
+                    const dx = '23%';
+                    const dy = '-47%';
+                    const anchor = {
+                        name,
+                        args: {
+                            useModelGeometry: true,
+                            dx,
+                            dy
+                        }
+                    };
+
+                    link.prop(['source', 'anchor'], anchor, { rewrite: true });
+
+                    const sourceBBox = link.getSourceElement().getBBox();
+                    const dxValue = parseFloat(dx) / 100 * sourceBBox.width;
+                    const dyValue = parseFloat(dy) / 100 * sourceBBox.height;
+                    const expectedPoint = sourceBBox[method]().offset(dxValue, dyValue).round();
+
+                    assert.ok(
+                        expectedPoint.equals(linkView.sourceAnchor)
+                    );
+                });
+
+                QUnit.test('calc expression', function(assert) {
+                    const dx = 'calc(w + 23)';
+                    const dy = 'calc(h - 47)';
+                    const anchor = {
+                        name,
+                        args: {
+                            useModelGeometry: true,
+                            dx,
+                            dy
+                        }
+                    };
+
+                    link.prop(['source', 'anchor'], anchor, { rewrite: true });
+
+                    const sourceBBox = link.getSourceElement().getBBox();
+                    const dxValue = Number(joint.util.evalCalcExpression(dx, sourceBBox));
+                    const dyValue = Number(joint.util.evalCalcExpression(dy, sourceBBox));
+                    const expectedPoint = sourceBBox[method]().offset(dxValue, dyValue).round();
+
+                    assert.ok(
+                        expectedPoint.equals(linkView.sourceAnchor)
+                    );
+                });
+            });
+
         });
 
     });


### PR DESCRIPTION
## Description

Added support for _calc_ expressions when offsetting anchors (options `dx` and `dy`).

```ts
link.prop('source/anchor': {
  name: 'topLeft',
  args: {
     dx: 'calc(w - 20)', // previously only a number or percentage
     dy: 'calc(h - 20)'
  }
});
```
Support added for the following anchors: `center`, `top`, `bottom`, `left`, `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`



