### PR TITLE
feat(dia.Paper): add API to update cell visibility

### DIFF
--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -97,8 +97,8 @@ export const LinkView = CellView.extend({
 
         if (
             paper && (
-                (sourceId && !paper.isCellViewMounted(sourceId)) ||
-                (targetId && !paper.isCellViewMounted(targetId))
+                (sourceId && !paper.isCellVisible(sourceId)) ||
+                (targetId && !paper.isCellVisible(targetId))
             )
         ) {
             // Wait for the source and target views to be rendered

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1546,7 +1546,7 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellViewVisibility: function(opt) {
+    checkCellVisibility: function(opt) {
         this.checkViewport(opt);
         if (!this.isAsync) {
             this.updateViews(opt);

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1136,7 +1136,7 @@ export const Paper = View.extend({
 
     /**
      * @deprecated use `updateCellsVisibility` instead.
-     * paper.updateCellsVisibility({ cellVisibility: () => true });
+     * `paper.updateCellsVisibility({ cellVisibility: () => true });`
      */
     dumpViews: function(opt) {
         // Update cell visibility without `cellVisibility` callback i.e. make the cells visible

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1134,6 +1134,10 @@ export const Paper = View.extend({
         return this._updates.mountedList.has(cid);
     },
 
+    /**
+     * @deprecated use `updateCellsVisibility` instead.
+     * paper.updateCellsVisibility({ cellVisibility: () => true });
+     */
     dumpViews: function(opt) {
         // Update cell visibility without `cellVisibility` callback i.e. make the cells visible
         const passingOpt = defaults({}, opt, { cellVisibility: null, viewport: null });

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1547,16 +1547,20 @@ export const Paper = View.extend({
 
     updateCellVisibility: function(cell, opt = {}) {
         const cellViewLike = this._getCellViewLike(cell);
+        if (!cellViewLike) return;
         const stats = this.checkViewVisibility(cellViewLike, opt);
+        // Note: `unmounted` views are removed immediately
         if (stats.mounted > 0) {
-            this.dumpView(cell, opt);
+            // Mounting is scheduled. Run the update.
+            // Note: the view might be a placeholder.
+            this.requireView(cell);
         }
     },
 
     updateCellsVisibility: function(opt) {
         // Note: this method currently runs the visibility check for all cells twice
-        // The first check is to determine which cells are mounted or unmounted
-        // The second check is done when the cell is being rendered
+        // - The first check is to determine which cells are mounted or unmounted
+        // - The second check is done when the cell is being rendered
         this.checkViewport(opt);
         this.updateViews(opt);
     },

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1548,7 +1548,7 @@ export const Paper = View.extend({
 
     updateCellsVisibility: function(opt = {}) {
         const stats = this.checkViewport(opt);
-        if (!this.isAsync && opt.async === false) {
+        if (!this.isAsync() || (opt.async === false)) {
             this.updateViews(opt);
         }
         return stats;

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1571,8 +1571,7 @@ export const Paper = View.extend({
 
     /**
      * @deprecated use `updateCellsVisibility` instead
-     * This method is deprecated, use `updateCellsVisibility` instead.
-     * The method will be renamed and make private in the future.
+     * This method will be renamed and made private in the future.
      */
     checkViewport: function(opt) {
         var passingOpt = defaults({}, opt, {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -584,7 +584,9 @@ export const Paper = View.extend({
         // Copy and set defaults for the view management options.
         options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
-            lazyInitialize: false,
+            lazyInitialize: true,
+            // Whether to add initialize cell views in the unmounted queue.
+            initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
             disposeHidden: false,
         });
@@ -1542,6 +1544,15 @@ export const Paper = View.extend({
             mounted: isMounted ? 1 : 0,
             unmounted: isUnmounted ? 1 : 0
         };
+    },
+
+    checkCellViewVisibility: function(opt) {
+        this.checkViewport(opt);
+        if (!this.isAsync) {
+            this.updateViews(opt);
+        } else {
+            this.wakeUp();
+        }
     },
 
     checkViewport: function(opt) {
@@ -3790,4 +3801,3 @@ export const Paper = View.extend({
         }]
     }
 });
-

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1570,7 +1570,7 @@ export const Paper = View.extend({
     },
 
     /**
-     * @deprecated
+     * @deprecated use `updateCellsVisibility` instead
      * This method is deprecated, use `updateCellsVisibility` instead.
      * The method will be renamed and make private in the future.
      */

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -585,7 +585,7 @@ export const Paper = View.extend({
         options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
             lazyInitialize: !!options.viewManagement, // default `true` if options.viewManagement provided
-            // Whether to add initialize cell views in the unmounted queue.
+            // Whether to add initialized cell views into the unmounted queue.
             initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
             disposeHidden: false,

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1548,10 +1548,8 @@ export const Paper = View.extend({
 
     checkCellVisibility: function(opt) {
         this.checkViewport(opt);
-        if (!this.isAsync) {
+        if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);
-        } else {
-            this.wakeUp();
         }
     },
 

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1557,7 +1557,7 @@ export const Paper = View.extend({
         if (stats.mounted > 0) {
             // Mounting is scheduled. Run the update.
             // Note: the view might be a placeholder.
-            this.requireView(cell);
+            this.requireView(cell, opt);
         }
     },
 

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -582,7 +582,7 @@ export const Paper = View.extend({
             options.highlighting = defaultsDeep({}, highlighting, defaultHighlighting);
         }
         // Copy and set defaults for the view management options.
-        options.viewManagement = defaults({}, options.viewManagement, {
+        options.viewManagement = options.viewManagement && defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
             lazyInitialize: true,
             // Whether to add initialize cell views in the unmounted queue.

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1546,11 +1546,12 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellVisibility: function(opt = {}) {
-        this.checkViewport(opt);
+    updateCellsVisibility: function(opt = {}) {
+        const stats = this.checkViewport(opt);
         if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);
         }
+        return stats;
     },
 
     checkViewport: function(opt) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1546,12 +1546,19 @@ export const Paper = View.extend({
         };
     },
 
+    updateCellVisibility: function(cell, opt = {}) {
+        const stats = this.checkViewVisibility(this._getCellViewLike(cell), opt);
+        // Note: unmounting is done along with the visibility update
+        if (stats.mounted > 0 && (!this.isAsync() || (opt.async === false))) {
+            this.dumpView(cell, opt);
+        }
+    },
+
     updateCellsVisibility: function(opt = {}) {
-        const stats = this.checkViewport(opt);
+        this.checkViewport(opt);
         if (!this.isAsync() || (opt.async === false)) {
             this.updateViews(opt);
         }
-        return stats;
     },
 
     checkViewport: function(opt) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -582,9 +582,9 @@ export const Paper = View.extend({
             options.highlighting = defaultsDeep({}, highlighting, defaultHighlighting);
         }
         // Copy and set defaults for the view management options.
-        options.viewManagement = options.viewManagement && defaults({}, options.viewManagement, {
+        options.viewManagement = defaults({}, options.viewManagement, {
             // Whether to lazy initialize the cell views.
-            lazyInitialize: true,
+            lazyInitialize: !!options.viewManagement, // default `true` if options.viewManagement provided
             // Whether to add initialize cell views in the unmounted queue.
             initializeUnmounted: false,
             // Whether to dispose the cell views that are not visible.
@@ -1546,7 +1546,7 @@ export const Paper = View.extend({
         };
     },
 
-    checkCellVisibility: function(opt) {
+    checkCellVisibility: function(opt = {}) {
         this.checkViewport(opt);
         if (!this.isAsync && opt.async === false) {
             this.updateViews(opt);

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -3701,4 +3701,176 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             });
         });
     });
+
+
+    QUnit.module('updateCellVisibility()', function(hooks) {
+
+        let graph;
+        let paper;
+
+        hooks.beforeEach(function() {
+            graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            paper = new Paper({
+                el: paperEl,
+                model: graph,
+                viewManagement: {
+                    disposeHidden: false
+                },
+            });
+        });
+
+        hooks.afterEach(function() {
+            paper.remove();
+        });
+
+        QUnit.test('hide mounted view', function(assert) {
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+
+            paper.updateCellVisibility(rect1, { cellVisibility: () => false});
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('show detached view', function(assert) {
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+
+            paper.updateCellsVisibility({ cellVisibility: () => false });
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            paper.updateCellVisibility(rect1, { cellVisibility: () => true });
+            assert.ok(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('show disposed view', function(assert) {
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+
+            paper.updateCellsVisibility({ cellVisibility: () => false });
+            paper.disposeHiddenCellViews();
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            paper.updateCellVisibility(rect1, { cellVisibility: () => true });
+            assert.ok(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('re-evaluate the default visibility', function(assert) {
+
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+
+            let visibleRect = rect1.id;
+            paper.options.cellVisibility = (cell) => visibleRect === cell.id;
+
+            graph.addCell([rect1, rect2]);
+            assert.ok(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            paper.updateCellVisibility(rect1);
+            assert.ok(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            visibleRect = rect2.id;
+            paper.updateCellVisibility(rect2);
+            assert.ok(paper.isCellVisible(rect2));
+            assert.ok(paper.isCellVisible(rect1));
+
+            paper.updateCellVisibility(rect1);
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+        });
+    });
+
+    QUnit.module('updateCellsVisibility()', function(hooks) {
+
+        let graph;
+        let paper;
+
+        hooks.beforeEach(function() {
+            graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            paper = new Paper({
+                el: paperEl,
+                model: graph,
+                viewManagement: {
+                    disposeHidden: false
+                },
+            });
+        });
+
+        hooks.afterEach(function() {
+            paper.remove();
+        });
+
+        QUnit.test('hide mounted views', function(assert) {
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+
+            paper.updateCellsVisibility({ cellVisibility: () => false});
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('show detached views', function(assert) {
+            paper.options.cellVisibility = () => false;
+
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            paper.updateCellsVisibility({ cellVisibility: () => true });
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('show disposed views', function(assert) {
+            paper.options.cellVisibility = () => false;
+
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+            paper.disposeHiddenCellViews();
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+
+            paper.updateCellsVisibility({ cellVisibility: () => true });
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+        });
+
+        QUnit.test('re-evaluate the default visibility', function(assert) {
+            let visible = true;
+            paper.options.cellVisibility = () => visible;
+
+            const rect1 = new joint.shapes.standard.Rectangle();
+            const rect2 = new joint.shapes.standard.Rectangle();
+            graph.addCell([rect1, rect2]);
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+
+            paper.updateCellsVisibility();
+            assert.ok(paper.isCellVisible(rect1));
+            assert.ok(paper.isCellVisible(rect2));
+
+            visible = false;
+            paper.updateCellsVisibility();
+            assert.notOk(paper.isCellVisible(rect1));
+            assert.notOk(paper.isCellVisible(rect2));
+        });
+    });
 });

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -2847,13 +2847,13 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 1, 'One view is mounted after checkViewport with mountBatchSize 1');
-            assert.ok(paper.isCellViewMounted(rects[0]), 'First view is mounted');
+            assert.ok(paper.isCellVisible(rects[0]), 'First view is mounted');
 
             paper.checkViewport({ mountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 2, 'Two views are mounted after second updateViewsBatch');
-            assert.ok(paper.isCellViewMounted(rects[1]), 'Second view is mounted');
+            assert.ok(paper.isCellVisible(rects[1]), 'Second view is mounted');
 
             paper.prioritizeCellViewMount(rects[9]);
 
@@ -2861,13 +2861,13 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 3, 'Three views are mounted after prioritizing unmounted view');
-            assert.ok(paper.isCellViewMounted(rects[9]), 'Prioritized view is mounted');
+            assert.ok(paper.isCellVisible(rects[9]), 'Prioritized view is mounted');
 
             paper.checkViewport({ mountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 4, 'Four views are mounted after another updateViewsBatch');
-            assert.ok(paper.isCellViewMounted(rects[2]), 'Third view is mounted');
+            assert.ok(paper.isCellVisible(rects[2]), 'Third view is mounted');
 
             // Check the return values of prioritizeCellViewMount
             assert.equal(paper.prioritizeCellViewMount(rects[5]), true, 'Prioritization of unmounted view returned true');
@@ -2909,27 +2909,27 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 9, 'One view is unmounted after checkViewport with unmountBatchSize 1');
-            assert.notOk(paper.isCellViewMounted(rects[0]), 'First view is not mounted');
+            assert.notOk(paper.isCellVisible(rects[0]), 'First view is not mounted');
 
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 8, 'Two views are unmounted after second updateViewsBatch');
-            assert.notOk(paper.isCellViewMounted(rects[1]), 'Second view is not mounted');
-            assert.ok(paper.isCellViewMounted(rects[9]), 'Last view is still mounted');
+            assert.notOk(paper.isCellVisible(rects[1]), 'Second view is not mounted');
+            assert.ok(paper.isCellVisible(rects[9]), 'Last view is still mounted');
 
             paper.prioritizeCellViewUnmount(rects[9]);
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 7, 'Three views are unmounted after prioritizing mounted view');
-            assert.notOk(paper.isCellViewMounted(rects[9]), 'Prioritized view is not mounted');
+            assert.notOk(paper.isCellVisible(rects[9]), 'Prioritized view is not mounted');
 
             paper.checkViewport({ unmountBatchSize: 1 });
             paper.updateViewsBatch({ batchSize: 1 });
 
             assert.equal(cellNodesCount(paper), 6, 'Four views are unmounted after another updateViewsBatch');
-            assert.notOk(paper.isCellViewMounted(rects[2]), 'Third view is not mounted');
+            assert.notOk(paper.isCellVisible(rects[2]), 'Third view is not mounted');
 
             // Check the return values of prioritizeCellViewUnmount
             assert.equal(paper.prioritizeCellViewUnmount(rects[5]), true, 'Prioritization of mounted view returned true');
@@ -3575,14 +3575,14 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     const rect = new joint.shapes.standard.Rectangle();
                     graph.addCell(rect);
 
-                    assert.ok(paper.isCellViewMounted(rect));
+                    assert.ok(paper.isCellVisible(rect));
 
                     paper.checkViewport({ cellVisibility: () => false });
                     paper.updateViews({ cellVisibility: () => false });
 
                     const rv1 = rect.findView(paper);
                     assert.ok(rv1 instanceof joint.dia.ElementView);
-                    assert.notOk(paper.isCellViewMounted(rect));
+                    assert.notOk(paper.isCellVisible(rect));
                     assert.ok(rv1.el.childElementCount === 0, 'The view is not yet rendered');
                     assert.notOk(rv1.el.isConnected, 'The view is not connected');
 
@@ -3591,14 +3591,14 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
                     const rv2 = rect.findView(paper);
                     assert.ok(rv2 instanceof joint.dia.ElementView);
-                    assert.ok(paper.isCellViewMounted(rect));
+                    assert.ok(paper.isCellVisible(rect));
                     assert.ok(rv2.el.childElementCount > 0, 'The view is rendered');
                     assert.ok(rv2.el.isConnected, 'The view is connected');
 
                     // View has been removed
                     rect.remove();
                     assert.notOk(rect.findView(paper));
-                    assert.notOk(paper.isCellViewMounted(rect));
+                    assert.notOk(paper.isCellVisible(rect));
 
                     paper.remove();
                 });
@@ -3619,7 +3619,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     graph.addCell(rect);
 
                     assert.ok(rect.findView(paper) instanceof joint.dia.ElementView);
-                    assert.ok(paper.isCellViewMounted(rect));
+                    assert.ok(paper.isCellVisible(rect));
 
                     // View has been moved to the unmounted queue
                     paper.checkViewport({ cellVisibility: () => false });
@@ -3629,7 +3629,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     paper.checkViewport({ cellVisibility: () => true });
 
                     const rv2 = rect.findView(paper);
-                    assert.ok(paper.isCellViewMounted(rect));
+                    assert.ok(paper.isCellVisible(rect));
                     assert.ok(rv2 instanceof joint.dia.ElementView);
                     assert.ok(
                         rv2.el.childElementCount === 0,
@@ -3647,7 +3647,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     // View has been removed
                     rect.remove();
                     assert.notOk(rect.findView(paper));
-                    assert.notOk(paper.isCellViewMounted(rect));
+                    assert.notOk(paper.isCellVisible(rect));
 
                     paper.remove();
                 });

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -1978,7 +1978,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 autoFreeze: true,
                 sorting: Paper.sorting.APPROX,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 cellVisibility: (cell) => cell.get('visible')
@@ -2014,7 +2013,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 autoFreeze: true,
                 sorting: Paper.sorting.APPROX,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 cellVisibility: (cell) => cell.get('visible')
@@ -2681,8 +2679,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
-                    disposeHidden: true
+                    disposeHidden: true,
                 },
                 cellVisibility: cellVisibilityTrueSpy,
             });
@@ -2776,7 +2773,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper = new Paper({
                 el: paperEl,
                 model: graph,
-                viewManagement: {},
+                viewManagement: true,
                 cellVisibility: cellVisibilitySpy,
             });
 
@@ -2802,7 +2799,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             paper = new Paper({
                 el: paperEl,
                 model: graph,
-                viewManagement: {},
+                viewManagement: true,
                 cellVisibility: () => true,
             });
 
@@ -2831,7 +2828,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 async: true,
@@ -2894,7 +2890,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 el: paperEl,
                 model: graph,
                 viewManagement: {
-                    lazyInitialize: true,
                     disposeHidden: true,
                 },
                 async: true,
@@ -3006,9 +3001,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     elementView: SpyElementView,
-                    viewManagement: {
-                        lazyInitialize: true,
-                    },
+                    viewManagement: true,
                 });
 
                 const rect = new joint.shapes.standard.Rectangle();
@@ -3047,7 +3040,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
                     },
                 });
@@ -3094,6 +3086,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
+                        lazyInitialize: false,
                         initializeUnmounted: true,
                     },
                 });
@@ -3140,8 +3133,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3187,7 +3179,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3233,9 +3226,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3281,8 +3273,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
+                        lazyInitialize: false,
                         initializeUnmounted: true,
-                        disposeHidden: true
+                        disposeHidden: true,
                     },
                 });
 
@@ -3326,9 +3319,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     cellVisibility: () => false,
-                    viewManagement: {
-                        lazyInitialize: true
-                    },
+                    viewManagement: true
                 });
 
                 const initialCount = getNumberOfViews();
@@ -3343,7 +3334,9 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                 assert.equal(getNumberOfViews() - initialCount, 2, 'View for el2 is initialized');
 
                 paper.remove();
-                        QUnit.test('lazyInitialize, initializeUnmounted', function(assert) {
+            });
+
+            QUnit.test('lazyInitialize, initializeUnmounted', function(assert) {
 
                 const graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
 
@@ -3356,7 +3349,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     model: graph,
                     elementView: SpyElementView,
                     viewManagement: {
-                        lazyInitialize: true,
                         initializeUnmounted: true,
                     },
                 });
@@ -3389,7 +3381,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
 
                 paper.remove();
             });
-});
         });
 
         QUnit.module('disposeHidden', function() {
@@ -3402,7 +3393,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3440,7 +3432,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3473,7 +3466,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3510,8 +3504,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        lazyInitialize: true,
-                        disposeHidden: true
+                        lazyInitialize: false,
+                        disposeHidden: true,
                     },
                 });
 
@@ -3540,7 +3534,8 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     el: paperEl,
                     model: graph,
                     viewManagement: {
-                        disposeHidden: false
+                        lazyInitialize: false,
+                        disposeHidden: false,
                     },
                 });
 
@@ -3573,7 +3568,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });
@@ -3617,7 +3611,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });
@@ -3668,7 +3661,6 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                         el: paperEl,
                         model: graph,
                         viewManagement: {
-                            lazyInitialize: true,
                             disposeHidden: true,
                         },
                     });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1415,10 +1415,10 @@ export namespace dia {
         type AfterRenderCallback = (stats: UpdateStats, opt: { [key: string]: any }, paper: Paper) => void;
 
         interface CellVisibilityOptions {
-            cellVisibility?: CellVisibilityCallback;
+            cellVisibility?: CellVisibilityCallback | null;
 
             /** @deprecated disable `legacyMode` and use `cellVisibility` instead */
-            viewport?: ViewportCallback;
+            viewport?: ViewportCallback | null;
         }
 
         interface MountOptions {
@@ -1488,7 +1488,7 @@ export namespace dia {
         type FindParentByCallback = ((this: dia.Graph, elementView: ElementView, evt: dia.Event, x: number, y: number) => Cell[]);
         type MeasureNodeCallback = (node: SVGGraphicsElement, cellView: dia.CellView) => g.Rect;
 
-        interface Options extends mvc.ViewOptions<Graph> {
+        interface Options extends mvc.ViewOptions<Graph>, CellVisibilityOptions, BeforeRenderOptions, AfterRenderOptions {
             // appearance
             width?: Dimension;
             height?: Dimension;
@@ -1551,13 +1551,8 @@ export namespace dia {
             frozen?: boolean;
             autoFreeze?: boolean;
             viewManagement?: ViewManagementOptions;
-            /** @deprecated Use `cellVisibility` */
-            viewport?: ViewportCallback | null;
-            cellVisibility?: CellVisibilityCallback | null;
             onViewUpdate?: (view: mvc.View<any, any>, flag: number, priority: number, opt: { [key: string]: any }, paper: Paper) => void;
             onViewPostponed?: (view: mvc.View<any, any>, flag: number, paper: Paper) => boolean;
-            beforeRender?: Paper.BeforeRenderCallback;
-            afterRender?: Paper.AfterRenderCallback;
             overflow?: boolean;
         }
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1929,9 +1929,7 @@ export namespace dia {
 
         requestViewUpdate(view: mvc.View<any, any>, flag: number, priority: number, opt?: { [key: string]: any }): void;
 
-        requireView<T extends ElementView | LinkView>(model: Cell | Cell.ID, opt?: dia.Cell.Options): T;
-
-        dumpViews(opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions): void;
+        requireView<T extends ElementView | LinkView>(cellOrId: Cell | Cell.ID, opt?: dia.Cell.Options): T;
 
         updateViews(opt?: Paper.UpdateViewsOptions): Paper.RenderStats & { batches: number };
 
@@ -2103,6 +2101,11 @@ export namespace dia {
          * @deprecated Use `updateCellsVisibility()`
          */
         checkViewport(opt?: Paper.UpdateCellVisibilityOptions): Paper.UpdateVisibilityStats;
+
+        /**
+         * @deprecated Use `updateCellsVisibility()`
+         */
+        dumpViews(opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions): void;
     }
 
     namespace PaperLayer {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1441,16 +1441,8 @@ export namespace dia {
             afterRender?: AfterRenderCallback;
         }
 
-        interface RenderCallbackOptions extends BeforeRenderOptions, AfterRenderOptions {
+        interface RenderCallbackOptions extends BeforeRenderOptions, AfterRenderOptions, mvc.Silenceable {
 
-        }
-
-        interface ProgressOptions {
-            progress?: ProgressCallback;
-        }
-
-        interface AsyncOptions {
-            async?: boolean;
         }
 
         interface KeyOptions {
@@ -1461,16 +1453,16 @@ export namespace dia {
             [key: string]: any;
         }
 
-        interface UpdateViewsOptions extends RenderCallbackOptions, UpdateViewsBatchOptions {
+        interface UpdateViewsBatchOptions extends UpdateViewOptions, BatchSizeOptions, CellVisibilityOptions {
 
         }
 
-        interface UpdateViewsBatchOptions extends BatchSizeOptions, CellVisibilityOptions, UpdateViewOptions {
+        interface UpdateViewsOptions extends UpdateViewsBatchOptions, RenderCallbackOptions {
 
         }
 
-        interface UpdateViewsAsyncOptions extends UpdateViewsBatchOptions, MountOptions, UnmountOptions, ProgressOptions, RenderCallbackOptions {
-
+        interface UpdateViewsAsyncOptions extends UpdateViewsBatchOptions, MountOptions, UnmountOptions, RenderCallbackOptions {
+            progress?: ProgressCallback;
         }
 
         interface UpdateCellVisibilityOptions extends CellVisibilityOptions, MountOptions, UnmountOptions {
@@ -1946,25 +1938,22 @@ export namespace dia {
 
         dumpViews(opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions): void;
 
-        updateCellVisibility(
-            cell: Cell | Cell.ID,
-            opt?: Paper.UpdateCellVisibilityOptions & Paper.AsyncOptions
-        ): void;
-
-        updateCellsVisibility(
-            opt?: Paper.UpdateCellVisibilityOptions & Paper.AsyncOptions
-        ): void;
-
-        /** @deprecated Use `updateCellsVisibility()` */
-        checkViewport(opt?: Paper.UpdateCellVisibilityOptions): Paper.UpdateVisibilityStats;
-
         updateViews(opt?: Paper.UpdateViewsOptions): Paper.RenderStats & { batches: number };
 
         hasScheduledUpdates(): boolean;
 
         disposeHiddenCellViews(): void;
 
-        isCellViewMounted(cellOrId: dia.Cell | dia.Cell.ID): boolean;
+        isCellVisible(cellOrId: dia.Cell | dia.Cell.ID): boolean;
+
+        updateCellVisibility(
+            cell: Cell | Cell.ID,
+            opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewOptions & Paper.RenderCallbackOptions
+        ): void;
+
+        updateCellsVisibility(
+            opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions
+        ): void;
 
         // events
 
@@ -2114,6 +2103,11 @@ export namespace dia {
          * @deprecated use transformToFitContent
          */
         scaleContentToFit(opt?: Paper.ScaleContentOptions): void;
+
+        /**
+         * @deprecated Use `updateCellsVisibility()`
+         */
+        checkViewport(opt?: Paper.UpdateCellVisibilityOptions): Paper.UpdateVisibilityStats;
     }
 
     namespace PaperLayer {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1884,15 +1884,19 @@ export namespace dia {
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
 
-        checkCellVisibility(opt?: {
+        updateCellsVisibility(opt?: {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
             /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
-        }): void;
+        }): {
+            mounted: number;
+            unmounted: number;
+        };
 
+        /** @deprecated Use `updateCellsVisibility()` */
         checkViewport(opt?: {
             mountBatchSize?: number;
             unmountBatchSize?: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1884,7 +1884,7 @@ export namespace dia {
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
 
-        checkCellViewVisibility(opt?: {
+        checkCellVisibility(opt?: {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1398,13 +1398,7 @@ export namespace dia {
             empty: boolean;
         }
 
-        type UpdateStats = {
-            priority: number;
-            updated: number;
-            empty?: boolean;
-            postponed?: number;
-            unmounted?: number;
-            mounted?: number;
+        type UpdateStats = RenderStats & Partial<RenderBatchStats> & {
             batches?: number;
         };
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1888,8 +1888,6 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
-            /** @deprecated Use `cellVisibility` */
-            viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
             mounted: number;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1455,11 +1455,11 @@ export namespace dia {
 
         }
 
-        interface UpdateViewsAsyncOptions extends UpdateViewsBatchOptions, MountOptions, UnmountOptions, RenderCallbackOptions {
+        interface UpdateViewsAsyncOptions extends UpdateViewsBatchOptions, ScheduleCellVisibilityOptions, RenderCallbackOptions {
             progress?: ProgressCallback;
         }
 
-        interface UpdateCellVisibilityOptions extends CellVisibilityOptions, MountOptions, UnmountOptions {
+        interface ScheduleCellVisibilityOptions extends CellVisibilityOptions, MountOptions, UnmountOptions {
 
         }
 
@@ -1923,7 +1923,7 @@ export namespace dia {
 
         requestViewUpdate(view: mvc.View<any, any>, flag: number, priority: number, opt?: { [key: string]: any }): void;
 
-        requireView<T extends ElementView | LinkView>(cellOrId: Cell | Cell.ID, opt?: dia.Cell.Options): T;
+        requireView<T extends ElementView | LinkView>(cellOrId: Cell | Cell.ID, opt?: Paper.UpdateViewOptions & Paper.RenderCallbackOptions): T;
 
         updateViews(opt?: Paper.UpdateViewsOptions): Paper.RenderStats & { batches: number };
 
@@ -1935,11 +1935,11 @@ export namespace dia {
 
         updateCellVisibility(
             cell: Cell | Cell.ID,
-            opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewOptions & Paper.RenderCallbackOptions
+            opt?: Paper.CellVisibilityOptions & Paper.UpdateViewOptions & Paper.RenderCallbackOptions
         ): void;
 
         updateCellsVisibility(
-            opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions
+            opt?: Paper.ScheduleCellVisibilityOptions & Paper.UpdateViewsOptions
         ): void;
 
         // events
@@ -1977,7 +1977,7 @@ export namespace dia {
 
         protected updateViewsAsync(opt?: Paper.UpdateViewsAsyncOptions): void;
 
-        protected updateViewsBatch(opt?: Paper.UpdateViewsBatchOptions): Paper.UpdateStats;
+        protected updateViewsBatch(opt?: Paper.UpdateViewsBatchOptions): Paper.RenderBatchStats;
 
         protected checkMountedViews(viewport: Paper.ViewportCallback, opt?: Paper.UnmountOptions): number;
 
@@ -2094,12 +2094,12 @@ export namespace dia {
         /**
          * @deprecated Use `updateCellsVisibility()`
          */
-        checkViewport(opt?: Paper.UpdateCellVisibilityOptions): Paper.UpdateVisibilityStats;
+        checkViewport(opt?: Paper.ScheduleCellVisibilityOptions): Paper.UpdateVisibilityStats;
 
         /**
          * @deprecated Use `updateCellsVisibility()`
          */
-        dumpViews(opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions): void;
+        dumpViews(opt?: Paper.ScheduleCellVisibilityOptions & Paper.UpdateViewsOptions): void;
     }
 
     namespace PaperLayer {

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1408,6 +1408,7 @@ export namespace dia {
             mountBatchSize?: number;
             unmountBatchSize?: number;
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: ViewportCallback;
             cellVisibility?: CellVisibilityCallback;
             progress?: ProgressCallback;
@@ -1489,6 +1490,7 @@ export namespace dia {
             frozen?: boolean;
             autoFreeze?: boolean;
             viewManagement?: ViewManagementOptions;
+            /** @deprecated Use `cellVisibility` */
             viewport?: ViewportCallback | null;
             cellVisibility?: CellVisibilityCallback | null;
             onViewUpdate?: (view: mvc.View<any, any>, flag: number, priority: number, opt: { [key: string]: any }, paper: Paper) => void;
@@ -1877,6 +1879,16 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
+            viewport?: Paper.ViewportCallback;
+            cellVisibility?: Paper.CellVisibilityCallback;
+        }): void;
+
+        checkCellViewVisibility(opt?: {
+            batchSize?: number;
+            mountBatchSize?: number;
+            unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): void;
@@ -1884,6 +1896,7 @@ export namespace dia {
         checkViewport(opt?: {
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1893,6 +1906,7 @@ export namespace dia {
 
         updateViews(opt?: {
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1916,14 +1930,15 @@ export namespace dia {
         // protected
 
         /**
-        * For the specified view, calls the visibility viewport function specified by the paper.options.viewport function.
+        * For the specified view, calls the cell visibility function specified by the `paper.options.cellVisibility` function.
         * If the function returns true, the view is attached to the DOM; in other case it is detached.
-        * While async papers do this automatically, synchronous papers require an explicit call to this method for this functionality to be applied. To show the view again, use paper.requestView().
-        * If you are using autoFreeze option you should call this function if you are calling paper.requestView() if you want paper.options.viewport function to be applied.
+        * While async papers do this automatically, synchronous papers require an explicit call to this method for this functionality to be applied. To show the view again, use `paper.requestView()`.
+        * If you are using `autoFreeze` option you should call this function if you are calling `paper.requestView()` if you want `paper.options.cellVisibility` function to be applied.
         * @param cellView cellView for which the visibility check is performed
-        * @param opt if opt.viewport is provided, it is used as the callback function instead of paper.options.viewport.
+        * @param opt if opt.cellVisibility is provided, it is used as the callback function instead of paper.options.cellVisibility.
         */
         protected checkViewVisibility(cellView: dia.CellView, opt?: {
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): {
@@ -1947,6 +1962,7 @@ export namespace dia {
             batchSize?: number;
             mountBatchSize?: number;
             unmountBatchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
             progress?: Paper.ProgressCallback;
@@ -1955,6 +1971,7 @@ export namespace dia {
 
         protected updateViewsBatch(opt?: {
             batchSize?: number;
+            /** @deprecated Use `cellVisibility` */
             viewport?: Paper.ViewportCallback;
             cellVisibility?: Paper.CellVisibilityCallback;
         }): Paper.UpdateStats;


### PR DESCRIPTION
### Description

The PR aims to simplify the API for cell visibility toggling.

#### Synchronous mode
Toggling visibility of cells is done via `updateCellsVisibility()` or `updateCellVisibility()`.

#### Asynchronous mode
Toggling visibility of cells is done automatically by checking `cellVisibility()` callback periodically.
When `autoFreeze` option is enabled, one has to call `wakeUp()` to re-run the visibility checks.

The `updateCellsVisibility()` method can be used here, to synchronously show/hide cells e.g. before export to an image.

### Changes

**feat(dia.Paper)** - add `updateCellVisibility(cell, opt)` to synchronously update visibility for a singe cell
```ts
updateCellVisibility(
    cell: dia.Cell | dia.Cell.ID,
    opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewOptions & Paper.RenderCallbackOptions
): void;
```

**feat(dia.Paper)** - add`updateCellsVisibility(cell, opt)` to synchronously update visibility for all cels
```ts
updateCellsVisibility(
    opt?: Paper.UpdateCellVisibilityOptions & Paper.UpdateViewsOptions
): void;
```

**refactor(dia.Paper)** - set `viewManagement > lazyInitialize` to `true` by default (in non-legacy mode) and remove the option from public API.

There is no reason NOT to use `lazyInitialization` if you already check visibility with `cellVisibility` callback.
The `viewport()` callback can not be used without it, because it accepts views that would not exist yet.
*Note: `cellVisibility()` accepts a cell model as the first paramater*

**refactor(dia.Paper)** - rename `isCellViewMounted()` to `isCellVisible()`

**refactor(dia.Paper)** - deprecate `dumpViews()` and `checkViewport()`  in favor of `updateCellsVisibility()`
```ts
// checkViewport();
paper.updateCellsVisibility();

// dumpViews();
paper.updateCellsVisibility({ cellVisibility: () => true });
```

**types(dia.Paper)** - define render & visibility options as interfaces
**types(dia.Paper)** - define rendering stats as interfaces
