### PR TITLE
chore: improve coverage reporting

### DIFF
--- a/packages/joint-core/coverage.json
+++ b/packages/joint-core/coverage.json
@@ -1,26 +1,26 @@
 {
     "joint": {
         "global": {
-            "statements": 72,
-            "branches": 66,
-            "functions": 71,
-            "lines": 73
+            "statements": 83,
+            "branches": 76,
+            "functions": 85,
+            "lines": 85
         }
     },
     "vectorizer": {
         "global": {
-            "statements": 73,
-            "branches": 62,
-            "functions": 74,
-            "lines": 74
+            "statements": 82,
+            "branches": 75,
+            "functions": 79,
+            "lines": 83
         }
     },
     "geometry": {
         "global": {
-            "statements": 81,
-            "branches": 78,
-            "functions": 75,
-            "lines": 82
+            "statements": 85,
+            "branches": 80,
+            "functions": 79,
+            "lines": 86
         }
     }
 }

--- a/packages/joint-core/grunt/config/aliases.js
+++ b/packages/joint-core/grunt/config/aliases.js
@@ -66,7 +66,10 @@ module.exports = function(grunt) {
             'qunit:vectorizer',
             'qunit:geometry'
         ],
-        'test:coverage': ['test:src'],
+        'test:coverage': [
+            'shell:rollup-test-bundle',
+            'test:src'
+        ],
         'test:e2e': ['mochaTest:e2e'],
         'test:e2e:all': [
             'test:e2e:chrome-linux',

--- a/packages/joint-core/grunt/config/karma.js
+++ b/packages/joint-core/grunt/config/karma.js
@@ -23,9 +23,11 @@ module.exports = function(grunt) {
         switch (reporter) {
             case 'lcov':
                 reporters = [{ type: 'lcovonly', subdir: '.', file: `${name}.lcov` }];
+                check = grunt.file.readJSON('coverage.json')[name];
                 break;
             case 'html':
                 reporters = [{ type: 'html' }];
+                check = grunt.file.readJSON('coverage.json')[name];
                 break;
             case '':
                 reporters = [{ type: 'text-summary' }];


### PR DESCRIPTION
## Description

Improves `'test:coverage'` grunt task so that `yarn run test-coverage` can be run directly after `yarn run dist`. Updates coverage requirements upwards to reflect current state of the codebase and enforces them on `'test:coverage'` check.

## Motivation and Context

Coverage is important. This PR makes checking it easier.