### PR TITLE
types(dia.Cell): toJson ignoreDefaults fix

### DIFF
--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -551,7 +551,7 @@ export namespace dia {
         }
 
         interface ExportOptions {
-            ignoreDefault?: boolean | string[];
+            ignoreDefaults?: boolean | string[];
             ignoreEmptyAttributes?: boolean;
         }
 


### PR DESCRIPTION
## Description

Wrong name of option of `Cell.toJSON()` in typings. It should be `ignoreDefaults`, not `ignoreDefault`, as per documentation.