### PR TITLE
feat(joint-core): add directional modes to midSide anchor

### DIFF
--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -74,16 +74,16 @@ function getMiddleSide(rect, point, opt, endType) {
         }
 
         case SideMode.TOP_BOTTOM:
-            return endType === 'source' ? Side.BOTTOM : Side.TOP;
-
-        case SideMode.BOTTOM_TOP:
             return endType === 'source' ? Side.TOP : Side.BOTTOM;
 
+        case SideMode.BOTTOM_TOP:
+            return endType === 'source' ? Side.BOTTOM : Side.TOP;
+
         case SideMode.LEFT_RIGHT:
-            return endType === 'source' ? Side.RIGHT : Side.LEFT;
+            return endType === 'source' ? Side.LEFT : Side.RIGHT;
 
         case SideMode.RIGHT_LEFT:
-            return endType === 'source' ? Side.LEFT : Side.RIGHT;
+            return endType === 'source' ? Side.RIGHT : Side.LEFT;
 
         case SideMode.AUTO:
         default: {

--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -15,6 +15,10 @@ const SideMode = {
     HORIZONTAL: 'horizontal',
     VERTICAL: 'vertical',
     AUTO: 'auto',
+    TOP_BOTTOM: 'top-bottom',
+    BOTTOM_TOP: 'bottom-top',
+    LEFT_RIGHT: 'left-right',
+    RIGHT_LEFT: 'right-left',
 };
 
 function getModelBBoxFromConnectedLink(element, link, endType, rotate) {
@@ -27,7 +31,7 @@ function getModelBBoxFromConnectedLink(element, link, endType, rotate) {
     return element.getBBox({ rotate });
 }
 
-function getMiddleSide(rect, point, opt) {
+function getMiddleSide(rect, point, opt, endType) {
 
     const { preferenceThreshold = 0, mode } = opt;
     const { x, y } = point;
@@ -68,6 +72,18 @@ function getMiddleSide(rect, point, opt) {
             const cx = left + width / 2;
             return (x < cx) ? Side.LEFT : Side.RIGHT;
         }
+
+        case SideMode.TOP_BOTTOM:
+            return endType === 'source' ? Side.BOTTOM : Side.TOP;
+
+        case SideMode.BOTTOM_TOP:
+            return endType === 'source' ? Side.TOP : Side.BOTTOM;
+
+        case SideMode.LEFT_RIGHT:
+            return endType === 'source' ? Side.RIGHT : Side.LEFT;
+
+        case SideMode.RIGHT_LEFT:
+            return endType === 'source' ? Side.LEFT : Side.RIGHT;
 
         case SideMode.AUTO:
         default: {
@@ -188,7 +204,7 @@ function _midSide(view, magnet, refPoint, opt, endType, linkView) {
 
     if (rotate) refPoint.rotate(center, angle);
 
-    var side = getMiddleSide(bbox, refPoint, opt);
+    var side = getMiddleSide(bbox, refPoint, opt, endType);
     var anchor;
     switch (side) {
         case Side.LEFT:

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -4298,7 +4298,7 @@ export namespace anchors {
     }
 
     interface MidSideAnchorArguments extends RotateAnchorArguments, PaddingAnchorArguments {
-        mode?: 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 'vertical' | 'auto';
+        mode?: 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 'vertical' | 'auto' | 'top-bottom' | 'bottom-top' | 'left-right' | 'right-left';
         preferenceThreshold?: dia.Sides;
     }
 


### PR DESCRIPTION
## Summary

Adds four directional modes to the `midSide` anchor: `'top-bottom'`, `'bottom-top'`, `'left-right'`, `'right-left'`.

These modes set the anchor side based on `endType` (source vs target). The mode name describes where the anchors are placed:
- `'top-bottom'` — source anchor at top, target anchor at bottom
- `'bottom-top'` — source anchor at bottom, target anchor at top
- `'left-right'` — source anchor at left, target anchor at right
- `'right-left'` — source anchor at right, target anchor at left

Useful for directed layouts (e.g. flowcharts, org charts) where links should flow in a consistent direction.

### Changes
- `packages/joint-core/src/anchors/index.mjs` — add modes to `SideMode`, pass `endType` to `getMiddleSide()`, handle new modes in switch
- `packages/joint-core/types/joint.d.ts` — add new modes to `MidSideAnchorArguments.mode` type

## Test plan
- [ ] Existing `midSide` modes (`auto`, `horizontal`, `vertical`, etc.) unchanged
- [ ] New modes correctly pick source/target sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)