### PR TITLE
fix(dia.ElementView): validate unembedding on pointerdown when whenNotAllowed is set

### DIFF
--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -758,6 +758,19 @@ export const ElementView = CellView.extend({
             pointerOffset: position.difference(x, y),
             restrictedArea: this.paper.getRestrictedArea(view, x, y)
         });
+
+        const { paper } = this;
+
+        const data = this.eventData(evt);
+
+        // If `whenNotAllowed` is set, run embedding validation immediately on drag start.
+        // This ensures `validateUnembedding` is called even if no drag occurs (click without
+        // movement), which enforces validation on single-click interactions.
+        if (paper.options.embeddingMode && data.whenNotAllowed) {
+            this.prepareEmbedding(data);
+            this.processEmbedding(data, evt, x, y);
+            this.eventData(evt, { embedding: true });
+        }
     },
 
     dragMagnetStart: function(evt, x, y) {

--- a/packages/joint-core/test/jointjs/elementView.js
+++ b/packages/joint-core/test/jointjs/elementView.js
@@ -362,4 +362,35 @@ QUnit.module('elementView', function(hooks) {
         });
 
     });
+
+    QUnit.module('dragStart', function() {
+
+        QUnit.test('Run unembedding validation on pointerdown when whenNotAllowed is set', function(assert) {
+            const validateUnembeddingSpy = sinon.spy(() => false);
+
+            paper.options.validateUnembedding = validateUnembeddingSpy;
+            paper.options.embeddingMode = true;
+
+            const element = new joint.shapes.standard.Rectangle();
+            paper.model.resetCells([element]);
+            const elementView = element.findView(paper);
+
+            const event = {
+                target: elementView.el
+            };
+
+            // Set the event data to enable embedding validation.
+            // `whenNotAllowed` is set so the embedding validation should be called on pointerdown.
+            elementView.eventData(event, {
+                initialParentId: 'initial-parent-id',
+                whenNotAllowed: 'remove'
+            });
+
+            elementView.pointerdown(event, 0, 0);
+            elementView.pointerup(event, 0, 0);
+
+            assert.ok(validateUnembeddingSpy.calledOnce);
+            assert.equal(element.graph, undefined);
+        });
+    });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Ensure embedding logic is run on `elementView.pointerdown()` when `embeddingMode` is enabled and `whenNotAllowed` flag was explicitly set, instead of only running it when the element is moved.

Connected with #3024

## Motivation and Context

This resolves an edge case where Halo's fork/clone actions (after being only clicked) bypassed the unembedding validation logic, resulting in incorrect behaviour.