### PR TITLE
feat(joint-react): add new set hooks and better ts support

### DIFF
--- a/packages/joint-react/.storybook/decorators/with-simple-data.tsx
+++ b/packages/joint-react/.storybook/decorators/with-simple-data.tsx
@@ -19,7 +19,7 @@ const initialElements = createElements([
     data: { label: 'Node 1', color: PRIMARY },
     x: 100,
     y: 20,
-    width: 100,
+    width: 150,
     height: 50,
   },
   {
@@ -27,7 +27,7 @@ const initialElements = createElements([
     data: { label: 'Node 2', color: PRIMARY },
     x: 200,
     y: 250,
-    width: 100,
+    width: 150,
     height: 50,
   },
 ]);
@@ -46,7 +46,7 @@ const defaultLinks = createLinks([
   },
 ]);
 
-function SimpleGraphProviderDecorator({ children }: Readonly<PropsWithChildren>) {
+export function SimpleGraphProviderDecorator({ children }: Readonly<PropsWithChildren>) {
   return (
     <GraphProvider defaultElements={initialElements} defaultLinks={defaultLinks}>
       {children}
@@ -68,14 +68,13 @@ export function RenderItemDecorator(
   }>
 ) {
   return (
-    <div style={{ width: '100%', height: 350 }}>
+    <div style={{ width: '100%', height: 450 }}>
       <SimpleGraphProviderDecorator>
         <Paper
           width={'100%'}
-          height={350}
+          height={450}
           renderElement={properties.renderElement}
           linkPinning={false}
-          // snapLinks={{ radius: 20 }}
         />
       </SimpleGraphProviderDecorator>
     </div>

--- a/packages/joint-react/docs/README.md
+++ b/packages/joint-react/docs/README.md
@@ -14,9 +14,12 @@
 
 ## Hooks
 
+- [useAddElement](functions/useAddElement.md)
+- [useAddLink](functions/useAddLink.md)
 - [useElements](functions/useElements.md)
 - [useGraph](functions/useGraph.md)
 - [useLinks](functions/useLinks.md)
+- [useRemoveCell](functions/useRemoveCell.md)
 - [useSetElement](functions/useSetElement.md)
 
 ## Models
@@ -75,6 +78,7 @@ const paper = usePaper();
 - [PaperProps](interfaces/PaperProps.md)
 - [PortGroupProps](interfaces/PortGroupProps.md)
 - [PortProps](interfaces/PortProps.md)
+- [ReactElementAttributes](interfaces/ReactElementAttributes.md)
 - [StrokeHighlighterProps](interfaces/StrokeHighlighterProps.md)
 - [TextNodeProps](interfaces/TextNodeProps.md)
 

--- a/packages/joint-react/docs/classes/ReactElement.md
+++ b/packages/joint-react/docs/classes/ReactElement.md
@@ -224,7 +224,7 @@ Defined in: [joint-core/types/joint.d.ts:485](https://github.com/samuelgja/joint
 
 > **bind**(`eventName`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3241)
+Defined in: [joint-core/types/joint.d.ts:3243](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3243)
 
 ##### Parameters
 
@@ -252,7 +252,7 @@ Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/join
 
 > **bind**(`eventMap`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3242](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3242)
+Defined in: [joint-core/types/joint.d.ts:3244](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3244)
 
 ##### Parameters
 
@@ -300,7 +300,7 @@ Defined in: [joint-core/types/joint.d.ts:503](https://github.com/samuelgja/joint
 
 > **changedAttributes**(`attributes`?): `false` \| [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)\<`Attributes` & `Attributes`\>
 
-Defined in: [joint-core/types/joint.d.ts:3327](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3327)
+Defined in: [joint-core/types/joint.d.ts:3329](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3329)
 
 Return an object containing all the attributes that have changed, or
 false if there are no changed attributes. Useful for determining what
@@ -329,7 +329,7 @@ determining if there *would be* a change.
 
 > **clear**(`options`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3328](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3328)
+Defined in: [joint-core/types/joint.d.ts:3330](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3330)
 
 #### Parameters
 
@@ -455,7 +455,7 @@ Defined in: [joint-core/types/joint.d.ts:499](https://github.com/samuelgja/joint
 
 > **escape**(`attribute`): `string`
 
-Defined in: [joint-core/types/joint.d.ts:3330](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3330)
+Defined in: [joint-core/types/joint.d.ts:3332](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3332)
 
 #### Parameters
 
@@ -565,7 +565,7 @@ Defined in: [joint-core/types/joint.d.ts:658](https://github.com/samuelgja/joint
 
 > **get**\<`A`\>(`attributeName`): `undefined` \| `Attributes` & `Attributes`\[`A`\]
 
-Defined in: [joint-core/types/joint.d.ts:3306](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3306)
+Defined in: [joint-core/types/joint.d.ts:3308](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3308)
 
 For strongly-typed access to attributes, use the `get` method only privately in public getter properties.
 
@@ -1035,7 +1035,7 @@ Defined in: [joint-core/types/joint.d.ts:495](https://github.com/samuelgja/joint
 
 > **has**(`attribute`): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3331](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3331)
+Defined in: [joint-core/types/joint.d.ts:3333](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3333)
 
 #### Parameters
 
@@ -1057,7 +1057,7 @@ Defined in: [joint-core/types/joint.d.ts:3331](https://github.com/samuelgja/join
 
 > **hasChanged**(`attribute`?): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3332](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3332)
+Defined in: [joint-core/types/joint.d.ts:3334](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3334)
 
 #### Parameters
 
@@ -1117,7 +1117,7 @@ Defined in: [joint-core/types/joint.d.ts:675](https://github.com/samuelgja/joint
 
 > **initialize**(`attributes`?, `options`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:3296](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3296)
+Defined in: [joint-core/types/joint.d.ts:3298](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3298)
 
 #### Parameters
 
@@ -1247,7 +1247,7 @@ Defined in: [joint-core/types/joint.d.ts:509](https://github.com/samuelgja/joint
 
 > **isValid**(`options`?): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3333](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3333)
+Defined in: [joint-core/types/joint.d.ts:3335](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3335)
 
 #### Parameters
 
@@ -1271,7 +1271,7 @@ Defined in: [joint-core/types/joint.d.ts:3333](https://github.com/samuelgja/join
 
 > **listenTo**(`object`, `events`, `callback`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3247)
+Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3249)
 
 ##### Parameters
 
@@ -1299,7 +1299,7 @@ Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/join
 
 > **listenTo**(`object`, `eventMap`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3248)
+Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3250)
 
 ##### Parameters
 
@@ -1327,7 +1327,7 @@ Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/join
 
 > **listenToOnce**(`object`, `events`, `callback`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3249)
+Defined in: [joint-core/types/joint.d.ts:3251](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3251)
 
 ##### Parameters
 
@@ -1355,7 +1355,7 @@ Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/join
 
 > **listenToOnce**(`object`, `eventMap`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3250)
+Defined in: [joint-core/types/joint.d.ts:3252](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3252)
 
 ##### Parameters
 
@@ -1381,7 +1381,7 @@ Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/join
 
 > **off**(`eventName`?, `callback`?, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3239](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3239)
+Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3241)
 
 #### Parameters
 
@@ -1413,7 +1413,7 @@ Defined in: [joint-core/types/joint.d.ts:3239](https://github.com/samuelgja/join
 
 > **on**(`eventName`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3237](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3237)
+Defined in: [joint-core/types/joint.d.ts:3239](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3239)
 
 ##### Parameters
 
@@ -1441,7 +1441,7 @@ Defined in: [joint-core/types/joint.d.ts:3237](https://github.com/samuelgja/join
 
 > **on**(`eventMap`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3238](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3238)
+Defined in: [joint-core/types/joint.d.ts:3240](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3240)
 
 ##### Parameters
 
@@ -1469,7 +1469,7 @@ Defined in: [joint-core/types/joint.d.ts:3238](https://github.com/samuelgja/join
 
 > **once**(`events`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3245)
+Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3247)
 
 ##### Parameters
 
@@ -1497,7 +1497,7 @@ Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/join
 
 > **once**(`eventMap`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3246](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3246)
+Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3248)
 
 ##### Parameters
 
@@ -1651,7 +1651,7 @@ Defined in: [joint-core/types/joint.d.ts:643](https://github.com/samuelgja/joint
 
 > **preinitialize**(`attributes`?, `options`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:3293](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3293)
+Defined in: [joint-core/types/joint.d.ts:3295](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3295)
 
 For use with models as ES classes. If you define a preinitialize
 method, it will be invoked when the Model is first created, before
@@ -1681,7 +1681,7 @@ any instantiation logic is run for the Model.
 
 > **previous**\<`A`\>(`attribute`): `undefined` \| `null` \| `Attributes` & `Attributes`\[`A`\]
 
-Defined in: [joint-core/types/joint.d.ts:3334](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3334)
+Defined in: [joint-core/types/joint.d.ts:3336](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3336)
 
 #### Type Parameters
 
@@ -1709,7 +1709,7 @@ Defined in: [joint-core/types/joint.d.ts:3334](https://github.com/samuelgja/join
 
 > **previousAttributes**(): [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)\<`Attributes` & `Attributes`\>
 
-Defined in: [joint-core/types/joint.d.ts:3335](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3335)
+Defined in: [joint-core/types/joint.d.ts:3337](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3337)
 
 #### Returns
 
@@ -2045,7 +2045,7 @@ Defined in: [joint-core/types/joint.d.ts:655](https://github.com/samuelgja/joint
 
 > **set**\<`A`\>(`attributeName`, `value`?, `options`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3315](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3315)
+Defined in: [joint-core/types/joint.d.ts:3317](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3317)
 
 For strongly-typed assignment of attributes, use the `set` method only privately in public setter properties.
 
@@ -2089,7 +2089,7 @@ set name(value: string) {
 
 > **set**(`attributeName`, `options`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3316](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3316)
+Defined in: [joint-core/types/joint.d.ts:3318](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3318)
 
 For strongly-typed assignment of attributes, use the `set` method only privately in public setter properties.
 
@@ -2123,7 +2123,7 @@ set name(value: string) {
 
 > **set**\<`A`\>(`attributeName`, `value`?, `options`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3317](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3317)
+Defined in: [joint-core/types/joint.d.ts:3319](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3319)
 
 For strongly-typed assignment of attributes, use the `set` method only privately in public setter properties.
 
@@ -2291,7 +2291,7 @@ Defined in: [joint-core/types/joint.d.ts:515](https://github.com/samuelgja/joint
 
 > **stopListening**(`object`?, `events`?, `callback`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3251](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3251)
+Defined in: [joint-core/types/joint.d.ts:3253](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3253)
 
 #### Parameters
 
@@ -2477,7 +2477,7 @@ Defined in: [joint-core/types/joint.d.ts:640](https://github.com/samuelgja/joint
 
 > **trigger**(`eventName`, ...`args`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3240](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3240)
+Defined in: [joint-core/types/joint.d.ts:3242](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3242)
 
 #### Parameters
 
@@ -2503,7 +2503,7 @@ Defined in: [joint-core/types/joint.d.ts:3240](https://github.com/samuelgja/join
 
 > **unbind**(`eventName`?, `callback`?, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3243](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3243)
+Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3245)
 
 #### Parameters
 
@@ -2559,7 +2559,7 @@ Defined in: [joint-core/types/joint.d.ts:501](https://github.com/samuelgja/joint
 
 > **unset**(`attribute`, `options`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3336](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3336)
+Defined in: [joint-core/types/joint.d.ts:3338](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3338)
 
 #### Parameters
 
@@ -2585,7 +2585,7 @@ Defined in: [joint-core/types/joint.d.ts:3336](https://github.com/samuelgja/join
 
 > **validate**(`attributes`, `options`?): `any`
 
-Defined in: [joint-core/types/joint.d.ts:3337](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3337)
+Defined in: [joint-core/types/joint.d.ts:3339](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3339)
 
 #### Parameters
 
@@ -2661,7 +2661,7 @@ Defined in: [joint-core/types/joint.d.ts:699](https://github.com/samuelgja/joint
 
 > `static` **extend**(`properties`, `classProperties`?): `any`
 
-Defined in: [joint-core/types/joint.d.ts:3266](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3266)
+Defined in: [joint-core/types/joint.d.ts:3268](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3268)
 
 Do not use, prefer TypeScript's extend functionality.
 
@@ -2689,7 +2689,7 @@ Do not use, prefer TypeScript's extend functionality.
 
 > **attributes**: [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)\<`Attributes` & `Attributes`\>
 
-Defined in: [joint-core/types/joint.d.ts:3268](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3268)
+Defined in: [joint-core/types/joint.d.ts:3270](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3270)
 
 #### Inherited from
 
@@ -2701,7 +2701,7 @@ Defined in: [joint-core/types/joint.d.ts:3268](https://github.com/samuelgja/join
 
 > **changed**: [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)\<`Attributes` & `Attributes`\>
 
-Defined in: [joint-core/types/joint.d.ts:3269](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3269)
+Defined in: [joint-core/types/joint.d.ts:3271](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3271)
 
 #### Inherited from
 
@@ -2713,7 +2713,7 @@ Defined in: [joint-core/types/joint.d.ts:3269](https://github.com/samuelgja/join
 
 > **cid**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3271](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3271)
+Defined in: [joint-core/types/joint.d.ts:3273](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3273)
 
 #### Inherited from
 
@@ -2725,7 +2725,7 @@ Defined in: [joint-core/types/joint.d.ts:3271](https://github.com/samuelgja/join
 
 > **cidPrefix**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3270](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3270)
+Defined in: [joint-core/types/joint.d.ts:3272](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3272)
 
 #### Inherited from
 
@@ -2737,7 +2737,7 @@ Defined in: [joint-core/types/joint.d.ts:3270](https://github.com/samuelgja/join
 
 > **collection**: `Collection`\<`ReactElement`\<`Attributes`\>\>
 
-Defined in: [joint-core/types/joint.d.ts:3272](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3272)
+Defined in: [joint-core/types/joint.d.ts:3274](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3274)
 
 #### Inherited from
 
@@ -2773,7 +2773,7 @@ Defined in: [joint-core/types/joint.d.ts:446](https://github.com/samuelgja/joint
 
 > **idAttribute**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3285](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3285)
+Defined in: [joint-core/types/joint.d.ts:3287](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3287)
 
 #### Inherited from
 
@@ -2809,7 +2809,7 @@ Defined in: [joint-core/types/joint.d.ts:449](https://github.com/samuelgja/joint
 
 > **validationError**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:3286](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3286)
+Defined in: [joint-core/types/joint.d.ts:3288](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3288)
 
 #### Inherited from
 

--- a/packages/joint-react/docs/functions/createElements.md
+++ b/packages/joint-react/docs/functions/createElements.md
@@ -6,9 +6,9 @@
 
 # Function: createElements()
 
-> **createElements**\<`Data`, `Type`, `Element`\>(`data`): `Element` & `object`[]
+> **createElements**\<`Data`, `Type`, `Element`\>(`data`): `Element` & `RequiredElementProps`[]
 
-Defined in: [joint-react/src/utils/create.ts:30](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L30)
+Defined in: [joint-react/src/utils/create.ts:36](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L36)
 
 Create elements helper function.
 
@@ -20,7 +20,7 @@ Create elements helper function.
 
 ### Type
 
-`Type` *extends* `string` = `string`
+`Type` *extends* `string` = `"react"`
 
 ### Element
 
@@ -36,7 +36,7 @@ Array of elements to create.
 
 ## Returns
 
-`Element` & `object`[]
+`Element` & `RequiredElementProps`[]
 
 Array of elements. (Nodes)
 

--- a/packages/joint-react/docs/functions/createLinks.md
+++ b/packages/joint-react/docs/functions/createLinks.md
@@ -8,7 +8,7 @@
 
 > **createLinks**\<`Link`, `Type`\>(`data`): `Link` & [`GraphLink`](../interfaces/GraphLink.md)[]
 
-Defined in: [joint-react/src/utils/create.ts:70](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L70)
+Defined in: [joint-react/src/utils/create.ts:74](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L74)
 
 Create links helper function.
 
@@ -20,7 +20,7 @@ Create links helper function.
 
 ### Type
 
-`Type` *extends* `string` = `string`
+`Type` *extends* `string` = `"standard.Link"`
 
 ## Parameters
 

--- a/packages/joint-react/docs/functions/useAddElement.md
+++ b/packages/joint-react/docs/functions/useAddElement.md
@@ -1,0 +1,42 @@
+[**@joint/react**](../README.md)
+
+***
+
+[@joint/react](../README.md) / useAddElement
+
+# Function: useAddElement()
+
+> **useAddElement**\<`T`\>(): (`element`) => `void`
+
+Defined in: [joint-react/src/hooks/use-add-element.ts:22](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/hooks/use-add-element.ts#L22)
+
+A custom hook that adds an element to the graph.
+
+## Type Parameters
+
+### T
+
+`T` *extends* `Element`\<`Attributes`, `ModelSetOptions`\> \| [`GraphElementBase`](../interfaces/GraphElementBase.md)\<`string`\>
+
+## Returns
+
+`Function`
+
+A function that adds the element to the graph.
+
+### Parameters
+
+#### element
+
+`SetElement`\<`T`\>
+
+### Returns
+
+`void`
+
+## Example
+
+```ts
+const addElement = useAddElement();
+addElement({ id: '1', data: { label: 'Node 1' } });
+```

--- a/packages/joint-react/docs/functions/useAddLink.md
+++ b/packages/joint-react/docs/functions/useAddLink.md
@@ -1,0 +1,42 @@
+[**@joint/react**](../README.md)
+
+***
+
+[@joint/react](../README.md) / useAddLink
+
+# Function: useAddLink()
+
+> **useAddLink**\<`T`\>(): (`link`) => `void`
+
+Defined in: [joint-react/src/hooks/use-add-link.ts:17](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/hooks/use-add-link.ts#L17)
+
+A custom hook that adds a link to the graph.
+
+## Type Parameters
+
+### T
+
+`T` *extends* `Link`\<`Attributes`, `ModelSetOptions`\> \| [`GraphLinkBase`](../interfaces/GraphLinkBase.md)\<`string`\>
+
+## Returns
+
+`Function`
+
+A function that adds the link to the graph.
+
+### Parameters
+
+#### link
+
+`T`
+
+### Returns
+
+`void`
+
+## Example
+
+```ts
+const addLink = useAddLink();
+addLink({ id: '1', source: { id: '2' }, target: { id: '3' } });
+```

--- a/packages/joint-react/docs/functions/useElement.md
+++ b/packages/joint-react/docs/functions/useElement.md
@@ -30,7 +30,7 @@ How it works:
 
 ### Element
 
-`Element` = [`GraphElement`](../interfaces/GraphElement.md)\<`unknown`, `string`\>
+`Element` = [`GraphElement`](../interfaces/GraphElement.md)\<`unknown`, `"react"`\>
 
 ### ReturnedElements
 

--- a/packages/joint-react/docs/functions/useElements.md
+++ b/packages/joint-react/docs/functions/useElements.md
@@ -28,7 +28,7 @@ checks if the selected value really changed.
 
 ### Elements
 
-`Elements` *extends* [`GraphElementBase`](../interfaces/GraphElementBase.md)\<`string`\> = [`GraphElement`](../interfaces/GraphElement.md)\<`unknown`, `string`\>
+`Elements` *extends* [`GraphElementBase`](../interfaces/GraphElementBase.md)\<`string`\> = [`GraphElement`](../interfaces/GraphElement.md)\<`unknown`, `"react"`\>
 
 ### SelectorReturnType
 

--- a/packages/joint-react/docs/functions/useRemoveCell.md
+++ b/packages/joint-react/docs/functions/useRemoveCell.md
@@ -1,0 +1,36 @@
+[**@joint/react**](../README.md)
+
+***
+
+[@joint/react](../README.md) / useRemoveCell
+
+# Function: useRemoveCell()
+
+> **useRemoveCell**(): (`id`) => `void`
+
+Defined in: [joint-react/src/hooks/use-remove-cell.ts:15](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/hooks/use-remove-cell.ts#L15)
+
+A custom hook that removes an node or link from the graph by its ID.
+
+## Returns
+
+`Function`
+
+A function that removes the element from the graph.
+
+### Parameters
+
+#### id
+
+`ID`
+
+### Returns
+
+`void`
+
+## Example
+
+```ts
+const removeCell = useRemoveCell();
+removeCell('1');
+```

--- a/packages/joint-react/docs/functions/useSetElement.md
+++ b/packages/joint-react/docs/functions/useSetElement.md
@@ -14,7 +14,7 @@ Defined in: [joint-react/src/hooks/use-set-element.ts:81](https://github.com/sam
 
 **`Experimental`**
 
-Use this hook to set element attributes.
+Set the element attribute in the graph.
 It returns a function to set the element attribute.
 
 It must be used inside the GraphProvider.
@@ -89,7 +89,7 @@ Defined in: [joint-react/src/hooks/use-set-element.ts:89](https://github.com/sam
 
 **`Experimental`**
 
-Use this hook to set element attributes.
+Set the element attribute in the graph.
 It returns a function to set the element attribute.
 
 It must be used inside the GraphProvider.
@@ -164,7 +164,7 @@ Defined in: [joint-react/src/hooks/use-set-element.ts:93](https://github.com/sam
 
 **`Experimental`**
 
-Use this hook to set element attributes.
+Set the element attribute in the graph.
 It returns a function to set the element attribute.
 
 It must be used inside the GraphProvider.

--- a/packages/joint-react/docs/interfaces/GraphElement.md
+++ b/packages/joint-react/docs/interfaces/GraphElement.md
@@ -6,7 +6,7 @@
 
 # Interface: GraphElement\<Data, Type\>
 
-Defined in: [joint-react/src/types/element-types.ts:78](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L78)
+Defined in: [joint-react/src/types/element-types.ts:85](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L85)
 
 Base interface for graph element.
 It's a subset of `dia.Element` with some additional properties.
@@ -28,7 +28,7 @@ It's a subset of `dia.Element` with some additional properties.
 
 ### Type
 
-`Type` *extends* [`StandardShapesType`](../type-aliases/StandardShapesType.md) \| `string` = `string`
+`Type` *extends* [`StandardShapesType`](../type-aliases/StandardShapesType.md) \| `string` = `"react"`
 
 ## Indexable
 
@@ -42,7 +42,7 @@ It's a subset of `dia.Element` with some additional properties.
 
 > `readonly` `optional` **attrs**: `Type` *extends* keyof `StandardShapesTypeMapper` ? `StandardShapesTypeMapper`\[`Type`\<`Type`\>\] : `unknown`
 
-Defined in: [joint-react/src/types/element-types.ts:68](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L68)
+Defined in: [joint-react/src/types/element-types.ts:73](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L73)
 
 Attributes of the element.
 
@@ -56,7 +56,7 @@ Attributes of the element.
 
 > `readonly` **data**: `Data`
 
-Defined in: [joint-react/src/types/element-types.ts:76](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L76)
+Defined in: [joint-react/src/types/element-types.ts:83](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L83)
 
 Generic data for the element.
 
@@ -70,7 +70,7 @@ Generic data for the element.
 
 > `readonly` `optional` **height**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:62](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L62)
+Defined in: [joint-react/src/types/element-types.ts:67](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L67)
 
 Optional height of the element.
 
@@ -84,7 +84,7 @@ Optional height of the element.
 
 > `readonly` **id**: `ID`
 
-Defined in: [joint-react/src/types/element-types.ts:33](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L33)
+Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
 
 Unique identifier of the element.
 
@@ -98,7 +98,7 @@ Unique identifier of the element.
 
 > `readonly` **isElement**: `true`
 
-Defined in: [joint-react/src/types/element-types.ts:83](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L83)
+Defined in: [joint-react/src/types/element-types.ts:90](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L90)
 
 Flag to distinguish between elements and links.
 
@@ -108,7 +108,7 @@ Flag to distinguish between elements and links.
 
 > `readonly` **isLink**: `false`
 
-Defined in: [joint-react/src/types/element-types.ts:87](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L87)
+Defined in: [joint-react/src/types/element-types.ts:94](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L94)
 
 Flag to distinguish between elements and links.
 
@@ -118,7 +118,7 @@ Flag to distinguish between elements and links.
 
 > `readonly` `optional` **markup**: `string` \| `MarkupJSON`
 
-Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L64)
+Defined in: [joint-react/src/types/element-types.ts:69](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L69)
 
 #### Inherited from
 
@@ -130,7 +130,7 @@ Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samue
 
 > `readonly` `optional` **ports**: `Ports`
 
-Defined in: [joint-react/src/types/element-types.ts:42](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L42)
+Defined in: [joint-react/src/types/element-types.ts:47](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L47)
 
 Ports of the element.
 
@@ -144,7 +144,7 @@ Ports of the element.
 
 > `readonly` `optional` **type**: `Type`
 
-Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
+Defined in: [joint-react/src/types/element-types.ts:43](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L43)
 
 Optional element type.
 
@@ -162,7 +162,7 @@ Optional element type.
 
 > `readonly` `optional` **width**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:58](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L58)
+Defined in: [joint-react/src/types/element-types.ts:63](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L63)
 
 Optional width of the element.
 
@@ -176,7 +176,7 @@ Optional width of the element.
 
 > `readonly` `optional` **x**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:50](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L50)
+Defined in: [joint-react/src/types/element-types.ts:55](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L55)
 
 X position of the element.
 
@@ -190,7 +190,7 @@ X position of the element.
 
 > `readonly` `optional` **y**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:54](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L54)
+Defined in: [joint-react/src/types/element-types.ts:59](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L59)
 
 Y position of the element.
 

--- a/packages/joint-react/docs/interfaces/GraphElementBase.md
+++ b/packages/joint-react/docs/interfaces/GraphElementBase.md
@@ -6,7 +6,7 @@
 
 # Interface: GraphElementBase\<Type\>
 
-Defined in: [joint-react/src/types/element-types.ts:28](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L28)
+Defined in: [joint-react/src/types/element-types.ts:33](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L33)
 
 Base interface for graph element.
 It's a subset of `dia.Element` with some additional properties.
@@ -42,7 +42,7 @@ It's a subset of `dia.Element` with some additional properties.
 
 > `readonly` `optional` **attrs**: `Type` *extends* keyof `StandardShapesTypeMapper` ? `StandardShapesTypeMapper`\[`Type`\<`Type`\>\] : `unknown`
 
-Defined in: [joint-react/src/types/element-types.ts:68](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L68)
+Defined in: [joint-react/src/types/element-types.ts:73](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L73)
 
 Attributes of the element.
 
@@ -52,7 +52,7 @@ Attributes of the element.
 
 > `readonly` `optional` **data**: `unknown`
 
-Defined in: [joint-react/src/types/element-types.ts:46](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L46)
+Defined in: [joint-react/src/types/element-types.ts:51](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L51)
 
 Generic data for the element.
 
@@ -62,7 +62,7 @@ Generic data for the element.
 
 > `readonly` `optional` **height**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:62](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L62)
+Defined in: [joint-react/src/types/element-types.ts:67](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L67)
 
 Optional height of the element.
 
@@ -72,7 +72,7 @@ Optional height of the element.
 
 > `readonly` **id**: `ID`
 
-Defined in: [joint-react/src/types/element-types.ts:33](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L33)
+Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
 
 Unique identifier of the element.
 
@@ -82,7 +82,7 @@ Unique identifier of the element.
 
 > `readonly` `optional` **markup**: `string` \| `MarkupJSON`
 
-Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L64)
+Defined in: [joint-react/src/types/element-types.ts:69](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L69)
 
 ***
 
@@ -90,7 +90,7 @@ Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samue
 
 > `readonly` `optional` **ports**: `Ports`
 
-Defined in: [joint-react/src/types/element-types.ts:42](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L42)
+Defined in: [joint-react/src/types/element-types.ts:47](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L47)
 
 Ports of the element.
 
@@ -100,7 +100,7 @@ Ports of the element.
 
 > `readonly` `optional` **type**: `Type`
 
-Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
+Defined in: [joint-react/src/types/element-types.ts:43](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L43)
 
 Optional element type.
 
@@ -114,7 +114,7 @@ Optional element type.
 
 > `readonly` `optional` **width**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:58](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L58)
+Defined in: [joint-react/src/types/element-types.ts:63](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L63)
 
 Optional width of the element.
 
@@ -124,7 +124,7 @@ Optional width of the element.
 
 > `readonly` `optional` **x**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:50](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L50)
+Defined in: [joint-react/src/types/element-types.ts:55](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L55)
 
 X position of the element.
 
@@ -134,6 +134,6 @@ X position of the element.
 
 > `readonly` `optional` **y**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:54](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L54)
+Defined in: [joint-react/src/types/element-types.ts:59](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L59)
 
 Y position of the element.

--- a/packages/joint-react/docs/interfaces/GraphElementItem.md
+++ b/packages/joint-react/docs/interfaces/GraphElementItem.md
@@ -6,7 +6,7 @@
 
 # Interface: GraphElementItem\<Data, Type\>
 
-Defined in: [joint-react/src/types/element-types.ts:71](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L71)
+Defined in: [joint-react/src/types/element-types.ts:76](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L76)
 
 Base interface for graph element.
 It's a subset of `dia.Element` with some additional properties.
@@ -32,7 +32,7 @@ It's a subset of `dia.Element` with some additional properties.
 
 ### Type
 
-`Type` *extends* [`StandardShapesType`](../type-aliases/StandardShapesType.md) \| `string` = `string`
+`Type` *extends* [`StandardShapesType`](../type-aliases/StandardShapesType.md) \| `string` = `"react"`
 
 ## Indexable
 
@@ -46,7 +46,7 @@ It's a subset of `dia.Element` with some additional properties.
 
 > `readonly` `optional` **attrs**: `Type` *extends* keyof `StandardShapesTypeMapper` ? `StandardShapesTypeMapper`\[`Type`\<`Type`\>\] : `unknown`
 
-Defined in: [joint-react/src/types/element-types.ts:68](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L68)
+Defined in: [joint-react/src/types/element-types.ts:73](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L73)
 
 Attributes of the element.
 
@@ -60,7 +60,7 @@ Attributes of the element.
 
 > `readonly` **data**: `Data`
 
-Defined in: [joint-react/src/types/element-types.ts:76](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L76)
+Defined in: [joint-react/src/types/element-types.ts:83](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L83)
 
 Generic data for the element.
 
@@ -74,7 +74,7 @@ Generic data for the element.
 
 > `readonly` `optional` **height**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:62](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L62)
+Defined in: [joint-react/src/types/element-types.ts:67](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L67)
 
 Optional height of the element.
 
@@ -88,7 +88,7 @@ Optional height of the element.
 
 > `readonly` **id**: `ID`
 
-Defined in: [joint-react/src/types/element-types.ts:33](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L33)
+Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
 
 Unique identifier of the element.
 
@@ -102,7 +102,7 @@ Unique identifier of the element.
 
 > `readonly` `optional` **markup**: `string` \| `MarkupJSON`
 
-Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L64)
+Defined in: [joint-react/src/types/element-types.ts:69](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L69)
 
 #### Inherited from
 
@@ -114,7 +114,7 @@ Defined in: [joint-react/src/types/element-types.ts:64](https://github.com/samue
 
 > `readonly` `optional` **ports**: `Ports`
 
-Defined in: [joint-react/src/types/element-types.ts:42](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L42)
+Defined in: [joint-react/src/types/element-types.ts:47](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L47)
 
 Ports of the element.
 
@@ -128,7 +128,7 @@ Ports of the element.
 
 > `readonly` `optional` **type**: `Type`
 
-Defined in: [joint-react/src/types/element-types.ts:38](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L38)
+Defined in: [joint-react/src/types/element-types.ts:43](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L43)
 
 Optional element type.
 
@@ -146,7 +146,7 @@ Optional element type.
 
 > `readonly` `optional` **width**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:58](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L58)
+Defined in: [joint-react/src/types/element-types.ts:63](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L63)
 
 Optional width of the element.
 
@@ -160,7 +160,7 @@ Optional width of the element.
 
 > `readonly` `optional` **x**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:50](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L50)
+Defined in: [joint-react/src/types/element-types.ts:55](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L55)
 
 X position of the element.
 
@@ -174,7 +174,7 @@ X position of the element.
 
 > `readonly` `optional` **y**: `number`
 
-Defined in: [joint-react/src/types/element-types.ts:54](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L54)
+Defined in: [joint-react/src/types/element-types.ts:59](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L59)
 
 Y position of the element.
 

--- a/packages/joint-react/docs/interfaces/GraphProps.md
+++ b/packages/joint-react/docs/interfaces/GraphProps.md
@@ -58,7 +58,7 @@ Children to render.
 
 ### defaultElements?
 
-> `readonly` `optional` **defaultElements**: ([`GraphElementBase`](GraphElementBase.md)\<`string`\> \| `Element`\<`Attributes`, `ModelSetOptions`\>)[]
+> `readonly` `optional` **defaultElements**: (`Element`\<`Attributes`, `ModelSetOptions`\> \| [`GraphElementBase`](GraphElementBase.md)\<`string`\>)[]
 
 Defined in: [joint-react/src/components/graph-provider/graph-provider.tsx:88](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/graph-provider/graph-provider.tsx#L88)
 
@@ -69,7 +69,7 @@ It's loaded just once, so it cannot be used as React state.
 
 ### defaultLinks?
 
-> `readonly` `optional` **defaultLinks**: ([`GraphLink`](GraphLink.md) \| `Link`\<`Attributes`, `ModelSetOptions`\>)[]
+> `readonly` `optional` **defaultLinks**: (`Link`\<`Attributes`, `ModelSetOptions`\> \| [`GraphLink`](GraphLink.md))[]
 
 Defined in: [joint-react/src/components/graph-provider/graph-provider.tsx:93](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/graph-provider/graph-provider.tsx#L93)
 

--- a/packages/joint-react/docs/interfaces/PaperContext.md
+++ b/packages/joint-react/docs/interfaces/PaperContext.md
@@ -18,7 +18,7 @@ Defined in: [joint-react/src/context/paper-context.tsx:6](https://github.com/sam
 
 > **$**(`selector`): `unknown`
 
-Defined in: [joint-core/types/joint.d.ts:3487](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3487)
+Defined in: [joint-core/types/joint.d.ts:3489](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3489)
 
 #### Parameters
 
@@ -40,7 +40,7 @@ Defined in: [joint-core/types/joint.d.ts:3487](https://github.com/samuelgja/join
 
 > **addLayer**(`layerName`, `layerView`, `options`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1786](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1786)
+Defined in: [joint-core/types/joint.d.ts:1788](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1788)
 
 #### Parameters
 
@@ -74,7 +74,7 @@ Defined in: [joint-core/types/joint.d.ts:1786](https://github.com/samuelgja/join
 
 > **bind**(`eventName`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3241)
+Defined in: [joint-core/types/joint.d.ts:3243](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3243)
 
 ##### Parameters
 
@@ -102,7 +102,7 @@ Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/join
 
 > **bind**(`eventMap`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3242](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3242)
+Defined in: [joint-core/types/joint.d.ts:3244](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3244)
 
 ##### Parameters
 
@@ -128,7 +128,7 @@ Defined in: [joint-core/types/joint.d.ts:3242](https://github.com/samuelgja/join
 
 > **checkViewport**(`opt`?): `object`
 
-Defined in: [joint-core/types/joint.d.ts:1817](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1817)
+Defined in: [joint-core/types/joint.d.ts:1819](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1819)
 
 #### Parameters
 
@@ -168,7 +168,7 @@ Defined in: [joint-core/types/joint.d.ts:1817](https://github.com/samuelgja/join
 
 > **clientMatrix**(): [`DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
 
-Defined in: [joint-core/types/joint.d.ts:1615](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1615)
+Defined in: [joint-core/types/joint.d.ts:1617](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1617)
 
 #### Returns
 
@@ -184,7 +184,7 @@ Defined in: [joint-core/types/joint.d.ts:1615](https://github.com/samuelgja/join
 
 > **clientOffset**(): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1617](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1617)
+Defined in: [joint-core/types/joint.d.ts:1619](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1619)
 
 #### Returns
 
@@ -202,7 +202,7 @@ Defined in: [joint-core/types/joint.d.ts:1617](https://github.com/samuelgja/join
 
 > **clientToLocalPoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1621](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1621)
+Defined in: [joint-core/types/joint.d.ts:1623](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1623)
 
 ##### Parameters
 
@@ -226,7 +226,7 @@ Defined in: [joint-core/types/joint.d.ts:1621](https://github.com/samuelgja/join
 
 > **clientToLocalPoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1622](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1622)
+Defined in: [joint-core/types/joint.d.ts:1624](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1624)
 
 ##### Parameters
 
@@ -250,7 +250,7 @@ Defined in: [joint-core/types/joint.d.ts:1622](https://github.com/samuelgja/join
 
 > **clientToLocalRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1624](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1624)
+Defined in: [joint-core/types/joint.d.ts:1626](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1626)
 
 ##### Parameters
 
@@ -282,7 +282,7 @@ Defined in: [joint-core/types/joint.d.ts:1624](https://github.com/samuelgja/join
 
 > **clientToLocalRect**(`rect`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1625](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1625)
+Defined in: [joint-core/types/joint.d.ts:1627](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1627)
 
 ##### Parameters
 
@@ -304,7 +304,7 @@ Defined in: [joint-core/types/joint.d.ts:1625](https://github.com/samuelgja/join
 
 > **confirmUpdate**(`flag`, `opt`): `number`
 
-Defined in: [joint-core/types/joint.d.ts:3565](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3565)
+Defined in: [joint-core/types/joint.d.ts:3567](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3567)
 
 #### Parameters
 
@@ -328,7 +328,7 @@ Defined in: [joint-core/types/joint.d.ts:3565](https://github.com/samuelgja/join
 
 > **defineFilter**(`filter`): `string`
 
-Defined in: [joint-core/types/joint.d.ts:1660](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1660)
+Defined in: [joint-core/types/joint.d.ts:1662](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1662)
 
 #### Parameters
 
@@ -350,7 +350,7 @@ Defined in: [joint-core/types/joint.d.ts:1660](https://github.com/samuelgja/join
 
 > **defineGradient**(`gradient`): `string`
 
-Defined in: [joint-core/types/joint.d.ts:1662](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1662)
+Defined in: [joint-core/types/joint.d.ts:1664](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1664)
 
 #### Parameters
 
@@ -372,7 +372,7 @@ Defined in: [joint-core/types/joint.d.ts:1662](https://github.com/samuelgja/join
 
 > **defineMarker**(`marker`): `string`
 
-Defined in: [joint-core/types/joint.d.ts:1664](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1664)
+Defined in: [joint-core/types/joint.d.ts:1666](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1666)
 
 #### Parameters
 
@@ -394,7 +394,7 @@ Defined in: [joint-core/types/joint.d.ts:1664](https://github.com/samuelgja/join
 
 > **definePattern**(`pattern`): `string`
 
-Defined in: [joint-core/types/joint.d.ts:1666](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1666)
+Defined in: [joint-core/types/joint.d.ts:1668](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1668)
 
 #### Parameters
 
@@ -416,7 +416,7 @@ Defined in: [joint-core/types/joint.d.ts:1666](https://github.com/samuelgja/join
 
 > **delegate**(`eventName`, `selector`, `listener`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3491](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3491)
+Defined in: [joint-core/types/joint.d.ts:3493](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3493)
 
 #### Parameters
 
@@ -446,7 +446,7 @@ Defined in: [joint-core/types/joint.d.ts:3491](https://github.com/samuelgja/join
 
 > **delegateDocumentEvents**(`events`?, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3547](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3547)
+Defined in: [joint-core/types/joint.d.ts:3549](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3549)
 
 #### Parameters
 
@@ -472,7 +472,7 @@ Defined in: [joint-core/types/joint.d.ts:3547](https://github.com/samuelgja/join
 
 > **delegateElementEvents**(`element`, `events`?, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3551](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3551)
+Defined in: [joint-core/types/joint.d.ts:3553](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3553)
 
 #### Parameters
 
@@ -502,7 +502,7 @@ Defined in: [joint-core/types/joint.d.ts:3551](https://github.com/samuelgja/join
 
 > **delegateEvents**(`events`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3490](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3490)
+Defined in: [joint-core/types/joint.d.ts:3492](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3492)
 
 #### Parameters
 
@@ -524,7 +524,7 @@ Defined in: [joint-core/types/joint.d.ts:3490](https://github.com/samuelgja/join
 
 > **dispatchToolsEvent**(`eventName`, ...`args`): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1770](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1770)
+Defined in: [joint-core/types/joint.d.ts:1772](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1772)
 
 #### Parameters
 
@@ -550,7 +550,7 @@ Defined in: [joint-core/types/joint.d.ts:1770](https://github.com/samuelgja/join
 
 > **drawBackground**(`opt`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1734](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1734)
+Defined in: [joint-core/types/joint.d.ts:1736](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1736)
 
 #### Parameters
 
@@ -572,7 +572,7 @@ Defined in: [joint-core/types/joint.d.ts:1734](https://github.com/samuelgja/join
 
 > **dumpViews**(`opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1810](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1810)
+Defined in: [joint-core/types/joint.d.ts:1812](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1812)
 
 #### Parameters
 
@@ -610,7 +610,7 @@ Defined in: [joint-core/types/joint.d.ts:1810](https://github.com/samuelgja/join
 
 > **eventData**(`evt`): `viewEventData`
 
-Defined in: [joint-core/types/joint.d.ts:3555](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3555)
+Defined in: [joint-core/types/joint.d.ts:3557](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3557)
 
 ##### Parameters
 
@@ -630,7 +630,7 @@ Defined in: [joint-core/types/joint.d.ts:3555](https://github.com/samuelgja/join
 
 > **eventData**(`evt`, `data`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3556](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3556)
+Defined in: [joint-core/types/joint.d.ts:3558](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3558)
 
 ##### Parameters
 
@@ -656,7 +656,7 @@ Defined in: [joint-core/types/joint.d.ts:3556](https://github.com/samuelgja/join
 
 > **events**(): `EventsHash`
 
-Defined in: [joint-core/types/joint.d.ts:3471](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3471)
+Defined in: [joint-core/types/joint.d.ts:3473](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3473)
 
 Events hash or a method returning the events hash that maps events/selectors to methods on your View.
 For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
@@ -676,7 +676,7 @@ That works only if you set it in the constructor or the initialize method.
 
 > **findAttribute**(`attributeName`, `node`): `null` \| `string`
 
-Defined in: [joint-core/types/joint.d.ts:3563](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3563)
+Defined in: [joint-core/types/joint.d.ts:3565](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3565)
 
 #### Parameters
 
@@ -702,7 +702,7 @@ Defined in: [joint-core/types/joint.d.ts:3563](https://github.com/samuelgja/join
 
 > **findCellViewsAtPoint**(`point`, `opt`?): `CellView`[]
 
-Defined in: [joint-core/types/joint.d.ts:1704](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1704)
+Defined in: [joint-core/types/joint.d.ts:1706](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1706)
 
 Finds all the cell views at the specified point
 
@@ -734,7 +734,7 @@ options for the search
 
 > **findCellViewsInArea**(`area`, `opt`?): `CellView`[]
 
-Defined in: [joint-core/types/joint.d.ts:1725](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1725)
+Defined in: [joint-core/types/joint.d.ts:1727](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1727)
 
 Finds all the cell views in the specified area
 
@@ -766,7 +766,7 @@ options for the search
 
 > **findElementViewsAtPoint**(`point`, `opt`?): `ElementView`\<`Element`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1690](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1690)
+Defined in: [joint-core/types/joint.d.ts:1692](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1692)
 
 Finds all the element views at the specified point
 
@@ -798,7 +798,7 @@ options for the search
 
 > **findElementViewsInArea**(`area`, `opt`?): `ElementView`\<`Element`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1711](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1711)
+Defined in: [joint-core/types/joint.d.ts:1713](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1713)
 
 Finds all the element views in the specified area
 
@@ -830,7 +830,7 @@ options for the search
 
 > **findLinkViewsAtPoint**(`point`, `opt`?): `LinkView`\<`Link`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1697](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1697)
+Defined in: [joint-core/types/joint.d.ts:1699](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1699)
 
 Finds all the link views at the specified point
 
@@ -862,7 +862,7 @@ options for the search
 
 > **findLinkViewsInArea**(`area`, `opt`?): `LinkView`\<`Link`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1718](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1718)
+Defined in: [joint-core/types/joint.d.ts:1720](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1720)
 
 Finds all the link views in the specified area
 
@@ -894,7 +894,7 @@ options for the search
 
 > **findView**\<`T`\>(`element`): `T`
 
-Defined in: [joint-core/types/joint.d.ts:1681](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1681)
+Defined in: [joint-core/types/joint.d.ts:1683](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1683)
 
 #### Type Parameters
 
@@ -922,7 +922,7 @@ Defined in: [joint-core/types/joint.d.ts:1681](https://github.com/samuelgja/join
 
 > **findViewByModel**\<`T`\>(`model`): `T`
 
-Defined in: [joint-core/types/joint.d.ts:1683](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1683)
+Defined in: [joint-core/types/joint.d.ts:1685](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1685)
 
 #### Type Parameters
 
@@ -950,7 +950,7 @@ Defined in: [joint-core/types/joint.d.ts:1683](https://github.com/samuelgja/join
 
 > **findViewsFromPoint**(`point`): `ElementView`\<`Element`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1976](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1976)
+Defined in: [joint-core/types/joint.d.ts:1978](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1978)
 
 #### Parameters
 
@@ -976,7 +976,7 @@ use `findElementViewsAtPoint()
 
 > **findViewsInArea**(`rect`, `opt`?): `ElementView`\<`Element`\<`Attributes`, `ModelSetOptions`\>\>[]
 
-Defined in: [joint-core/types/joint.d.ts:1981](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1981)
+Defined in: [joint-core/types/joint.d.ts:1983](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1983)
 
 #### Parameters
 
@@ -1010,7 +1010,7 @@ use `findElementViewsInArea()
 
 > **fitToContent**(`opt`?): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1727](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1727)
+Defined in: [joint-core/types/joint.d.ts:1729](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1729)
 
 ##### Parameters
 
@@ -1030,7 +1030,7 @@ Defined in: [joint-core/types/joint.d.ts:1727](https://github.com/samuelgja/join
 
 > **fitToContent**(`gridWidth`?, `gridHeight`?, `padding`?, `opt`?): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1728](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1728)
+Defined in: [joint-core/types/joint.d.ts:1730](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1730)
 
 ##### Parameters
 
@@ -1064,7 +1064,7 @@ Defined in: [joint-core/types/joint.d.ts:1728](https://github.com/samuelgja/join
 
 > **freeze**(`opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1800](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1800)
+Defined in: [joint-core/types/joint.d.ts:1802](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1802)
 
 #### Parameters
 
@@ -1086,7 +1086,7 @@ Defined in: [joint-core/types/joint.d.ts:1800](https://github.com/samuelgja/join
 
 > **getArea**(): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1672](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1672)
+Defined in: [joint-core/types/joint.d.ts:1674](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1674)
 
 #### Returns
 
@@ -1102,7 +1102,7 @@ Defined in: [joint-core/types/joint.d.ts:1672](https://github.com/samuelgja/join
 
 > **getComputedSize**(): `Size`
 
-Defined in: [joint-core/types/joint.d.ts:1670](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1670)
+Defined in: [joint-core/types/joint.d.ts:1672](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1672)
 
 #### Returns
 
@@ -1118,7 +1118,7 @@ Defined in: [joint-core/types/joint.d.ts:1670](https://github.com/samuelgja/join
 
 > **getContentArea**(`opt`?): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1677](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1677)
+Defined in: [joint-core/types/joint.d.ts:1679](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1679)
 
 #### Parameters
 
@@ -1142,7 +1142,7 @@ Defined in: [joint-core/types/joint.d.ts:1677](https://github.com/samuelgja/join
 
 > **getContentBBox**(`opt`?): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1679](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1679)
+Defined in: [joint-core/types/joint.d.ts:1681](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1681)
 
 #### Parameters
 
@@ -1166,7 +1166,7 @@ Defined in: [joint-core/types/joint.d.ts:1679](https://github.com/samuelgja/join
 
 > **getDefaultLink**(`cellView`, `magnet`): `Link`
 
-Defined in: [joint-core/types/joint.d.ts:1736](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1736)
+Defined in: [joint-core/types/joint.d.ts:1738](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1738)
 
 #### Parameters
 
@@ -1192,7 +1192,7 @@ Defined in: [joint-core/types/joint.d.ts:1736](https://github.com/samuelgja/join
 
 > **getEventNamespace**(): `string`
 
-Defined in: [joint-core/types/joint.d.ts:3545](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3545)
+Defined in: [joint-core/types/joint.d.ts:3547](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3547)
 
 #### Returns
 
@@ -1208,7 +1208,7 @@ Defined in: [joint-core/types/joint.d.ts:3545](https://github.com/samuelgja/join
 
 > **getFitToContentArea**(`opt`?): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1730](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1730)
+Defined in: [joint-core/types/joint.d.ts:1732](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1732)
 
 #### Parameters
 
@@ -1230,7 +1230,7 @@ Defined in: [joint-core/types/joint.d.ts:1730](https://github.com/samuelgja/join
 
 > **getLayerNames**(): `string`[]
 
-Defined in: [joint-core/types/joint.d.ts:1794](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1794)
+Defined in: [joint-core/types/joint.d.ts:1796](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1796)
 
 #### Returns
 
@@ -1246,7 +1246,7 @@ Defined in: [joint-core/types/joint.d.ts:1794](https://github.com/samuelgja/join
 
 > **getLayerNode**(`layerName`): [`SVGGElement`](https://developer.mozilla.org/docs/Web/API/SVGGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1774](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1774)
+Defined in: [joint-core/types/joint.d.ts:1776](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1776)
 
 #### Parameters
 
@@ -1268,7 +1268,7 @@ Defined in: [joint-core/types/joint.d.ts:1774](https://github.com/samuelgja/join
 
 > **getLayers**(): `PaperLayer`[]
 
-Defined in: [joint-core/types/joint.d.ts:1796](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1796)
+Defined in: [joint-core/types/joint.d.ts:1798](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1798)
 
 #### Returns
 
@@ -1284,7 +1284,7 @@ Defined in: [joint-core/types/joint.d.ts:1796](https://github.com/samuelgja/join
 
 > **getLayerView**(`layerName`): `PaperLayer`
 
-Defined in: [joint-core/types/joint.d.ts:1776](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1776)
+Defined in: [joint-core/types/joint.d.ts:1778](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1778)
 
 #### Parameters
 
@@ -1306,7 +1306,7 @@ Defined in: [joint-core/types/joint.d.ts:1776](https://github.com/samuelgja/join
 
 > **getModelById**(`id`): `Cell`
 
-Defined in: [joint-core/types/joint.d.ts:1738](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1738)
+Defined in: [joint-core/types/joint.d.ts:1740](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1740)
 
 #### Parameters
 
@@ -1328,7 +1328,7 @@ Defined in: [joint-core/types/joint.d.ts:1738](https://github.com/samuelgja/join
 
 > **getPointerArgs**(`evt`): \[`Event`, `number`, `number`\]
 
-Defined in: [joint-core/types/joint.d.ts:1754](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1754)
+Defined in: [joint-core/types/joint.d.ts:1756](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1756)
 
 #### Parameters
 
@@ -1352,7 +1352,7 @@ Defined in: [joint-core/types/joint.d.ts:1754](https://github.com/samuelgja/join
 
 > **getRestrictedArea**(): `null` \| `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1674](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1674)
+Defined in: [joint-core/types/joint.d.ts:1676](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1676)
 
 ##### Returns
 
@@ -1366,7 +1366,7 @@ Defined in: [joint-core/types/joint.d.ts:1674](https://github.com/samuelgja/join
 
 > **getRestrictedArea**(`elementView`, `x`, `y`): `null` \| `Rect` \| `PointConstraintCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1675](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1675)
+Defined in: [joint-core/types/joint.d.ts:1677](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1677)
 
 ##### Parameters
 
@@ -1396,7 +1396,7 @@ Defined in: [joint-core/types/joint.d.ts:1675](https://github.com/samuelgja/join
 
 > **hasLayer**(`layer`): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1792](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1792)
+Defined in: [joint-core/types/joint.d.ts:1794](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1794)
 
 #### Parameters
 
@@ -1418,7 +1418,7 @@ Defined in: [joint-core/types/joint.d.ts:1792](https://github.com/samuelgja/join
 
 > **hasLayerView**(`layerName`): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1778](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1778)
+Defined in: [joint-core/types/joint.d.ts:1780](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1780)
 
 #### Parameters
 
@@ -1440,7 +1440,7 @@ Defined in: [joint-core/types/joint.d.ts:1778](https://github.com/samuelgja/join
 
 > **hasScheduledUpdates**(): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1835](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1835)
+Defined in: [joint-core/types/joint.d.ts:1837](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1837)
 
 #### Returns
 
@@ -1456,7 +1456,7 @@ Defined in: [joint-core/types/joint.d.ts:1835](https://github.com/samuelgja/join
 
 > **hideTools**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1766](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1766)
+Defined in: [joint-core/types/joint.d.ts:1768](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1768)
 
 #### Returns
 
@@ -1472,7 +1472,7 @@ Defined in: [joint-core/types/joint.d.ts:1766](https://github.com/samuelgja/join
 
 > **initialize**(`options`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:3464](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3464)
+Defined in: [joint-core/types/joint.d.ts:3466](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3466)
 
 #### Parameters
 
@@ -1494,7 +1494,7 @@ Defined in: [joint-core/types/joint.d.ts:3464](https://github.com/samuelgja/join
 
 > **isDefined**(`defId`): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1668](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1668)
+Defined in: [joint-core/types/joint.d.ts:1670](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1670)
 
 #### Parameters
 
@@ -1516,7 +1516,7 @@ Defined in: [joint-core/types/joint.d.ts:1668](https://github.com/samuelgja/join
 
 > **isFrozen**(): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1804](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1804)
+Defined in: [joint-core/types/joint.d.ts:1806](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1806)
 
 #### Returns
 
@@ -1532,7 +1532,7 @@ Defined in: [joint-core/types/joint.d.ts:1804](https://github.com/samuelgja/join
 
 > **isMounted**(): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3569](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3569)
+Defined in: [joint-core/types/joint.d.ts:3571](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3571)
 
 #### Returns
 
@@ -1548,7 +1548,7 @@ Defined in: [joint-core/types/joint.d.ts:3569](https://github.com/samuelgja/join
 
 > **isPropagationStopped**(`evt`): `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3559](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3559)
+Defined in: [joint-core/types/joint.d.ts:3561](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3561)
 
 #### Parameters
 
@@ -1572,7 +1572,7 @@ Defined in: [joint-core/types/joint.d.ts:3559](https://github.com/samuelgja/join
 
 > **listenTo**(`object`, `events`, `callback`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3247)
+Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3249)
 
 ##### Parameters
 
@@ -1600,7 +1600,7 @@ Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/join
 
 > **listenTo**(`object`, `eventMap`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3248)
+Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3250)
 
 ##### Parameters
 
@@ -1628,7 +1628,7 @@ Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/join
 
 > **listenToOnce**(`object`, `events`, `callback`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3249)
+Defined in: [joint-core/types/joint.d.ts:3251](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3251)
 
 ##### Parameters
 
@@ -1656,7 +1656,7 @@ Defined in: [joint-core/types/joint.d.ts:3249](https://github.com/samuelgja/join
 
 > **listenToOnce**(`object`, `eventMap`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3250)
+Defined in: [joint-core/types/joint.d.ts:3252](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3252)
 
 ##### Parameters
 
@@ -1684,7 +1684,7 @@ Defined in: [joint-core/types/joint.d.ts:3250](https://github.com/samuelgja/join
 
 > **localToClientPoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1627](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1627)
+Defined in: [joint-core/types/joint.d.ts:1629](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1629)
 
 ##### Parameters
 
@@ -1708,7 +1708,7 @@ Defined in: [joint-core/types/joint.d.ts:1627](https://github.com/samuelgja/join
 
 > **localToClientPoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1628](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1628)
+Defined in: [joint-core/types/joint.d.ts:1630](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1630)
 
 ##### Parameters
 
@@ -1732,7 +1732,7 @@ Defined in: [joint-core/types/joint.d.ts:1628](https://github.com/samuelgja/join
 
 > **localToClientRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1630](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1630)
+Defined in: [joint-core/types/joint.d.ts:1632](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1632)
 
 ##### Parameters
 
@@ -1764,7 +1764,7 @@ Defined in: [joint-core/types/joint.d.ts:1630](https://github.com/samuelgja/join
 
 > **localToClientRect**(`rect`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1631](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1631)
+Defined in: [joint-core/types/joint.d.ts:1633](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1633)
 
 ##### Parameters
 
@@ -1788,7 +1788,7 @@ Defined in: [joint-core/types/joint.d.ts:1631](https://github.com/samuelgja/join
 
 > **localToPagePoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1633](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1633)
+Defined in: [joint-core/types/joint.d.ts:1635](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1635)
 
 ##### Parameters
 
@@ -1812,7 +1812,7 @@ Defined in: [joint-core/types/joint.d.ts:1633](https://github.com/samuelgja/join
 
 > **localToPagePoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1634](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1634)
+Defined in: [joint-core/types/joint.d.ts:1636](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1636)
 
 ##### Parameters
 
@@ -1836,7 +1836,7 @@ Defined in: [joint-core/types/joint.d.ts:1634](https://github.com/samuelgja/join
 
 > **localToPageRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1636](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1636)
+Defined in: [joint-core/types/joint.d.ts:1638](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1638)
 
 ##### Parameters
 
@@ -1868,7 +1868,7 @@ Defined in: [joint-core/types/joint.d.ts:1636](https://github.com/samuelgja/join
 
 > **localToPageRect**(`rect`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1637](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1637)
+Defined in: [joint-core/types/joint.d.ts:1639](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1639)
 
 ##### Parameters
 
@@ -1892,7 +1892,7 @@ Defined in: [joint-core/types/joint.d.ts:1637](https://github.com/samuelgja/join
 
 > **localToPaperPoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1639](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1639)
+Defined in: [joint-core/types/joint.d.ts:1641](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1641)
 
 ##### Parameters
 
@@ -1916,7 +1916,7 @@ Defined in: [joint-core/types/joint.d.ts:1639](https://github.com/samuelgja/join
 
 > **localToPaperPoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1640](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1640)
+Defined in: [joint-core/types/joint.d.ts:1642](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1642)
 
 ##### Parameters
 
@@ -1940,7 +1940,7 @@ Defined in: [joint-core/types/joint.d.ts:1640](https://github.com/samuelgja/join
 
 > **localToPaperRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1642](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1642)
+Defined in: [joint-core/types/joint.d.ts:1644](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1644)
 
 ##### Parameters
 
@@ -1972,7 +1972,7 @@ Defined in: [joint-core/types/joint.d.ts:1642](https://github.com/samuelgja/join
 
 > **localToPaperRect**(`rect`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1643](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1643)
+Defined in: [joint-core/types/joint.d.ts:1645](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1645)
 
 ##### Parameters
 
@@ -1996,7 +1996,7 @@ Defined in: [joint-core/types/joint.d.ts:1643](https://github.com/samuelgja/join
 
 > **matrix**(): [`DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
 
-Defined in: [joint-core/types/joint.d.ts:1612](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1612)
+Defined in: [joint-core/types/joint.d.ts:1614](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1614)
 
 ##### Returns
 
@@ -2010,7 +2010,7 @@ Defined in: [joint-core/types/joint.d.ts:1612](https://github.com/samuelgja/join
 
 > **matrix**(`ctm`, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1613](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1613)
+Defined in: [joint-core/types/joint.d.ts:1615](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1615)
 
 ##### Parameters
 
@@ -2036,7 +2036,7 @@ Defined in: [joint-core/types/joint.d.ts:1613](https://github.com/samuelgja/join
 
 > **moveLayer**(`layer`, `insertBefore`): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1790](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1790)
+Defined in: [joint-core/types/joint.d.ts:1792](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1792)
 
 #### Parameters
 
@@ -2062,7 +2062,7 @@ Defined in: [joint-core/types/joint.d.ts:1790](https://github.com/samuelgja/join
 
 > **off**(`eventName`?, `callback`?, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3239](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3239)
+Defined in: [joint-core/types/joint.d.ts:3241](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3241)
 
 #### Parameters
 
@@ -2094,7 +2094,7 @@ Defined in: [joint-core/types/joint.d.ts:3239](https://github.com/samuelgja/join
 
 > **on**\<`T`\>(`eventName`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1839](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1839)
+Defined in: [joint-core/types/joint.d.ts:1841](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1841)
 
 ##### Type Parameters
 
@@ -2128,7 +2128,7 @@ Defined in: [joint-core/types/joint.d.ts:1839](https://github.com/samuelgja/join
 
 > **on**\<`T`\>(`events`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1841](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1841)
+Defined in: [joint-core/types/joint.d.ts:1843](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1843)
 
 ##### Type Parameters
 
@@ -2162,7 +2162,7 @@ Defined in: [joint-core/types/joint.d.ts:1841](https://github.com/samuelgja/join
 
 > **once**(`events`, `callback`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3245)
+Defined in: [joint-core/types/joint.d.ts:3247](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3247)
 
 ##### Parameters
 
@@ -2190,7 +2190,7 @@ Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/join
 
 > **once**(`eventMap`, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3246](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3246)
+Defined in: [joint-core/types/joint.d.ts:3248](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3248)
 
 ##### Parameters
 
@@ -2216,7 +2216,7 @@ Defined in: [joint-core/types/joint.d.ts:3246](https://github.com/samuelgja/join
 
 > **pageOffset**(): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1619](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1619)
+Defined in: [joint-core/types/joint.d.ts:1621](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1621)
 
 #### Returns
 
@@ -2234,7 +2234,7 @@ Defined in: [joint-core/types/joint.d.ts:1619](https://github.com/samuelgja/join
 
 > **pageToLocalPoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1645](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1645)
+Defined in: [joint-core/types/joint.d.ts:1647](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1647)
 
 ##### Parameters
 
@@ -2258,7 +2258,7 @@ Defined in: [joint-core/types/joint.d.ts:1645](https://github.com/samuelgja/join
 
 > **pageToLocalPoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1646](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1646)
+Defined in: [joint-core/types/joint.d.ts:1648](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1648)
 
 ##### Parameters
 
@@ -2282,7 +2282,7 @@ Defined in: [joint-core/types/joint.d.ts:1646](https://github.com/samuelgja/join
 
 > **pageToLocalRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1648](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1648)
+Defined in: [joint-core/types/joint.d.ts:1650](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1650)
 
 ##### Parameters
 
@@ -2314,7 +2314,7 @@ Defined in: [joint-core/types/joint.d.ts:1648](https://github.com/samuelgja/join
 
 > **pageToLocalRect**(`rect`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1649](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1649)
+Defined in: [joint-core/types/joint.d.ts:1651](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1651)
 
 ##### Parameters
 
@@ -2338,7 +2338,7 @@ Defined in: [joint-core/types/joint.d.ts:1649](https://github.com/samuelgja/join
 
 > **paperToLocalPoint**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1651](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1651)
+Defined in: [joint-core/types/joint.d.ts:1653](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1653)
 
 ##### Parameters
 
@@ -2362,7 +2362,7 @@ Defined in: [joint-core/types/joint.d.ts:1651](https://github.com/samuelgja/join
 
 > **paperToLocalPoint**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1652](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1652)
+Defined in: [joint-core/types/joint.d.ts:1654](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1654)
 
 ##### Parameters
 
@@ -2386,7 +2386,7 @@ Defined in: [joint-core/types/joint.d.ts:1652](https://github.com/samuelgja/join
 
 > **paperToLocalRect**(`x`, `y`, `width`, `height`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1654](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1654)
+Defined in: [joint-core/types/joint.d.ts:1656](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1656)
 
 ##### Parameters
 
@@ -2418,7 +2418,7 @@ Defined in: [joint-core/types/joint.d.ts:1654](https://github.com/samuelgja/join
 
 > **paperToLocalRect**(`x`): `Rect`
 
-Defined in: [joint-core/types/joint.d.ts:1655](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1655)
+Defined in: [joint-core/types/joint.d.ts:1657](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1657)
 
 ##### Parameters
 
@@ -2440,7 +2440,7 @@ Defined in: [joint-core/types/joint.d.ts:1655](https://github.com/samuelgja/join
 
 > **preinitialize**(`options`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:3461](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3461)
+Defined in: [joint-core/types/joint.d.ts:3463](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3463)
 
 For use with views as ES classes. If you define a preinitialize
 method, it will be invoked when the view is first created, before any
@@ -2466,7 +2466,7 @@ instantiation logic is run.
 
 > **remove**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3489](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3489)
+Defined in: [joint-core/types/joint.d.ts:3491](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3491)
 
 #### Returns
 
@@ -2482,7 +2482,7 @@ Defined in: [joint-core/types/joint.d.ts:3489](https://github.com/samuelgja/join
 
 > **removeLayer**(`layer`): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1788](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1788)
+Defined in: [joint-core/types/joint.d.ts:1790](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1790)
 
 #### Parameters
 
@@ -2504,7 +2504,7 @@ Defined in: [joint-core/types/joint.d.ts:1788](https://github.com/samuelgja/join
 
 > **removeTools**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1764](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1764)
+Defined in: [joint-core/types/joint.d.ts:1766](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1766)
 
 #### Returns
 
@@ -2520,7 +2520,7 @@ Defined in: [joint-core/types/joint.d.ts:1764](https://github.com/samuelgja/join
 
 > **render**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3488](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3488)
+Defined in: [joint-core/types/joint.d.ts:3490](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3490)
 
 #### Returns
 
@@ -2536,7 +2536,7 @@ Defined in: [joint-core/types/joint.d.ts:3488](https://github.com/samuelgja/join
 
 > **renderChildren**(`children`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3561](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3561)
+Defined in: [joint-core/types/joint.d.ts:3563](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3563)
 
 #### Parameters
 
@@ -2558,7 +2558,7 @@ Defined in: [joint-core/types/joint.d.ts:3561](https://github.com/samuelgja/join
 
 > **renderLayers**(`layers`): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1780](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1780)
+Defined in: [joint-core/types/joint.d.ts:1782](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1782)
 
 #### Parameters
 
@@ -2580,7 +2580,7 @@ Defined in: [joint-core/types/joint.d.ts:1780](https://github.com/samuelgja/join
 
 > **requestViewUpdate**(`view`, `flag`, `priority`, `opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1806](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1806)
+Defined in: [joint-core/types/joint.d.ts:1808](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1808)
 
 #### Parameters
 
@@ -2612,7 +2612,7 @@ Defined in: [joint-core/types/joint.d.ts:1806](https://github.com/samuelgja/join
 
 > **requireView**\<`T`\>(`model`, `opt`?): `T`
 
-Defined in: [joint-core/types/joint.d.ts:1808](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1808)
+Defined in: [joint-core/types/joint.d.ts:1810](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1810)
 
 #### Type Parameters
 
@@ -2646,7 +2646,7 @@ Defined in: [joint-core/types/joint.d.ts:1808](https://github.com/samuelgja/join
 
 > **scale**(): `Scale`
 
-Defined in: [joint-core/types/joint.d.ts:1744](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1744)
+Defined in: [joint-core/types/joint.d.ts:1746](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1746)
 
 ##### Returns
 
@@ -2660,7 +2660,7 @@ Defined in: [joint-core/types/joint.d.ts:1744](https://github.com/samuelgja/join
 
 > **scale**(`sx`, `sy`?, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1745](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1745)
+Defined in: [joint-core/types/joint.d.ts:1747](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1747)
 
 ##### Parameters
 
@@ -2690,7 +2690,7 @@ Defined in: [joint-core/types/joint.d.ts:1745](https://github.com/samuelgja/join
 
 > **scaleContentToFit**(`opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1986](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1986)
+Defined in: [joint-core/types/joint.d.ts:1988](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1988)
 
 #### Parameters
 
@@ -2716,7 +2716,7 @@ use transformToFitContent
 
 > **scaleUniformAtPoint**(`scale`, `point`, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1747](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1747)
+Defined in: [joint-core/types/joint.d.ts:1749](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1749)
 
 #### Parameters
 
@@ -2746,7 +2746,7 @@ Defined in: [joint-core/types/joint.d.ts:1747](https://github.com/samuelgja/join
 
 > **setDimensions**(`width`, `height`, `data`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1740](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1740)
+Defined in: [joint-core/types/joint.d.ts:1742](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1742)
 
 #### Parameters
 
@@ -2776,7 +2776,7 @@ Defined in: [joint-core/types/joint.d.ts:1740](https://github.com/samuelgja/join
 
 > **setElement**(`element`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3476](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3476)
+Defined in: [joint-core/types/joint.d.ts:3478](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3478)
 
 #### Parameters
 
@@ -2798,7 +2798,7 @@ Defined in: [joint-core/types/joint.d.ts:3476](https://github.com/samuelgja/join
 
 > **setGrid**(`opt`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1758](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1758)
+Defined in: [joint-core/types/joint.d.ts:1760](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1760)
 
 #### Parameters
 
@@ -2820,7 +2820,7 @@ Defined in: [joint-core/types/joint.d.ts:1758](https://github.com/samuelgja/join
 
 > **setGridSize**(`gridSize`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1760](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1760)
+Defined in: [joint-core/types/joint.d.ts:1762](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1762)
 
 #### Parameters
 
@@ -2842,7 +2842,7 @@ Defined in: [joint-core/types/joint.d.ts:1760](https://github.com/samuelgja/join
 
 > **setInteractivity**(`value`): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1742](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1742)
+Defined in: [joint-core/types/joint.d.ts:1744](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1744)
 
 #### Parameters
 
@@ -2864,7 +2864,7 @@ Defined in: [joint-core/types/joint.d.ts:1742](https://github.com/samuelgja/join
 
 > **setTheme**(`theme`, `opt`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3543](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3543)
+Defined in: [joint-core/types/joint.d.ts:3545](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3545)
 
 #### Parameters
 
@@ -2892,7 +2892,7 @@ Defined in: [joint-core/types/joint.d.ts:3543](https://github.com/samuelgja/join
 
 > **showTools**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1768](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1768)
+Defined in: [joint-core/types/joint.d.ts:1770](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1770)
 
 #### Returns
 
@@ -2910,7 +2910,7 @@ Defined in: [joint-core/types/joint.d.ts:1768](https://github.com/samuelgja/join
 
 > **snapToGrid**(`x`, `y`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1657](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1657)
+Defined in: [joint-core/types/joint.d.ts:1659](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1659)
 
 ##### Parameters
 
@@ -2934,7 +2934,7 @@ Defined in: [joint-core/types/joint.d.ts:1657](https://github.com/samuelgja/join
 
 > **snapToGrid**(`point`): `Point`
 
-Defined in: [joint-core/types/joint.d.ts:1658](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1658)
+Defined in: [joint-core/types/joint.d.ts:1660](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1660)
 
 ##### Parameters
 
@@ -2956,7 +2956,7 @@ Defined in: [joint-core/types/joint.d.ts:1658](https://github.com/samuelgja/join
 
 > **stopListening**(`object`?, `events`?, `callback`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3251](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3251)
+Defined in: [joint-core/types/joint.d.ts:3253](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3253)
 
 #### Parameters
 
@@ -2986,7 +2986,7 @@ Defined in: [joint-core/types/joint.d.ts:3251](https://github.com/samuelgja/join
 
 > **stopPropagation**(`evt`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3558](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3558)
+Defined in: [joint-core/types/joint.d.ts:3560](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3560)
 
 #### Parameters
 
@@ -3008,7 +3008,7 @@ Defined in: [joint-core/types/joint.d.ts:3558](https://github.com/samuelgja/join
 
 > **transformToFitContent**(`opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1732](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1732)
+Defined in: [joint-core/types/joint.d.ts:1734](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1734)
 
 #### Parameters
 
@@ -3032,7 +3032,7 @@ Defined in: [joint-core/types/joint.d.ts:1732](https://github.com/samuelgja/join
 
 > **translate**(): `Translation`
 
-Defined in: [joint-core/types/joint.d.ts:1749](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1749)
+Defined in: [joint-core/types/joint.d.ts:1751](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1751)
 
 ##### Returns
 
@@ -3046,7 +3046,7 @@ Defined in: [joint-core/types/joint.d.ts:1749](https://github.com/samuelgja/join
 
 > **translate**(`tx`, `ty`?, `data`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1750](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1750)
+Defined in: [joint-core/types/joint.d.ts:1752](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1752)
 
 ##### Parameters
 
@@ -3076,7 +3076,7 @@ Defined in: [joint-core/types/joint.d.ts:1750](https://github.com/samuelgja/join
 
 > **trigger**(`eventName`, ...`args`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3240](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3240)
+Defined in: [joint-core/types/joint.d.ts:3242](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3242)
 
 #### Parameters
 
@@ -3102,7 +3102,7 @@ Defined in: [joint-core/types/joint.d.ts:3240](https://github.com/samuelgja/join
 
 > **unbind**(`eventName`?, `callback`?, `context`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3243](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3243)
+Defined in: [joint-core/types/joint.d.ts:3245](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3245)
 
 #### Parameters
 
@@ -3132,7 +3132,7 @@ Defined in: [joint-core/types/joint.d.ts:3243](https://github.com/samuelgja/join
 
 > **undelegate**(`eventName`, `selector`?, `listener`?): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3493](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3493)
+Defined in: [joint-core/types/joint.d.ts:3495](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3495)
 
 #### Parameters
 
@@ -3162,7 +3162,7 @@ Defined in: [joint-core/types/joint.d.ts:3493](https://github.com/samuelgja/join
 
 > **undelegateDocumentEvents**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3549](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3549)
+Defined in: [joint-core/types/joint.d.ts:3551](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3551)
 
 #### Returns
 
@@ -3178,7 +3178,7 @@ Defined in: [joint-core/types/joint.d.ts:3549](https://github.com/samuelgja/join
 
 > **undelegateElementEvents**(`element`): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3553](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3553)
+Defined in: [joint-core/types/joint.d.ts:3555](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3555)
 
 #### Parameters
 
@@ -3200,7 +3200,7 @@ Defined in: [joint-core/types/joint.d.ts:3553](https://github.com/samuelgja/join
 
 > **undelegateEvents**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:3492](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3492)
+Defined in: [joint-core/types/joint.d.ts:3494](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3494)
 
 #### Returns
 
@@ -3216,7 +3216,7 @@ Defined in: [joint-core/types/joint.d.ts:3492](https://github.com/samuelgja/join
 
 > **unfreeze**(`opt`?): `void`
 
-Defined in: [joint-core/types/joint.d.ts:1802](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1802)
+Defined in: [joint-core/types/joint.d.ts:1804](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1804)
 
 #### Parameters
 
@@ -3238,7 +3238,7 @@ Defined in: [joint-core/types/joint.d.ts:1802](https://github.com/samuelgja/join
 
 > **unmount**(): `void`
 
-Defined in: [joint-core/types/joint.d.ts:3567](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3567)
+Defined in: [joint-core/types/joint.d.ts:3569](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3569)
 
 #### Returns
 
@@ -3254,7 +3254,7 @@ Defined in: [joint-core/types/joint.d.ts:3567](https://github.com/samuelgja/join
 
 > **update**(): `this`
 
-Defined in: [joint-core/types/joint.d.ts:1752](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1752)
+Defined in: [joint-core/types/joint.d.ts:1754](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1754)
 
 #### Returns
 
@@ -3270,7 +3270,7 @@ Defined in: [joint-core/types/joint.d.ts:1752](https://github.com/samuelgja/join
 
 > **updateViews**(`opt`?): `object`
 
-Defined in: [joint-core/types/joint.d.ts:1826](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1826)
+Defined in: [joint-core/types/joint.d.ts:1828](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1828)
 
 #### Parameters
 
@@ -3310,7 +3310,7 @@ Defined in: [joint-core/types/joint.d.ts:1826](https://github.com/samuelgja/join
 
 > **$el**: `unknown`
 
-Defined in: [joint-core/types/joint.d.ts:3485](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3485)
+Defined in: [joint-core/types/joint.d.ts:3487](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3487)
 
 #### Inherited from
 
@@ -3322,7 +3322,7 @@ Defined in: [joint-core/types/joint.d.ts:3485](https://github.com/samuelgja/join
 
 > **attributes**: [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `any`\>
 
-Defined in: [joint-core/types/joint.d.ts:3483](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3483)
+Defined in: [joint-core/types/joint.d.ts:3485](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3485)
 
 #### Inherited from
 
@@ -3334,7 +3334,7 @@ Defined in: [joint-core/types/joint.d.ts:3483](https://github.com/samuelgja/join
 
 > **cells**: [`SVGGElement`](https://developer.mozilla.org/docs/Web/API/SVGGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1604](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1604)
+Defined in: [joint-core/types/joint.d.ts:1606](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1606)
 
 #### Inherited from
 
@@ -3346,7 +3346,7 @@ Defined in: [joint-core/types/joint.d.ts:1604](https://github.com/samuelgja/join
 
 > `optional` **childNodes**: `null` \| \{\}
 
-Defined in: [joint-core/types/joint.d.ts:3539](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3539)
+Defined in: [joint-core/types/joint.d.ts:3541](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3541)
 
 #### Inherited from
 
@@ -3358,7 +3358,7 @@ Defined in: [joint-core/types/joint.d.ts:3539](https://github.com/samuelgja/join
 
 > `optional` **children**: `MarkupJSON`
 
-Defined in: [joint-core/types/joint.d.ts:3537](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3537)
+Defined in: [joint-core/types/joint.d.ts:3539](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3539)
 
 #### Inherited from
 
@@ -3370,7 +3370,7 @@ Defined in: [joint-core/types/joint.d.ts:3537](https://github.com/samuelgja/join
 
 > **cid**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3478](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3478)
+Defined in: [joint-core/types/joint.d.ts:3480](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3480)
 
 #### Inherited from
 
@@ -3382,7 +3382,7 @@ Defined in: [joint-core/types/joint.d.ts:3478](https://github.com/samuelgja/join
 
 > `optional` **className**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3479](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3479)
+Defined in: [joint-core/types/joint.d.ts:3481](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3481)
 
 #### Inherited from
 
@@ -3394,7 +3394,7 @@ Defined in: [joint-core/types/joint.d.ts:3479](https://github.com/samuelgja/join
 
 > **collection**: `Collection`\<`any`\>
 
-Defined in: [joint-core/types/joint.d.ts:3475](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3475)
+Defined in: [joint-core/types/joint.d.ts:3477](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3477)
 
 #### Inherited from
 
@@ -3406,7 +3406,7 @@ Defined in: [joint-core/types/joint.d.ts:3475](https://github.com/samuelgja/join
 
 > **defaultTheme**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3531](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3531)
+Defined in: [joint-core/types/joint.d.ts:3533](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3533)
 
 #### Inherited from
 
@@ -3418,7 +3418,7 @@ Defined in: [joint-core/types/joint.d.ts:3531](https://github.com/samuelgja/join
 
 > **defs**: [`SVGDefsElement`](https://developer.mozilla.org/docs/Web/API/SVGDefsElement)
 
-Defined in: [joint-core/types/joint.d.ts:1603](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1603)
+Defined in: [joint-core/types/joint.d.ts:1605](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1605)
 
 #### Inherited from
 
@@ -3430,7 +3430,7 @@ Defined in: [joint-core/types/joint.d.ts:1603](https://github.com/samuelgja/join
 
 > **DETACHABLE**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3516](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3516)
+Defined in: [joint-core/types/joint.d.ts:3518](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3518)
 
 #### Inherited from
 
@@ -3442,7 +3442,7 @@ Defined in: [joint-core/types/joint.d.ts:3516](https://github.com/samuelgja/join
 
 > `optional` **documentEvents**: `EventsHash`
 
-Defined in: [joint-core/types/joint.d.ts:3535](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3535)
+Defined in: [joint-core/types/joint.d.ts:3537](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3537)
 
 #### Inherited from
 
@@ -3454,7 +3454,7 @@ Defined in: [joint-core/types/joint.d.ts:3535](https://github.com/samuelgja/join
 
 > **el**: [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
-Defined in: [joint-core/types/joint.d.ts:3482](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3482)
+Defined in: [joint-core/types/joint.d.ts:3484](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3484)
 
 #### Inherited from
 
@@ -3466,7 +3466,7 @@ Defined in: [joint-core/types/joint.d.ts:3482](https://github.com/samuelgja/join
 
 > **FLAG\_INIT**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:3519](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3519)
+Defined in: [joint-core/types/joint.d.ts:3521](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3521)
 
 #### Inherited from
 
@@ -3478,7 +3478,7 @@ Defined in: [joint-core/types/joint.d.ts:3519](https://github.com/samuelgja/join
 
 > **FLAG\_INSERT**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:3517](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3517)
+Defined in: [joint-core/types/joint.d.ts:3519](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3519)
 
 #### Inherited from
 
@@ -3490,7 +3490,7 @@ Defined in: [joint-core/types/joint.d.ts:3517](https://github.com/samuelgja/join
 
 > **FLAG\_REMOVE**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:3518](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3518)
+Defined in: [joint-core/types/joint.d.ts:3520](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3520)
 
 #### Inherited from
 
@@ -3502,7 +3502,7 @@ Defined in: [joint-core/types/joint.d.ts:3518](https://github.com/samuelgja/join
 
 > **FORM\_CONTROLS\_TAG\_NAMES**: `string`[]
 
-Defined in: [joint-core/types/joint.d.ts:1610](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1610)
+Defined in: [joint-core/types/joint.d.ts:1612](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1612)
 
 #### Inherited from
 
@@ -3514,7 +3514,7 @@ Defined in: [joint-core/types/joint.d.ts:1610](https://github.com/samuelgja/join
 
 > **GUARDED\_TAG\_NAMES**: `string`[]
 
-Defined in: [joint-core/types/joint.d.ts:1609](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1609)
+Defined in: [joint-core/types/joint.d.ts:1611](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1611)
 
 #### Inherited from
 
@@ -3526,7 +3526,7 @@ Defined in: [joint-core/types/joint.d.ts:1609](https://github.com/samuelgja/join
 
 > `optional` **id**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3477](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3477)
+Defined in: [joint-core/types/joint.d.ts:3479](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3479)
 
 #### Inherited from
 
@@ -3538,7 +3538,7 @@ Defined in: [joint-core/types/joint.d.ts:3477](https://github.com/samuelgja/join
 
 > **layers**: [`SVGGElement`](https://developer.mozilla.org/docs/Web/API/SVGGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1606](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1606)
+Defined in: [joint-core/types/joint.d.ts:1608](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1608)
 
 #### Inherited from
 
@@ -3550,7 +3550,7 @@ Defined in: [joint-core/types/joint.d.ts:1606](https://github.com/samuelgja/join
 
 > **model**: `Graph`\<`Attributes`, `ModelSetOptions`\>
 
-Defined in: [joint-core/types/joint.d.ts:3474](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3474)
+Defined in: [joint-core/types/joint.d.ts:3476](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3476)
 
 #### Inherited from
 
@@ -3562,7 +3562,7 @@ Defined in: [joint-core/types/joint.d.ts:3474](https://github.com/samuelgja/join
 
 > **options**: `Options`
 
-Defined in: [joint-core/types/joint.d.ts:1598](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1598)
+Defined in: [joint-core/types/joint.d.ts:1600](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1600)
 
 #### Inherited from
 
@@ -3582,7 +3582,7 @@ Defined in: [joint-react/src/context/paper-context.tsx:7](https://github.com/sam
 
 > **requireSetThemeOverride**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3533](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3533)
+Defined in: [joint-core/types/joint.d.ts:3535](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3535)
 
 #### Inherited from
 
@@ -3594,7 +3594,7 @@ Defined in: [joint-core/types/joint.d.ts:3533](https://github.com/samuelgja/join
 
 > `optional` **style**: `object`
 
-Defined in: [joint-core/types/joint.d.ts:3541](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3541)
+Defined in: [joint-core/types/joint.d.ts:3543](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3543)
 
 #### Index Signature
 
@@ -3610,7 +3610,7 @@ Defined in: [joint-core/types/joint.d.ts:3541](https://github.com/samuelgja/join
 
 > **stylesheet**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:1600](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1600)
+Defined in: [joint-core/types/joint.d.ts:1602](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1602)
 
 #### Inherited from
 
@@ -3622,7 +3622,7 @@ Defined in: [joint-core/types/joint.d.ts:1600](https://github.com/samuelgja/join
 
 > **svg**: [`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1602](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1602)
+Defined in: [joint-core/types/joint.d.ts:1604](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1604)
 
 #### Inherited from
 
@@ -3634,7 +3634,7 @@ Defined in: [joint-core/types/joint.d.ts:1602](https://github.com/samuelgja/join
 
 > **svgElement**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:3523](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3523)
+Defined in: [joint-core/types/joint.d.ts:3525](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3525)
 
 #### Inherited from
 
@@ -3646,7 +3646,7 @@ Defined in: [joint-core/types/joint.d.ts:3523](https://github.com/samuelgja/join
 
 > **tagName**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3480](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3480)
+Defined in: [joint-core/types/joint.d.ts:3482](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3482)
 
 #### Inherited from
 
@@ -3658,7 +3658,7 @@ Defined in: [joint-core/types/joint.d.ts:3480](https://github.com/samuelgja/join
 
 > **theme**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3527](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3527)
+Defined in: [joint-core/types/joint.d.ts:3529](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3529)
 
 #### Inherited from
 
@@ -3670,7 +3670,7 @@ Defined in: [joint-core/types/joint.d.ts:3527](https://github.com/samuelgja/join
 
 > **themeClassNamePrefix**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3529](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3529)
+Defined in: [joint-core/types/joint.d.ts:3531](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3531)
 
 #### Inherited from
 
@@ -3682,7 +3682,7 @@ Defined in: [joint-core/types/joint.d.ts:3529](https://github.com/samuelgja/join
 
 > **tools**: [`SVGGElement`](https://developer.mozilla.org/docs/Web/API/SVGGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1605](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1605)
+Defined in: [joint-core/types/joint.d.ts:1607](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1607)
 
 #### Inherited from
 
@@ -3694,7 +3694,7 @@ Defined in: [joint-core/types/joint.d.ts:1605](https://github.com/samuelgja/join
 
 > **UPDATE\_PRIORITY**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:3515](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3515)
+Defined in: [joint-core/types/joint.d.ts:3517](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3517)
 
 #### Inherited from
 
@@ -3706,7 +3706,7 @@ Defined in: [joint-core/types/joint.d.ts:3515](https://github.com/samuelgja/join
 
 > **vel**: `null`
 
-Defined in: [joint-core/types/joint.d.ts:3521](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3521)
+Defined in: [joint-core/types/joint.d.ts:3523](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3523)
 
 #### Inherited from
 
@@ -3718,7 +3718,7 @@ Defined in: [joint-core/types/joint.d.ts:3521](https://github.com/samuelgja/join
 
 > **viewport**: [`SVGGElement`](https://developer.mozilla.org/docs/Web/API/SVGGElement)
 
-Defined in: [joint-core/types/joint.d.ts:1607](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1607)
+Defined in: [joint-core/types/joint.d.ts:1609](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1609)
 
 #### Inherited from
 

--- a/packages/joint-react/docs/interfaces/PaperProps.md
+++ b/packages/joint-react/docs/interfaces/PaperProps.md
@@ -35,7 +35,7 @@ https://docs.jointjs.com/api/dia/Paper
 
 > `optional` **afterRender**: `AfterRenderCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1456](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1456)
+Defined in: [joint-core/types/joint.d.ts:1458](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1458)
 
 #### Inherited from
 
@@ -47,7 +47,7 @@ Defined in: [joint-core/types/joint.d.ts:1456](https://github.com/samuelgja/join
 
 > `optional` **allowLink**: `null` \| (`linkView`, `paper`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1413](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1413)
+Defined in: [joint-core/types/joint.d.ts:1415](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1415)
 
 #### Inherited from
 
@@ -59,7 +59,7 @@ Defined in: [joint-core/types/joint.d.ts:1413](https://github.com/samuelgja/join
 
 > `optional` **anchorNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1436](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1436)
+Defined in: [joint-core/types/joint.d.ts:1438](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1438)
 
 #### Inherited from
 
@@ -71,7 +71,7 @@ Defined in: [joint-core/types/joint.d.ts:1436](https://github.com/samuelgja/join
 
 > `optional` **async**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1448](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1448)
+Defined in: [joint-core/types/joint.d.ts:1450](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1450)
 
 #### Inherited from
 
@@ -83,7 +83,7 @@ Defined in: [joint-core/types/joint.d.ts:1448](https://github.com/samuelgja/join
 
 > `optional` **attributes**: [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `any`\>
 
-Defined in: [joint-core/types/joint.d.ts:3442](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3442)
+Defined in: [joint-core/types/joint.d.ts:3444](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3444)
 
 #### Inherited from
 
@@ -95,7 +95,7 @@ Defined in: [joint-core/types/joint.d.ts:3442](https://github.com/samuelgja/join
 
 > `optional` **autoFreeze**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1451](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1451)
+Defined in: [joint-core/types/joint.d.ts:1453](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1453)
 
 #### Inherited from
 
@@ -107,7 +107,7 @@ Defined in: [joint-core/types/joint.d.ts:1451](https://github.com/samuelgja/join
 
 > `optional` **background**: `BackgroundOptions`
 
-Defined in: [joint-core/types/joint.d.ts:1397](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1397)
+Defined in: [joint-core/types/joint.d.ts:1399](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1399)
 
 #### Inherited from
 
@@ -119,7 +119,7 @@ Defined in: [joint-core/types/joint.d.ts:1397](https://github.com/samuelgja/join
 
 > `optional` **beforeRender**: `BeforeRenderCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1455](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1455)
+Defined in: [joint-core/types/joint.d.ts:1457](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1457)
 
 #### Inherited from
 
@@ -131,7 +131,7 @@ Defined in: [joint-core/types/joint.d.ts:1455](https://github.com/samuelgja/join
 
 > `optional` **cellViewNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1432](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1432)
+Defined in: [joint-core/types/joint.d.ts:1434](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1434)
 
 #### Inherited from
 
@@ -188,7 +188,7 @@ If the mouse moves more than this distance, it will be considered a drag event.
 
 > `optional` **collection**: `Collection`\<`any`\>
 
-Defined in: [joint-core/types/joint.d.ts:3439](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3439)
+Defined in: [joint-core/types/joint.d.ts:3441](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3441)
 
 #### Inherited from
 
@@ -200,7 +200,7 @@ Defined in: [joint-core/types/joint.d.ts:3439](https://github.com/samuelgja/join
 
 > `optional` **connectionPointNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1438](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1438)
+Defined in: [joint-core/types/joint.d.ts:1440](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1440)
 
 #### Inherited from
 
@@ -212,7 +212,7 @@ Defined in: [joint-core/types/joint.d.ts:1438](https://github.com/samuelgja/join
 
 > `optional` **connectionStrategy**: `ConnectionStrategy`
 
-Defined in: [joint-core/types/joint.d.ts:1446](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1446)
+Defined in: [joint-core/types/joint.d.ts:1448](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1448)
 
 #### Inherited from
 
@@ -224,7 +224,7 @@ Defined in: [joint-core/types/joint.d.ts:1446](https://github.com/samuelgja/join
 
 > `optional` **connectorNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1434](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1434)
+Defined in: [joint-core/types/joint.d.ts:1436](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1436)
 
 #### Inherited from
 
@@ -236,7 +236,7 @@ Defined in: [joint-core/types/joint.d.ts:1434](https://github.com/samuelgja/join
 
 > `optional` **defaultAnchor**: `AnchorJSON` \| `Anchor`
 
-Defined in: [joint-core/types/joint.d.ts:1442](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1442)
+Defined in: [joint-core/types/joint.d.ts:1444](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1444)
 
 #### Inherited from
 
@@ -248,7 +248,7 @@ Defined in: [joint-core/types/joint.d.ts:1442](https://github.com/samuelgja/join
 
 > `optional` **defaultConnectionPoint**: `ConnectionPointJSON` \| `ConnectionPoint` \| (...`args`) => `ConnectionPoint`
 
-Defined in: [joint-core/types/joint.d.ts:1444](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1444)
+Defined in: [joint-core/types/joint.d.ts:1446](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1446)
 
 #### Inherited from
 
@@ -260,7 +260,7 @@ Defined in: [joint-core/types/joint.d.ts:1444](https://github.com/samuelgja/join
 
 > `optional` **defaultConnector**: `Connector` \| `ConnectorJSON`
 
-Defined in: [joint-core/types/joint.d.ts:1441](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1441)
+Defined in: [joint-core/types/joint.d.ts:1443](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1443)
 
 #### Inherited from
 
@@ -272,7 +272,7 @@ Defined in: [joint-core/types/joint.d.ts:1441](https://github.com/samuelgja/join
 
 > `optional` **defaultLink**: `Link`\<`Attributes`, `ModelSetOptions`\> \| (`cellView`, `magnet`) => `Link`
 
-Defined in: [joint-core/types/joint.d.ts:1439](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1439)
+Defined in: [joint-core/types/joint.d.ts:1441](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1441)
 
 #### Inherited from
 
@@ -284,7 +284,7 @@ Defined in: [joint-core/types/joint.d.ts:1439](https://github.com/samuelgja/join
 
 > `optional` **defaultLinkAnchor**: `AnchorJSON` \| `Anchor`
 
-Defined in: [joint-core/types/joint.d.ts:1443](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1443)
+Defined in: [joint-core/types/joint.d.ts:1445](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1445)
 
 #### Inherited from
 
@@ -296,7 +296,7 @@ Defined in: [joint-core/types/joint.d.ts:1443](https://github.com/samuelgja/join
 
 > `optional` **defaultRouter**: `Router` \| `RouterJSON`
 
-Defined in: [joint-core/types/joint.d.ts:1440](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1440)
+Defined in: [joint-core/types/joint.d.ts:1442](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1442)
 
 #### Inherited from
 
@@ -308,7 +308,7 @@ Defined in: [joint-core/types/joint.d.ts:1440](https://github.com/samuelgja/join
 
 > `optional` **drawGrid**: `boolean` \| `GridOptions` \| `GridOptions`[]
 
-Defined in: [joint-core/types/joint.d.ts:1395](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1395)
+Defined in: [joint-core/types/joint.d.ts:1397](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1397)
 
 #### Inherited from
 
@@ -320,7 +320,7 @@ Defined in: [joint-core/types/joint.d.ts:1395](https://github.com/samuelgja/join
 
 > `optional` **drawGridSize**: `null` \| `number`
 
-Defined in: [joint-core/types/joint.d.ts:1396](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1396)
+Defined in: [joint-core/types/joint.d.ts:1398](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1398)
 
 #### Inherited from
 
@@ -332,7 +332,7 @@ Defined in: [joint-core/types/joint.d.ts:1396](https://github.com/samuelgja/join
 
 > `optional` **el**: `unknown`
 
-Defined in: [joint-core/types/joint.d.ts:3440](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3440)
+Defined in: [joint-core/types/joint.d.ts:3442](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3442)
 
 #### Inherited from
 
@@ -373,7 +373,7 @@ GraphElement<Data>
 
 > `optional` **elementView**: *typeof* `ElementView` \| (`element`) => *typeof* `ElementView`
 
-Defined in: [joint-core/types/joint.d.ts:1423](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1423)
+Defined in: [joint-core/types/joint.d.ts:1425](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1425)
 
 #### Inherited from
 
@@ -385,7 +385,7 @@ Defined in: [joint-core/types/joint.d.ts:1423](https://github.com/samuelgja/join
 
 > `optional` **embeddingMode**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1426](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1426)
+Defined in: [joint-core/types/joint.d.ts:1428](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1428)
 
 #### Inherited from
 
@@ -397,7 +397,7 @@ Defined in: [joint-core/types/joint.d.ts:1426](https://github.com/samuelgja/join
 
 > `optional` **events**: `_Result`\<`EventsHash`\>
 
-Defined in: [joint-core/types/joint.d.ts:3445](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3445)
+Defined in: [joint-core/types/joint.d.ts:3447](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3447)
 
 #### Inherited from
 
@@ -409,7 +409,7 @@ Defined in: [joint-core/types/joint.d.ts:3445](https://github.com/samuelgja/join
 
 > `optional` **findParentBy**: `FindParentByType` \| `FindParentByCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1428](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1428)
+Defined in: [joint-core/types/joint.d.ts:1430](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1430)
 
 #### Inherited from
 
@@ -421,7 +421,7 @@ Defined in: [joint-core/types/joint.d.ts:1428](https://github.com/samuelgja/join
 
 > `optional` **frontParentOnly**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1427](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1427)
+Defined in: [joint-core/types/joint.d.ts:1429](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1429)
 
 #### Inherited from
 
@@ -433,7 +433,7 @@ Defined in: [joint-core/types/joint.d.ts:1427](https://github.com/samuelgja/join
 
 > `optional` **frozen**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1450](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1450)
+Defined in: [joint-core/types/joint.d.ts:1452](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1452)
 
 #### Inherited from
 
@@ -445,7 +445,7 @@ Defined in: [joint-core/types/joint.d.ts:1450](https://github.com/samuelgja/join
 
 > `optional` **gridSize**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:1400](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1400)
+Defined in: [joint-core/types/joint.d.ts:1402](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1402)
 
 #### Inherited from
 
@@ -457,7 +457,7 @@ Defined in: [joint-core/types/joint.d.ts:1400](https://github.com/samuelgja/join
 
 > `optional` **guard**: (`evt`, `view`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1415](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1415)
+Defined in: [joint-core/types/joint.d.ts:1417](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1417)
 
 #### Parameters
 
@@ -483,7 +483,7 @@ Defined in: [joint-core/types/joint.d.ts:1415](https://github.com/samuelgja/join
 
 > `optional` **height**: `Dimension`
 
-Defined in: [joint-core/types/joint.d.ts:1394](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1394)
+Defined in: [joint-core/types/joint.d.ts:1396](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1396)
 
 #### Inherited from
 
@@ -495,7 +495,7 @@ Defined in: [joint-core/types/joint.d.ts:1394](https://github.com/samuelgja/join
 
 > `optional` **highlighterNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1435](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1435)
+Defined in: [joint-core/types/joint.d.ts:1437](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1437)
 
 #### Inherited from
 
@@ -507,7 +507,7 @@ Defined in: [joint-core/types/joint.d.ts:1435](https://github.com/samuelgja/join
 
 > `optional` **highlighting**: `boolean` \| [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `boolean` \| `HighlighterJSON`\>
 
-Defined in: [joint-core/types/joint.d.ts:1401](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1401)
+Defined in: [joint-core/types/joint.d.ts:1403](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1403)
 
 #### Inherited from
 
@@ -519,7 +519,7 @@ Defined in: [joint-core/types/joint.d.ts:1401](https://github.com/samuelgja/join
 
 > `optional` **id**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3441](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3441)
+Defined in: [joint-core/types/joint.d.ts:3443](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3443)
 
 #### Inherited from
 
@@ -531,7 +531,7 @@ Defined in: [joint-core/types/joint.d.ts:3441](https://github.com/samuelgja/join
 
 > `optional` **interactive**: `boolean` \| (`cellView`, `event`) => `boolean` \| `InteractivityOptions` \| `InteractivityOptions`
 
-Defined in: [joint-core/types/joint.d.ts:1402](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1402)
+Defined in: [joint-core/types/joint.d.ts:1404](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1404)
 
 #### Inherited from
 
@@ -543,7 +543,7 @@ Defined in: [joint-core/types/joint.d.ts:1402](https://github.com/samuelgja/join
 
 > `optional` **labelsLayer**: `string` \| `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1398](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1398)
+Defined in: [joint-core/types/joint.d.ts:1400](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1400)
 
 #### Inherited from
 
@@ -555,7 +555,7 @@ Defined in: [joint-core/types/joint.d.ts:1398](https://github.com/samuelgja/join
 
 > `optional` **linkAnchorNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1437](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1437)
+Defined in: [joint-core/types/joint.d.ts:1439](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1439)
 
 #### Inherited from
 
@@ -567,7 +567,7 @@ Defined in: [joint-core/types/joint.d.ts:1437](https://github.com/samuelgja/join
 
 > `optional` **linkPinning**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1412](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1412)
+Defined in: [joint-core/types/joint.d.ts:1414](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1414)
 
 #### Inherited from
 
@@ -579,7 +579,7 @@ Defined in: [joint-core/types/joint.d.ts:1412](https://github.com/samuelgja/join
 
 > `optional` **linkView**: *typeof* `LinkView` \| (`link`) => *typeof* `LinkView`
 
-Defined in: [joint-core/types/joint.d.ts:1424](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1424)
+Defined in: [joint-core/types/joint.d.ts:1426](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1426)
 
 #### Inherited from
 
@@ -591,7 +591,7 @@ Defined in: [joint-core/types/joint.d.ts:1424](https://github.com/samuelgja/join
 
 > `optional` **magnetThreshold**: `string` \| `number`
 
-Defined in: [joint-core/types/joint.d.ts:1421](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1421)
+Defined in: [joint-core/types/joint.d.ts:1423](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1423)
 
 #### Inherited from
 
@@ -603,7 +603,7 @@ Defined in: [joint-core/types/joint.d.ts:1421](https://github.com/samuelgja/join
 
 > `optional` **markAvailable**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1406](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1406)
+Defined in: [joint-core/types/joint.d.ts:1408](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1408)
 
 #### Inherited from
 
@@ -615,7 +615,7 @@ Defined in: [joint-core/types/joint.d.ts:1406](https://github.com/samuelgja/join
 
 > `optional` **model**: `Graph`\<`Attributes`, `ModelSetOptions`\>
 
-Defined in: [joint-core/types/joint.d.ts:3437](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3437)
+Defined in: [joint-core/types/joint.d.ts:3439](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3439)
 
 #### Inherited from
 
@@ -627,7 +627,7 @@ Defined in: [joint-core/types/joint.d.ts:3437](https://github.com/samuelgja/join
 
 > `optional` **moveThreshold**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:1420](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1420)
+Defined in: [joint-core/types/joint.d.ts:1422](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1422)
 
 #### Inherited from
 
@@ -639,7 +639,7 @@ Defined in: [joint-core/types/joint.d.ts:1420](https://github.com/samuelgja/join
 
 > `optional` **multiLinks**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1411](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1411)
+Defined in: [joint-core/types/joint.d.ts:1413](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1413)
 
 #### Inherited from
 
@@ -1645,9 +1645,9 @@ Defined in: [joint-react/src/types/event.types.ts:234](https://github.com/samuel
 
 ***
 
-### onElementSizeChange()?
+### onElementsSizeChange()?
 
-> `readonly` `optional` **onElementSizeChange**: (`options`) => `void`
+> `readonly` `optional` **onElementsSizeChange**: (`options`) => `void`
 
 Defined in: [joint-react/src/components/paper/paper.tsx:70](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/paper/paper.tsx#L70)
 
@@ -1666,9 +1666,9 @@ It is useful for like onLoad event to do some layout or other operations with `g
 
 ***
 
-### onElementsMeasured()?
+### onElementsSizeReady()?
 
-> `readonly` `optional` **onElementsMeasured**: (`options`) => `void`
+> `readonly` `optional` **onElementsSizeReady**: (`options`) => `void`
 
 Defined in: [joint-react/src/components/paper/paper.tsx:64](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/paper/paper.tsx#L64)
 
@@ -2528,7 +2528,7 @@ Defined in: [joint-react/src/types/event.types.ts:441](https://github.com/samuel
 
 > `optional` **onViewPostponed**: (`view`, `flag`, `paper`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1454](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1454)
+Defined in: [joint-core/types/joint.d.ts:1456](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1456)
 
 #### Parameters
 
@@ -2558,7 +2558,7 @@ Defined in: [joint-core/types/joint.d.ts:1454](https://github.com/samuelgja/join
 
 > `optional` **onViewUpdate**: (`view`, `flag`, `priority`, `opt`, `paper`) => `void`
 
-Defined in: [joint-core/types/joint.d.ts:1453](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1453)
+Defined in: [joint-core/types/joint.d.ts:1455](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1455)
 
 #### Parameters
 
@@ -2594,7 +2594,7 @@ Defined in: [joint-core/types/joint.d.ts:1453](https://github.com/samuelgja/join
 
 > `optional` **overflow**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1457](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1457)
+Defined in: [joint-core/types/joint.d.ts:1459](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1459)
 
 #### Inherited from
 
@@ -2631,7 +2631,7 @@ The paper instance
 
 > `optional` **preventContextMenu**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1416](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1416)
+Defined in: [joint-core/types/joint.d.ts:1418](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1418)
 
 #### Inherited from
 
@@ -2643,7 +2643,7 @@ Defined in: [joint-core/types/joint.d.ts:1416](https://github.com/samuelgja/join
 
 > `optional` **preventDefaultBlankAction**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1418](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1418)
+Defined in: [joint-core/types/joint.d.ts:1420](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1420)
 
 #### Inherited from
 
@@ -2655,7 +2655,7 @@ Defined in: [joint-core/types/joint.d.ts:1418](https://github.com/samuelgja/join
 
 > `optional` **preventDefaultViewAction**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1417](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1417)
+Defined in: [joint-core/types/joint.d.ts:1419](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1419)
 
 #### Inherited from
 
@@ -2702,7 +2702,7 @@ const renderElement: RenderElement<BaseElementWithData> = useCallback(
 
 > `optional` **restrictTranslate**: `boolean` \| `PlainRect` \| `RestrictTranslateCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1410](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1410)
+Defined in: [joint-core/types/joint.d.ts:1412](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1412)
 
 #### Inherited from
 
@@ -2714,7 +2714,7 @@ Defined in: [joint-core/types/joint.d.ts:1410](https://github.com/samuelgja/join
 
 > `optional` **routerNamespace**: `any`
 
-Defined in: [joint-core/types/joint.d.ts:1433](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1433)
+Defined in: [joint-core/types/joint.d.ts:1435](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1435)
 
 #### Inherited from
 
@@ -2736,7 +2736,7 @@ The scale of the paper. It's useful to create for example a zoom feature or mini
 
 > `optional` **snapLabels**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1403](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1403)
+Defined in: [joint-core/types/joint.d.ts:1405](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1405)
 
 #### Inherited from
 
@@ -2748,7 +2748,7 @@ Defined in: [joint-core/types/joint.d.ts:1403](https://github.com/samuelgja/join
 
 > `optional` **snapLinks**: `boolean` \| `SnapLinksOptions`
 
-Defined in: [joint-core/types/joint.d.ts:1404](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1404)
+Defined in: [joint-core/types/joint.d.ts:1406](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1406)
 
 #### Inherited from
 
@@ -2760,7 +2760,7 @@ Defined in: [joint-core/types/joint.d.ts:1404](https://github.com/samuelgja/join
 
 > `optional` **snapLinksSelf**: `boolean` \| \{ `distance`: `number`; \}
 
-Defined in: [joint-core/types/joint.d.ts:1405](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1405)
+Defined in: [joint-core/types/joint.d.ts:1407](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1407)
 
 #### Inherited from
 
@@ -2772,7 +2772,7 @@ Defined in: [joint-core/types/joint.d.ts:1405](https://github.com/samuelgja/join
 
 > `optional` **sorting**: `sorting`
 
-Defined in: [joint-core/types/joint.d.ts:1449](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1449)
+Defined in: [joint-core/types/joint.d.ts:1451](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1451)
 
 #### Inherited from
 
@@ -2794,7 +2794,7 @@ The style of the paper element.
 
 > `optional` **tagName**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3444](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3444)
+Defined in: [joint-core/types/joint.d.ts:3446](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3446)
 
 #### Inherited from
 
@@ -2806,7 +2806,7 @@ Defined in: [joint-core/types/joint.d.ts:3444](https://github.com/samuelgja/join
 
 > `optional` **theme**: `string`
 
-Defined in: [joint-core/types/joint.d.ts:3503](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3503)
+Defined in: [joint-core/types/joint.d.ts:3505](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L3505)
 
 #### Inherited from
 
@@ -2818,7 +2818,7 @@ Defined in: [joint-core/types/joint.d.ts:3503](https://github.com/samuelgja/join
 
 > `optional` **validateConnection**: (`cellViewS`, `magnetS`, `cellViewT`, `magnetT`, `end`, `linkView`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1409](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1409)
+Defined in: [joint-core/types/joint.d.ts:1411](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1411)
 
 #### Parameters
 
@@ -2860,7 +2860,7 @@ Defined in: [joint-core/types/joint.d.ts:1409](https://github.com/samuelgja/join
 
 > `optional` **validateEmbedding**: (`this`, `childView`, `parentView`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1429](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1429)
+Defined in: [joint-core/types/joint.d.ts:1431](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1431)
 
 #### Parameters
 
@@ -2890,7 +2890,7 @@ Defined in: [joint-core/types/joint.d.ts:1429](https://github.com/samuelgja/join
 
 > `optional` **validateMagnet**: (`cellView`, `magnet`, `evt`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1408](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1408)
+Defined in: [joint-core/types/joint.d.ts:1410](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1410)
 
 #### Parameters
 
@@ -2920,7 +2920,7 @@ Defined in: [joint-core/types/joint.d.ts:1408](https://github.com/samuelgja/join
 
 > `optional` **validateUnembedding**: (`this`, `childView`) => `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:1430](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1430)
+Defined in: [joint-core/types/joint.d.ts:1432](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1432)
 
 #### Parameters
 
@@ -2946,7 +2946,7 @@ Defined in: [joint-core/types/joint.d.ts:1430](https://github.com/samuelgja/join
 
 > `optional` **viewport**: `null` \| `ViewportCallback`
 
-Defined in: [joint-core/types/joint.d.ts:1452](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1452)
+Defined in: [joint-core/types/joint.d.ts:1454](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1454)
 
 #### Inherited from
 
@@ -2958,7 +2958,7 @@ Defined in: [joint-core/types/joint.d.ts:1452](https://github.com/samuelgja/join
 
 > `optional` **width**: `Dimension`
 
-Defined in: [joint-core/types/joint.d.ts:1393](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1393)
+Defined in: [joint-core/types/joint.d.ts:1395](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L1395)
 
 #### Inherited from
 

--- a/packages/joint-react/docs/interfaces/PortGroupProps.md
+++ b/packages/joint-react/docs/interfaces/PortGroupProps.md
@@ -18,7 +18,7 @@ Defined in: [joint-react/src/components/port/port-group.tsx:8](https://github.co
 
 > `optional` **angle**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:2981](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2981)
+Defined in: [joint-core/types/joint.d.ts:2983](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2983)
 
 #### Inherited from
 
@@ -38,7 +38,7 @@ Defined in: [joint-react/src/components/port/port-group.tsx:10](https://github.c
 
 > `optional` **compensateRotation**: `boolean`
 
-Defined in: [joint-core/types/joint.d.ts:2986](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2986)
+Defined in: [joint-core/types/joint.d.ts:2988](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2988)
 
 #### Inherited from
 
@@ -50,7 +50,7 @@ Defined in: [joint-core/types/joint.d.ts:2986](https://github.com/samuelgja/join
 
 > `optional` **dx**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:2979](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2979)
+Defined in: [joint-core/types/joint.d.ts:2981](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2981)
 
 #### Inherited from
 
@@ -62,7 +62,7 @@ Defined in: [joint-core/types/joint.d.ts:2979](https://github.com/samuelgja/join
 
 > `optional` **dy**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:2980](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2980)
+Defined in: [joint-core/types/joint.d.ts:2982](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2982)
 
 #### Inherited from
 
@@ -74,7 +74,7 @@ Defined in: [joint-core/types/joint.d.ts:2980](https://github.com/samuelgja/join
 
 > `optional` **end**: `Position`
 
-Defined in: [joint-core/types/joint.d.ts:2983](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2983)
+Defined in: [joint-core/types/joint.d.ts:2985](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2985)
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: [joint-react/src/components/port/port.types.ts:20](https://github.co
 
 > `optional` **start**: `Position`
 
-Defined in: [joint-core/types/joint.d.ts:2982](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2982)
+Defined in: [joint-core/types/joint.d.ts:2984](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2984)
 
 #### Inherited from
 
@@ -118,7 +118,7 @@ Defined in: [joint-core/types/joint.d.ts:2982](https://github.com/samuelgja/join
 
 > `optional` **startAngle**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:2984](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2984)
+Defined in: [joint-core/types/joint.d.ts:2986](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2986)
 
 #### Inherited from
 
@@ -130,7 +130,7 @@ Defined in: [joint-core/types/joint.d.ts:2984](https://github.com/samuelgja/join
 
 > `optional` **step**: `number`
 
-Defined in: [joint-core/types/joint.d.ts:2985](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2985)
+Defined in: [joint-core/types/joint.d.ts:2987](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2987)
 
 #### Inherited from
 
@@ -142,7 +142,7 @@ Defined in: [joint-core/types/joint.d.ts:2985](https://github.com/samuelgja/join
 
 > `optional` **x**: `string` \| `number`
 
-Defined in: [joint-core/types/joint.d.ts:2977](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2977)
+Defined in: [joint-core/types/joint.d.ts:2979](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2979)
 
 #### Inherited from
 
@@ -154,7 +154,7 @@ Defined in: [joint-core/types/joint.d.ts:2977](https://github.com/samuelgja/join
 
 > `optional` **y**: `string` \| `number`
 
-Defined in: [joint-core/types/joint.d.ts:2978](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2978)
+Defined in: [joint-core/types/joint.d.ts:2980](https://github.com/samuelgja/joint/blob/main/packages/joint-core/types/joint.d.ts#L2980)
 
 #### Inherited from
 

--- a/packages/joint-react/docs/interfaces/PortProps.md
+++ b/packages/joint-react/docs/interfaces/PortProps.md
@@ -6,7 +6,7 @@
 
 # Interface: PortProps
 
-Defined in: [joint-react/src/components/port/port-item.tsx:11](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L11)
+Defined in: [joint-react/src/components/port/port-item.tsx:12](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L12)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:11](https://github.co
 
 > `readonly` `optional` **children**: `ReactNode`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:16](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L16)
+Defined in: [joint-react/src/components/port/port-item.tsx:17](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L17)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:16](https://github.co
 
 > `readonly` `optional` **groupId**: `string`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:14](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L14)
+Defined in: [joint-react/src/components/port/port-item.tsx:15](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L15)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:14](https://github.co
 
 > `readonly` **id**: `string`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:13](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L13)
+Defined in: [joint-react/src/components/port/port-item.tsx:14](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L14)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:13](https://github.co
 
 > `readonly` `optional` **isPassive**: `boolean`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:12](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L12)
+Defined in: [joint-react/src/components/port/port-item.tsx:13](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L13)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:12](https://github.co
 
 > `readonly` `optional` **x**: `string` \| `number`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:17](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L17)
+Defined in: [joint-react/src/components/port/port-item.tsx:18](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L18)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [joint-react/src/components/port/port-item.tsx:17](https://github.co
 
 > `readonly` `optional` **y**: `string` \| `number`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:18](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L18)
+Defined in: [joint-react/src/components/port/port-item.tsx:19](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L19)
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: [joint-react/src/components/port/port-item.tsx:18](https://github.co
 
 > `readonly` `optional` **z**: `number` \| `"auto"`
 
-Defined in: [joint-react/src/components/port/port-item.tsx:15](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L15)
+Defined in: [joint-react/src/components/port/port-item.tsx:16](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/port/port-item.tsx#L16)

--- a/packages/joint-react/docs/interfaces/ReactElementAttributes.md
+++ b/packages/joint-react/docs/interfaces/ReactElementAttributes.md
@@ -1,0 +1,25 @@
+[**@joint/react**](../README.md)
+
+***
+
+[@joint/react](../README.md) / ReactElementAttributes
+
+# Interface: ReactElementAttributes
+
+Defined in: [joint-react/src/types/element-types.ts:4](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L4)
+
+## Properties
+
+### rect?
+
+> `optional` **rect**: `SVGAttributes`
+
+Defined in: [joint-react/src/types/element-types.ts:6](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L6)
+
+***
+
+### root?
+
+> `optional` **root**: `SVGAttributes`
+
+Defined in: [joint-react/src/types/element-types.ts:5](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L5)

--- a/packages/joint-react/docs/type-aliases/InferElement.md
+++ b/packages/joint-react/docs/type-aliases/InferElement.md
@@ -8,7 +8,7 @@
 
 > **InferElement**\<`T`\> = `T`\[`number`\]
 
-Defined in: [joint-react/src/utils/create.ts:55](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L55)
+Defined in: [joint-react/src/utils/create.ts:59](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/utils/create.ts#L59)
 
 Infer element based on typeof createElements
 

--- a/packages/joint-react/docs/type-aliases/StandardShapesType.md
+++ b/packages/joint-react/docs/type-aliases/StandardShapesType.md
@@ -8,4 +8,4 @@
 
 > **StandardShapesType** = keyof `StandardShapesTypeMapper`
 
-Defined in: [joint-react/src/types/element-types.ts:20](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L20)
+Defined in: [joint-react/src/types/element-types.ts:25](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/types/element-types.ts#L25)

--- a/packages/joint-react/docs/variables/Paper.md
+++ b/packages/joint-react/docs/variables/Paper.md
@@ -8,7 +8,7 @@
 
 > `const` **Paper**: \<`ElementItem`\>(`props`) => `Element`
 
-Defined in: [joint-react/src/components/paper/paper.tsx:322](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/paper/paper.tsx#L322)
+Defined in: [joint-react/src/components/paper/paper.tsx:341](https://github.com/samuelgja/joint/blob/main/packages/joint-react/src/components/paper/paper.tsx#L341)
 
 Paper component that renders the JointJS paper elements inside HTML.
 It uses `renderElement` to render the elements.

--- a/packages/joint-react/src/components/paper/paper-item.tsx
+++ b/packages/joint-react/src/components/paper/paper-item.tsx
@@ -1,8 +1,9 @@
-import { type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import type { CellWithId } from '../../types/cell.types';
 import type { GraphElement } from '../../types/element-types';
 import typedMemo from '../../utils/typed-memo';
+import { usePaper } from '../../hooks';
 
 export interface PaperPortalProps<Data extends CellWithId = GraphElement> {
   /**
@@ -31,6 +32,11 @@ function Component<Data extends CellWithId = GraphElement>(props: PaperPortalPro
   const { renderElement, nodeSvgGElement, ...rest } = props;
   const cell = rest as Data;
   const element = renderElement(cell);
+  const paper = usePaper();
+  useEffect(() => {
+    const elementView = paper.findViewByModel(cell.id);
+    elementView.cleanNodeCache(elementView.el);
+  });
 
   return createPortal(element, nodeSvgGElement);
 }

--- a/packages/joint-react/src/components/port/port-item.tsx
+++ b/packages/joint-react/src/components/port/port-item.tsx
@@ -6,6 +6,7 @@ import { PortGroupContext } from '../../context/port-group-context';
 import { useGraphStore } from '../../hooks/use-graph-store';
 import { PORTAL_SELECTOR } from '../../data/create-ports-data';
 import { jsx } from '../../utils/joint-jsx/jsx-to-markup';
+import { createElements } from '../../utils/create';
 
 const elementMarkup = jsx(<g joint-selector={PORTAL_SELECTOR} />);
 export interface PortItemProps {
@@ -79,7 +80,7 @@ function Component(props: PortItemProps) {
     }
 
     const elementView = paper.findViewByModel(cellId);
-    // @ts-expect-error we use private jointjs api method, it throw error here.
+
     elementView.cleanNodesCache();
     for (const link of graph.getConnectedLinks(elementView.model)) {
       const target = link.target();
@@ -130,3 +131,9 @@ function Component(props: PortItemProps) {
  * ```
  */
 export const PortItem = memo(Component);
+
+createElements([
+  {
+    id: 'port-one',
+  },
+]);

--- a/packages/joint-react/src/hooks/index.ts
+++ b/packages/joint-react/src/hooks/index.ts
@@ -6,3 +6,6 @@ export * from './use-element';
 export * from './use-measure-node-size';
 export * from './use-set-element';
 export * from './use-cell-id';
+export * from './use-remove-cell';
+export * from './use-add-element';
+export * from './use-add-link';

--- a/packages/joint-react/src/hooks/use-add-element.stories.tsx
+++ b/packages/joint-react/src/hooks/use-add-element.stories.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-hooks/rules-of-hooks */
+import type { Meta, StoryObj } from '@storybook/react';
+import { useAddElement } from './use-add-element';
+import { makeRootDocs, makeStory } from '@joint/react/src/stories/utils/make-story';
+import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation-link';
+import type { SimpleElement } from '../../.storybook/decorators/with-simple-data';
+import { HTMLNode, SimpleGraphDecorator } from '../../.storybook/decorators/with-simple-data';
+import '../stories/examples/index.css';
+import { Paper } from '../components';
+
+const API_URL = getAPILink('useAddElement');
+const BUTTON_CLASSNAME =
+  'bg-blue-500 cursor-pointer hover:bg-blue-700 text-white font-bold py-2 px-4 rounded m-2 text-sm';
+export type Story = StoryObj<typeof Hook>;
+
+const meta: Meta<typeof Hook> = {
+  title: 'Hooks/useAddElement',
+  component: Hook,
+  decorators: [SimpleGraphDecorator],
+  render: () => {
+    const addElement = useAddElement<SimpleElement>();
+    return (
+      <div className="flex flex-row">
+        <div style={{ width: '100%', height: 450 }}>
+          <Paper width={'100%'} height={450} renderElement={Hook} linkPinning={false} />
+        </div>
+        <div>
+          <button
+            type="button"
+            className={BUTTON_CLASSNAME}
+            onClick={() =>
+              addElement({
+                id: '10',
+                data: { label: 'New node added', color: 'red' },
+                x: 300,
+                y: 100,
+              })
+            }
+          >
+            Add Node
+          </button>
+        </div>
+      </div>
+    );
+  },
+  parameters: makeRootDocs({
+    apiURL: API_URL,
+    description: `\`useAddElement\` is a hook to add elements to the graph. It returns a function to add an element. It must be used inside the GraphProvider.`,
+    code: `import { useAddElement } from '@joint/react'
+
+function Component() {
+  const addElement = useAddElement();
+  return <button onClick={() => addElement({ id: '1', data: { label: 'Node 1' } })}>Add Element</button>;
+}`,
+  }),
+};
+
+export default meta;
+
+function Hook({ data: { label } }: Readonly<{ id: string; data: { label: string } }>) {
+  return <HTMLNode className="node">{label}</HTMLNode>;
+}
+
+export const Default: Story = makeStory<Story>({
+  args: {},
+  apiURL: API_URL,
+  code: `import { useAddElement } from '@joint/react'
+
+function Hook() {
+  const addElement = useAddElement();
+
+  return (
+    <div>
+      <button onClick={() => addElement({ id: '1', data: { label: 'Node 1' } })}>
+        Add Node 1
+      </button>
+      <button onClick={() => addElement({ id: '2', data: { label: 'Node 2' } })}>
+        Add Node 2
+      </button>
+    </div>
+  );
+}`,
+  description: 'Add elements to the graph.',
+});

--- a/packages/joint-react/src/hooks/use-add-element.ts
+++ b/packages/joint-react/src/hooks/use-add-element.ts
@@ -1,0 +1,30 @@
+import type { dia } from '@joint/core';
+import type { GraphElementBase } from '../types/element-types';
+import { useGraph } from './use-graph';
+import { useCallback } from 'react';
+import { processElement } from '../utils/cell/set-cells';
+
+type SetElement<T extends dia.Element | GraphElementBase> = Omit<
+  Partial<T> & { id: dia.Cell.ID },
+  'isElement' | 'isLink'
+>;
+
+/**
+ * A custom hook that adds an element to the graph.
+ * @group Hooks
+ * @returns A function that adds the element to the graph.
+ * @example
+ * ```ts
+ * const addElement = useAddElement();
+ * addElement({ id: '1', data: { label: 'Node 1' } });
+ * ```
+ */
+export function useAddElement<T extends dia.Element | GraphElementBase>() {
+  const graph = useGraph();
+  return useCallback(
+    (element: SetElement<T>) => {
+      graph.addCell(processElement(element));
+    },
+    [graph]
+  );
+}

--- a/packages/joint-react/src/hooks/use-add-link.ts
+++ b/packages/joint-react/src/hooks/use-add-link.ts
@@ -1,0 +1,25 @@
+import type { dia } from '@joint/core';
+import { useGraph } from './use-graph';
+import { useCallback } from 'react';
+import { processLink } from '../utils/cell/set-cells';
+import type { GraphLinkBase } from '../types/link-types';
+
+/**
+ * A custom hook that adds a link to the graph.
+ * @group Hooks
+ * @returns A function that adds the link to the graph.
+ * @example
+ * ```ts
+ * const addLink = useAddLink();
+ * addLink({ id: '1', source: { id: '2' }, target: { id: '3' } });
+ * ```
+ */
+export function useAddLink<T extends dia.Link | GraphLinkBase>() {
+  const graph = useGraph();
+  return useCallback(
+    (link: T) => {
+      graph.addCell(processLink(link));
+    },
+    [graph]
+  );
+}

--- a/packages/joint-react/src/hooks/use-remove-cell.ts
+++ b/packages/joint-react/src/hooks/use-remove-cell.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useGraph } from './use-graph';
+import type { dia } from '@joint/core';
+
+/**
+ * A custom hook that removes an node or link from the graph by its ID.
+ * @group Hooks
+ * @returns A function that removes the element from the graph.
+ * @example
+ * ```ts
+ * const removeCell = useRemoveCell();
+ * removeCell('1');
+ * ```
+ */
+export function useRemoveCell() {
+  const graph = useGraph();
+  return useCallback(
+    (id: dia.Cell.ID) => {
+      const cell = graph.getCell(id);
+      if (cell) {
+        cell.remove();
+      }
+    },
+    [graph]
+  );
+}

--- a/packages/joint-react/src/hooks/use-set-element.stories.tsx
+++ b/packages/joint-react/src/hooks/use-set-element.stories.tsx
@@ -9,6 +9,8 @@ import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation
 import '../stories/examples/index.css';
 
 const API_URL = getAPILink('useSetElement');
+const BUTTON_CLASSNAME =
+  'bg-blue-500 cursor-pointer hover:bg-blue-700 text-white font-bold py-2 px-4 rounded m-2 text-sm';
 
 export type Story = StoryObj<typeof Hook>;
 
@@ -36,7 +38,9 @@ function Hook({ data: { label }, id }: SimpleElement) {
 
   return (
     <HTMLNode className="node">
-      <button onClick={() => set({ label: 'hello' })}>Set label</button>
+      <button className={BUTTON_CLASSNAME} onClick={() => set({ label: 'hello' })}>
+        Set label
+      </button>
       label: {label}
     </HTMLNode>
   );
@@ -69,6 +73,7 @@ function HookSetPosition({ data: { label }, id }: SimpleElement) {
   return (
     <HTMLNode className="node">
       <button
+        className={BUTTON_CLASSNAME}
         onClick={() =>
           set((previous) => {
             if (previous === undefined) {
@@ -121,6 +126,7 @@ function HookSetSize({ data: { label }, id }: SimpleElement) {
   return (
     <HTMLNode className="node">
       <button
+        className={BUTTON_CLASSNAME}
         onClick={() =>
           set((previous) => {
             if (previous === undefined) {
@@ -172,6 +178,7 @@ function HookSetAngle({ data: { label }, id }: SimpleElement) {
   return (
     <HTMLNode className="node">
       <button
+        className={BUTTON_CLASSNAME}
         onClick={() =>
           set((previous) => {
             if (previous === undefined) {
@@ -221,6 +228,7 @@ function HookSetAny({ data: { label }, id }: SimpleElement) {
   return (
     <HTMLNode className="node">
       <button
+        className={BUTTON_CLASSNAME}
         onClick={() =>
           set('position', (previous) => {
             if (previous === undefined) {
@@ -233,6 +241,7 @@ function HookSetAny({ data: { label }, id }: SimpleElement) {
         Set Position
       </button>
       <button
+        className={BUTTON_CLASSNAME}
         onClick={() =>
           set('size', (previous) => {
             if (previous === undefined) {

--- a/packages/joint-react/src/hooks/use-set-element.ts
+++ b/packages/joint-react/src/hooks/use-set-element.ts
@@ -47,7 +47,7 @@ function setCellHelper<Attributes, Attribute extends keyof Attributes>(
 }
 
 /**
- * Use this hook to set element attributes.
+ * Set the element attribute in the graph.
  * It returns a function to set the element attribute.
  *
  * It must be used inside the GraphProvider.

--- a/packages/joint-react/src/models/react-element.tsx
+++ b/packages/joint-react/src/models/react-element.tsx
@@ -3,7 +3,7 @@ import { dia } from '@joint/core';
 import { jsx } from '../utils/joint-jsx/jsx-to-markup';
 export const REACT_TYPE = 'ReactElement';
 
-const elementMarkup = jsx(<rect joint-selector="rect" />);
+const elementMarkup = jsx(<rect joint-selector="placeholder" />);
 /**
  * A custom JointJS element that can render React components.
  * @group Models
@@ -21,7 +21,7 @@ export class ReactElement<Attributes = dia.Element.Attributes> extends dia.Eleme
       type: REACT_TYPE,
       data: {},
       attrs: {
-        rect: {
+        placeholder: {
           width: 'calc(w)',
           height: 'calc(h)',
           fill: 'transparent',

--- a/packages/joint-react/src/stories/demos/flowchart/index.css
+++ b/packages/joint-react/src/stories/demos/flowchart/index.css
@@ -65,11 +65,6 @@
   stroke-width: 1px;
 }
 
-.jj-flow-line {
-  stroke: #ed2637;
-  stroke-width: 1;
-}
-
 .jj-flow-tools circle {
   stroke: var(--frame-color);
   fill: var(--background-color);
@@ -78,4 +73,16 @@
 
 .jj-flow-tools rect {
   stroke: var(--frame-color);
+}
+
+.link {
+  stroke-dasharray: 5 5; /* dash length 10, gap 10 */
+  stroke-dashoffset: 0;
+  animation: dashmove 1s linear infinite;
+}
+
+@keyframes dashmove {
+  to {
+    stroke-dashoffset: -20; /* dash + gap length */
+  }
 }

--- a/packages/joint-react/src/stories/demos/user-flow/code.tsx
+++ b/packages/joint-react/src/stories/demos/user-flow/code.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-nested-functions */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 // We have pre-loaded tailwind css
@@ -31,7 +30,9 @@ const nodes = createElements<Data>([
     x: 50,
     y: 50,
     attrs: {
-      magnet: 'active',
+      root: {
+        magnet: false,
+      },
     },
   },
   {
@@ -44,7 +45,9 @@ const nodes = createElements<Data>([
     x: 120,
     y: 200,
     attrs: {
-      magnet: 'passive',
+      root: {
+        magnet: false,
+      },
     },
   },
   {
@@ -53,6 +56,11 @@ const nodes = createElements<Data>([
       title: 'User Action',
       description: 'Get account balance',
       type: 'user-action',
+    },
+    attrs: {
+      root: {
+        magnet: false,
+      },
     },
     x: 190,
     y: 350,

--- a/packages/joint-react/src/stories/examples/with-auto-layout/code-with-build-in-shapes.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-layout/code-with-build-in-shapes.tsx
@@ -23,7 +23,8 @@ const shape = {
       fill: 'white',
     },
   },
-};
+} as const;
+
 const initialElements = createElements([
   {
     id: '1',
@@ -111,7 +112,7 @@ function Main() {
       width={PAPER_WIDTH}
       height={280}
       renderElement={renderElement}
-      onElementsMeasured={makeLayout}
+      onElementsSizeReady={makeLayout}
     />
   );
 }

--- a/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
@@ -15,8 +15,8 @@ import {
   type RenderElement,
 } from '@joint/react';
 import { useCallback, useState } from 'react';
-import { processElement } from '../../../utils/cell/set-cells';
 import type { dia } from '@joint/core';
+import { useAddElement } from '../../../hooks/use-add-element';
 
 const initialElements = createElements([
   { id: '1', data: { label: 'Node 1' } },
@@ -52,6 +52,7 @@ function Main() {
     []
   );
   const graph = useGraph();
+  const addElement = useAddElement<BaseElementWithData>();
 
   // Number of elements per row
   const [gridXSize, setGridXSize] = useState(3);
@@ -106,12 +107,10 @@ function Main() {
 
         <button
           onClick={() => {
-            graph.addCell(
-              processElement({
-                id: `${Math.random()}`,
-                data: { label: `Node ${elementsLength + 1}` },
-              })
-            );
+            addElement({
+              id: `${Math.random()}`,
+              data: { label: `Node ${elementsLength + 1}` },
+            });
           }}
           type="button"
           className="bg-blue-500 cursor-pointer hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.css
+++ b/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.css
@@ -1,0 +1,11 @@
+.link {
+  stroke-dasharray: 5 5; /* dash length 10, gap 10 */
+  stroke-dashoffset: 0;
+  animation: dashmove 1s linear infinite;
+}
+
+@keyframes dashmove {
+  to {
+    stroke-dashoffset: -20; /* dash + gap length */
+  }
+}

--- a/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
-import { PRIMARY } from 'storybook-config/theme';
+
 import {
   createElements,
   createLinks,
@@ -12,6 +12,8 @@ import {
 } from '@joint/react';
 import { useCallback } from 'react';
 import { HTMLNode } from 'storybook-config/decorators/with-simple-data';
+import './code-with-create-links-classname.css';
+import { PRIMARY } from 'storybook-config/theme';
 
 const initialElements = createElements([
   { id: '1', data: { label: 'Node 1' }, x: 100, y: 0 },
@@ -25,8 +27,7 @@ const initialEdges = createLinks([
     attrs: {
       line: {
         stroke: PRIMARY,
-        strokeWidth: 2, // Set stroke width
-        strokeDasharray: '5,5', // Makes the line da
+        class: 'link',
       },
     },
   },

--- a/packages/joint-react/src/stories/examples/with-custom-link/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-link/story.tsx
@@ -2,6 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
 import '../index.css';
 import CodeWithCreateLinks from './code-with-create-links';
+import CodeWithDiaLinksClassName from './code-with-create-links-classname';
 import CodeWithDiaLinks from './code-with-dia-links';
 import { makeRootDocs, makeStory } from '@joint/react/src/stories/utils/make-story';
 
@@ -9,6 +10,8 @@ import { makeRootDocs, makeStory } from '@joint/react/src/stories/utils/make-sto
 import CodeWithCreateLinksCode from './code-with-create-links?raw';
 // @ts-expect-error
 import CodeWithDiaLinksCode from './code-with-dia-links?raw';
+// @ts-expect-error
+import CodeWithCreateLinksClassName from './code-with-create-links-classname?raw';
 
 export type Story = StoryObj<typeof CodeWithCreateLinks>;
 
@@ -26,6 +29,27 @@ export const WithCreateLinks = makeStory({
   code: CodeWithCreateLinksCode,
   description: 'Code with create links.',
   component: CodeWithCreateLinks,
+  apiURL: 'https://resources.jointjs.com/tutorial/links',
+});
+
+export const WithCreateLinkClassName = makeStory({
+  code: `${CodeWithCreateLinksClassName}\n
+css:
+.link {
+  stroke-dasharray: 5 5; /* dash length 10, gap 10 */
+  stroke-dashoffset: 0;
+  animation: dashmove 1s linear infinite;
+}
+
+@keyframes dashmove {
+  to {
+    stroke-dashoffset: -20; /* dash + gap length */
+  }
+}
+
+  `,
+  description: 'Code with create links with class name.',
+  component: CodeWithDiaLinksClassName,
   apiURL: 'https://resources.jointjs.com/tutorial/links',
 });
 

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -18,5 +18,5 @@ export function isReactElement(element: unknown): boolean {
   if (!isGraphElement(element)) {
     return false;
   }
-  return element.type === REACT_TYPE || element.type == undefined;
+  return (element.type as string) === REACT_TYPE || element.type == undefined;
 }

--- a/packages/joint-react/src/types/element-types.ts
+++ b/packages/joint-react/src/types/element-types.ts
@@ -1,6 +1,10 @@
-import type { dia, shapes } from '@joint/core';
+import type { attributes, dia, shapes } from '@joint/core';
 import type { Attributes, Ports } from '../utils/cell/get-cell';
 
+export interface ReactElementAttributes {
+  root?: attributes.SVGAttributes;
+  rect?: attributes.SVGAttributes;
+}
 interface StandardShapesTypeMapper {
   'standard.Rectangle': shapes.standard.RectangleSelectors;
   'standard.Circle': shapes.standard.CircleSelectors;
@@ -15,6 +19,7 @@ interface StandardShapesTypeMapper {
   'standard.Polygon': shapes.standard.PolygonSelectors;
   'standard.Polyline': shapes.standard.PolylineSelectors;
   'standard.TextBlock': shapes.standard.TextBlockSelectors;
+  react: ReactElementAttributes;
 }
 
 export type StandardShapesType = keyof StandardShapesTypeMapper;
@@ -68,14 +73,16 @@ export interface GraphElementBase<Type extends StandardShapesType | string = str
   readonly attrs?: Type extends StandardShapesType ? StandardShapesTypeMapper[Type] : unknown;
 }
 
-export interface GraphElementItem<Data = unknown, Type extends StandardShapesType | string = string>
-  extends GraphElementBase<Type> {
+export interface GraphElementItem<
+  Data = unknown,
+  Type extends StandardShapesType | string = 'react',
+> extends GraphElementBase<Type> {
   /**
    * Generic data for the element.
    */
   readonly data: Data;
 }
-export interface GraphElement<Data = unknown, Type extends StandardShapesType | string = string>
+export interface GraphElement<Data = unknown, Type extends StandardShapesType | string = 'react'>
   extends GraphElementItem<Data, Type> {
   /**
    * Flag to distinguish between elements and links.

--- a/packages/joint-react/src/utils/cell/set-cells.ts
+++ b/packages/joint-react/src/utils/cell/set-cells.ts
@@ -1,6 +1,6 @@
 import type { dia } from '@joint/core';
 import { REACT_TYPE } from '../../models/react-element';
-import type { GraphLink } from '../../types/link-types';
+import type { GraphLink, GraphLinkBase } from '../../types/link-types';
 import type { GraphElementBase } from '../../types/element-types';
 import { isCellInstance, isLinkInstance, isUnsized } from '../is';
 import { getTargetOrSource } from './get-link-targe-and-source-ids';
@@ -22,7 +22,7 @@ interface Options {
  * @returns
  * A standard JointJS link or a JSON representation of the link.
  */
-export function processLink(link: dia.Link | GraphLink): dia.Link | dia.Cell.JSON {
+export function processLink(link: dia.Link | GraphLinkBase): dia.Link | dia.Cell.JSON {
   if (isLinkInstance(link)) {
     const json = link.toJSON();
 

--- a/packages/joint-react/src/utils/create.ts
+++ b/packages/joint-react/src/utils/create.ts
@@ -5,6 +5,12 @@ import type {
 } from '../types/element-types';
 import type { GraphLink, GraphLinkBase, StandardLinkShapesType } from '../types/link-types';
 
+type RequiredElementProps = {
+  isElement: true;
+  isLink: false;
+  width: number;
+  height: number;
+};
 /**
  * Create elements helper function.
  * @group Utils
@@ -29,13 +35,11 @@ import type { GraphLink, GraphLinkBase, StandardLinkShapesType } from '../types/
  */
 export function createElements<
   Data,
-  Type extends StandardShapesType | string = string,
+  Type extends StandardShapesType | string = 'react',
   Element extends GraphElementBase<Type> = GraphElementItem<Data, Type>,
->(
-  data: Array<Element & GraphElementBase<Type>>
-): Array<Element & { isElement: true; isLink: false; width: number; height: number }> {
+>(data: Array<Element & GraphElementBase<Type>>): Array<Element & RequiredElementProps> {
   return data.map((element) => ({ ...element, isElement: true, isLink: false })) as Array<
-    Element & { isElement: true; isLink: false; width: number; height: number }
+    Element & RequiredElementProps
   >;
 }
 
@@ -69,7 +73,7 @@ export type InferElement<T extends Array<Record<string, unknown>>> = T[number];
  */
 export function createLinks<
   Link extends GraphLinkBase<Type>,
-  Type extends StandardLinkShapesType | string = string,
+  Type extends StandardLinkShapesType | string = 'standard.Link',
 >(data: Array<Link & GraphLinkBase<Type>>): Array<Link & GraphLink> {
   return data.map((link) => ({ ...link, isElement: false, isLink: true }));
 }


### PR DESCRIPTION
## Description
https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=107895468
This PR addresses several improvements and fixes related to TypeScript support in `@joint/react`, particularly focusing on method visibility and the addition of new functions. Below are the key changes introduced:


### `@joint/react` Changes:
1. **New set hooks**:
   - New `useAddLink` and `useAddElement` hooks for adding (pushing) new data to the state
   - New `useRemoveCell` hook, for remove cell or link based on `dia.cell.id`

2. **Minor Adjustments in React Components**:
   - The component rendering logic has been fine-tuned in various places, including the handling of SVG elements and dynamic updates.

## Motivation and Context

The main motivation for this update is to improve the accessibility and flexibility of the cache-clearing functionality by making the `clearNodeCache` and `clearNodesCache` methods publicly available. The new set methods for `@joint/react` - we had been missing adding and removing elements.

Plus generate new autogerated docs.

---

These changes ensure better performance and usability for users who interact with the JointJS API, making it easier to manage elements and their cached states within a graph.
