### PR TITLE
refactor(dia.LinkView): extract closest-magnet search to Paper.findClosestMagnetToPoint

### DIFF
--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1859,10 +1859,7 @@ export const LinkView = CellView.extend({
         // checking view in close area of the pointer
 
         const radius = snapLinks.radius || 50;
-        const viewsInArea = paper.findCellViewsInArea(
-            { x: x - radius, y: y - radius, width: 2 * radius, height: 2 * radius },
-            snapLinks.findInAreaOptions
-        );
+        const findInAreaOptions = snapLinks.findInAreaOptions;
 
         const prevClosestView = data.closestView || null;
         const prevClosestMagnet = data.closestMagnet || null;
@@ -1870,86 +1867,21 @@ export const LinkView = CellView.extend({
 
         data.closestView = data.closestMagnet = data.magnetProxy = null;
 
-        let minDistance = Number.MAX_VALUE;
-        let bestPriority = -Infinity;
-        const pointer = new Point(x, y);
-
-        // Note: If snapRadius is smaller than magnet size, views will not be found.
-        viewsInArea.forEach((view) => {
-
+        const validationFn = (view, magnet) => {
             // Do not snap to the current view
             if (view === this) {
-                return;
+                return false;
             }
 
-            const candidates = [];
-            const { model } = view;
-            // skip connecting to the element in case '.': { magnet: false } attribute present
-            if (view.el.getAttribute('magnet') !== 'false') {
+            const isAlreadyValidated = prevClosestMagnet === magnet;
+            return isAlreadyValidated || paper.options.validateConnection.apply(
+                paper, data.validateConnectionArgs(view, (view.el === magnet) ? null : magnet)
+            );
+        };
 
-                if (model.isLink()) {
-                    const connection = view.getConnection();
-                    candidates.push({
-                        // find distance from the closest point of a link to pointer coordinates
-                        priority: 0,
-                        distance: connection.closestPoint(pointer).squaredDistance(pointer),
-                        magnet: view.el
-                    });
-                } else {
-                    candidates.push({
-                        // Set the priority to the level of nested elements of the model
-                        // To ensure that the embedded cells get priority over the parent cells
-                        priority: model.getAncestors().length,
-                        // find distance from the center of the model to pointer coordinates
-                        distance: model.getBBox().center().squaredDistance(pointer),
-                        magnet: view.el
-                    });
-                }
-            }
-
-            view.$('[magnet]').toArray().forEach(magnet => {
-
-                const magnetBBox = view.getNodeBBox(magnet);
-                let magnetDistance = magnetBBox.pointNearestToPoint(pointer).squaredDistance(pointer);
-                if (magnetBBox.containsPoint(pointer)) {
-                    // Pointer sits inside this magnet.
-                    // Push its distance far into the negative range so any
-                    // "under-pointer" magnet outranks magnets that are only nearby
-                    // (positive distance) and every non-magnet candidate.
-                    // We add the original distance back to keep ordering among
-                    // overlapping magnets: the one whose border is closest to the
-                    // pointer (smaller original distance) still wins.
-                    magnetDistance = -Number.MAX_SAFE_INTEGER + magnetDistance;
-                }
-
-                // Check if magnet is inside the snap radius.
-                if (magnetDistance <= radius * radius) {
-                    candidates.push({
-                        // Give magnets priority over other candidates.
-                        priority: Number.MAX_SAFE_INTEGER,
-                        distance: magnetDistance,
-                        magnet
-                    });
-                }
-            });
-
-            candidates.forEach(candidate => {
-                const { magnet, distance, priority } = candidate;
-                const isBetterCandidate = (priority > bestPriority) || (priority === bestPriority && distance < minDistance);
-                if (isBetterCandidate) {
-                    const isAlreadyValidated = prevClosestMagnet === magnet;
-                    if (isAlreadyValidated || paper.options.validateConnection.apply(
-                        paper, data.validateConnectionArgs(view, (view.el === magnet) ? null : magnet)
-                    )) {
-                        bestPriority = priority;
-                        minDistance = distance;
-                        data.closestView = view;
-                        data.closestMagnet = magnet;
-                    }
-                }
-            });
-
-        }, this);
+        const closest = paper.findClosestMagnetToPoint({ x, y }, { radius, findInAreaOptions, validation: validationFn });
+        data.closestView = closest?.view;
+        data.closestMagnet = closest?.magnet;
 
         var end;
         var magnetProxy = null;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1617,6 +1617,17 @@ export namespace dia {
 
         interface FindInAreaOptions extends Graph.FindInAreaOptions, BufferOptions {
         }
+
+        interface FindClosestMagnetToPointOptions {
+            radius?: number;
+            findInAreaOptions?: FindInAreaOptions;
+            validation?: (view: CellView, magnet: SVGElement) => boolean;
+        }
+
+        interface ClosestMagnet {
+            view: CellView;
+            magnet: SVGElement;
+        }
     }
 
     class Paper extends mvc.View<Graph> {
@@ -1751,6 +1762,13 @@ export namespace dia {
          * @param opt options for the search
          */
         findCellViewsInArea(area: BBox, opt?: Paper.FindInAreaOptions): CellView[];
+
+        /**
+         * Finds the closest magnet to the specified point
+         * @param point a point in local paper coordinates
+         * @param opt options for the search
+         */
+        findClosestMagnetToPoint(point: Point, opt?: Paper.FindClosestMagnetToPointOptions): Paper.ClosestMagnet | null;
 
         fitToContent(opt?: Paper.FitToContentOptions): g.Rect;
         fitToContent(gridWidth?: number, gridHeight?: number, padding?: number, opt?: any): g.Rect;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Extract `findClosestMagnetToPoint()` logic out of `dia.LinkView._snapArrowhead` into a new `dia.Paper` helper so the algorithm can be reused outside of link-drag interactions.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

`_snapArrowhead` contained generic "find nearest valid magnet" code that is useful for other features. Moving it to `dia.Paper` lets external code call it directly and simplifies `dia.LinkView` responsibility.

## Docs

**Paper**

### findClosestMagnetToPoint()

```ts
paper.findClosestMagnetToPoint(
    point: dia.Point,
    opt?: Paper.FindClosestMagnetToPointOptions
): Paper.ClosestMagnet | null
```

Find the nearest "magnet" to the given point - i.e. an SVG node that can accept a link connection (`magnet="true"`).

Returns `{ view, magnet }` where `view` is the owning `dia.CellView` and `magnet` the matching SVG element, or `null` if no candidate lies within `opt.radius`.  

| Option | Default | Description |
| --- | --- | --- |
| radius | `Number.MAX_SAFE_INTEGER` | The radius of the search area in pixels. |
| findInAreaOptions | _See default options of [`findCellViewsInArea()`](#findcellviewsinarea)_ | Forwarded to [`findCellViewsInArea()`](#findcellviewsinarea) method when searching candidates for the given radius. |
| validation | `(view, magnet) => true` | Callback to accept/reject a candidate that is found within the search radius. |
