### PR TITLE
fix(joint-react): fix type errors in defaultLinkJointJS

### DIFF
--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable @typescript-eslint/no-shadow */
-import { dia } from '@joint/core';
+import { dia, util } from '@joint/core';
 import type { LinkRecord } from '../types/data-types';
 import {
   useCallback,
@@ -188,7 +188,9 @@ export function useCreatePortalPaper(
       const link = isDefaultLinkFactory ? defaultLink(cellView, magnet) : defaultLink;
       const PortalLinkModel = getPortalLinkConstructor(graph);
       if (!link) {
+        const id = util.uuid();
         const defaultAttributes = gv.mapLinkToAttributes({
+          id,
           link: { data: {} },
         });
         return new PortalLinkModel(defaultAttributes);
@@ -199,7 +201,9 @@ export function useCreatePortalPaper(
         }
         return link.clone();
       }
+      const id = util.uuid();
       const attributes = gv.mapLinkToAttributes({
+        id,
         link: { data: {}, ...link } as LinkRecord,
       });
       return new PortalLinkModel(attributes);


### PR DESCRIPTION
## Summary
- `gv.mapLinkToAttributes()` expects `{ id, link }` but was called without `id` in two branches of the `defaultLinkJointJS` callback, causing TypeScript errors.
- Generate `id` via `util.uuid()` for both the no-link fallback and the `LinkRecord` branch.
- Resolves the 2 pre-existing `TS2345` errors in `use-create-portal-paper.tsx`.

## Test plan
- [x] `yarn typecheck` — zero errors (was 2 before)
- [ ] Storybook: interactive link creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)