### PR TITLE
feat(mvc.Collection):  use a `Map` instead of a plain object to store references.

### DIFF
--- a/packages/joint-core/test/jointjs/mvc.collection.js
+++ b/packages/joint-core/test/jointjs/mvc.collection.js
@@ -1044,16 +1044,16 @@ QUnit.module('joint.mvc.Collection', function(hooks) {
             _addReference: function(model) {
                 joint.mvc.Collection.prototype._addReference.apply(this, arguments);
                 calls.add++;
-                assert.equal(model, this._byId[model.id]);
-                assert.equal(model, this._byId[model.cid]);
+                assert.equal(model, this._byId.get(model.id));
+                assert.equal(model, this._byId.get(model.cid));
                 assert.equal(model._events.all.length, 1);
             },
 
             _removeReference: function(model) {
                 joint.mvc.Collection.prototype._removeReference.apply(this, arguments);
                 calls.remove++;
-                assert.equal(this._byId[model.id], void 0);
-                assert.equal(this._byId[model.cid], void 0);
+                assert.equal(this._byId.get(model.id), void 0);
+                assert.equal(this._byId.get(model.cid), void 0);
                 assert.equal(model.collection, void 0);
             }
 


### PR DESCRIPTION
## Description

Replace plain object for `_byId` reference map with native Map object.

## Motivation and Context

 This update improves performance of add/remove operations within a collection.
 The main goal is to speed up resetting `dia.Graph` with a large amount of cells.

## Benchmark

Run `graph.resetCells()` 100 times.

**Before:**
```
1k cells   : Min = 6.90 ms,    Max = 19.80 ms,   Average = 8.46 ms
10k cells  : Min = 72.70 ms,   Max = 108.50 ms,  Average = 83.38 ms
100k cells : Min = 1186.80 ms, Max = 2067.00 ms, Average = 1371.10 ms
```

**After:**
```
1k cells   : Min = 8.00 ms,    Max = 14.50 ms,   Average = 10.03 ms
10k cells  : Min = 75.30 ms,   Max = 92.70 ms,   Average = 81.54 ms
100k cells : Min = 1157.10 ms, Max = 1650.50 ms, Average = 1271.07 ms
```