### PR TITLE
chore: include @joint/layout-msagl in pack-all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-e2e-all": "yarn workspaces foreach --all -tvv run test-e2e-all",
     "lint": "yarn workspaces foreach --all -tvv run lint",
     "lint-fix": "yarn workspaces foreach --all -tvv run lint-fix",
-    "pack-all": "yarn workspaces foreach --all -tvv --include \"@joint/layout-msagl\" --include \"@joint/layout-directed-graph\" --include \"@joint/core\" pack --out %s-%v.tgz"
+    "pack-all": "yarn workspaces foreach --all -tvv --include \"@joint/core\" --include \"@joint/layout-directed-graph\" --include \"@joint/layout-msagl\" pack --out %s-%v.tgz"
   },
   "workspaces": [
     "./packages/*",


### PR DESCRIPTION
## Description

Include `@joint/layout-msagl` in `yarn run pack-all` script, since it is another package we will be publishing alongside `@joint/core` and `@joint/layout-directed-graph`.