### PR TITLE
chore(joint-core): update ts support

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -971,6 +971,10 @@ export namespace dia {
 
         isIntersecting(geometryShape: g.Shape, geometryData?: g.SegmentSubdivisionsOpt | null): boolean;
 
+        cleanNodesCache(): void;
+
+        cleanNodeCache(node: SVGElement): void
+
         protected isEnclosedIn(area: g.Rect): boolean;
 
         protected isInArea(area: g.Rect, options: g.StrictOpt): boolean;
@@ -1026,8 +1030,6 @@ export namespace dia {
         protected customizeLinkEnd(end: dia.Link.EndJSON, magnet: SVGElement, x: number, y: number, link: dia.Link, endType: dia.LinkEnd): dia.Link.EndJSON;
 
         protected addLinkFromMagnet(magnet: SVGElement, x: number, y: number): LinkView;
-
-        protected cleanNodesCache(): void;
 
         protected nodeCache(magnet: SVGElement): CellView.NodeMetrics;
 


### PR DESCRIPTION
## Description
- Change `cleanNodesCache` ts to public - needed for `@joint/react`
- Add missing `cleanNodeCache` ts def -  needed for `@joint/react`

## Motivation and Context
It's essential to be able to clear node cache from outside the view. For instance, after the element views are rendered asynchronously through **`React` portals.** (`@joint/react`).

