### PR TITLE
chore(package): update version to 1.0.0-alpha.5 and add metadata

### DIFF
--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/react",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -11,6 +11,16 @@
     "README.md",
     "LICENSE",
     "src"
+  ],
+  "license": "MPL-2.0",
+  "homepage": "https://react.jointjs.com/learn/?path=/docs/introduction--docs",
+  "author": {
+    "name": "client IO",
+    "url": "https://client.io"
+  },
+  "contributors": [
+    "Roman Bruckner <roman@client.io> (https://github.com/kumilingus)",
+    "Samuel <samuel@client.io> (https://github.com/samuelgja)"
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
### <!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Bump package version of `@joint/react` to **1.0.0-alpha.5** and add missing metadata fields to `package.json`.

Changes include:
- Updated `version` from `1.0.0-alpha.4` → `1.0.0-alpha.5`
- Added `homepage` field pointing to React JointJS documentation
- Added `author` and `contributors` metadata
- Preserved existing license and scripts

## Motivation and Context

This update ensures that `@joint/react` has complete and accurate package metadata when published.  
Adding the homepage, author, and contributors makes the package easier to identify, improves discoverability, and maintains consistency with other JointJS packages.

### Screenshots (if appropriate):

N/A
