### PR TITLE
feat(dia.Paper): add `isCellViewMounted()` method

### DIFF
--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -97,8 +97,8 @@ export const LinkView = CellView.extend({
 
         if (
             paper && (
-                (sourceId && !paper.isViewMounted(sourceId)) ||
-                (targetId && !paper.isViewMounted(targetId))
+                (sourceId && !paper.isCellViewMounted(sourceId)) ||
+                (targetId && !paper.isCellViewMounted(targetId))
             )
         ) {
             // Wait for the source and target views to be rendered

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -968,19 +968,21 @@ export const Paper = View.extend({
 
     forcePostponedViewUpdate: function(view, flag) {
         if (!view || !(view instanceof CellView)) return false;
-        var model = view.model;
+        const model = view.model;
         if (model.isElement()) return false;
-        var dumpOptions = { silent: true };
+        const dumpOptions = { silent: true };
         // LinkView is waiting for the target or the source cellView to be rendered
         // This can happen when the cells are not in the viewport.
-        var sourceFlag = 0;
-        var sourceView = this.findViewByModel(model.getSourceCell());
-        if (sourceView && !this.isViewMounted(sourceView)) {
+        let sourceFlag = 0;
+        const sourceCell = model.getSourceCell();
+        if (sourceCell && !this.isCellViewMounted(sourceCell)) {
+            const sourceView = this.findViewByModel(sourceCell);
             sourceFlag = this.dumpView(sourceView, dumpOptions);
         }
-        var targetFlag = 0;
-        var targetView = this.findViewByModel(model.getTargetCell());
-        if (targetView && !this.isViewMounted(targetView)) {
+        let targetFlag = 0;
+        const targetCell = model.getTargetCell();
+        if (targetCell && !this.isCellViewMounted(targetCell)) {
+            const targetView = this.findViewByModel(targetCell);
             targetFlag = this.dumpView(targetView, dumpOptions);
         }
         if (sourceFlag === 0 && targetFlag === 0) {
@@ -1116,17 +1118,20 @@ export const Paper = View.extend({
         return flag;
     },
 
-    isViewMounted: function(viewOrId) {
-        if (!viewOrId) return false;
-        let cid;
-        if (viewOrId[CELL_VIEW_MARKER] || viewOrId[CELL_VIEW_PLACEHOLDER_MARKER]) {
-            // If the view is a CellView, we can use its cid.
-            cid = viewOrId.cid;
-        } else {
-            // `view` is model id
-            cid = this._idToCid[viewOrId];
-        }
+    isCellViewMounted: function(cellOrId) {
+        const cid = cellOrId && this._idToCid[cellOrId.id || cellOrId];
         if (!cid) return false; // The view is not registered.
+        return this.isViewMounted(cid);
+    },
+
+    isViewMounted: function(viewOrCid) {
+        if (!viewOrCid) return false;
+        let cid;
+        if (viewOrCid[CELL_VIEW_MARKER] || viewOrCid[CELL_VIEW_PLACEHOLDER_MARKER]) {
+            cid = viewOrCid.cid;
+        } else {
+            cid = viewOrCid;
+        }
         return this._updates.mountedList.has(cid);
     },
 
@@ -1410,6 +1415,12 @@ export const Paper = View.extend({
         };
     },
 
+
+    /**
+     * @ignore This method returns an array of cellViewLike objects and therefore
+     * is meant for internal/test use only.
+     * The view placeholders are not exposed via public API.
+    */
     getUnmountedViews: function() {
         const updates = this._updates;
         const unmountedViews = new Array(updates.unmountedList.length);
@@ -1423,6 +1434,11 @@ export const Paper = View.extend({
         return unmountedViews;
     },
 
+    /**
+     * @ignore This method returns an array of cellViewLike objects and therefore
+     * is meant for internal/test use only.
+     * The view placeholders are not exposed via public API.
+     */
     getMountedViews: function() {
         const updates = this._updates;
         const mountedViews = new Array(updates.mountedList.length);

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -2773,13 +2773,13 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             graph.addCell(rect);
 
             assert.ok(paper.isViewMounted(rect.findView(paper)), 'View is mounted');
-            assert.ok(paper.isViewMounted(rect.id), 'View is mounted by ID');
-            assert.notOk(paper.isViewMounted('non-existing-id'), 'View is not mounted for non-existing ID');
+            assert.ok(paper.isViewMounted(rect.findView(paper).cid), 'View is mounted by CID');
+            assert.notOk(paper.isViewMounted('non-existing-id'), 'View is not mounted for non-existing CID');
             assert.ok(rect.findView(paper).el.isConnected, 'View element is connected to the DOM');
 
             paper.dumpViews({ cellVisibility: () => false });
             assert.notOk(paper.isViewMounted(rect.findView(paper)), 'View is not mounted after dumpViews with cellVisibility returning false');
-            assert.notOk(paper.isViewMounted(rect.id), 'View is not mounted after dumpViews with cellVisibility returning false by ID');
+            assert.notOk(paper.isViewMounted(rect.findView(paper).cid), 'View is not mounted after dumpViews with cellVisibility returning false by CID');
             assert.notOk(rect.findView(paper).el.isConnected);
 
             paper.remove();
@@ -2814,13 +2814,13 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 1, 'One view is mounted after checkViewport with mountBatchSize 1');
-            assert.ok(paper.isViewMounted(rects[0].id), 'First view is mounted');
+            assert.ok(paper.isCellViewMounted(rects[0]), 'First view is mounted');
 
             paper.checkViewport({ mountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 2, 'Two views are mounted after second updateViewsBatch');
-            assert.ok(paper.isViewMounted(rects[1].id), 'Second view is mounted');
+            assert.ok(paper.isCellViewMounted(rects[1]), 'Second view is mounted');
 
             paper.prioritizeCellViewMount(rects[9]);
 
@@ -2828,13 +2828,13 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 3, 'Three views are mounted after prioritizing unmounted view');
-            assert.ok(paper.isViewMounted(rects[9].id), 'Prioritized view is mounted');
+            assert.ok(paper.isCellViewMounted(rects[9]), 'Prioritized view is mounted');
 
             paper.checkViewport({ mountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 4, 'Four views are mounted after another updateViewsBatch');
-            assert.ok(paper.isViewMounted(rects[2].id), 'Third view is mounted');
+            assert.ok(paper.isCellViewMounted(rects[2]), 'Third view is mounted');
 
             // Check the return values of prioritizeCellViewMount
             assert.equal(paper.prioritizeCellViewMount(rects[5]), true, 'Prioritization of unmounted view returned true');
@@ -2877,27 +2877,27 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 9, 'One view is unmounted after checkViewport with unmountBatchSize 1');
-            assert.notOk(paper.isViewMounted(rects[0].id), 'First view is not mounted');
+            assert.notOk(paper.isCellViewMounted(rects[0]), 'First view is not mounted');
 
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 8, 'Two views are unmounted after second updateViewsBatch');
-            assert.notOk(paper.isViewMounted(rects[1].id), 'Second view is not mounted');
-            assert.ok(paper.isViewMounted(rects[9].id), 'Last view is still mounted');
+            assert.notOk(paper.isCellViewMounted(rects[1]), 'Second view is not mounted');
+            assert.ok(paper.isCellViewMounted(rects[9]), 'Last view is still mounted');
 
             paper.prioritizeCellViewUnmount(rects[9]);
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 7, 'Three views are unmounted after prioritizing mounted view');
-            assert.notOk(paper.isViewMounted(rects[9].id), 'Prioritized view is not mounted');
+            assert.notOk(paper.isCellViewMounted(rects[9]), 'Prioritized view is not mounted');
 
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 6, 'Four views are unmounted after another updateViewsBatch');
-            assert.notOk(paper.isViewMounted(rects[2].id), 'Third view is not mounted');
+            assert.notOk(paper.isCellViewMounted(rects[2]), 'Third view is not mounted');
 
             // Check the return values of prioritizeCellViewUnmount
             assert.equal(paper.prioritizeCellViewUnmount(rects[5]), true, 'Prioritization of mounted view returned true');

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1905,6 +1905,8 @@ export namespace dia {
 
         disposeHiddenCellViews(): void;
 
+        isCellViewMounted(cellOrId: dia.Cell | dia.Cell.ID): boolean;
+
         // events
 
         on<T extends keyof Paper.EventMap = keyof Paper.EventMap>(eventName: T, callback: Paper.EventMap[T], context?: any): this;
@@ -1964,6 +1966,8 @@ export namespace dia {
         protected prioritizeCellViewMount(cellOrId: dia.Cell | dia.Cell.ID): boolean;
 
         protected prioritizeCellViewUnmount(cellOrId: dia.Cell | dia.Cell.ID): boolean;
+
+        protected isViewMounted(viewOrCid: dia.CellView | string): boolean;
 
         protected isAsync(): boolean;
 


### PR DESCRIPTION
The PR adds the `isCellViewMounted()` method, which returns `true` if the specified `cell` is currently mounted.

```ts
isCellViewMounted(cellOrId: dia.Cell | dia.Cell.ID): boolean;
```

**Note:** Previously, the (non-public) `isViewMounted()` method accepted either a generic `mvc.View` or a model id. However, not all `mvc.View` instances are connected to a model. This pattern is not ideal, so this PR refactors it into two distinct methods:
- `protected isViewMounted()`, which takes any `view` instance or its `cid`
- `public isCellViewMounted()`, which accepts a `model` or its `id` 

Note that unmounting generic views is deprecated due to the new `cellVisibility` callback.