### PR TITLE
feat(dia.ElementView): allow setting initialParentId explicitly for unembedding validation

### DIFF
--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -389,7 +389,8 @@ export const ElementView = CellView.extend({
             parent.unembed(element, { ui: true });
             data.initialParentId = parentId;
         } else {
-            data.initialParentId = null;
+            // `data.initialParentId` can be explicitly set to a dummy value to enable validation of unembedding.
+            data.initialParentId = data.initialParentId || null;
         }
     },
 


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Do not discard `initialParentId` that has been explicitly set beforehand in event data.

<!-- If relevant, include the issue number.-->
<!-- Fixes # -->

## Motivation and Context

`Halo` will use the existing mechanism to revert (remove) forked/cloned elements if `paper.options.validateUnembedding` returns `false`.
