### PR TITLE
types(dia): fix types which use dia.Sides

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -2392,7 +2392,7 @@ export namespace highlighters {
             position?: Positions | dia.PositionName;
             size?: number | dia.Size;
             gap?: number;
-            margin?: number | dia.Sides;
+            margin?: dia.Sides;
         }
     }
 
@@ -4484,7 +4484,7 @@ export namespace elementTools {
 
     namespace Boundary {
         interface Options extends dia.ToolView.Options<dia.ElementView> {
-            padding?: number | dia.Sides;
+            padding?: dia.Sides;
             useModelGeometry?: boolean;
             rotate?: boolean;
         }
@@ -4727,7 +4727,7 @@ export namespace linkTools {
 
     namespace Boundary {
         interface Options extends dia.ToolView.Options<dia.LinkView> {
-            padding?: number | dia.Sides;
+            padding?: dia.Sides;
             useModelGeometry?: boolean;
         }
     }


### PR DESCRIPTION
## Description

Fixes the type of properties which use `number | dia.Sides` as a type.

## Motivation and Context

The `dia.Sides` type already contains `number | dia.SidesJSON`, so defining another `number` is not necessary.