### PR TITLE
example(elk-layout-ts): center on interesting area

### DIFF
--- a/examples/layout-elk-ts/src/index.ts
+++ b/examples/layout-elk-ts/src/index.ts
@@ -46,10 +46,11 @@ const init = () => {
     const elk = new ELK({
         workerUrl: '../node_modules/elkjs/lib/elk-worker.js',
     });
-    elk.layout(getElkGraph(graph)).then((elkGraph) => {
-        updateGraph(elkGraph as ElkGraph, graph);
+    elk.layout(getElkGraph(graph)).then((elkGraph: ElkGraph) => {
+        updateGraph(elkGraph, graph);
         paper.unfreeze();
         zoom(paper, 1);
+        // Scroll into a busy area of the example
         window.scroll(650, 560);
     }).catch((error) => {
         console.error('ELK layout error:', error.message);


### PR DESCRIPTION
## Description

Center the `elk-layout-ts` example in an interesting area of the diagram initially.

<img width="1110" height="740" alt="Screenshot 2025-11-07 at 19 04 03" src="https://github.com/user-attachments/assets/190b3cd7-89b0-479a-8258-8071e997d0f9" />