### PR TITLE
fix(dia.Paper): wakes up paper when autofreeze: true and initializeUnmounted: true

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -719,6 +719,9 @@ export const Paper = View.extend({
         var position = opt.position;
         if (this.isAsync() || !isNumber(position)) {
             this.renderView(cell, opt);
+            // Wake up the paper in case it was idle
+            // When using initializeUnmounted: true the paper won't wake up by itself
+            this.wakeUp();
         } else {
             if (opt.maxPosition === position) this.freeze({ key: 'addCells' });
             this.renderView(cell, opt);


### PR DESCRIPTION
## Description

Fixed an issue when async paper won't wake up when `initializeUnmounted: true` and it is in idle state when a new cell was added to the graph.
