### PR TITLE
fix: render legacy layer view by default

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1299,7 +1299,7 @@ export const Paper = View.extend({
             const type = modelType + 'View';
 
             // For backward compatibility we use the LegacyGraphLayerView for the default `cells` layer.
-            if (this.model.layersController.legacyMode) {
+            if (this.model.legacyMode) {
                 viewConstructor = LegacyGraphLayerView;
             } else {
                 viewConstructor = this.layerViewNamespace[type] || LayerView;

--- a/packages/joint-core/test/jointjs/layers.js
+++ b/packages/joint-core/test/jointjs/layers.js
@@ -20,6 +20,26 @@ QUnit.module('Layers', function(hooks) {
         this.paper = null;
     });
 
+    /**
+     * @todo remove the legacy mode tests in v5.0
+     */
+    QUnit.module('legacyMode', (assert) => {
+
+        QUnit.test('should enter legacy mode by default', (assert) => {
+            assert.ok(this.graph.legacyMode, 'Graph is in legacy mode');
+            this.graph.addLayer({ id: 'layer1' });
+            assert.notOk(this.graph.legacyMode, 'Graph exited legacy mode after adding a layer');
+        });
+
+        QUnit.test('should render legacy view in legacy mode', (assert) => {
+            const layerView = this.paper.getLayerView('cells');
+            assert.ok(layerView.el.classList.contains('joint-viewport'));
+            this.graph.addLayer({ id: 'layer1' });
+            const layerView2 = this.paper.getLayerView('layer1');
+            assert.notOk(layerView2.el.classList.contains('joint-viewport'));
+        });
+    });
+
     QUnit.test('Default layers setup', (assert) => {
         assert.ok(this.graph.layersController, 'Layers controller is created');
 


### PR DESCRIPTION
## Description

Make sure the `LegacyGraphLayerView` is used by default. Any use of layers API should exit the legacy mode and start using the `GraphLayerView`.