### PR TITLE
feat(joint-react): deploy storybook and docs api to the github page

### DIFF
--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -24,16 +24,15 @@ jobs:
         with:
           node-version: '22.14.0'
 
-      - name: Prepare Yarn workspace (from monorepo root)
-        run: |
-          mkdir -p .yarn/cache
-          yarn config set enableGlobalCache false
-          yarn config set enableImmutableInstalls false
-          yarn config set enableImmutableCache false
-        working-directory: ./
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+          key: yarn-cache-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies from root
-        run: yarn install --immutable --immutable-cache
+        run: yarn install --immutable
         working-directory: ./
 
       - name: Ensure docs folders

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -23,7 +23,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          
+
+      - name: Configure Yarn to avoid global cache
+        run: |
+          yarn config set enableGlobalCache false
+          yarn config set enableImmutableInstalls false
+          yarn config set enableImmutableCache false
+
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
 

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -9,6 +9,15 @@ on:
       - feat/release-joint-react-storybook
   workflow_call:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-joint-react-docs:
     runs-on: ubuntu-latest
@@ -16,8 +25,11 @@ jobs:
       run:
         working-directory: ./packages/joint-react
 
+    outputs:
+      pages_path: ${{ steps.prepare.outputs.pages_path }}
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 22.14.0
         uses: actions/setup-node@v4
@@ -40,9 +52,11 @@ jobs:
         working-directory: ./
 
       - name: Ensure docs folders
+        id: prepare
         run: |
           mkdir -p docs/joint-react-storybook
           mkdir -p docs/joint-react-api
+          echo "pages_path=$(pwd)/docs" >> $GITHUB_OUTPUT
 
       - name: Build Storybook
         run: NODE_ENV=production yarn build-storybook -o docs/joint-react-storybook
@@ -50,27 +64,22 @@ jobs:
       - name: Build Typedoc
         run: NODE_ENV=production yarn docs:typedoc
 
-      - name: Upload built docs
-        uses: actions/upload-artifact@v4
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: joint-react-docs
-          path: packages/joint-react/docs
+          path: docs
 
   deploy-docs:
     needs: build-joint-react-docs
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Download built docs
-        uses: actions/download-artifact@v4
-        with:
-          name: joint-react-docs
-          path: ./packages/joint-react/docs
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/joint-react/docs
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -35,6 +35,10 @@ jobs:
         run: yarn install --immutable
         working-directory: ./
 
+      - name: Build @joint/core package
+        run: yarn workspace @joint/core build
+        working-directory: ./
+
       - name: Ensure docs folders
         run: |
           mkdir -p docs/joint-react-storybook

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -91,7 +91,7 @@ jobs:
           path: ./packages/joint-react/docs
 
   # Deploy the docs to GitHub Pages
-  deploy-docs:
+  deploy-joint-react-docs:
     needs: build-joint-react-docs
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 jobs:
-  build-docs:
+  build-joint-react-docs:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
           path: packages/joint-react/docs
 
   deploy-docs:
-    needs: build-docs
+    needs: build-joint-react-docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -1,0 +1,66 @@
+name: Publish Joint React Docs
+# Builds and deploys Storybook + API docs for Joint React
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - dev
+      - feat/release-joint-react-storybook  # TODO: remove once merged
+  workflow_call:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/joint-react
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies (from root)
+        run: yarn install --frozen-lockfile
+        working-directory: ./
+
+      - name: Ensure local docs folders exist
+        run: |
+          mkdir -p docs/joint-react-storybook
+          mkdir -p docs/joint-react-api
+
+      - name: Build Storybook
+        run: NODE_ENV=production yarn build-storybook -o docs/joint-react-storybook
+
+      - name: Build Typedoc
+        run: NODE_ENV=production yarn docs:typedoc
+
+      - name: Upload built docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: joint-react-docs
+          path: packages/joint-react/docs
+
+  deploy-docs:
+    needs: build-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download built docs
+        uses: actions/download-artifact@v3
+        with:
+          name: joint-react-docs
+          path: ./packages/joint-react/docs
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./packages/joint-react/docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22.14.0
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22.14.0'
 
       - name: Prepare Yarn workspace (from monorepo root)
         run: |

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -1,24 +1,30 @@
+# This GitHub Actions workflow builds and deploys the documentation
+# for the `@joint/react` package to GitHub Pages.
 name: Publish Joint React Docs
 
+# Trigger this workflow on:
 on:
-  workflow_dispatch:
-  push:
+  workflow_dispatch:                      # Manual trigger via GitHub UI
+  push:                                   # Automatic trigger on push to specific branches
     branches:
       - master
       - dev
       - feat/release-joint-react-storybook
-  workflow_call:
+  workflow_call:                          # Allow this workflow to be called by another workflow
 
+# Permissions needed to write to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Prevent concurrent runs of this workflow
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
+  # Job to build the documentation (Storybook + TypeDoc)
   build-joint-react-docs:
     runs-on: ubuntu-latest
     defaults:
@@ -26,16 +32,20 @@ jobs:
         working-directory: ./packages/joint-react
 
     outputs:
+      # Save the docs output path for the next job
       pages_path: ${{ steps.prepare.outputs.pages_path }}
 
     steps:
+      # Checkout the repo contents
       - uses: actions/checkout@v4
 
+      # Set up Node.js version for building
       - name: Use Node.js 22.14.0
         uses: actions/setup-node@v4
         with:
           node-version: '22.14.0'
 
+      # Cache Yarn packages to speed up CI
       - name: Cache Yarn
         uses: actions/cache@v4
         with:
@@ -43,14 +53,17 @@ jobs:
             .yarn/cache
           key: yarn-cache-${{ hashFiles('yarn.lock') }}
 
+      # Install all dependencies from the monorepo root
       - name: Install dependencies from root
         run: yarn install --immutable
         working-directory: ./
 
+      # Build the core package (dependency of joint-react)
       - name: Build @joint/core package
         run: yarn workspace @joint/core build
         working-directory: ./
 
+      # Create output folders for Storybook and Typedoc
       - name: Ensure docs folders
         id: prepare
         run: |
@@ -58,6 +71,7 @@ jobs:
           mkdir -p docs/joint-react-api
           echo "pages_path=$(pwd)/docs" >> $GITHUB_OUTPUT
 
+      # Build Storybook with proper BASE_DOCS_URL for MD linking
       - name: Build Storybook
         env:
           STORYBOOK_BASE_DOCS_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/joint-react-api
@@ -65,15 +79,17 @@ jobs:
           echo "Using BASE_DOCS_URL=$STORYBOOK_BASE_DOCS_URL"
           yarn build-storybook -o docs/joint-react-storybook
 
-
+      # Generate API reference using TypeDoc
       - name: Build Typedoc
         run: NODE_ENV=production yarn docs:typedoc
 
+      # Upload the built docs as an artifact for GitHub Pages deployment
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./packages/joint-react/docs
 
+  # Deploy the docs to GitHub Pages
   deploy-docs:
     needs: build-joint-react-docs
     runs-on: ubuntu-latest
@@ -82,9 +98,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      # Setup GitHub Pages deployment environment
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
 
+      # Deploy the uploaded artifact to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-
+          
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable --immutable-cache
 
       - name: Ensure docs folders
         run: |

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -24,11 +24,12 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Configure Yarn to avoid global cache
+      - name: Configure Yarn and create cache folder
         run: |
           yarn config set enableGlobalCache false
           yarn config set enableImmutableInstalls false
           yarn config set enableImmutableCache false
+          mkdir -p .yarn/cache
 
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -24,15 +24,17 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Configure Yarn and create cache folder
+      - name: Prepare Yarn workspace (from monorepo root)
         run: |
+          mkdir -p .yarn/cache
           yarn config set enableGlobalCache false
           yarn config set enableImmutableInstalls false
           yarn config set enableImmutableCache false
-          mkdir -p .yarn/cache
+        working-directory: ./
 
-      - name: Install dependencies
+      - name: Install dependencies from root
         run: yarn install --immutable --immutable-cache
+        working-directory: ./
 
       - name: Ensure docs folders
         run: |

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -1,5 +1,4 @@
 name: Publish Joint React Docs
-# Builds and deploys Storybook + API docs for Joint React
 
 on:
   workflow_dispatch:
@@ -7,7 +6,7 @@ on:
     branches:
       - master
       - dev
-      - feat/release-joint-react-storybook  # TODO: remove once merged
+      - feat/release-joint-react-storybook
   workflow_call:
 
 jobs:
@@ -25,11 +24,10 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies (from root)
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
-        working-directory: ./
 
-      - name: Ensure local docs folders exist
+      - name: Ensure docs folders
         run: |
           mkdir -p docs/joint-react-storybook
           mkdir -p docs/joint-react-api
@@ -41,7 +39,7 @@ jobs:
         run: NODE_ENV=production yarn docs:typedoc
 
       - name: Upload built docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: joint-react-docs
           path: packages/joint-react/docs
@@ -54,13 +52,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download built docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: joint-react-docs
           path: ./packages/joint-react/docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          publish_dir: ./packages/joint-react/docs
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./packages/joint-react/docs

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -59,7 +59,12 @@ jobs:
           echo "pages_path=$(pwd)/docs" >> $GITHUB_OUTPUT
 
       - name: Build Storybook
-        run: NODE_ENV=production yarn build-storybook -o docs/joint-react-storybook
+        env:
+          STORYBOOK_BASE_DOCS_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/joint-react-api
+        run: |
+          echo "Using BASE_DOCS_URL=$STORYBOOK_BASE_DOCS_URL"
+          yarn build-storybook -o docs/joint-react-storybook
+
 
       - name: Build Typedoc
         run: NODE_ENV=production yarn docs:typedoc

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: ./packages/joint-react/docs
 
   deploy-docs:
     needs: build-joint-react-docs

--- a/.github/workflows/publish-join-react-docs.yml
+++ b/.github/workflows/publish-join-react-docs.yml
@@ -4,13 +4,14 @@ name: Publish Joint React Docs
 
 # Trigger this workflow on:
 on:
-  workflow_dispatch:                      # Manual trigger via GitHub UI
-  push:                                   # Automatic trigger on push to specific branches
+  workflow_dispatch:
+  push:
     branches:
       - master
-      - dev
-      - feat/release-joint-react-storybook
-  workflow_call:                          # Allow this workflow to be called by another workflow
+    paths:
+      - 'packages/joint-react/**'           # Only trigger if files in this folder change
+      - '.github/workflows/**'              # (optional) include changes to the workflow itself
+  workflow_call:
 
 # Permissions needed to write to GitHub Pages
 permissions:

--- a/packages/joint-react/.gitignore
+++ b/packages/joint-react/.gitignore
@@ -12,7 +12,7 @@
 .yarn/cache/
 .yarn/install-state.gz
 .pnp.*
-
+docs
 # Vite
 .vite/
 

--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -15,7 +15,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "build": "node --experimental-json-modules --loader ts-node/esm build.ts",
-    "doc:readme:gen": "npx typedoc"
+    "docs:typedoc": "typedoc --out docs/joint-react-api src"
   },
   "devDependencies": {
     "@andypf/json-viewer": "^2.1.10",
@@ -59,10 +59,10 @@
     "storybook-multilevel-sort": "^2.0.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typedoc": "0.28.0",
-    "typedoc-github-theme": "^0.2.1",
+    "typedoc": "^0.28.5",
+    "typedoc-github-theme": "^0.3.0",
     "typedoc-plugin-external-module-name": "^4.0.6",
-    "typedoc-plugin-markdown": "4.5.2 ",
+    "typedoc-plugin-markdown": "^4.6.4",
     "typedoc-plugin-mdn-links": "5.0.1",
     "typescript": "5.7.3",
     "vite-plugin-md": "^0.21.5",

--- a/packages/joint-react/src/components/highlighters/custom.stories.tsx
+++ b/packages/joint-react/src/components/highlighters/custom.stories.tsx
@@ -8,7 +8,7 @@ import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation
 import { forwardRef, type PropsWithChildren } from 'react';
 import { useElement } from '../../hooks';
 
-const API_URL = getAPILink('Highlighter/variables/Custom', 'namespaces');
+const API_URL = getAPILink('Highlighter.Custom', 'variables');
 
 export type Story = StoryObj<typeof Custom>;
 const meta: Meta<typeof Custom> = {

--- a/packages/joint-react/src/components/highlighters/mask.stories.tsx
+++ b/packages/joint-react/src/components/highlighters/mask.stories.tsx
@@ -7,7 +7,7 @@ import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation
 import { forwardRef, type PropsWithChildren } from 'react';
 import { useElement } from '../../hooks';
 
-const API_URL = getAPILink('Highlighter/variables/Mask', 'namespaces');
+const API_URL = getAPILink('Highlighter.Mask', 'variables');
 
 export type Story = StoryObj<typeof Mask>;
 const meta: Meta<typeof Mask> = {

--- a/packages/joint-react/src/components/highlighters/opacity.stories.tsx
+++ b/packages/joint-react/src/components/highlighters/opacity.stories.tsx
@@ -7,7 +7,7 @@ import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation
 import { forwardRef, type PropsWithChildren } from 'react';
 import { useElement } from '../../hooks';
 
-const API_URL = getAPILink('Highlighter/variables/Opacity', 'namespaces');
+const API_URL = getAPILink('Highlighter.Opacity', 'variables');
 
 export type Story = StoryObj<typeof Opacity>;
 const meta: Meta<typeof Opacity> = {

--- a/packages/joint-react/src/components/highlighters/stroke.stories.tsx
+++ b/packages/joint-react/src/components/highlighters/stroke.stories.tsx
@@ -7,7 +7,7 @@ import { getAPILink } from '@joint/react/src/stories/utils/get-api-documentation
 import { useElement } from '../../hooks';
 import { forwardRef, type PropsWithChildren } from 'react';
 
-const API_URL = getAPILink('Highlighter/variables/Stroke', 'namespaces');
+const API_URL = getAPILink('Highlighter.Stroke', 'variables');
 
 export type Story = StoryObj<typeof Stroke>;
 

--- a/packages/joint-react/src/components/port/port-group.stories.tsx
+++ b/packages/joint-react/src/components/port/port-group.stories.tsx
@@ -55,7 +55,7 @@ const initialLinks = createLinks([
 ]);
 
 export type Story = StoryObj<typeof PortGroup>;
-const API_URL = getAPILink('Port/variables/Group', 'namespaces');
+const API_URL = getAPILink('Port.Group', 'variables');
 
 function RenderItem(Story: React.FC) {
   const { width, height } = useElement();

--- a/packages/joint-react/src/components/port/port-item.stories.tsx
+++ b/packages/joint-react/src/components/port/port-item.stories.tsx
@@ -63,7 +63,7 @@ const initialLinks = createLinks([
 ]);
 
 export type Story = StoryObj<typeof Port.Item>;
-const API_URL = getAPILink('Port/variables/Item', 'namespaces');
+const API_URL = getAPILink('Port.Item', 'variables');
 function RenderItem(Story: React.FC) {
   const { width, height } = useElement();
   return (

--- a/packages/joint-react/src/components/text-node/text-node.stories.tsx
+++ b/packages/joint-react/src/components/text-node/text-node.stories.tsx
@@ -10,7 +10,7 @@ import { PRIMARY } from 'storybook-config/theme';
 import { useElement } from '../../hooks';
 import { MeasuredNode } from '../measured-node/measured-node';
 
-const API_URL = getAPILink('TextNode');
+const API_URL = getAPILink('TextNode', 'variables');
 export type Story = StoryObj<typeof TextNode>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/joint-react/src/hooks/use-create-element.stories.tsx
+++ b/packages/joint-react/src/hooks/use-create-element.stories.tsx
@@ -72,7 +72,6 @@ function Hook({ label }: SimpleElement) {
 
 export const Default: Story = makeStory<Story>({
   args: {},
-  apiURL: API_URL,
   code: `import { useCreateElement } from '@joint/react'
 
 function Hook() {

--- a/packages/joint-react/src/stories/utils/get-api-documentation-link.tsx
+++ b/packages/joint-react/src/stories/utils/get-api-documentation-link.tsx
@@ -1,7 +1,9 @@
-const BASE_DOCS_URL = 'https://github.com/clientIO/joint/tree/master/packages/joint-react/docs';
+const STORYBOOK_BASE_DOCS_URL =
+  // @ts-expect-error Vite config
+  import.meta.env.STORYBOOK_BASE_DOCS_URL ?? 'https://docs.official.com';
 
 export function getAPILink(name: string, path = 'functions') {
-  return `${BASE_DOCS_URL}/${path}/${name}.md`;
+  return `${STORYBOOK_BASE_DOCS_URL}/${path}/${name}.html`;
 }
 export function getAPIDocumentationLink(name: string, path = 'functions') {
   const href = getAPILink(name, path);

--- a/packages/joint-react/src/stories/utils/make-story.tsx
+++ b/packages/joint-react/src/stories/utils/make-story.tsx
@@ -6,7 +6,7 @@ interface MakeStoryOptions<T extends StoryObj> {
   readonly component?: React.FC;
   readonly code?: string;
   readonly name?: string;
-  readonly apiURL: string;
+  readonly apiURL?: string;
   readonly description?: string;
   readonly args?: T['args'];
   readonly decorators?: T['decorators'];
@@ -69,7 +69,8 @@ export function makeRootDocumentation(options: MakeRootDocsOptions) {
   return {
     docs: {
       description: {
-        component: `[API reference](${apiURL})<br/>${description}`,
+        // eslint-disable-next-line sonarjs/no-nested-template-literals
+        component: `${apiURL ? `[API reference](${apiURL})` : ''}<br/>${description}`,
       },
       source: {
         code,

--- a/packages/joint-react/typedoc.css
+++ b/packages/joint-react/typedoc.css
@@ -1,0 +1,14 @@
+:root {
+  /* Backgrounds */
+  --tsd-background: #131e29;
+  --tsd-background-inset: #131e29;
+
+  /* Text */
+  --tsd-text: #dde6ed;
+  --tsd-link-color: #ed2637;
+
+  /* Primary color accents */
+  --tsd-color-primary: #ed2637;
+  --tsd-block-heading-background: #131e29;
+  --tsd-block-heading-text-color: #dde6ed;
+}

--- a/packages/joint-react/typedoc.json
+++ b/packages/joint-react/typedoc.json
@@ -1,12 +1,6 @@
 {
   "entryPoints": ["src/index.ts"],
-  "outputs": [
-    {
-      "name": "markdown",
-      "path": "./docs"
-    }
-  ],
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-mdn-links"],
+  "out": "docs/joint-react-api",
   "readme": "none",
   "name": "@joint/react",
   "excludePrivate": true,
@@ -14,5 +8,7 @@
   "excludeExternals": true,
   "excludeNotDocumented": false,
   "groupOrder": ["Components", "Hooks", "Models", "Utils", "*"],
-  "gitRevision": "main"
+  "gitRevision": "master",
+  "customCss": "typedoc.css",
+  "plugin": ["typedoc-github-theme"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,16 +2692,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gerrit0/mini-shiki@npm:^3.2.1":
-  version: 3.2.2
-  resolution: "@gerrit0/mini-shiki@npm:3.2.2"
+"@gerrit0/mini-shiki@npm:^3.2.2":
+  version: 3.6.0
+  resolution: "@gerrit0/mini-shiki@npm:3.6.0"
   dependencies:
-    "@shikijs/engine-oniguruma": "npm:^3.2.1"
-    "@shikijs/langs": "npm:^3.2.1"
-    "@shikijs/themes": "npm:^3.2.1"
-    "@shikijs/types": "npm:^3.2.1"
+    "@shikijs/engine-oniguruma": "npm:^3.6.0"
+    "@shikijs/langs": "npm:^3.6.0"
+    "@shikijs/themes": "npm:^3.6.0"
+    "@shikijs/types": "npm:^3.6.0"
     "@shikijs/vscode-textmate": "npm:^10.0.2"
-  checksum: 10/2e5e287be8a8dcd36aa9f1b8d33cb6ada836bd7b1455a9921568c630ea12160c6a210779ff29a7a36fc5c13964a390f25022f0b90bee30934ac041b6500ac239
+  checksum: 10/8f33f76598f3088dc2c632aad37389929300d4cee4cd868a318809133de86d96a68d0334ee0061fb62cc732cb12fe7cc9f64eed7885ce1e76e77000ed12ceb99
   languageName: node
   linkType: hard
 
@@ -3403,10 +3403,10 @@ __metadata:
     storybook-multilevel-sort: "npm:^2.0.1"
     ts-jest: "npm:^29.2.5"
     ts-node: "npm:^10.9.2"
-    typedoc: "npm:0.28.0"
-    typedoc-github-theme: "npm:^0.2.1"
+    typedoc: "npm:^0.28.5"
+    typedoc-github-theme: "npm:^0.3.0"
     typedoc-plugin-external-module-name: "npm:^4.0.6"
-    typedoc-plugin-markdown: "npm:4.5.2 "
+    typedoc-plugin-markdown: "npm:^4.6.4"
     typedoc-plugin-mdn-links: "npm:5.0.1"
     typescript: "npm:5.7.3"
     use-sync-external-store: "npm:^1.4.0"
@@ -4450,41 +4450,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/engine-oniguruma@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/engine-oniguruma@npm:3.2.1"
+"@shikijs/engine-oniguruma@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.6.0"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
+    "@shikijs/types": "npm:3.6.0"
     "@shikijs/vscode-textmate": "npm:^10.0.2"
-  checksum: 10/56ac0aea3d20149e807196d2ea4b0ed74099852bee36b7aadefcb3620425551f044cb803f30b4f234c009b8179a3fff82fa4aed2d866e7228d58a80ab94c6212
+  checksum: 10/f97481aefba3eee0ab0e797c9a164e55e4e8797519762150ad01fa3d7da571e35620c193b84f58cd170820f0df96eb85ca3f464598406d683fefaf8445a8c828
   languageName: node
   linkType: hard
 
-"@shikijs/langs@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/langs@npm:3.2.1"
+"@shikijs/langs@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@shikijs/langs@npm:3.6.0"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
-  checksum: 10/ccda5e09d67a2d4ad5aa6a06a9f85f9efb96a6c5cf2a6e0aa1dff2f0283ab4140fc12609975bb249b81c921469bfe9d004fcea7f45c6363385c639fbd5256310
+    "@shikijs/types": "npm:3.6.0"
+  checksum: 10/ff8bd42cd3528649f9aa278c2030e844389f1bf61cc8d9eba64e43517aeb72d54b95a68038788159c5286b0550012964cdb4f2007d845f7c4f3fe14cb3021cf6
   languageName: node
   linkType: hard
 
-"@shikijs/themes@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/themes@npm:3.2.1"
+"@shikijs/themes@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@shikijs/themes@npm:3.6.0"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
-  checksum: 10/ab27aff5437ec85010899545058640ad2c41e935b74b4213300609ea62a8dd5b84229cd15f491650ce05b7c6f965beadfe67aa53de022fa0a1cb48f19ab59865
+    "@shikijs/types": "npm:3.6.0"
+  checksum: 10/dc28668d1fa03f08eace564d1b9fb4466a84774cd486695d9d66261a3470147dd06e0ab16173861338ea63026008f58269ba5e8b27179616e9b7ad235ddf181d
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:3.2.1, @shikijs/types@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/types@npm:3.2.1"
+"@shikijs/types@npm:3.6.0, @shikijs/types@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@shikijs/types@npm:3.6.0"
   dependencies:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10/a9a70a98daf93041ae5199714fe0a7cfae8ba82f31967c3f349da83ca2b16fbaeab3e8ce3cf63672c09ed85da34093f94e7203f46722c88764f314dbe4c8d21c
+  checksum: 10/0dde01f5733d156b57946911ae461d6e9172f4ccd7e8d99d8ba9de6004275de37fba53e38d853de2a187357ac4540b2c2dbd8de09ef2d12c37e913829a89566b
   languageName: node
   linkType: hard
 
@@ -23971,12 +23971,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-github-theme@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "typedoc-github-theme@npm:0.2.1"
+"typedoc-github-theme@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "typedoc-github-theme@npm:0.3.0"
   peerDependencies:
-    typedoc: ^0.27.6
-  checksum: 10/cff1a8ea00a78cfe465ff48a28616849875f9705cdc6f1863c96739a58f2baa4ba90b3b5a4d0e31381502d41d79f1acca5de901ee7cc3aa5b3b590bb213a86d5
+    typedoc: ~0.28.0
+  checksum: 10/20193c366169b19619e4e247a0c5e02509ef85b4588523837766929b2cd16507eac81c35fe59ed66aae5148406ee4a302d1b3d49c0aa27e63aee772524b10ad2
   languageName: node
   linkType: hard
 
@@ -23992,12 +23992,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:4.5.2 ":
-  version: 4.5.2
-  resolution: "typedoc-plugin-markdown@npm:4.5.2"
+"typedoc-plugin-markdown@npm:^4.6.4":
+  version: 4.6.4
+  resolution: "typedoc-plugin-markdown@npm:4.6.4"
   peerDependencies:
     typedoc: 0.28.x
-  checksum: 10/33402eeabedf0f74c72ff45b139f95bbc4dae5a3e3c36c9e34f2b183da4d3dcbe91afdfcf2597b0f731c83a9ffeff9f87d693098d0f61d76236b28919984c9f3
+  checksum: 10/b720a20b7c2fbf06645473ce0d0454c7cd498571c9994839f0d39b102c606eaedf47ebd63a38cf405a25bdb25d4f1bd8c3ca4b27d44dfc9a1de8a54890d9844a
   languageName: node
   linkType: hard
 
@@ -24010,20 +24010,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.28.0":
-  version: 0.28.0
-  resolution: "typedoc@npm:0.28.0"
+"typedoc@npm:^0.28.5":
+  version: 0.28.5
+  resolution: "typedoc@npm:0.28.5"
   dependencies:
-    "@gerrit0/mini-shiki": "npm:^3.2.1"
+    "@gerrit0/mini-shiki": "npm:^3.2.2"
     lunr: "npm:^2.3.9"
     markdown-it: "npm:^14.1.0"
     minimatch: "npm:^9.0.5"
-    yaml: "npm:^2.7.0 "
+    yaml: "npm:^2.7.1"
   peerDependencies:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10/41f5f871d314c5a9166e3e449ec01c916d3516c5fcb198304bfeb2bbcab8139f9f090c41035c52556a4b549f55e39822f345e0472641cea24c04b344f6dd34fa
+  checksum: 10/620426f4fd593dea5ffd37bce8741bfa996cb25e0f67c6aac11434788652c3cd10af2a9c47d1445f10b9fbb44304ffcf6ec59f5cedd353175e3b3d9a24cb5d29
   languageName: node
   linkType: hard
 
@@ -25880,12 +25880,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.7.0 ":
-  version: 2.7.1
-  resolution: "yaml@npm:2.7.1"
+"yaml@npm:^2.7.1":
+  version: 2.8.0
+  resolution: "yaml@npm:2.8.0"
   bin:
     yaml: bin.mjs
-  checksum: 10/af57658d37c5efae4bac7204589b742ae01878a278554d632f01012868cf7fa66cba09b39140f12e7f6ceecc693ae52bcfb737596c4827e6e233338cb3a9528e
+  checksum: 10/7d4bd9c10d0e467601f496193f2ac254140f8e36f96f5ff7f852b9ce37974168eb7354f4c36dc8837dde527a2043d004b6aff48818ec24a69ab2dd3c6b6c381c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--  
Thank you for submitting a pull request!

Please verify that:  
* [x] Code is up-to-date with the `master` branch  
* [x] You've successfully run `grunt test` locally *(not applicable)*  
* [x] If applicable, there are new or updated unit tests validating the change *(not applicable)*  
* [x] If applicable, there are new or updated @types *(not applicable)*  
* [x] If applicable, documentation has been updated  
-->

## Description

This PR introduces an automated GitHub Actions workflow to build and publish documentation for the `@joint/react` package. It generates and deploys:

- 📘 **Storybook UI** (`docs/joint-react-storybook/`)
- 📚 **API reference** via TypeDoc (`docs/joint-react-api/`)

The workflow is triggered automatically when:
- Files under `packages/joint-react/` are changed on the `master` branch
- The workflow file itself is updated
- Or manually via the GitHub UI

Docs are deployed to GitHub Pages at:

- https://clientio.github.io/joint/joint-react-storybook/
- https://clientio.github.io/joint/joint-react-api/

## Motivation and Context

This update streamlines the documentation process by:

- Ensuring documentation is always up-to-date after relevant changes
- Eliminating the need for manual doc builds or pushes
- Providing a single source of truth for both usage (Storybook) and reference (TypeDoc)
- Supporting public access for users, contributors, and stakeholders

### Screenshots (if appropriate)

> **Storybook UI**  
> [https://clientio.github.io/joint/joint-react-storybook/](https://clientio.github.io/joint/joint-react-storybook/)

> **API Reference**  
> [https://clientio.github.io/joint/joint-react-api/](https://clientio.github.io/joint/joint-react-api/)
