### PR TITLE
type(util): refactor breakText function options for improved readability

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2675,20 +2675,22 @@ export namespace util {
     export function isPercentage(val: any): boolean;
 
     export function parseCssNumeric(val: any, restrictUnits: string | string[]): { value: number, unit?: string } | null;
-
+    
+    type BreakTextOptions = {
+        svgDocument?: SVGElement;
+        separator?: string | any;
+        eol?: string;
+        ellipsis?: boolean | string;
+        hyphen?: string | RegExp;
+        maxLineCount?: number;
+        preserveSpaces?: boolean;
+    }
+    
     type BreakTextFunction = (
         text: string,
         size: { width: number, height?: number },
         attrs?: attributes.NativeSVGAttributes,
-        opt?: {
-            svgDocument?: SVGElement;
-            separator?: string | any;
-            eol?: string;
-            ellipsis?: boolean | string;
-            hyphen?: string | RegExp;
-            maxLineCount?: number;
-            preserveSpaces?: boolean;
-        }
+        opt?: BreakTextOptions
     ) => string;
 
     export var breakText: BreakTextFunction;


### PR DESCRIPTION
## Description

Separate the `options`  from `BreakTextFunction` into `BreakTextOptions` type.

## Motivation and Context

Needed by `@joint/react` package.
