### PR TITLE
fix(dia.Paper): ensure CellView placeholders are removed from the unmounted queue

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -731,6 +731,9 @@ export const Paper = View.extend({
         const viewLike = this._getCellViewLike(cell);
         if (!viewLike) return;
         if (viewLike[CELL_VIEW_PLACEHOLDER_MARKER]) {
+            // It's a cell placeholder, it must be in the unmounted list.
+            // Remove it from there and unregister.
+            this._updates.unmountedList.delete(viewLike.cid);
             this._unregisterCellViewPlaceholder(viewLike);
         } else {
             this.requestViewUpdate(viewLike, this.FLAG_REMOVE, viewLike.UPDATE_PRIORITY, opt);
@@ -2031,6 +2034,8 @@ export const Paper = View.extend({
             let view = viewsRegistry[cid] || this._viewPlaceholders[cid];
             if (!view) {
                 // This should not occur
+                // Prevent looping over this invalid cid
+                unmountedList.popHead();
                 continue;
             }
             if (!this._evalCellVisibility(view, false, visibilityCb)) {

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -1807,6 +1807,44 @@ QUnit.module('joint.dia.Paper', function(hooks) {
         });
     });
 
+
+    QUnit.test('removing a cell placeholder should remove it from unmounted queue', function(assert) {
+
+        const rect1 = new joint.shapes.standard.Rectangle();
+        const rect2 = new joint.shapes.standard.Rectangle();
+        const link1 = new joint.shapes.standard.Link();
+        link1.target(rect1);
+
+        const testPaper = new Paper({
+            el: paperEl,
+            model: graph,
+            async: false,
+            viewManagement: true,
+            cellVisibility: (cell) => cell === rect1,
+        });
+
+        testPaper.freeze();
+
+        rect1.addTo(graph); // add to mounted queue
+        link1.addTo(graph); // add to unmounted queue
+
+        assert.notOk(testPaper.isCellVisible(rect1));
+
+        link1.remove(); // and remove the link1 placeholder
+        rect2.addTo(graph); // add to unmounted queue
+
+        testPaper.unfreeze();
+
+        assert.ok(testPaper.isCellVisible(rect1));
+        assert.notOk(testPaper.isCellVisible(rect2));
+
+        // Try to make both rect1 and rect2 visible
+        testPaper.updateCellsVisibility({ cellVisibility: (cell) => cell === rect2 || cell === rect1 });
+
+        assert.ok(testPaper.isCellVisible(rect1));
+        assert.ok(testPaper.isCellVisible(rect2));
+    });
+
     QUnit.module('async = TRUE, autoFreeze = TRUE', function(hooks) {
 
         const onRenderDone = (paper) => new Promise(resolve => paper.once('render:done', (opt) => resolve(opt)));


### PR DESCRIPTION
## Description

Fix an edge case where removing a lazy-loaded `CellView` prevented another view in the `unmounted` queue from updating its visibility.