### PR TITLE
types(dia.Paper): fix elementView and linkView paper option

### DIFF
--- a/packages/joint-core/test/ts/index.test.ts
+++ b/packages/joint-core/test/ts/index.test.ts
@@ -118,10 +118,21 @@ const cylinder = new joint.shapes.standard.Cylinder({ z: 0 });
 cylinder.set({ position: { x: 4, y: 5 }});
 cylinder.set('z', (cylinder.attributes.z || 0) + 1);
 
+class CustomLinkView extends joint.dia.LinkView {
+
+}
+
 const paper = new joint.dia.Paper({
     model: graph,
     frozen: true,
-    findParentBy: (_elementView, _evt, x, y) => graph.findModelsFromPoint({ x, y })
+    findParentBy: (_elementView, _evt, x, y) => graph.findModelsFromPoint({ x, y }),
+    elementView: (element) => {
+        if (element.get('type') === 'standard.Rectangle') {
+            return CustomElementView;
+        }
+        return null;
+    },
+    linkView: CustomLinkView
 });
 
 paper.fitToContent({ padding: { top: 10  }, allowNewOrigin: false });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -1668,8 +1668,8 @@ export namespace dia {
             moveThreshold?: number;
             magnetThreshold?: number | string;
             // views
-            elementView?: typeof ElementView | ((element: Element) => typeof ElementView);
-            linkView?: typeof LinkView | ((link: Link) => typeof LinkView);
+            elementView?: typeof ElementView<any> | ((element: Element) => typeof ElementView<any> | null | undefined);
+            linkView?: typeof LinkView<any> | ((link: Link) => typeof LinkView<any> | null | undefined);
             measureNode?: MeasureNodeCallback;
             // embedding
             embeddingMode?: boolean;


### PR DESCRIPTION
## Description

1. Make the elementView (and linkView) types more general to allow passing custom views without the need for casting.

**Before:**
```ts
new dia.Paper({
 elementView: CustomElementView as typeof dia.ElementView
})
```

**After:**
```ts
new dia.Paper({
  elementView: CustomElementView
})
```

2. Allow `elementView` callback to return `null` or `undefined` (to signalize using the default view).

**Before:**
```ts
new dia.Paper({
 elementView: (element) => 
      if (element.get('type) === 'CustomElement') {
        return CustomElementView;
      }
      // otherwise use the default view (either one from namespace or `dia.ElementView`).
      return null;
   }
})
```