### PR TITLE
refactor(dia.Cell): return explicit null from getAttributeDefinition

### DIFF
--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -962,9 +962,10 @@ export const Cell = Model.extend({
 
     getAttributeDefinition: function(attrName) {
 
-        var defNS = this.attributes;
-        var globalDefNS = attributes;
-        return (defNS && defNS[attrName]) || globalDefNS[attrName];
+        const defNS = this.attributes;
+        const globalDefNS = attributes;
+        const definition = (defNS && defNS[attrName]) || globalDefNS[attrName];
+        return definition !== undefined ? definition : null;
     },
 
     define: function(type, defaults, protoProps, staticProps) {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -539,7 +539,7 @@ export namespace dia {
 
         static define(type: string, defaults?: any, protoProps?: any, staticProps?: any): Cell.Constructor<Cell>;
 
-        static getAttributeDefinition(attrName: string): Cell.PresentationAttributeDefinition<CellView> | undefined;
+        static getAttributeDefinition(attrName: string): Cell.PresentationAttributeDefinition<CellView> | null;
 
         /**
          * @deprecated


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Return `null` explicitly when no matching attribute definition is found by `dia.Cell.getAttributeDefinition()` method.

## Motivation and Context

This change maintains consistency across different methods, where `null` represents a missing value.