### PR TITLE
fix: add 'use strict' for minified files

### DIFF
--- a/packages/joint-core/grunt/config/uglify.js
+++ b/packages/joint-core/grunt/config/uglify.js
@@ -11,9 +11,8 @@ module.exports = function() {
             banner: `'use strict';`
         },
         deps: {
-            files: {
-                'build/min/lodash.min.js': 'node_modules/lodash/lodash.js'
-            }
+            src: 'node_modules/lodash/lodash.js',
+            dest: 'build/min/lodash.min.js'
         },
         geometry: {
             src: modules.geometry.umd,

--- a/packages/joint-core/grunt/config/uglify.js
+++ b/packages/joint-core/grunt/config/uglify.js
@@ -7,7 +7,8 @@ module.exports = function() {
         options: {
             output: {
                 ascii_only: true
-            }
+            },
+            banner: `'use strict';`
         },
         deps: {
             files: {

--- a/packages/joint-core/grunt/resources/banner.js
+++ b/packages/joint-core/grunt/resources/banner.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
 
-    let template = '/*! <%= pkg.title %> v<%= pkg.version %> (<%= grunt.template.today("yyyy-mm-dd") %>) - <%= pkg.description %>\n\n\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.\n*/\n';
+    let template = '/*! <%= pkg.title %> v<%= pkg.version %> (<%= grunt.template.today("yyyy-mm-dd") %>) - <%= pkg.description %>\n\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.\n*/\n\n';
 
     let opt = {
         data: {

--- a/packages/joint-layout-directed-graph/rollup.config.mjs
+++ b/packages/joint-layout-directed-graph/rollup.config.mjs
@@ -5,7 +5,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const today = new Date();
 const formattedDate = today.toLocaleDateString("en-US", { year: 'numeric' }) + "-" + today.toLocaleDateString("en-US", { month: '2-digit' }) + "-" + today.toLocaleDateString("en-US", { day: '2-digit' });
-const bannerText = `/*! ${packageJson.title} v${packageJson.version} (${formattedDate}) - ${packageJson.description}\n\n\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.\n*/\n`;
+const bannerText = `/*! ${packageJson.title} v${packageJson.version} (${formattedDate}) - ${packageJson.description}\n\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at http://mozilla.org/MPL/2.0/.\n*/\n\n`;
 
 const input = ['./DirectedGraph.mjs'];
 
@@ -29,6 +29,7 @@ export default [
                     '@joint/core': 'joint'
                 },
                 plugins: [
+                    // Add JointJS banner to all distribution files.
                     banner(() => bannerText)
                 ]
             },
@@ -43,7 +44,9 @@ export default [
                     '@joint/core': 'joint'
                 },
                 plugins: [
-                    terser({ format: { ascii_only: true }}),
+                    // Uglify.
+                    terser({ format: { ascii_only: true, preamble: `'use strict';` }}),
+                    // Add JointJS banner to all distribution files.
                     banner(() => bannerText)
                 ]
             },


### PR DESCRIPTION
## Description

Adds `'use strict';` at the beginning of minified files (in **@joint/core**, **@joint/layout-directed-graph**).

Additionally, slightly improves banner text formatting when it comes to newlines.

## Motivation and Context

Our minification process removes all `'use strict';` statements from our code, which previously lead to subtle bugs (due to reuse of variable names in minified code). We are now adding one `'use strict';` statement explicitly at the beginning of each minified `.js` file.

### Comparison (beginning of `dist/joint.min.js`):
- Old version:
```
/*! JointJS v4.1.3 (2025-02-04) - JavaScript diagramming library


This Source Code Form is subject to the terms of the Mozilla Public
License, v. 2.0. If a copy of the MPL was not distributed with this
file, You can obtain one at http://mozilla.org/MPL/2.0/.
*/
var g,V,Vectorizer;((t,e)=>
```

- New version:
```
/*! JointJS v4.1.3 (2025-09-24) - JavaScript diagramming library

This Source Code Form is subject to the terms of the Mozilla Public
License, v. 2.0. If a copy of the MPL was not distributed with this
file, You can obtain one at http://mozilla.org/MPL/2.0/.
*/

'use strict';
var g,V,Vectorizer;((t,e)=>
```
