### PR TITLE
fix(dia.Paper): request re-eval of source/target magnets on connected view update

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -1484,17 +1484,21 @@ export const Paper = View.extend({
 
     requestConnectedLinksUpdate: function(view, priority, opt) {
         if (!view || !view[CELL_VIEW_MARKER]) return;
-        var model = view.model;
-        var links = this.model.getConnectedLinks(model);
-        for (var j = 0, n = links.length; j < n; j++) {
-            var link = links[j];
-            var linkView = this._getCellViewLike(link);
+        const model = view.model;
+        const links = this.model.getConnectedLinks(model);
+        for (let j = 0, n = links.length; j < n; j++) {
+            const link = links[j];
+            const linkView = this._getCellViewLike(link);
             if (!linkView) continue;
             // We do not have to update placeholder views.
             // They will be updated on initial render.
             if (linkView[CELL_VIEW_PLACEHOLDER_MARKER]) continue;
-            var nextPriority = Math.max(priority + 1, linkView.UPDATE_PRIORITY);
-            this.scheduleViewUpdate(linkView, linkView.getFlag(LinkView.Flags.UPDATE), nextPriority, opt);
+            const flagLabels = [LinkView.Flags.UPDATE];
+            // We need to tell the link view which end requested this update.
+            if (link.getTargetCell() === model) flagLabels.push(LinkView.Flags.TARGET);
+            if (link.getSourceCell() === model) flagLabels.push(LinkView.Flags.SOURCE);
+            const nextPriority = Math.max(priority + 1, linkView.UPDATE_PRIORITY);
+            this.scheduleViewUpdate(linkView, linkView.getFlag(flagLabels), nextPriority, opt);
         }
     },
 

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -1112,11 +1112,12 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                             paper.unfreeze();
                             var onViewUpdateSpy = sinon.spy(paper.options, 'onViewUpdate');
                             var confirmUpdateSpy = sinon.spy(joint.dia.LinkView.prototype, 'confirmUpdate');
-                            // This will trigger onViewUpdate twice (link1 attrs, link2 source/target)
+                            // This will trigger onViewUpdate thrice (link1 attrs, link2 source/target, link1 source/target)
                             link1.attr('line/stroke', 'red', { test: true });
-                            assert.ok(onViewUpdateSpy.calledTwice);
-                            assert.ok(onViewUpdateSpy.calledWithExactly(link1.findView(paper), sinon.match.number, sinon.match.number, sinon.match({ test: true }), paper));
-                            assert.ok(onViewUpdateSpy.calledWithExactly(link2.findView(paper), sinon.match.number, sinon.match.number, sinon.match({ test: true }), paper));
+                            assert.ok(onViewUpdateSpy.calledThrice);
+                            assert.ok(onViewUpdateSpy.calledWithExactly(link1.findView(paper), sinon.match.number, 1, sinon.match({ test: true }), paper));
+                            assert.ok(onViewUpdateSpy.calledWithExactly(link2.findView(paper), sinon.match.number, 2, sinon.match({ test: true }), paper));
+                            assert.ok(onViewUpdateSpy.calledWithExactly(link1.findView(paper), sinon.match.number, 3, sinon.match({ test: true }), paper));
                             assert.ok(confirmUpdateSpy.calledTwice);
                             onViewUpdateSpy.restore();
                             confirmUpdateSpy.restore();

--- a/packages/joint-core/test/jointjs/linkView.js
+++ b/packages/joint-core/test/jointjs/linkView.js
@@ -1866,5 +1866,36 @@ QUnit.module('linkView', function(hooks) {
                 assert.equal(linkView.getEndMagnet(end), rv1b.el.querySelector('rect'));
             });
         });
+
+        QUnit.test('is re-evaluated when connected element updates', function(assert) {
+            link.source(r1);
+            link.target(r2);
+            const r1EvalMagnetSpy = sinon.spy(rv1, 'getMagnetFromLinkEnd');
+            const r2EvalMagnetSpy = sinon.spy(rv2, 'getMagnetFromLinkEnd');
+
+            r1.translate(10, 0);
+            linkView.getEndMagnet('source');
+            assert.ok(r1EvalMagnetSpy.calledOnce, 'Magnet is evaluated on first call');
+            assert.ok(r1EvalMagnetSpy.calledOn(rv1));
+            assert.ok(r1EvalMagnetSpy.calledWithExactly(link.source()));
+            assert.notOk(r2EvalMagnetSpy.called);
+            linkView.getEndMagnet('source');
+            assert.ok(r1EvalMagnetSpy.calledOnce, 'Cache is used on second call');
+            assert.notOk(r2EvalMagnetSpy.called);
+
+            r1EvalMagnetSpy.resetHistory();
+
+            r2.translate(0, 10);
+            linkView.getEndMagnet('target');
+            assert.notOk(r1EvalMagnetSpy.called);
+            assert.ok(r2EvalMagnetSpy.calledOnce, 'Magnet is evaluated on first call');
+            assert.ok(r2EvalMagnetSpy.calledOn(rv2));
+            assert.ok(r2EvalMagnetSpy.calledWithExactly(link.target()));
+            linkView.getEndMagnet('target');
+            assert.notOk(r1EvalMagnetSpy.called);
+            assert.ok(r2EvalMagnetSpy.calledOnce, 'Cache is used on second call');
+
+            r2EvalMagnetSpy.resetHistory();
+        });
     });
 });


### PR DESCRIPTION
## Description

Make sure that `sourceMagnet` and `targetMagnet` properties cache is invalidated when connected end model changes.
This is important for backward compatibility (this PR is a rollback for changes made in https://github.com/clientIO/joint/pull/2974).

