### PR TITLE
fix(linkTools/Vertices): call blur when redundancyRemoval: false

### DIFF
--- a/packages/joint-core/src/linkTools/Vertices.mjs
+++ b/packages/joint-core/src/linkTools/Vertices.mjs
@@ -221,18 +221,16 @@ export const Vertices = ToolView.extend({
     onHandleChanged: function(_handle, evt) {
         const { options, relatedView: linkView } = this;
         if (options.vertexAdding) this.updatePath();
-        if (!options.redundancyRemoval) {
-            linkView.checkMouseleave(util.normalizeEvent(evt));
-            return;
+        if (options.redundancyRemoval) {
+            const verticesRemoved = linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
+            if (verticesRemoved) this.render();
         }
-        var verticesRemoved = linkView.removeRedundantLinearVertices({ ui: true, tool: this.cid });
-        if (verticesRemoved) this.render();
         this.blur();
         linkView.model.stopBatch('vertex-move', { ui: true, tool: this.cid });
         if (this.eventData(evt).vertexAdded) {
             linkView.model.stopBatch('vertex-add', { ui: true, tool: this.cid });
         }
-        var [normalizedEvt, x, y] = linkView.paper.getPointerArgs(evt);
+        const [normalizedEvt, x, y] = linkView.paper.getPointerArgs(evt);
         if (!options.stopPropagation) linkView.notifyPointerup(normalizedEvt, x, y);
         linkView.checkMouseleave(normalizedEvt);
     },


### PR DESCRIPTION
## Description

Fixes the blur logic of Vertices link tool when `redundancyRemoval: false`. We now call `blur()` as well as all appropriate `linkView` logic:
- stop the 'vertex-move' batch (and 'vertex-add', if relevant)
- `notifyPointerup()`
- `checkMouseleave()`

This brings the tool in line with other link tools when `redundancyRemoval: false`.