### PR TITLE
fix(demo): fix text selection in FSA example

### DIFF
--- a/packages/joint-core/demo/fsa/src/fsa.js
+++ b/packages/joint-core/demo/fsa/src/fsa.js
@@ -88,7 +88,7 @@ function link(source, target, label, vertices) {
                 },
                 text: {
                     text: label,
-                    fontWeight: 'bold',
+                    fontWeight: 'bold'
                 }
             }
         }],

--- a/packages/joint-core/demo/fsa/src/fsa.js
+++ b/packages/joint-core/demo/fsa/src/fsa.js
@@ -7,7 +7,8 @@ const paper = new joint.dia.Paper({
     model: graph,
     cellViewNamespace: joint.shapes,
     defaultConnector: { name: 'smooth' },
-    interactive: { linkMove: false },
+    interactive: { linkMove: false, labelMove: false },
+    preventDefaultViewAction: false,
     labelsLayer: true,
     frozen: true
 });
@@ -79,9 +80,15 @@ function link(source, target, label, vertices) {
                 }
             },
             attrs: {
+                root: {
+                    cursor: 'text',
+                    style: {
+                        userSelect: 'text'
+                    }
+                },
                 text: {
                     text: label,
-                    fontWeight: 'bold'
+                    fontWeight: 'bold',
                 }
             }
         }],


### PR DESCRIPTION
## Description

Make sure that the text of link labels and elements can be selected.
