### PR TITLE
chore(joint-core): use distributed umd file as module

### DIFF
--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -5,7 +5,7 @@
   "description": "JavaScript diagramming library",
   "sideEffects": false,
   "main": "./dist/joint.min.js",
-  "module": "joint.mjs",
+  "module": "./dist/joint.js",
   "types": "./types/index.d.ts",
   "homepage": "https://jointjs.com",
   "author": {


### PR DESCRIPTION
## Description

Replaced by `publishConfig` setup in `joint-core/package.json` in #3072.

For tooling which uses ES6 modules but cannot handle optional chaining used in our module code. The UMD file has been processed by Babel to transpile optional chaining (see #3099).

Use `yarn install && yarn run dist && yarn pack --out joint-core.tgz` to get the package.