### PR TITLE
feat: disable text sanitization by default

### DIFF
--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -485,10 +485,13 @@ const V = (function() {
 
         if (content && typeof content !== 'string') throw new Error('Vectorizer: text() expects the first argument to be a string.');
 
-        // Replace all spaces with the Unicode No-break space (http://www.fileformat.info/info/unicode/char/a0/index.htm).
-        // IE would otherwise collapse all spaces into one.
-        content = V.sanitizeText(content);
         opt || (opt = {});
+
+        if (opt.sanitize) {
+            // Replace all spaces with the Unicode No-break space (http://www.fileformat.info/info/unicode/char/a0/index.htm).
+            // IE would otherwise collapse all spaces into one.
+            content = V.sanitizeText(content);
+        }
         // Should we allow the text to be selected?
         var displayEmpty = opt.displayEmpty;
         // End of Line character
@@ -1332,6 +1335,9 @@ const V = (function() {
     // also exposed so that the programmer can use it in case he needs to. This is useful e.g. in tests
     // when you want to compare the actual DOM text content without having to add the unicode character in
     // the place of all spaces.
+    /** 
+     * @deprecated Use regular spaces and rely on xml:space="preserve" instead.
+     */
     V.sanitizeText = function(text) {
 
         return (text || '').replace(/ /g, '\u00A0');

--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -487,7 +487,7 @@ const V = (function() {
 
         opt || (opt = {});
 
-        if (opt.sanitize) {
+        if (opt.useNoBreakSpace) {
             // Replace all spaces with the Unicode No-break space (http://www.fileformat.info/info/unicode/char/a0/index.htm).
             // IE would otherwise collapse all spaces into one.
             content = V.sanitizeText(content);

--- a/packages/joint-core/src/V/index.mjs
+++ b/packages/joint-core/src/V/index.mjs
@@ -487,6 +487,12 @@ const V = (function() {
 
         opt || (opt = {});
 
+        // Backwards-compatibility: if no content was provided, treat it as an
+        // empty string so that subsequent string operations (e.g. split) do
+        // not throw and behaviour matches the previous implementation that
+        // always sanitised the input.
+        if (content == null) content = '';
+
         if (opt.useNoBreakSpace) {
             // Replace all spaces with the Unicode No-break space (http://www.fileformat.info/info/unicode/char/a0/index.htm).
             // IE would otherwise collapse all spaces into one.

--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -79,7 +79,8 @@ const textAttributesNS = {
                     x,
                     textVerticalAnchor,
                     eol,
-                    displayEmpty
+                    displayEmpty,
+                    sanitize: attrs.sanitize === true
                 });
                 $.data.set(node, cacheName, textHash);
             }

--- a/packages/joint-core/src/dia/attributes/text.mjs
+++ b/packages/joint-core/src/dia/attributes/text.mjs
@@ -54,9 +54,10 @@ const textAttributesNS = {
             const eol = attrs.eol;
             const x = attrs.x;
             let textPath = attrs['text-path'];
+            const useNoBreakSpace = attrs['use-no-break-space'] === true;
             // Update the text only if there was a change in the string
             // or any of its attributes.
-            const textHash = JSON.stringify([text, lineHeight, annotations, textVerticalAnchor, eol, displayEmpty, textPath, x, fontSize]);
+            const textHash = JSON.stringify([text, lineHeight, annotations, textVerticalAnchor, eol, displayEmpty, textPath, x, fontSize, useNoBreakSpace]);
             if (cache === undefined || cache !== textHash) {
                 // Chrome bug:
                 // <tspan> positions defined as `em` are not updated
@@ -80,7 +81,7 @@ const textAttributesNS = {
                     textVerticalAnchor,
                     eol,
                     displayEmpty,
-                    sanitize: attrs.sanitize === true
+                    useNoBreakSpace
                 });
                 $.data.set(node, cacheName, textHash);
             }

--- a/packages/joint-core/test/jointjs/basic.js
+++ b/packages/joint-core/test/jointjs/basic.js
@@ -1,3 +1,7 @@
+const USE_NO_BREAK_SPACE_LABEL_ATTRS = {
+    useNoBreakSpace: true
+}
+
 QUnit.module('basic', function(hooks) {
 
     hooks.beforeEach(function() {
@@ -55,7 +59,7 @@ QUnit.module('basic', function(hooks) {
         var myrect = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle', sanitize: true }}
+            attrs: { label: { ...USE_NO_BREAK_SPACE_LABEL_ATTRS, text: 'my rectangle' }}
         });
 
         this.graph.addCell(myrect);
@@ -78,7 +82,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle', sanitize: true }}
+            attrs: { label: { ...USE_NO_BREAK_SPACE_LABEL_ATTRS, text: 'my rectangle' }}
         });
         var r2 = r1.clone();
         var r3 = r1.clone();
@@ -109,7 +113,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle', sanitize: true }}
+            attrs: { label: { ...USE_NO_BREAK_SPACE_LABEL_ATTRS, text: 'my rectangle' }}
         });
         var r2 = r1.clone();
         var r3 = r1.clone();
@@ -140,7 +144,7 @@ QUnit.module('basic', function(hooks) {
         var myrect = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle', sanitize: true }}
+            attrs: { label: { text: 'my rectangle' }}
         });
 
         this.graph.addCell(myrect);
@@ -1167,7 +1171,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle', sanitize: true }}
+            attrs: { label: { ...USE_NO_BREAK_SPACE_LABEL_ATTRS, text: 'my rectangle' }}
         });
 
         this.graph.addCell(r1);

--- a/packages/joint-core/test/jointjs/basic.js
+++ b/packages/joint-core/test/jointjs/basic.js
@@ -55,7 +55,7 @@ QUnit.module('basic', function(hooks) {
         var myrect = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle' }}
+            attrs: { label: { text: 'my rectangle', sanitize: true }}
         });
 
         this.graph.addCell(myrect);
@@ -78,7 +78,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle' }}
+            attrs: { label: { text: 'my rectangle', sanitize: true }}
         });
         var r2 = r1.clone();
         var r3 = r1.clone();
@@ -109,7 +109,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle' }}
+            attrs: { label: { text: 'my rectangle', sanitize: true }}
         });
         var r2 = r1.clone();
         var r3 = r1.clone();
@@ -140,7 +140,7 @@ QUnit.module('basic', function(hooks) {
         var myrect = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle' }}
+            attrs: { label: { text: 'my rectangle', sanitize: true }}
         });
 
         this.graph.addCell(myrect);
@@ -1167,7 +1167,7 @@ QUnit.module('basic', function(hooks) {
         var r1 = new joint.shapes.standard.Rectangle({
             position: { x: 20, y: 30 },
             size: { width: 120, height: 80 },
-            attrs: { label: { text: 'my rectangle' }}
+            attrs: { label: { text: 'my rectangle', sanitize: true }}
         });
 
         this.graph.addCell(r1);

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -46,7 +46,7 @@ QUnit.module('Attributes', function() {
             paper.remove();
         });
 
-        QUnit.module('sanitize', function() {
+        QUnit.module('useNoBreakSpace', function() {
 
             QUnit.test('false by default', function(assert) {
 
@@ -58,7 +58,7 @@ QUnit.module('Attributes', function() {
             QUnit.test('true', function(assert) {
 
                 const text = joint.dia.attributes['text'];
-                text.set.call(cellView, '  text  ', refBBox, node, { sanitize: true });
+                text.set.call(cellView, '  text  ', refBBox, node, { 'use-no-break-space': true });
                 assert.equal(node.textContent, V.sanitizeText('  text  '), 'Text uses non-breaking whitespace character');
             });
         });

--- a/packages/joint-core/test/jointjs/dia/attributes.js
+++ b/packages/joint-core/test/jointjs/dia/attributes.js
@@ -46,6 +46,23 @@ QUnit.module('Attributes', function() {
             paper.remove();
         });
 
+        QUnit.module('sanitize', function() {
+
+            QUnit.test('false by default', function(assert) {
+
+                const text = joint.dia.attributes['text'];
+                text.set.call(cellView, '  text  ', refBBox, node, {});
+                assert.equal(node.textContent, '  text  ', 'Text uses normal whitespace character');
+            });
+
+            QUnit.test('true', function(assert) {
+
+                const text = joint.dia.attributes['text'];
+                text.set.call(cellView, '  text  ', refBBox, node, { sanitize: true });
+                assert.equal(node.textContent, V.sanitizeText('  text  '), 'Text uses non-breaking whitespace character');
+            });
+        });
+
         QUnit.module('textWrap', function() {
 
             QUnit.test('qualify', function(assert) {

--- a/packages/joint-core/types/vectorizer.d.ts
+++ b/packages/joint-core/types/vectorizer.d.ts
@@ -233,6 +233,9 @@ interface VStatic {
 
     ensureId(node: SVGElement | VElement): string;
 
+    /** 
+     * @deprecated Use regular spaces and rely on xml:space="preserve" instead.
+     */
     sanitizeText(text: string): string;
 
     isUndefined(value: any): boolean;

--- a/packages/joint-core/types/vectorizer.d.ts
+++ b/packages/joint-core/types/vectorizer.d.ts
@@ -27,6 +27,7 @@ export namespace Vectorizer {
         annotations?: TextAnnotation[];
         includeAnnotationIndices?: boolean;
         displayEmpty?: boolean;
+        useNoBreakSpace?: boolean;
     }
 
     interface GetBBoxOptions {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Mark the `V.sanitizeText()` method as `deprecated`. Hide the legacy functionality under `opt.useNoBreakSpace` for the `V.text()` method. And pass the `useNoBreakSpace` option for `text` attribute.

<!-- Fixes # -->
Fixes #2967

## Motivation and Context

The conversion from `U+0020` to `U+00A0` was introduced for historical reasons but is no longer necessary and can be safely removed from the codebase.
___

# attributes

### useNoBreakSpace

*applies to*: `<text/>`

If set to `true`, all spaces (`U+0020`) in the text content will be replaced with a Unicode no-break space (`U+00A0`). The default value is `false`.

```ts
element.attr('label', {
    text: '  Text',
    useNoBreakSpace: true
});
```
___
# Vectorizer

### text()

#### Misc

Setting the `opt.useNoBreakSpace` to `true` will cause every standard space character (`U+0020`) in the provided `content` to be replaced with a Unicode no-break space (`U+00A0`).