### PR TITLE
chore: upgrade node in travis to v22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: focal
 node_js:
-  - 18
+  - 22
 addons:
   apt:
     packages:


### PR DESCRIPTION
## Description

Align node version we use with the node version used by Travis CI for running tests.