### PR TITLE
feat(dia.Cell): add getCenter() method

### DIFF
--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -90,7 +90,7 @@ function bboxWrapper(method) {
             bbox = getModelBBoxFromConnectedLink(element, link, endType, !rotate);
             center = bbox.center();
         } else {
-            center = element.getBBox().center();
+            center = element.getCenter();
             bbox = (rotate) ? elementView.getNodeUnrotatedBBox(magnet) : elementView.getNodeBBox(magnet);
         }
 
@@ -173,7 +173,7 @@ function _perpendicular(elementView, magnet, refPoint, opt, endType, linkView) {
 function _midSide(view, magnet, refPoint, opt, endType, linkView) {
     var rotate = !!opt.rotate;
     var angle = view.model.angle();
-    var center = view.model.getBBox().center();
+    var center = view.model.getCenter();
 
     var bbox;
     if (opt.useModelGeometry) {

--- a/packages/joint-core/src/cellTools/Boundary.mjs
+++ b/packages/joint-core/src/cellTools/Boundary.mjs
@@ -35,7 +35,7 @@ export const Boundary = ToolView.extend({
             var angle = model.angle();
             if (angle) {
                 if (rotate) {
-                    var origin = model.getBBox().center();
+                    var origin = model.getCenter();
                     vel.rotate(angle, origin.x, origin.y, { absolute: true });
                 } else {
                     bbox = bbox.bbox(angle);

--- a/packages/joint-core/src/cellTools/Control.mjs
+++ b/packages/joint-core/src/cellTools/Control.mjs
@@ -103,7 +103,7 @@ export const Control = ToolView.extend({
         const model = relatedView.model;
         const angle = model.angle();
         const center = bbox.center();
-        if (angle) center.rotate(model.getBBox().center(), -angle);
+        if (angle) center.rotate(model.getCenter(), -angle);
         bbox.inflate(padding);
         extrasNode.setAttribute('x', -bbox.width / 2);
         extrasNode.setAttribute('y', -bbox.height / 2);

--- a/packages/joint-core/src/connectionStrategies/index.mjs
+++ b/packages/joint-core/src/connectionStrategies/index.mjs
@@ -21,7 +21,7 @@ function pinnedElementEnd(relative, end, view, magnet, coords) {
 
     var angle = view.model.angle();
     var bbox = view.getNodeUnrotatedBBox(magnet);
-    var origin = view.model.getBBox().center();
+    var origin = view.model.getCenter();
     coords.rotate(origin, angle);
     var dx = coords.x - bbox.x;
     var dy = coords.y - bbox.y;

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -921,9 +921,14 @@ export const Cell = Model.extend({
         return new g.Rect(0, 0, 0, 0);
     },
 
+    getCenter: function() {
+        // To be overridden
+        return new g.Point(0, 0);
+    },
+
     getPointRotatedAroundCenter(angle, x, y) {
         const point = new g.Point(x, y);
-        if (angle) point.rotate(this.getBBox().center(), angle);
+        if (angle) point.rotate(this.getCenter(), angle);
         return point;
     },
 

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -922,8 +922,7 @@ export const Cell = Model.extend({
     },
 
     getCenter: function() {
-        // To be overridden
-        return new g.Point(0, 0);
+        return this.getBBox().center();
     },
 
     getPointRotatedAroundCenter(angle, x, y) {

--- a/packages/joint-core/src/dia/Element.mjs
+++ b/packages/joint-core/src/dia/Element.mjs
@@ -495,7 +495,7 @@ export const Element = Cell.extend({
 
         if (origin) {
 
-            var center = this.getBBox().center();
+            var center = this.getCenter();
             var size = this.get('size');
             var position = this.get('position');
             center.rotate(origin, this.get('angle') - angle);
@@ -539,6 +539,11 @@ export const Element = Cell.extend({
             bbox.rotateAroundCenter(angle);
         }
         return bbox;
+    },
+
+    getCenter: function() {
+        const { position: { x, y }, size: { width, height }} = this.attributes;
+        return new Point(x + width / 2, y + height / 2);
     },
 
     getPointFromConnectedLink: function(link, endType) {

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -410,7 +410,7 @@ export const Link = Cell.extend({
     },
 
     getCenter: function() {
-        return this.getCenter();
+        return this.getBBox().center();
     },
 
     reparent: function(opt) {

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -409,6 +409,10 @@ export const Link = Cell.extend({
         return this.getPolyline().bbox();
     },
 
+    getCenter: function() {
+        return this.getCenter();
+    },
+
     reparent: function(opt) {
 
         var newParent;

--- a/packages/joint-core/src/dia/Link.mjs
+++ b/packages/joint-core/src/dia/Link.mjs
@@ -409,10 +409,6 @@ export const Link = Cell.extend({
         return this.getPolyline().bbox();
     },
 
-    getCenter: function() {
-        return this.getBBox().center();
-    },
-
     reparent: function(opt) {
 
         var newParent;

--- a/packages/joint-core/src/linkTools/Anchor.mjs
+++ b/packages/joint-core/src/linkTools/Anchor.mjs
@@ -118,7 +118,7 @@ const Anchor = ToolView.extend({
             bbox = view.getNodeUnrotatedBBox(magnet);
             angle = model.angle();
             center = bbox.center();
-            if (angle) center.rotate(model.getBBox().center(), -angle);
+            if (angle) center.rotate(model.getCenter(), -angle);
             // TODO: get the link's magnet rotation into account
         }
         bbox.inflate(padding);
@@ -185,7 +185,7 @@ const Anchor = ToolView.extend({
                 // snap coords within node bbox
                 var bbox = view.getNodeUnrotatedBBox(magnet);
                 var angle = model.angle();
-                var origin = model.getBBox().center();
+                var origin = model.getCenter();
                 var rotatedCoords = coords.clone().rotate(origin, angle);
                 if (!bbox.containsPoint(rotatedCoords)) {
                     coords = bbox.pointNearestToPoint(rotatedCoords).rotate(origin, -angle);

--- a/packages/joint-core/test/jointjs/elements.js
+++ b/packages/joint-core/test/jointjs/elements.js
@@ -682,4 +682,26 @@ QUnit.module('elements', function(hooks) {
             assert.deepEqual(this.group2.getBBox(), g.rect(502, 202, 100, 100), 'Deep: ShrinkOnly using padding options does not expand anywhere because no overlap.');
         });
     });
+
+    QUnit.module('getCenter()', function(hooks) {
+
+        QUnit.test('getCenter() returns the center of the element', function(assert) {
+
+            const x = 10;
+            const y = 20;
+            const width = 100;
+            const height = 200;
+
+            const rect = new joint.shapes.standard.Rectangle({
+                position: { x, y },
+                size: { width, height }
+            });
+
+            assert.ok(rect.getCenter() instanceof g.Point);
+            assert.ok(rect.getBBox().center().equals(rect.getCenter()));
+            assert.equal(rect.getCenter().x, x + width / 2);
+            assert.equal(rect.getCenter().y, y + height / 2);
+        });
+    });
+
 });

--- a/packages/joint-core/test/jointjs/links.js
+++ b/packages/joint-core/test/jointjs/links.js
@@ -2137,6 +2137,27 @@ QUnit.module('links', function(hooks) {
         });
     });
 
+    QUnit.module('getCenter()', function(hooks) {
+
+        QUnit.test('getCenter() returns the center of the link', function(assert) {
+
+            const x1 = 11;
+            const y1 = 13;
+            const x2 = 99;
+            const y2 = 101;
+
+            const link = new joint.shapes.standard.Link({
+                source: { x: x1, y: y1 },
+                target: { x: x2, y: y2 }
+            });
+
+            assert.ok(link.getCenter() instanceof g.Point);
+            assert.ok(link.getBBox().center().equals(link.getCenter()));
+            assert.equal(link.getCenter().x, (x1 + x2) / 2);
+            assert.equal(link.getCenter().y, (y1 + y2) / 2);
+        });
+    });
+
     QUnit.test('reparent()', function(assert) {
 
         var Rectangle = joint.shapes.standard.Rectangle;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -522,6 +522,8 @@ export namespace dia {
 
         getBBox(): g.Rect;
 
+        getCenter(): g.Point;
+
         getPointFromConnectedLink(link: dia.Link, endType: dia.LinkEnd): g.Point;
 
         getPointRotatedAroundCenter(angle: number, x: number, y: number): g.Point;


### PR DESCRIPTION
## Description

Add a new `getCenter()` method as a counterpart to `getBBox()`. Previously, getting the center of an element required computing the full bounding box and then extracting the center, which involved creating a temporary `Rect` object subject to garbage collection. Since the center is frequently needed in calculations, this new method helps reduce memory usage slightly.

## Documentation

```ts
element.getCenter()
```

Returns the element center point (an instance of `g.Point`).

---


```ts
link.getCenter()
```

Returns the link center point (an instance of `g.Point`), which is the center of link's polyline bbox.
