### PR TITLE
chore: update package.json of new examples and packages

### DIFF
--- a/examples/layout-elk-ts/package.json
+++ b/examples/layout-elk-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@joint/demo-elk-ts",
   "version": "4.1.3",
+  "description": "JointJS - ELK Layout Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-msagl/package.json
+++ b/examples/layout-msagl/package.json
@@ -1,53 +1,45 @@
 {
-    "name": "@joint/demo-layout-msagl",
-    "version": "4.1.3",
-    "main": "src/index.ts",
-    "homepage": "https://jointjs.com",
-    "author": {
-        "name": "client IO",
-        "url": "https://client.io"
-    },
-    "contributors": [
-        "Roman Bruckner <roman@client.io> (https://github.com/kumilingus)",
-        "Martin Kanera <martin@jointjs.com> (https://github.com/MartinKanera)"
-    ],
-    "licenses": [
-        {
-            "type": "JointJS+ License",
-            "url": "https://www.jointjs.com/license"
-        }
-    ],
-    "private": true,
-    "files": [
-        "src/",
-        "./index.html",
-        "./README.md",
-        "./tsconfig.json",
-        "./webpack.config.js"
-    ],
-    "installConfig": {
-        "hoistingLimits": "workspaces"
-    },
-    "scripts": {
-        "start": "webpack-dev-server",
-        "build": "webpack"
-    },
-    "dependencies": {
-        "@joint/core": "workspace:^",
-        "@joint/layout-msagl": "workspace:^"
-    },
-    "devDependencies": {
-        "css-loader": "^6.8.1",
-        "style-loader": "^3.3.3",
-        "ts-loader": "^9.2.5",
-        "typescript": "^5.7.3",
-        "webpack": "^5.53.0",
-        "webpack-cli": "^4.8.0",
-        "webpack-dev-server": "^4.2.1"
-    },
-    "volta": {
-        "node": "22.14.0",
-        "npm": "11.2.0",
-        "yarn": "4.7.0"
-    }
+  "name": "@joint/demo-layout-msagl",
+  "version": "4.1.3",
+  "description": "JointJS - MSAGL Demo",
+  "main": "dist/bundle.js",
+  "homepage": "https://jointjs.com",
+  "author": {
+    "name": "client IO",
+    "url": "https://client.io"
+  },
+  "license": "MPL-2.0",
+  "private": true,
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack"
+  },
+  "files": [
+    "src/",
+    "./index.html",
+    "./README.md",
+    "./tsconfig.json",
+    "./webpack.config.js"
+  ],
+  "dependencies": {
+    "@joint/core": "workspace:^",
+    "@joint/layout-msagl": "workspace:^"
+  },
+  "devDependencies": {
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "ts-loader": "^9.2.5",
+    "typescript": "^5.7.3",
+    "webpack": "^5.53.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.1"
+  },
+  "volta": {
+    "node": "22.14.0",
+    "npm": "11.2.0",
+    "yarn": "4.7.0"
+  }
 }

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/clientIO/joint.git",
-    "directory": "packages/joint-layout-directed"
+    "directory": "packages/joint-layout-directed-graph"
   },
   "bugs": {
     "url": "https://github.com/clientIO/joint/issues"

--- a/packages/joint-layout-msagl/package.json
+++ b/packages/joint-layout-msagl/package.json
@@ -1,25 +1,12 @@
 {
   "name": "@joint/layout-msagl",
   "title": "JointJS LayoutMSAGL",
+  "version": "4.1.3",
+  "description": "LayoutMSAGL module for JointJS",
+  "sideEffects": false,
   "main": "./dist/esm/index.mjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/esm/index.d.mts",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.mjs",
-      "types": "./dist/esm/index.d.mts",
-      "default": "./dist/esm/index.mjs"
-    }
-  },
-  "files": [
-    "dist",
-    "SECURITY.md",
-    "README.md",
-    "LICENSE"
-  ],
-  "sideEffects": false,
-  "version": "4.1.3",
-  "description": "LayoutMSAGL module for JointJS",
   "homepage": "https://jointjs.com",
   "author": {
     "name": "client IO",
@@ -41,6 +28,9 @@
   "installConfig": {
     "hoistingLimits": "workspaces"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
     "prepack": "yarn build",
@@ -54,6 +44,19 @@
     "lint": "eslint .",
     "lint-fix": "yarn run lint --fix"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    }
+  },
+  "files": [
+    "dist",
+    "SECURITY.md",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@joint/core": "workspace:~",
     "@msagl/core": "^1.1.23"


### PR DESCRIPTION
## Description

Fixes the `package.json` of `examples/layout-elk-ts`, `examples/layout-msagl` and `packages/joint-layout-msagl` to be in line with the rest of the repo.

Also fixes wrong directory reference in `repository` field of `packages/joint-layout-directed-graph`.