### PR TITLE
types: add cellNamespace property to GraphLayerCollection

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -166,6 +166,7 @@ export namespace dia {
 
     class GraphLayerCollection<L extends GraphLayer = GraphLayer> extends mvc.Collection<L> {
 
+        cellNamespace: any;
         layerNamespace: any;
         graph: Graph;
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/clientIO/joint/pull/3025.

Add missing `cellNamespace` property to `GraphLayerCollection`.
