### PR TITLE
chore(dia.Cell): add public getAttributeDefinition method definition

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -986,6 +986,8 @@ export namespace dia {
 
         dragLinkEnd(evt: dia.Event, x: number, y: number): void;
 
+        getAttributeDefinition(attrName: string): dia.Cell.PresentationAttributeDefinition<T> | undefined;
+
         preventDefaultInteraction(evt: dia.Event): void;
 
         isDefaultInteractionPrevented(evt: dia.Event): boolean;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -539,6 +539,8 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Cell>;
 
+        static getAttributeDefinition(attrName: string): Cell.PresentationAttributeDefinition<CellView> | undefined;
+
         /**
          * @deprecated
          */
@@ -722,6 +724,8 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Element>;
 
+        static getAttributeDefinition(attrName: string): Cell.PresentationAttributeDefinition<ElementView> | undefined;
+
         static attributes: { [attributeName: string]: Cell.PresentationAttributeDefinition<ElementView> };
     }
 
@@ -872,6 +876,8 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Link>;
 
+        static getAttributeDefinition(attrName: string): Cell.PresentationAttributeDefinition<LinkView> | undefined;
+
         static attributes: { [attributeName: string]: Cell.PresentationAttributeDefinition<LinkView> };
     }
 
@@ -985,8 +991,6 @@ export namespace dia {
         dragLink(evt: dia.Event, x: number, y: number): void;
 
         dragLinkEnd(evt: dia.Event, x: number, y: number): void;
-
-        getAttributeDefinition(attrName: string): dia.Cell.PresentationAttributeDefinition<T> | undefined;
 
         preventDefaultInteraction(evt: dia.Event): void;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Expose `dia.Cell.getAttributeDefinition()` in the public TypeScript typings.

## Motivation and Context

Library users writing custom presentation attributes need an officially typed way to retrieve a definition at runtime. The method existed in JavaScript for a long time, but it was missing from the type definitions.

## Docs

### getAttributeDefinition()

```ts
dia.Cell.getAttributeDefinition(attrName): Cell.PresentationAttributeDefinition<CellView> | undefined;
```

Return the definition object for the specified presentation attribute.

The method retrieves the attribute definition, based on the provided `attrName`, that determines how the attribute should be processed when applied to SVG subelements within the cell view. It first checks for model-specific definitions, then falls back to global attribute definitions.

If the attribute definition is found, the method returns the definition object, that consists of optional `set`, `unset`, `position` and `offset` properties:

| Property | Description |
| --- | --- |
| [set](https://docs.jointjs.com/learn/features/customizing-shapes/custom-special-presentation-attributes/#set) | Function invoked when the attribute value is non-null, returns attribute(s) to apply to the subelement based on the value and its `refBBox`. |
| [unset](https://docs.jointjs.com/learn/features/customizing-shapes/custom-special-presentation-attributes/#unset) | Evaluated when the attribute is assigned `null`; it tells JointJS which raw SVG attribute(s) to clear. In case of a function, is expected to return a string or an array of strings, representing the names of attributes to be removed from the subelement's SVGElement. If a string or an array of strings is provided, it is used as a key or keys to remove from the subelement's SVGElement. |
| [position](https://docs.jointjs.com/learn/features/customizing-shapes/custom-special-presentation-attributes/#position) | Function that returns `{ x, y }` offsets to shift the subelement’s anchor within the reference bounding box (`refBBox`). |
| [offset](https://docs.jointjs.com/learn/features/customizing-shapes/custom-special-presentation-attributes/#offset) | Function that returns `{ x, y }` offsets to shift the subelement’s anchor within its own measured bounding box (`nodeBBox`). |

> For a more detailed explanation of the capabilities of custom special presentation attributes, see [Custom special presentation attributes](https://docs.jointjs.com/learn/features/customizing-shapes/custom-special-presentation-attributes/).