### PR TITLE
feat(examples): update libavoid example

### DIFF
--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@joint/core": "workspace:^",
-    "libavoid-js": "0.4.0-beta.1"
+    "libavoid-js": "0.4.5"
   },
   "devDependencies": {
     "copy-webpack-plugin": "5.1.1",

--- a/examples/libavoid/src/shared/avoid-router.js
+++ b/examples/libavoid/src/shared/avoid-router.js
@@ -13,7 +13,6 @@ export class AvoidRouter {
         const Avoid = AvoidLib.getInstance();
 
         this.graph = graph;
-        window.graph = graph;
 
         this.connDirections = {
             top: Avoid.ConnDirUp,

--- a/examples/libavoid/src/shared/avoid-router.js
+++ b/examples/libavoid/src/shared/avoid-router.js
@@ -34,7 +34,7 @@ export class AvoidRouter {
         // to the libavoid pin id (which must be a number)
         this.pinIds = {
             // [element.id + port.id]: number
-        }
+        };
 
 
         // libavoid-js seems not to work properly

--- a/examples/libavoid/src/shared/avoid-router.js
+++ b/examples/libavoid/src/shared/avoid-router.js
@@ -13,6 +13,7 @@ export class AvoidRouter {
         const Avoid = AvoidLib.getInstance();
 
         this.graph = graph;
+        window.graph = graph;
 
         this.connDirections = {
             top: Avoid.ConnDirUp,
@@ -418,6 +419,7 @@ export class AvoidRouter {
             remove: (cell) => this.onCellRemoved(cell),
             add: (cell) => this.onCellAdded(cell),
             change: (cell, opt) => this.onCellChanged(cell, opt),
+            reset: (graph, opt) => this.onGraphReset(graph, opt),
         });
 
         this.graphListener = listener;
@@ -471,6 +473,18 @@ export class AvoidRouter {
         if (this.commitTransactions && needsRerouting) {
             this.avoidRouter.processTransaction();
         }
+    }
+
+    onGraphReset(_graph, { previousModels }) {
+        previousModels.forEach((cell) => {
+            if (cell.isElement()) {
+                this.deleteShape(cell);
+            } else {
+                this.deleteConnector(cell);
+            }
+        });
+
+        this.routeAll();
     }
 
     onAvoidConnectorChange(connRefPtr) {

--- a/examples/libavoid/src/shared/avoid-router.js
+++ b/examples/libavoid/src/shared/avoid-router.js
@@ -418,7 +418,7 @@ export class AvoidRouter {
             remove: (cell) => this.onCellRemoved(cell),
             add: (cell) => this.onCellAdded(cell),
             change: (cell, opt) => this.onCellChanged(cell, opt),
-            reset: (graph, opt) => this.onGraphReset(graph, opt),
+            reset: (_, opt) => this.onGraphReset(opt.previousModels),
         });
 
         this.graphListener = listener;
@@ -474,7 +474,7 @@ export class AvoidRouter {
         }
     }
 
-    onGraphReset(_graph, { previousModels }) {
+    onGraphReset(previousModels) {
         previousModels.forEach((cell) => {
             if (cell.isElement()) {
                 this.deleteShape(cell);

--- a/examples/libavoid/webpack.config.js
+++ b/examples/libavoid/webpack.config.js
@@ -4,21 +4,21 @@ const folder = process.env.USE_WEB_WORKERS ? 'web-worker' : 'ui-thread';
 
 module.exports = {
     entry: `./src/${folder}/index.js`,
-    mode: "development",
-    target: "web",
+    mode: 'development',
+    target: 'web',
     output: {
         path: path,
-        filename: "bundle.js",
+        filename: 'bundle.js',
     },
     resolve: {
-        extensions: [".js"],
+        extensions: ['.js'],
     },
-    devtool: "source-map",
+    devtool: 'source-map',
     devServer: {
-        watchFiles: ["*"],
+        watchFiles: ['*'],
         hot: true,
         port: process.env.PORT || 8080,
-        host: process.env.HOST || "localhost",
+        host: process.env.HOST || 'localhost',
         open: {
             target: ['index.html'],
         }
@@ -27,24 +27,24 @@ module.exports = {
         rules: [
             {
                 test: /\.css$/i,
-                use: ["style-loader", "css-loader"],
+                use: ['style-loader', 'css-loader'],
             },
             {
                 test: /\.s[ac]ss$/i,
                 use: [
                     {
-                        loader: "file-loader",
-                        options: { outputPath: "css/", name: "[name].css" },
+                        loader: 'file-loader',
+                        options: { outputPath: 'css/', name: '[name].css' },
                     },
-                    "sass-loader",
+                    'sass-loader',
                 ],
             }
         ]
     },
     plugins: [
         new CopyPlugin([
-            { from: "./index.html", to: "./" },
-            { from: "./node_modules/libavoid-js/dist/libavoid.wasm", to: "./" },
+            { from: './index.html', to: './' },
+            { from: './node_modules/libavoid-js/dist/libavoid.wasm', to: './' },
         ]),
     ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,7 +3094,7 @@ __metadata:
     copy-webpack-plugin: "npm:5.1.1"
     css-loader: "npm:3.5.3"
     file-loader: "npm:6.0.0"
-    libavoid-js: "npm:0.4.0-beta.1"
+    libavoid-js: "npm:0.4.5"
     sass: "npm:1.26.8"
     sass-loader: "npm:8.0.2"
     style-loader: "npm:1.2.1"
@@ -16509,10 +16509,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libavoid-js@npm:0.4.0-beta.1":
-  version: 0.4.0-beta.1
-  resolution: "libavoid-js@npm:0.4.0-beta.1"
-  checksum: 10/229617a0546a07f25528ea69915875c83e32f4b26d5b643e9d72067f9aeb677e591ea2bb27855daf7f7acfef16af43a98669fb50d91af6155718c232da1e4ffb
+"libavoid-js@npm:0.4.5":
+  version: 0.4.5
+  resolution: "libavoid-js@npm:0.4.5"
+  checksum: 10/0fe733e6840db27557584060a6d0920e191d7d36b005720d3c39aa5ea01f0dae6e7f93a0e5279310be99754a82cd9eaf3c2b2dc96c44d5ae7d81b962cfc70b75
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Update the libavoid package to the latest version, which introduces improvements in routing. This PR also introduces an event listener that handles resetting the graph.

<!-- Fixes # -->
Fixes #2914 

## Motivation and Context

> When user creates more than a few links (around 7)* between 2 elements and then moves third element near the links the Paper freezes or breaks in non-deterministic way.

### Screenshots:
<img width="699" height="598" alt="image" src="https://github.com/user-attachments/assets/b5a2daf5-cce7-4312-8534-3cf0418d2612" />

