### PR TITLE
feat(dia.ports): port position args now provided inside position property

### DIFF
--- a/packages/joint-core/src/dia/ports.mjs
+++ b/packages/joint-core/src/dia/ports.mjs
@@ -145,8 +145,9 @@ PortData.prototype = {
             },
             group.position,
             {
-                // TODO: remove `port.args`
-                args: (port.position?.args ?? port.args)
+                // TODO: remove `port.args` backwards compatibility
+                // NOTE: `x != null` is equivalent to `x !== null && x !== undefined`
+                args: (((port.position != null) && (port.position.args != null)) ? port.position.args : port.args)
             }
         );
     },

--- a/packages/joint-core/src/dia/ports.mjs
+++ b/packages/joint-core/src/dia/ports.mjs
@@ -138,10 +138,17 @@ PortData.prototype = {
 
     _createPositionNode: function(group, port) {
 
-        return util.merge({
-            name: 'left',
-            args: {}
-        }, group.position, { args: port.args });
+        return util.merge(
+            {
+                name: 'left',
+                args: {}
+            },
+            group.position,
+            {
+                // TODO: deprecate `port.args`
+                args: (port.position?.args ?? port.args)
+            }
+        );
     },
 
     _getPosition: function(position, setDefault) {
@@ -901,4 +908,3 @@ export const elementViewPortPrototype = {
         return label.markup || this.model.get('portLabelMarkup') || this.model.portLabelMarkup || this.portLabelMarkup;
     }
 };
-

--- a/packages/joint-core/src/dia/ports.mjs
+++ b/packages/joint-core/src/dia/ports.mjs
@@ -145,7 +145,7 @@ PortData.prototype = {
             },
             group.position,
             {
-                // TODO: deprecate `port.args`
+                // TODO: remove `port.args`
                 args: (port.position?.args ?? port.args)
             }
         );

--- a/packages/joint-core/test/jointjs/basic.js
+++ b/packages/joint-core/test/jointjs/basic.js
@@ -1447,7 +1447,11 @@ QUnit.module('basic', function(hooks) {
                     { id: '1', group: 'in' },
                     { id: '2', group: 'in' },
                     { id: '3', group: 'out' },
-                    { id: '4', group: 'out' }
+                    { id: '4', group: 'out' },
+                    { id: 'left0' },
+                    { id: 'left1', args: { dx: 10 }},
+                    { id: 'left2', position: { args: { dx: 10 }}},
+                    { id: 'left3', position: { args: { dx: 10 }}, args: { dx: 20 }}
                 ]
             }
         });
@@ -1477,6 +1481,28 @@ QUnit.module('basic', function(hooks) {
                 assert.equal(foundEl, true, 'port DOM element should exist ("' + port + '")');
             }
         });
+
+        allPorts.forEach((port) => {
+            if (!port.startsWith('left')) return;
+
+            const $portEl = view.$el.find('[port="' + port + '"]');
+            const portParentEl = $portEl[0].parentElement;
+            const { translateX } = V.decomposeMatrix(V.transformStringToMatrix(portParentEl.attributes.transform.value));
+            switch (port) {
+                case 'left0':
+                    assert.equal(translateX, 0, 'no position arguments = no translation');
+                    break;
+                case 'left1':
+                    assert.equal(translateX, 10, '`args.dx: 10` provided = translation of 10px');
+                    break;
+                case 'left2':
+                    assert.equal(translateX, 10, '`position.args.dx: 10` provided = translation of 10px');
+                    break;
+                case 'left3':
+                    assert.equal(translateX, 10, '`position.args.dx: 10` has priority over `args.dx: 10` = translation of 10px');
+                    break;
+            }
+        })
     });
 
     QUnit.test('ref-x, ref-y, ref', function(assert) {

--- a/packages/joint-core/test/jointjs/basic.js
+++ b/packages/joint-core/test/jointjs/basic.js
@@ -1499,7 +1499,7 @@ QUnit.module('basic', function(hooks) {
                     assert.equal(translateX, 10, '`position.args.dx: 10` provided = translation of 10px');
                     break;
                 case 'left3':
-                    assert.equal(translateX, 10, '`position.args.dx: 10` has priority over `args.dx: 10` = translation of 10px');
+                    assert.equal(translateX, 10, '`position.args.dx: 10` has priority over `args.dx: 20` = translation of 10px');
                     break;
             }
         })

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -586,6 +586,9 @@ export namespace dia {
             markup?: string | MarkupJSON;
             group?: string;
             attrs?: Cell.Selectors;
+            position?: {
+                args?: { [key: string]: any };
+            };
             args?: { [key: string]: any };
             size?: Size;
             label?: {


### PR DESCRIPTION
## Description

Currently, port position arguments are read from top-level `args` port property, which is inconsistent with port groups and port labels (they both read those from `position.args` property).

This PR aligns the three - port's `position.args` are the source of truth for port position arguments. (To keep backwards compatibility, if there are no `position.args`, `args` are checked second.) For example:

```
g1.addPort({
    position: {
        args: {
            dx: 20
        }
    },
    attrs: {
        circle: {
            magnet: true,
            stroke: '#31d0c6',
            'stroke-width': 2,
            fill: '#ffffff'
        }
    }
});
```