### PR TITLE
chore(joint-vitest-mock-svg): Fix mocks according to Jest

### DIFF
--- a/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
+++ b/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
@@ -1,12 +1,102 @@
 import { vi } from 'vitest';
 
+// Interfaces
+// ----------
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
+ */
+const createSVGAngle = () => ({
+    SVG_ANGLETYPE_UNKNOWN: 0,
+    SVG_ANGLETYPE_UNSPECIFIED: 1,
+    SVG_ANGLETYPE_DEG: 2,
+    SVG_ANGLETYPE_RAD: 3,
+    SVG_ANGLETYPE_GRAD: 4,
+});
+
+/**
+ * @description SVGMatrix is deprecated, we should use DOMMatrix instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix
+ */
+const createSVGMatrix = () => ({
+    a: 0,
+    b: 0,
+    c: 0,
+    d: 0,
+    e: 0,
+    f: 0,
+    flipX: vi.fn().mockImplementation(createSVGMatrix),
+    flipY: vi.fn().mockImplementation(createSVGMatrix),
+    inverse: vi.fn().mockImplementation(createSVGMatrix),
+    multiply: vi.fn().mockImplementation(createSVGMatrix),
+    rotate: vi.fn().mockImplementation(createSVGMatrix),
+    rotateFromVector: vi.fn().mockImplementation(createSVGMatrix),
+    scale: vi.fn().mockImplementation(createSVGMatrix),
+    scaleNonUniform: vi.fn().mockImplementation(createSVGMatrix),
+    skewX: vi.fn().mockImplementation(createSVGMatrix),
+    skewY: vi.fn().mockImplementation(createSVGMatrix),
+    translate: vi.fn().mockImplementation(createSVGMatrix),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
+ */
+const createSVGTransform = () => ({
+    type: 0,
+    angle: 0,
+    matrix: createSVGMatrix(),
+    SVG_TRANSFORM_UNKNOWN: 0,
+    SVG_TRANSFORM_MATRIX: 1,
+    SVG_TRANSFORM_TRANSLATE: 2,
+    SVG_TRANSFORM_SCALE: 3,
+    SVG_TRANSFORM_ROTATE: 4,
+    SVG_TRANSFORM_SKEWX: 5,
+    SVG_TRANSFORM_SKEWY: 6,
+    setMatrix: vi.fn(),
+    setRotate: vi.fn(),
+    setScale: vi.fn(),
+    setSkewX: vi.fn(),
+    setSkewY: vi.fn(),
+    setTranslate: vi.fn(),
+});
+
+/**
+ * @description SVGPoint is deprecated, we should use DOMPoint instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
+ */
+const createSVGPoint = () => ({
+    x: 0,
+    y: 0,
+    matrixTransform: vi.fn().mockImplementation(createSVGPoint),
+});
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGRect
+ */
+const createSVGRect = () => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+});
+
 // Mocks
 // -----
 
 /**
+ * @description Mock method which is not implemented in JSDOM
  * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement
  */
 globalThis.SVGPathElement = vi.fn();
+
+/**
+ * @description Mock SVGAngle which is used for sanity checks in Vectorizer library
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
+ */
+Object.defineProperty(globalThis, 'SVGAngle', {
+    writable: true,
+    value: vi.fn().mockImplementation(createSVGAngle),
+});
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
@@ -18,19 +108,11 @@ globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
 }));
 
 /**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
- */
-Object.defineProperty(globalThis, 'SVGAngle', {
-    writable: true,
-    value: vi.fn().mockImplementation(() => SVGAngle),
-});
-
-/**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement/createSVGMatrix
  */
 Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGMatrix', {
     writable: true,
-    value: vi.fn().mockImplementation(() => SVGMatrix),
+    value: vi.fn().mockImplementation(createSVGMatrix),
 });
 
 /**
@@ -38,7 +120,7 @@ Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGMatrix', {
  */
 Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGTransform', {
     writable: true,
-    value: vi.fn().mockImplementation(() => SVGTransform),
+    value: vi.fn().mockImplementation(createSVGTransform),
 });
 
 /**
@@ -46,7 +128,7 @@ Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGTransform', 
  */
 Object.defineProperty(globalThis.SVGSVGElement.prototype, 'createSVGPoint', {
     writable: true,
-    value: vi.fn().mockImplementation(() => SVGPoint),
+    value: vi.fn().mockImplementation(createSVGPoint),
 });
 
 /**
@@ -65,7 +147,7 @@ Object.defineProperty(globalThis.SVGElement.prototype, 'getComputedTextLength', 
  */
 Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
     writable: true,
-    value: vi.fn().mockImplementation(() => SVGMatrix),
+    value: vi.fn().mockImplementation(createSVGMatrix),
 });
 
 /**
@@ -74,84 +156,5 @@ Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
  */
 Object.defineProperty(globalThis.SVGElement.prototype, 'getBBox', {
     writable: true,
-    value: vi.fn().mockImplementation(() => SVGRect)
-});
-
-// Interfaces
-// ----------
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGAngle
- */
-const SVGAngle = ({
-    SVG_ANGLETYPE_UNKNOWN: 0,
-    SVG_ANGLETYPE_UNSPECIFIED: 1,
-    SVG_ANGLETYPE_DEG: 2,
-    SVG_ANGLETYPE_RAD: 3,
-    SVG_ANGLETYPE_GRAD: 4,
-});
-
-/**
- * @description SVGMatrix is deprecated, we should use DOMMatrix instead
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix
- */
-const SVGMatrix = ({
-    a: 0,
-    b: 0,
-    c: 0,
-    d: 0,
-    e: 0,
-    f: 0,
-    flipX: vi.fn().mockImplementation(() => SVGMatrix),
-    flipY: vi.fn().mockImplementation(() => SVGMatrix),
-    inverse: vi.fn().mockImplementation(() => SVGMatrix),
-    multiply: vi.fn().mockImplementation(() => SVGMatrix),
-    rotate: vi.fn().mockImplementation(() => SVGMatrix),
-    rotateFromVector: vi.fn().mockImplementation(() => SVGMatrix),
-    scale: vi.fn().mockImplementation(() => SVGMatrix),
-    scaleNonUniform: vi.fn().mockImplementation(() => SVGMatrix),
-    skewX: vi.fn().mockImplementation(() => SVGMatrix),
-    skewY: vi.fn().mockImplementation(() => SVGMatrix),
-    translate: vi.fn().mockImplementation(() => SVGMatrix),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGTransform
- */
-const SVGTransform = ({
-    type: 0,
-    angle: 0,
-    matrix: SVGMatrix,
-    SVG_TRANSFORM_UNKNOWN: 0,
-    SVG_TRANSFORM_MATRIX: 1,
-    SVG_TRANSFORM_TRANSLATE: 2,
-    SVG_TRANSFORM_SCALE: 3,
-    SVG_TRANSFORM_ROTATE: 4,
-    SVG_TRANSFORM_SKEWX: 5,
-    SVG_TRANSFORM_SKEWY: 6,
-    setMatrix: vi.fn(),
-    setRotate: vi.fn(),
-    setScale: vi.fn(),
-    setSkewX: vi.fn(),
-    setSkewY: vi.fn(),
-    setTranslate: vi.fn(),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint
- */
-const SVGPoint = ({
-    x: 0,
-    y: 0,
-    matrixTransform: vi.fn().mockImplementation(() => SVGPoint),
-});
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGRect
- */
-const SVGRect = ({
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
+    value: vi.fn().mockImplementation(createSVGRect)
 });

--- a/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
+++ b/packages/joint-vitest-plugin-mock-svg/mocks/index.ts
@@ -156,5 +156,5 @@ Object.defineProperty(globalThis.SVGElement.prototype, 'getScreenCTM', {
  */
 Object.defineProperty(globalThis.SVGElement.prototype, 'getBBox', {
     writable: true,
-    value: vi.fn().mockImplementation(createSVGRect)
+    value: vi.fn().mockImplementation(createSVGRect),
 });

--- a/packages/joint-vitest-plugin-mock-svg/test/vue/src/App.vue
+++ b/packages/joint-vitest-plugin-mock-svg/test/vue/src/App.vue
@@ -40,6 +40,7 @@ const toolsView = new dia.ToolsView({
 });
 rect.findView(paper).addTools(toolsView);
 rect.findView(paper).vel.translateAndAutoOrient({ x: 10, y: 10, }, { x: 100, y: 100 }, paper.svg);
+(rect.findView(paper).el as SVGGElement).getScreenCTM()!.inverse();
 
 onMounted(() => {
   canvas.value?.appendChild(paper.el);


### PR DESCRIPTION
## Description

Refactors mock logic according to a fix that was necessary to make the mocks work in Jest (https://github.com/clientIO/joint-plus-tutorial-react/pull/15). Applied here for consistency and/or eventual merging of the two duplicate codebases (i.e. [mocks/index.ts](https://github.com/clientIO/joint/blob/5a7f9e9cae8dd92a982643117f2d76479901ba40/packages/joint-vitest-plugin-mock-svg/mocks/index.ts) vs [setupTests.ts](https://github.com/clientIO/joint-plus-tutorial-react/blob/6e5eb9ca2a4f99f43bcfc981c6aee7dfa8432bac/src/setupTests.ts)):
- The `fn().mockImplementation(() => SVGMatrix)` pattern (where `const SVGMatrix = ({...});`) is replaced by `fn().mockImplementation(createSVGMatrix)` (where `const createSVGMatrix = () => ({...});`).

Also adds a line to Vue test matching that added to React test by https://github.com/clientIO/joint/pull/2913