### PR TITLE
feat(joint-react): add missing cleanup tests

### DIFF
--- a/packages/joint-react/src/components/highlighters/__tests__/highlighter-cleanup.test.tsx
+++ b/packages/joint-react/src/components/highlighters/__tests__/highlighter-cleanup.test.tsx
@@ -1,0 +1,202 @@
+/* eslint-disable unicorn/consistent-function-scoping */
+import { render, waitFor } from '@testing-library/react';
+import { getTestGraph, paperRenderElementWrapper } from '../../../utils/test-wrappers';
+import { highlighters, type dia } from '@joint/core';
+import { Mask } from '../mask';
+import { Stroke } from '../stroke';
+import { Opacity } from '../opacity';
+
+describe('Highlighter cleanup', () => {
+  const getTestWrapper = () => {
+    const graph = getTestGraph();
+    return {
+      graph,
+      wrapper: paperRenderElementWrapper({
+        graphProviderProps: {
+          graph,
+          elements: [
+            {
+              id: 'element-1',
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+            },
+          ],
+        },
+      }),
+    };
+  };
+
+  describe('Mask highlighter', () => {
+    it('should add mask highlighter on mount', async () => {
+      const { wrapper } = getTestWrapper();
+      const addSpy = jest.spyOn(highlighters.mask, 'add');
+
+      render(<Mask />, { wrapper });
+
+      await waitFor(() => {
+        expect(addSpy).toHaveBeenCalled();
+      });
+
+      addSpy.mockRestore();
+    });
+
+    it('should remove mask highlighter on unmount', async () => {
+      const { wrapper } = getTestWrapper();
+      let highlighterInstance: dia.HighlighterView | null = null;
+
+      const originalAdd = highlighters.mask.add.bind(highlighters.mask);
+      jest.spyOn(highlighters.mask, 'add').mockImplementation((...args) => {
+        highlighterInstance = originalAdd(...(args as Parameters<typeof originalAdd>));
+        return highlighterInstance;
+      });
+
+      const { unmount } = render(<Mask />, { wrapper });
+
+      await waitFor(() => {
+        expect(highlighterInstance).not.toBeNull();
+      });
+
+      const removeSpy = jest.spyOn(highlighterInstance!, 'remove');
+
+      unmount();
+
+      await waitFor(() => {
+        expect(removeSpy).toHaveBeenCalled();
+      });
+
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('Stroke highlighter', () => {
+    it('should add stroke highlighter on mount', async () => {
+      const { wrapper } = getTestWrapper();
+      const addSpy = jest.spyOn(highlighters.stroke, 'add');
+
+      render(<Stroke />, { wrapper });
+
+      await waitFor(() => {
+        expect(addSpy).toHaveBeenCalled();
+      });
+
+      addSpy.mockRestore();
+    });
+
+    it('should remove stroke highlighter on unmount', async () => {
+      const { wrapper } = getTestWrapper();
+      let highlighterInstance: dia.HighlighterView | null = null;
+
+      const originalAdd = highlighters.stroke.add.bind(highlighters.stroke);
+      jest.spyOn(highlighters.stroke, 'add').mockImplementation((...args) => {
+        highlighterInstance = originalAdd(...(args as Parameters<typeof originalAdd>));
+        return highlighterInstance;
+      });
+
+      const { unmount } = render(<Stroke />, { wrapper });
+
+      await waitFor(() => {
+        expect(highlighterInstance).not.toBeNull();
+      });
+
+      const removeSpy = jest.spyOn(highlighterInstance!, 'remove');
+
+      unmount();
+
+      await waitFor(() => {
+        expect(removeSpy).toHaveBeenCalled();
+      });
+
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('Opacity highlighter', () => {
+    it('should add opacity highlighter on mount', async () => {
+      const { wrapper } = getTestWrapper();
+      const addSpy = jest.spyOn(highlighters.opacity, 'add');
+
+      render(<Opacity alphaValue={0.5} />, { wrapper });
+
+      await waitFor(() => {
+        expect(addSpy).toHaveBeenCalled();
+      });
+
+      addSpy.mockRestore();
+    });
+
+    it('should remove opacity highlighter on unmount', async () => {
+      const { wrapper } = getTestWrapper();
+      let highlighterInstance: dia.HighlighterView | null = null;
+
+      const originalAdd = highlighters.opacity.add.bind(highlighters.opacity);
+      jest.spyOn(highlighters.opacity, 'add').mockImplementation((...args) => {
+        highlighterInstance = originalAdd(...(args as Parameters<typeof originalAdd>));
+        return highlighterInstance;
+      });
+
+      const { unmount } = render(<Opacity alphaValue={0.5} />, { wrapper });
+
+      await waitFor(() => {
+        expect(highlighterInstance).not.toBeNull();
+      });
+
+      const removeSpy = jest.spyOn(highlighterInstance!, 'remove');
+
+      unmount();
+
+      await waitFor(() => {
+        expect(removeSpy).toHaveBeenCalled();
+      });
+
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('Highlighter with isHidden', () => {
+    it('should not add highlighter when isHidden is true', async () => {
+      const { wrapper } = getTestWrapper();
+      const addSpy = jest.spyOn(highlighters.mask, 'add');
+
+      render(<Mask isHidden={true} />, { wrapper });
+
+      // Wait a bit to ensure it would have been called if it was going to be
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+
+      expect(addSpy).not.toHaveBeenCalled();
+
+      addSpy.mockRestore();
+    });
+
+    it('should remove highlighter when isHidden changes to true', async () => {
+      const { wrapper } = getTestWrapper();
+      let highlighterInstance: dia.HighlighterView | null = null;
+
+      const originalAdd = highlighters.mask.add.bind(highlighters.mask);
+      jest.spyOn(highlighters.mask, 'add').mockImplementation((...args) => {
+        highlighterInstance = originalAdd(...(args as Parameters<typeof originalAdd>));
+        return highlighterInstance;
+      });
+
+      const { rerender } = render(<Mask isHidden={false} />, { wrapper });
+
+      await waitFor(() => {
+        expect(highlighterInstance).not.toBeNull();
+      });
+
+      const removeSpy = jest.spyOn(highlighterInstance!, 'remove');
+
+      // Hide the highlighter
+      rerender(<Mask isHidden={true} />);
+
+      await waitFor(() => {
+        expect(removeSpy).toHaveBeenCalled();
+      });
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/packages/joint-react/src/components/port/__tests__/port-group.test.tsx
+++ b/packages/joint-react/src/components/port/__tests__/port-group.test.tsx
@@ -1,10 +1,145 @@
-import { runStorybookSnapshot } from '../../../utils/run-storybook-snapshot';
+/* eslint-disable unicorn/consistent-function-scoping */
+import { render, waitFor } from '@testing-library/react';
+import { getTestGraph, paperRenderElementWrapper } from '../../../utils/test-wrappers';
 import { PortGroup } from '../port-group';
+import { runStorybookSnapshot } from '../../../utils/run-storybook-snapshot';
 import * as stories from '../port-group.stories';
 
+// Keep the storybook snapshot tests
 runStorybookSnapshot({
   Component: PortGroup,
   stories,
   name: 'Port/Item',
   withRenderElementWrapper: true,
+});
+
+describe('PortGroup cleanup', () => {
+  const getTestWrapper = () => {
+    const graph = getTestGraph();
+    return {
+      graph,
+      wrapper: paperRenderElementWrapper({
+        graphProviderProps: {
+          graph,
+          elements: [
+            {
+              id: 'element-1',
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+            },
+          ],
+        },
+      }),
+    };
+  };
+
+  it('should add port group on mount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    render(<PortGroup id="test-group" position="absolute" />, { wrapper });
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['test-group']).toBeDefined();
+    });
+  });
+
+  it('should remove port group on unmount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    const { unmount } = render(<PortGroup id="test-group" position="absolute" />, { wrapper });
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['test-group']).toBeDefined();
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['test-group']).toBeUndefined();
+    });
+  });
+
+  it('should remove multiple port groups on unmount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    const { unmount } = render(
+      <>
+        <PortGroup id="group-1" position="absolute" />
+        <PortGroup id="group-2" position="absolute" />
+      </>,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['group-1']).toBeDefined();
+      expect(groups['group-2']).toBeDefined();
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['group-1']).toBeUndefined();
+      expect(groups['group-2']).toBeUndefined();
+    });
+  });
+
+  it('should only remove unmounted group, keeping others', async () => {
+    const { graph, wrapper } = getTestWrapper();
+
+    const TestComponent = ({ showSecondGroup }: { showSecondGroup: boolean }) => (
+      <>
+        <PortGroup id="group-1" position="absolute" />
+        {showSecondGroup && <PortGroup id="group-2" position="absolute" />}
+      </>
+    );
+
+    const { rerender } = render(<TestComponent showSecondGroup={true} />, { wrapper });
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['group-1']).toBeDefined();
+      expect(groups['group-2']).toBeDefined();
+    });
+
+    // Remove only the second group
+    rerender(<TestComponent showSecondGroup={false} />);
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      const groups = element.prop('ports/groups') ?? {};
+      expect(groups['group-1']).toBeDefined();
+      expect(groups['group-2']).toBeUndefined();
+    });
+  });
 });

--- a/packages/joint-react/src/components/port/__tests__/port-item.test.tsx
+++ b/packages/joint-react/src/components/port/__tests__/port-item.test.tsx
@@ -1,10 +1,152 @@
-import { runStorybookSnapshot } from '../../../utils/run-storybook-snapshot';
+/* eslint-disable unicorn/consistent-function-scoping */
+import { render, waitFor } from '@testing-library/react';
+import { getTestGraph, paperRenderElementWrapper } from '../../../utils/test-wrappers';
 import { PortItem } from '../port-item';
+import { PortGroup } from '../port-group';
+import { runStorybookSnapshot } from '../../../utils/run-storybook-snapshot';
 import * as stories from '../port-item.stories';
 
+// Keep the storybook snapshot tests
 runStorybookSnapshot({
   Component: PortItem,
   stories,
   name: 'Port/Item',
   withRenderElementWrapper: true,
+});
+
+describe('PortItem cleanup', () => {
+  const getTestWrapper = () => {
+    const graph = getTestGraph();
+    return {
+      graph,
+      wrapper: paperRenderElementWrapper({
+        graphProviderProps: {
+          graph,
+          elements: [
+            {
+              id: 'element-1',
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+            },
+          ],
+        },
+      }),
+    };
+  };
+
+  it('should add port on mount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    render(
+      <PortGroup id="test-group" position="absolute">
+        <PortItem id="test-port" />
+      </PortGroup>,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('test-port')).toBe(true);
+    });
+  });
+
+  it('should remove port on unmount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    const { unmount } = render(
+      <PortGroup id="test-group" position="absolute">
+        <PortItem id="test-port" />
+      </PortGroup>,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('test-port')).toBe(true);
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('test-port')).toBe(false);
+    });
+  });
+
+  it('should remove multiple ports on unmount', async () => {
+    const { graph, wrapper } = getTestWrapper();
+    const { unmount } = render(
+      <PortGroup id="test-group" position="absolute">
+        <PortItem id="port-1" />
+        <PortItem id="port-2" />
+        <PortItem id="port-3" />
+      </PortGroup>,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('port-1')).toBe(true);
+      expect(element.hasPort('port-2')).toBe(true);
+      expect(element.hasPort('port-3')).toBe(true);
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('port-1')).toBe(false);
+      expect(element.hasPort('port-2')).toBe(false);
+      expect(element.hasPort('port-3')).toBe(false);
+    });
+  });
+
+  it('should only remove unmounted port, keeping others', async () => {
+    const { graph, wrapper } = getTestWrapper();
+
+    const TestComponent = ({ showSecondPort }: { showSecondPort: boolean }) => (
+      <PortGroup id="test-group" position="absolute">
+        <PortItem id="port-1" />
+        {showSecondPort && <PortItem id="port-2" />}
+      </PortGroup>
+    );
+
+    const { rerender } = render(<TestComponent showSecondPort={true} />, { wrapper });
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('port-1')).toBe(true);
+      expect(element.hasPort('port-2')).toBe(true);
+    });
+
+    // Remove only the second port
+    rerender(<TestComponent showSecondPort={false} />);
+
+    await waitFor(() => {
+      const element = graph.getCell('element-1');
+      if (!element?.isElement()) {
+        throw new Error('Element not found');
+      }
+      expect(element.hasPort('port-1')).toBe(true);
+      expect(element.hasPort('port-2')).toBe(false);
+    });
+  });
 });

--- a/packages/joint-react/src/components/port/index.ts
+++ b/packages/joint-react/src/components/port/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-
 export * from './port.types';
 import { PortGroup } from './port-group';
 import { PortItem } from './port-item';

--- a/packages/joint-react/src/store/__tests__/paper-store.test.ts
+++ b/packages/joint-react/src/store/__tests__/paper-store.test.ts
@@ -1,0 +1,257 @@
+import { dia } from '@joint/core';
+import { PaperStore } from '../paper-store';
+import { GraphStore } from '../graph-store';
+
+describe('PaperStore', () => {
+  describe('constructor', () => {
+    it('should create a PaperStore with paper instance', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      expect(paperStore).toBeDefined();
+      expect(paperStore.paper).toBeInstanceOf(dia.Paper);
+      expect(paperStore.paperId).toBe('test-paper');
+    });
+
+    it('should set up paper with correct options', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {
+          width: 800,
+          height: 600,
+        },
+        id: 'test-paper',
+      });
+
+      expect(paperStore.paper.options.width).toBe(800);
+      expect(paperStore.paper.options.height).toBe(600);
+    });
+
+    it('should apply scale when provided', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+        scale: 2,
+      });
+
+      const currentScale = paperStore.paper.scale();
+      expect(currentScale.sx).toBe(2);
+      expect(currentScale.sy).toBe(2);
+    });
+  });
+
+  describe('destroy', () => {
+    it('should call paper.remove() when destroy is called', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      const removeSpy = jest.spyOn(paperStore.paper, 'remove');
+
+      paperStore.destroy();
+
+      expect(removeSpy).toHaveBeenCalled();
+    });
+
+    it('should be safe to call destroy multiple times', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      // First destroy should work
+      expect(() => paperStore.destroy()).not.toThrow();
+
+      // Second destroy should also not throw (unregisterPaperUpdate is undefined now)
+      expect(() => paperStore.destroy()).not.toThrow();
+    });
+
+    it('should unregister paper update callback on destroy', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      // Verify paper exists before destroy
+      expect(paperStore.paper).toBeDefined();
+
+      paperStore.destroy();
+
+      // The unregisterPaperUpdate is set to undefined after calling
+      // We verify this by ensuring multiple destroy calls don't throw
+      expect(() => paperStore.destroy()).not.toThrow();
+    });
+
+    it('should clean up paper DOM element', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+      document.body.append(paperElement);
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      // Verify paper element has children (the paper's SVG)
+      expect(paperElement.children.length).toBeGreaterThan(0);
+
+      paperStore.destroy();
+
+      // After destroy, paper.remove() should have been called
+      // Note: The parent element may still have children depending on how remove() works
+      // but the paper itself is cleaned up
+      expect(paperStore.paper.el.parentNode).toBeNull();
+
+      paperElement.remove();
+    });
+  });
+
+  describe('getPortId', () => {
+    it('should generate unique port ID from cell and port IDs', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      const portId = paperStore.getPortId('cell-1', 'port-a');
+      expect(portId).toBe('cell-1-port-a');
+    });
+  });
+
+  describe('getLinkLabelId', () => {
+    it('should generate unique link label ID from link ID and index', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const paperStore = new PaperStore({
+        graphStore,
+        paperElement,
+        paperOptions: {},
+        id: 'test-paper',
+      });
+
+      const labelId = paperStore.getLinkLabelId('link-1', 0);
+      expect(labelId).toBe('link-1-label-0');
+
+      const labelId2 = paperStore.getLinkLabelId('link-1', 2);
+      expect(labelId2).toBe('link-1-label-2');
+    });
+  });
+
+  describe('integration with GraphStore', () => {
+    it('should call paper.remove() when GraphStore removePaper is called', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      const cleanup = graphStore.addPaper('test-paper', {
+        paperElement,
+        paperOptions: {},
+      });
+
+      const paperStore = graphStore.getPaperStore('test-paper');
+      expect(paperStore).toBeDefined();
+
+      const removeSpy = jest.spyOn(paperStore!.paper, 'remove');
+
+      cleanup();
+
+      expect(removeSpy).toHaveBeenCalled();
+      expect(graphStore.getPaperStore('test-paper')).toBeUndefined();
+    });
+
+    it('should call paper.remove() for all papers when GraphStore is destroyed', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement1 = document.createElement('div');
+      const paperElement2 = document.createElement('div');
+
+      graphStore.addPaper('paper-1', {
+        paperElement: paperElement1,
+        paperOptions: {},
+      });
+      graphStore.addPaper('paper-2', {
+        paperElement: paperElement2,
+        paperOptions: {},
+      });
+
+      const paperStore1 = graphStore.getPaperStore('paper-1');
+      const paperStore2 = graphStore.getPaperStore('paper-2');
+
+      const removeSpy1 = jest.spyOn(paperStore1!.paper, 'remove');
+      const removeSpy2 = jest.spyOn(paperStore2!.paper, 'remove');
+
+      graphStore.destroy(false);
+
+      expect(removeSpy1).toHaveBeenCalled();
+      expect(removeSpy2).toHaveBeenCalled();
+    });
+
+    it('should call paper.remove() when GraphStore is destroyed with external graph', () => {
+      const graph = new dia.Graph();
+      const graphStore = new GraphStore({ graph });
+      const paperElement = document.createElement('div');
+
+      graphStore.addPaper('test-paper', {
+        paperElement,
+        paperOptions: {},
+      });
+
+      const paperStore = graphStore.getPaperStore('test-paper');
+      const removeSpy = jest.spyOn(paperStore!.paper, 'remove');
+
+      // Even with external graph (true), papers should be destroyed
+      graphStore.destroy(true);
+
+      expect(removeSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -704,6 +704,12 @@ export class GraphStore {
    * @param isGraphExternal - Whether the graph instance was provided externally (should not be cleared)
    */
   public destroy = (isGraphExternal: boolean) => {
+    // Destroy all paper instances first
+    for (const paperStore of this.papers.values()) {
+      paperStore.destroy();
+    }
+    this.papers.clear();
+
     this.internalState.clean();
     this.derivedStore.clean();
     this.layoutState.clean();
@@ -797,11 +803,9 @@ export class GraphStore {
 
   private removePaper = (id: string) => {
     const paperStore = this.papers.get(id);
-    // Cleanup paper update callback if it exists
-    if (paperStore && 'unregisterPaperUpdate' in paperStore) {
-      const unregister = (paperStore as unknown as { unregisterPaperUpdate?: () => void })
-        .unregisterPaperUpdate;
-      unregister?.();
+    // Cleanup paper instance and all its resources
+    if (paperStore) {
+      paperStore.destroy();
     }
     this.papers.delete(id);
     this.internalState.setState((previous) => {

--- a/packages/joint-react/src/store/paper-store.ts
+++ b/packages/joint-react/src/store/paper-store.ts
@@ -324,4 +324,20 @@ export class PaperStore {
   public getLinkLabelId(linkId: dia.Cell.ID, labelIndex: number) {
     return `${linkId}-label-${labelIndex}`;
   }
+
+  /**
+   * Cleans up the paper instance and all associated resources.
+   * Should be called when the paper is being removed from the graph store.
+   */
+  public destroy = () => {
+    // Unregister from GraphStore's update scheduler
+    this.unregisterPaperUpdate?.();
+    this.unregisterPaperUpdate = undefined;
+
+    // Remove the JointJS paper instance - this cleans up:
+    // - All event listeners on the paper
+    // - All cell views
+    // - The paper's DOM element
+    this.paper.remove();
+  };
 }


### PR DESCRIPTION
                                                                                                                                                           
  ---                                                                                                                                                       
  Description                                                                                                                                               
                                                                                                                                                            
  This PR fixes a memory leak in the joint-react package where paper.remove() was never called during cleanup. The changes include:                         
                                                                                                                                                            
  Implementation fixes:                                                                                                                                     
  - Added destroy() method to PaperStore that calls paper.remove() to properly dispose JointJS Paper instances                                              
  - Updated GraphStore.removePaper() to call paperStore.destroy() before removing from the Map                                                              
  - Updated GraphStore.destroy() to iterate all papers and destroy them before clearing other state                                                         
                                                                                                                                                            
  New tests:                                                                                                                                                
  - Added comprehensive paper-store.test.ts with 12 tests covering constructor, destroy, and integration with GraphStore                                    
  - Added highlighter-cleanup.test.tsx with 8 tests verifying Mask, Stroke, and Opacity highlighters call remove() on unmount                               
  - Updated port-item.test.tsx with 4 tests verifying ports are removed on unmount                                                                          
  - Updated port-group.test.tsx with 4 tests verifying port groups are removed on unmount                                                                   
                                                                                                                                                            
  Cleanup chain after fix:                                                                                                                                  
  Component Unmount → addPaper cleanup → removePaper(id) → paperStore.destroy()                                                                             
                                                                ├─ unregisterPaperUpdate()                                                                  
                                                                └─ paper.remove() ← NEW                                                                     
  GraphStore.destroy() → For each paper: paperStore.destroy() ← NEW                                                                                         
                       → papers.clear() ← NEW                                                                                                               
                       → ... other cleanup                                                                                                                  
                                                                                                                                                            
  Motivation and Context                                                                                                                                    
                                                                                                                                                            
  The PaperStore class creates a JointJS dia.Paper instance but never called paper.remove() to clean it up. This caused:                                    
  - Memory leaks from orphaned DOM elements                                                                                                                 
  - Orphaned event listeners on the paper                                                                                                                   
  - Cell views not being properly disposed                                                                                                                  
                                                                                                                                                            
  The fix ensures all JointJS resources are properly cleaned up when React components unmount or when the GraphStore is destroyed.                          
                                                                                                                                                            
  Verification checklist:                                                                                                                                   
                                                                                                                                                            
  - Code is up-to-date with the master branch                                                                                                               
  - You've successfully run grunt test locally (377 tests pass)                                                                                             
  - New unit tests validating the cleanup behavior for Paper, Ports, Port Groups, and Highlighters    