### PR TITLE
types(anchors): add types for new MidSideAnchorArguments

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -3926,7 +3926,8 @@ export namespace anchors {
     }
 
     interface MidSideAnchorArguments extends RotateAnchorArguments, PaddingAnchorArguments {
-
+        mode?: 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 'vertical' | 'auto';
+        preferenceThreshold?: dia.Sides;
     }
 
     interface ModelCenterAnchorArguments {


### PR DESCRIPTION
## Description

Adds types for new MidSideAnchorArguments, missed as part of https://github.com/clientIO/joint/pull/2922
