### PR TITLE
chore: do not run github actions outside clientIO/joint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    if: ${{ github.repository == 'clientIO/joint' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
@@ -48,11 +49,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -61,7 +62,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/publish-joint-react-docs.yml
+++ b/.github/workflows/publish-joint-react-docs.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   # Job to build the documentation (Storybook + TypeDoc)
   build-joint-react-docs:
+    if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -93,6 +94,7 @@ jobs:
   # Deploy the docs to GitHub Pages
   deploy-joint-react-docs:
     needs: build-joint-react-docs
+    if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   stale:
-
+    if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Description

Make all GitHub actions check the current repository, and exit if the current repository is not `clientIO/joint`.

## Motivation and Context

The GitHub actions defined in this repository mostly do not make sense on forks.