### PR TITLE
feat(dia.Paper): updateCellsVisibility()

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1546,7 +1546,7 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellViewVisibility: function(opt) {
+    checkCellVisibility: function(opt) {
         this.checkViewport(opt);
         if (!this.isAsync) {
             this.updateViews(opt);

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1548,7 +1548,7 @@ export const Paper = View.extend({
 
     updateCellsVisibility: function(opt = {}) {
         const stats = this.checkViewport(opt);
-        if (!this.isAsync && opt.async === false) {
+        if (!this.isAsync() || (opt.async === false)) {
             this.updateViews(opt);
         }
         return stats;

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -584,7 +584,9 @@ export const Paper = View.extend({
         // Copy and set defaults for the view management options.
         options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
-            lazyInitialize: false,
+            lazyInitialize: true,
+            // Whether to add initialize cell views in the unmounted queue.
+            initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
             disposeHidden: false,
         });
@@ -1542,6 +1544,15 @@ export const Paper = View.extend({
             mounted: isMounted ? 1 : 0,
             unmounted: isUnmounted ? 1 : 0
         };
+    },
+
+    checkCellViewVisibility: function(opt) {
+        this.checkViewport(opt);
+        if (!this.isAsync) {
+            this.updateViews(opt);
+        } else {
+            this.wakeUp();
+        }
     },
 
     checkViewport: function(opt) {
@@ -3790,4 +3801,3 @@ export const Paper = View.extend({
         }]
     }
 });
-

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -585,7 +585,7 @@ export const Paper = View.extend({
         options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
             lazyInitialize: !!options.viewManagement, // default `true` if options.viewManagement provided
-            // Whether to add initialize cell views in the unmounted queue.
+            // Whether to add initialized cell views into the unmounted queue.
             initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
             disposeHidden: false,

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1548,10 +1548,8 @@ export const Paper = View.extend({
 
     checkCellVisibility: function(opt) {
         this.checkViewport(opt);
-        if (!this.isAsync) {
+        if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);
-        } else {
-            this.wakeUp();
         }
     },
 

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -582,7 +582,7 @@ export const Paper = View.extend({
             options.highlighting = defaultsDeep({}, highlighting, defaultHighlighting);
         }
         // Copy and set defaults for the view management options.
-        options.viewManagement = defaults({}, options.viewManagement, {
+        options.viewManagement = options.viewManagement && defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
             lazyInitialize: true,
             // Whether to add initialize cell views in the unmounted queue.

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1546,11 +1546,12 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellVisibility: function(opt = {}) {
-        this.checkViewport(opt);
+    updateCellsVisibility: function(opt = {}) {
+        const stats = this.checkViewport(opt);
         if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);
         }
+        return stats;
     },
 
     checkViewport: function(opt) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -582,9 +582,9 @@ export const Paper = View.extend({
             options.highlighting = defaultsDeep({}, highlighting, defaultHighlighting);
         }
         // Copy and set defaults for the view management options.
-        options.viewManagement = options.viewManagement && defaults({}, options.viewManagement, {
+        options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
-            lazyInitialize: true,
+            lazyInitialize: !!options.viewManagement, // default `true` if options.viewManagement provided
             // Whether to add initialize cell views in the unmounted queue.
             initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
@@ -1546,7 +1546,7 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellVisibility: function(opt) {
+    checkCellVisibility: function(opt = {}) {
         this.checkViewport(opt);
         if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -1978,7 +1978,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 autoFreeze: true,
                 sorting: Paper.sorting.APPROX,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 cellVisibility: (cell) => cell.get('visible')
@@ -2014,7 +2013,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 autoFreeze: true,
                 sorting: Paper.sorting.APPROX,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 cellVisibility: (cell) => cell.get('visible')
@@ -2681,8 +2679,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
-                    disposeHidden: true
+                    disposeHidden: true,
                 },
                 cellVisibility: cellVisibilityTrueSpy,
             });
@@ -2776,7 +2773,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper = new Paper({
                 el: paperEl,
                 model: graph,
-                viewManagement: {},
+                viewManagement: true,
                 cellVisibility: cellVisibilitySpy,
             });
 
@@ -2802,7 +2799,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper = new Paper({
                 el: paperEl,
                 model: graph,
-                viewManagement: {},
+                viewManagement: true,
                 cellVisibility: () => true,
             });
 
@@ -2831,7 +2828,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 async: true,
@@ -2894,7 +2890,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 async: true,
@@ -3006,9 +3001,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     elementView: SpyElementView,
-                    viewManagement: {
-                        lazyInitialize: true,
-                    },
+                    viewManagement: true,
                 });
 
                 const rect = new joint.shapes.standard.Rectangle();
@@ -3047,7 +3040,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
                     },
                 });
@@ -3094,6 +3086,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
+                        lazyInitialize: false,
                         initializeUnmounted: true,
                     },
                 });
@@ -3140,8 +3133,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3187,7 +3179,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3233,9 +3226,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3281,8 +3273,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
+                        lazyInitialize: false,
                         initializeUnmounted: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3326,9 +3319,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     cellVisibility: () => false,
-                    viewManagement: {
-                        lazyInitialize: true
-                    },
+                    viewManagement: true
                 });
 
                 const initialCount = getNumberOfViews();
@@ -3343,7 +3334,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 assert.equal(getNumberOfViews() - initialCount, 2, 'View for el2 is initialized');
 
                 paper.remove();
-                        QUnit.test('lazyInitialize, initializeUnmounted', function(assert) {
+            });
+
+            QUnit.test('lazyInitialize, initializeUnmounted', function(assert) {
 
                 const graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
 
@@ -3356,7 +3349,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
                     },
                 });
@@ -3389,7 +3381,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
                 paper.remove();
             });
-});
         });
 
         QUnit.module('disposeHidden', function() {
@@ -3402,7 +3393,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3440,7 +3432,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3473,7 +3466,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3510,8 +3504,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        lazyInitialize: true,
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3540,7 +3534,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: false
+                        lazyInitialize: false,
+                        disposeHidden: false,
                     },
                 });
 
@@ -3573,7 +3568,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });
@@ -3617,7 +3611,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });
@@ -3668,7 +3661,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1884,15 +1884,19 @@ export namespace dia {
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
 
-        checkCellVisibility(opt?: {
+        updateCellsVisibility(opt?: {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
             /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
-        }): void;
+        }): {
+            mounted: number;
+            unmounted: number;
+        };
 
+        /** @deprecated Use `updateCellsVisibility()` */
         checkViewport(opt?: {
             mountBatchSize?: number;
             unmountBatchSize?: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1884,7 +1884,7 @@ export namespace dia {
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
 
-        checkCellViewVisibility(opt?: {
+        checkCellVisibility(opt?: {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1888,8 +1888,6 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
-            /** @deprecated Use `cellVisibility` */
-            viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
             mounted: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1408,6 +1408,7 @@ export namespace dia {
             mountBatchSize?: number;
             unmountBatchSize?: number;
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: ViewportCallback;
             cellVisibility?: CellVisibilityCallback;
             progress?: ProgressCallback;
@@ -1489,6 +1490,7 @@ export namespace dia {
             frozen?: boolean;
             autoFreeze?: boolean;
             viewManagement?: ViewManagementOptions;
+            /** @deprecated Use `cellVisibility` */
             viewport?: ViewportCallback | null;
             cellVisibility?: CellVisibilityCallback | null;
             onViewUpdate?: (view: mvc.View<any, any>, flag: number, priority: number, opt: { [key: string]: any }, paper: Paper) => void;
@@ -1877,6 +1879,16 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
+            viewport?: Paper.ViewportCallback;
+            cellVisibility?: Paper.CellVisibilityCallback;
+        }): void;
+
+        checkCellViewVisibility(opt?: {
+            batchSize?: number;
+            mountBatchSize?: number;
+            unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
@@ -1884,6 +1896,7 @@ export namespace dia {
         checkViewport(opt?: {
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1893,6 +1906,7 @@ export namespace dia {
 
         updateViews(opt?: {
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1916,14 +1930,15 @@ export namespace dia {
         // protected
 
         /**
-        * For the specified view, calls the visibility viewport function specified by the paper.options.viewport function.
+        * For the specified view, calls the cell visibility function specified by the `paper.options.cellVisibility` function.
         * If the function returns true, the view is attached to the DOM; in other case it is detached.
-        * While async papers do this automatically, synchronous papers require an explicit call to this method for this functionality to be applied. To show the view again, use paper.requestView().
-        * If you are using autoFreeze option you should call this function if you are calling paper.requestView() if you want paper.options.viewport function to be applied.
+        * While async papers do this automatically, synchronous papers require an explicit call to this method for this functionality to be applied. To show the view again, use `paper.requestView()`.
+        * If you are using `autoFreeze` option you should call this function if you are calling `paper.requestView()` if you want `paper.options.cellVisibility` function to be applied.
         * @param cellView cellView for which the visibility check is performed
-        * @param opt if opt.viewport is provided, it is used as the callback function instead of paper.options.viewport.
+        * @param opt if opt.cellVisibility is provided, it is used as the callback function instead of paper.options.cellVisibility.
         */
         protected checkViewVisibility(cellView: dia.CellView, opt?: {
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1947,6 +1962,7 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
             progress?: Paper.ProgressCallback;
@@ -1955,6 +1971,7 @@ export namespace dia {
 
         protected updateViewsBatch(opt?: {
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): Paper.UpdateStats;


### PR DESCRIPTION
## Description

Replaced by #3056.

Adds `paper.updateCellsVisibility()` as a replacement to `paper.checkViewport()` which also applies the changes in synchronous papers by calling `paper.updateViews()`. (No action is necessary in `async` papers.) Deprecates `paper.checkViewport()`.

Additionally, this PR deprecates the `viewport` option in all methods in favor of the `cellVisibility` option.

## Motivation and Context

The method has a better name that includes `cellVisibility` instead of deprecated `viewport`. The method is more useful since it combines the visibility callback check (which schedules view updates) with its execution on the graph (i.e. application of the scheduled updates to views in the paper).
