### PR TITLE
fix(dia.Cell): always create a deep copy of arrays in constructor

### DIFF
--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -39,7 +39,7 @@ import * as g from '../g/index.mjs';
 
 const attributesMerger = function(a, b) {
     if (Array.isArray(a)) {
-        return b;
+        return cloneDeep(b);
     }
 };
 

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -134,6 +134,11 @@ QUnit.module('cell', function(hooks) {
             assert.deepEqual(rect5.get('array'), [1,2]);
             const rect6 = new Rect({ array: [3] }, { mergeArrays: true });
             assert.deepEqual(rect6.get('array'), [3,2]);
+
+            const testArray7 = [4,5];
+            const rect7 = new Rect({ array: testArray7 }, { mergeArrays: false });
+            assert.deepEqual(rect7.get('array'), testArray7, 'mergeArrays=false does not merge arrays');
+            assert.notEqual(rect7.get('array'), testArray7, 'should not be the same array instance');
         });
     });
 
@@ -717,7 +722,7 @@ QUnit.module('cell', function(hooks) {
                     type: 'test.Element'
                 }
             });
-        
+
             const el = new El({
                 foo: {}
             });


### PR DESCRIPTION
Fix array handling in the `Cell` constructor by always creating a deep copy of arrays rather than reusing the original instances.

Specifically, the problem occurred when the default values of the model attributes contained an array value.
```ts
const MyElement = dia.Element.define('MyElement', { attribute: [] });
const array = [1, 2];
const myElement = new MyElement({ attribute: array });
// assert: myElement.get('attrribute') !== array

const myElement2 = myElement.clone();
// assert: myElemen2.get('attrribute') !== myElement.get('attrribute')
```
