### PR TITLE
Add note regarding required Node version.

### DIFF
--- a/packages/joint-core/README.md
+++ b/packages/joint-core/README.md
@@ -63,7 +63,9 @@ Make sure you have the following dependencies installed on your system:
 * [git](https://git-scm.com/)
 * [yarn](https://yarnpkg.com/getting-started/install)
 
-Make sure that you are using Yarn version >= 2.0.0, so that you have access to [Yarn workspace ranges](https://yarnpkg.com/features/workspaces#workspace-ranges-workspace) functionality. If you are using [Volta](https://volta.sh/), it will automatically read this restriction from `package.json`.
+The installation requires Node version >= 20.19.3, to avoid syntax errors during installation.
+
+Make sure that you are using Yarn version >= 2.0.0, so that you have access to [Yarn workspace ranges](https://yarnpkg.com/features/workspaces#workspace-ranges-workspace) functionality. If you are using [Volta](https://volta.sh/), it will automatically read this restriction from `package.json`. 
 
 ### Setup
 


### PR DESCRIPTION
Currently, trying to install on an older Node version such as 18.x results in a failure while installing @joint/layout-directed-graph, which results in a failed installation overall.

This change simply adds a note above the recommendation regarding Yarn version to make a similar recommendation regarding Node version, for future installers.

## Description

Adds a one-liner to assist installers who are using older versions of Node.js

## Motivation and Context

There is an indication on the required Yarn version, but not of the required Node version. Using an older version of Node (such as 18) results in the following error during install:

```
[@joint/layout-directed-graph]: Process started
[@joint/layout-directed-graph]: [!] SyntaxError: Unexpected token 'with'
[@joint/layout-directed-graph]:     at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:116:18)
[@joint/layout-directed-graph]:     at ESMLoader.moduleProvider (node:internal/modules/esm/loader:218:14)
[@joint/layout-directed-graph]:     at link (node:internal/modules/esm/module_job:67:21)
[@joint/layout-directed-graph]: 
[@joint/layout-directed-graph]: 
[@joint/layout-directed-graph]: Process exited (exit code 1), completed in 0s 688ms
```

This adds guidance to developers following the installation rules as written, as the error itself does not immediately imply that the Node.js version is the problem.