### PR TITLE
refactor(dia.Paper): rename validation option to filter in findCloses…

### DIFF
--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1842,7 +1842,7 @@ export const LinkView = CellView.extend({
 
         data.closestView = data.closestMagnet = data.magnetProxy = null;
 
-        const validationFn = (view, magnet) => {
+        const isValidCandidate = (view, magnet) => {
             // Do not snap to the current view
             if (view === this) {
                 return false;
@@ -1854,7 +1854,7 @@ export const LinkView = CellView.extend({
             );
         };
 
-        const closest = paper.findClosestMagnetToPoint({ x, y }, { radius, findInAreaOptions, validation: validationFn });
+        const closest = paper.findClosestMagnetToPoint({ x, y }, { radius, findInAreaOptions, filter: isValidCandidate });
         data.closestView = closest ? closest.view : null;
         data.closestMagnet = closest ? closest.magnet : null;
 

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2312,7 +2312,7 @@ export const Paper = View.extend({
             options.findInAreaOptions
         );
         // Enable all connections by default
-        const filterFn = options.filter || ((_view, _magnet) => true);
+        const filterFn = typeof options.filter === 'function' ? options.filter : null;
 
         let closestView = null;
         let closestMagnet = null;
@@ -2374,7 +2374,7 @@ export const Paper = View.extend({
             candidates.forEach(candidate => {
                 const { magnet, distance, priority } = candidate;
                 const isBetterCandidate = (priority > bestPriority) || (priority === bestPriority && distance < minDistance);
-                if (isBetterCandidate && filterFn(view, magnet)) {
+                if (isBetterCandidate && (!filterFn || filterFn(view, magnet))) {
                     bestPriority = priority;
                     minDistance = distance;
                     closestView = view;

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2312,7 +2312,7 @@ export const Paper = View.extend({
             options.findInAreaOptions
         );
         // Enable all connections by default
-        const validationFn = options.validation || ((_view, _magnet) => true);
+        const filterFn = options.filter || ((_view, _magnet) => true);
 
         let closestView = null;
         let closestMagnet = null;
@@ -2374,7 +2374,7 @@ export const Paper = View.extend({
             candidates.forEach(candidate => {
                 const { magnet, distance, priority } = candidate;
                 const isBetterCandidate = (priority > bestPriority) || (priority === bestPriority && distance < minDistance);
-                if (isBetterCandidate && validationFn(view, magnet)) {
+                if (isBetterCandidate && filterFn(view, magnet)) {
                     bestPriority = priority;
                     minDistance = distance;
                     closestView = view;

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -1760,7 +1760,7 @@ QUnit.module('paper', function(hooks) {
 
             const { view, magnet } = this.paper.findClosestMagnetToPoint(
                 { x: 25, y: 25 },
-                { radius: 100, validation: (view) => view.model.id === 'r2' }
+                { radius: 100, filter: (view) => view.model.id === 'r2' }
             );
             assert.strictEqual(view, this.paper.findViewByModel(rect2));
             assert.strictEqual(view.el, magnet);

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1639,7 +1639,7 @@ export namespace dia {
         interface FindClosestMagnetToPointOptions {
             radius?: number;
             findInAreaOptions?: FindInAreaOptions;
-            validation?: (view: CellView, magnet: SVGElement) => boolean;
+            filter?: (view: CellView, magnet: SVGElement) => boolean;
         }
 
         interface ClosestMagnet {


### PR DESCRIPTION
…tMagnetToPoint method

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Rename the `validation` option of `dia.Paper.findClosestMagnetToPoint()` method to `filter`.

## Motivation and Context

This change maintains consistency across different methods, where `filter` indicates an option to control what is a valid item.