### PR TITLE
fix(dia.Element): ensure getPortBBox() returns correct bbox when port has no size defined

### DIFF
--- a/packages/joint-core/src/dia/ports.mjs
+++ b/packages/joint-core/src/dia/ports.mjs
@@ -264,7 +264,7 @@ PortData.prototype = {
         evaluated.position = this._evaluatePortPositionProperty(group, evaluated);
         evaluated.label = this._evaluatePortLabelProperty(group, evaluated);
         evaluated.z = this._evaluatePortZProperty(group, evaluated);
-        evaluated.size = util.assign({}, group.size, evaluated.size);
+        evaluated.size = util.assign({ width: 0, height: 0 }, group.size, evaluated.size);
         return evaluated;
     },
 

--- a/packages/joint-core/test/jointjs/elementPorts.js
+++ b/packages/joint-core/test/jointjs/elementPorts.js
@@ -2683,6 +2683,34 @@ QUnit.module('element ports', function() {
             layoutSpy.restore();
         });
 
+        QUnit.test('returns correct bounding box when port has no size', function(assert) {
+
+            const x = 11;
+            const y = 13;
+            const width = 17;
+            const height = 19;
+
+            const shape = create({
+                groups: {
+                    'a': {
+                        position: 'bottom'
+                        // no size defined
+                    }
+                },
+                items: [
+                    { id: 'one', group: 'a' }
+                ]
+            }).position(x, y).resize(width, height);
+
+            const portBBox = shape.getPortBBox('one');
+            assert.ok(portBBox instanceof g.Rect);
+            assert.equal(portBBox.width, 0);
+            assert.equal(portBBox.height, 0);
+            // Note: Bottom port group layout rounds the coordinates.
+            assert.equal(portBBox.x, Math.round(x + width / 2));
+            assert.equal(portBBox.y, Math.round(y + height));
+        });
+
         QUnit.test('option: rotate', function(assert) {
 
             const width = 17;


### PR DESCRIPTION
## Description

If a port is defined without a size property, the `getPortBBox()` method should treat it as a zero-dimensional port (it currently returns _NaN_ values in the result).