### PR TITLE
chore: tsconfig lib update [master-debug]

### DIFF
--- a/packages/joint-core/tsconfig.json
+++ b/packages/joint-core/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "lib": [
-            "ES6",
+            "ES2022",
             "DOM"
         ],
         "types": [],

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -19,8 +19,8 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "lib": [
-      "es2016",
-      "dom"
+      "ES2022",
+      "DOM"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## Description

Updates the tsconfig `lib` parameter to `ES2022` to be in line with JointJS+.

Merging this PR in a testing branch first (`master-debug`) lets us test the change with our CI pipeline.

## Motivation and Context

The ES2022 standard is [widely supported by browsers](https://caniuse.com/?feats=mdn-javascript_builtins_array_at,mdn-javascript_builtins_regexp_hasindices,mdn-javascript_builtins_object_hasown,mdn-javascript_builtins_error_cause,mdn-javascript_operators_await_top_level,mdn-javascript_classes_private_class_fields,mdn-javascript_classes_private_class_methods,mdn-javascript_classes_static_class_fields,mdn-javascript_classes_static_initialization_blocks), so we can start using the functionality.