### PR TITLE
fix(Vectorizer): handle implicit coordinates when converting lines to path data

### DIFF
--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -1987,8 +1987,8 @@ const V = (function() {
 
         line = V(line);
         var d = [
-            'M', line.attr('x1'), line.attr('y1'),
-            'L', line.attr('x2'), line.attr('y2')
+            'M', line.attr('x1') || '0', line.attr('y1') || '0',
+            'L', line.attr('x2') || '0', line.attr('y2') || '0'
         ].join(' ');
         return d;
     };

--- a/packages/joint-core/test/vectorizer/vectorizer.js
+++ b/packages/joint-core/test/vectorizer/vectorizer.js
@@ -1117,6 +1117,11 @@ QUnit.module('vectorizer', function(hooks) {
             assert.equal(line.convertToPathData(), 'M 100 50 L 200 150');
         });
 
+        QUnit.test('<line> with implicit 0 coordinates', function(assert) {
+            var line = V('<line/>', { y1: 50, x2: 200 });
+            assert.equal(line.convertToPathData(), 'M 0 50 L 200 0');
+        });
+
         QUnit.test('<rect>', function(assert) {
             var rect = V('<rect/>', { x: 100, y: 50, width: 200, height: 150 });
             assert.equal(rect.convertToPathData(), 'M 100 50 H 300 V 200 H 100 V 50 Z');


### PR DESCRIPTION
## Description

If a line is missing any of its start/end coordinate attributes, it defaults to 0, but the `convertLineToPathData()` wasn't filling in zeros, but instead leaving missing attributes as the empty string, resulting in corrupt path data. So, default missing values to `0`.