### PR TITLE
refactor(joint-core): remove this-context dependency from link anchors

### DIFF
--- a/packages/joint-core/src/anchors/index.mjs
+++ b/packages/joint-core/src/anchors/index.mjs
@@ -210,8 +210,8 @@ function _midSide(view, magnet, refPoint, opt, endType, linkView) {
 
 // Can find anchor from model, when there is no selector or the link end
 // is connected to a port
-function _modelCenter(view, _magnet, _refPoint, opt, endType) {
-    return view.model.getPointFromConnectedLink(this.model, endType).offset(opt.dx, opt.dy);
+function _modelCenter(view, _magnet, _refPoint, opt, endType, linkView) {
+    return view.model.getPointFromConnectedLink(linkView.model, endType).offset(opt.dx, opt.dy);
 }
 
 //joint.anchors

--- a/packages/joint-core/src/connectors/jumpover.mjs
+++ b/packages/joint-core/src/connectors/jumpover.mjs
@@ -337,9 +337,9 @@ function buildRoundedSegment(offset, path, curr, prev, next) {
  * @property {number} size optional size of a jump arc
  * @return {string} created `D` attribute of SVG path
  */
-export const jumpover = function(sourcePoint, targetPoint, route, opt) {
+export const jumpover = function(sourcePoint, targetPoint, route, opt, linkView) {
 
-    setupUpdating(this);
+    setupUpdating(linkView);
 
     var raw = opt.raw;
     var jumpSize = opt.size || JUMP_SIZE;
@@ -352,7 +352,7 @@ export const jumpover = function(sourcePoint, targetPoint, route, opt) {
         jumpType = JUMP_TYPES[0];
     }
 
-    var paper = this.paper;
+    var paper = linkView.paper;
     var graph = paper.model;
     var allLinks = graph.getLinks();
 
@@ -364,7 +364,7 @@ export const jumpover = function(sourcePoint, targetPoint, route, opt) {
         );
     }
 
-    var thisModel = this.model;
+    var thisModel = linkView.model;
     var thisIndex = allLinks.indexOf(thisModel);
     var defaultConnector = paper.options.defaultConnector || {};
 

--- a/packages/joint-core/src/linkAnchors/index.mjs
+++ b/packages/joint-core/src/linkAnchors/index.mjs
@@ -42,7 +42,7 @@ function _connectionClosest(view, _magnet, refPoint, _opt) {
 export function resolveRef(fn) {
     return function(view, magnet, ref, opt, endType, linkView) {
         if (ref instanceof Element) {
-            var refView = this.paper.findView(ref);
+            var refView = linkView.paper.findView(ref);
             var refPoint;
             if (refView) {
                 if (refView.isNodeConnection(ref)) {
@@ -55,9 +55,9 @@ export function resolveRef(fn) {
                 // Something went wrong
                 refPoint = new Point();
             }
-            return fn.call(this, view, magnet, refPoint, opt, endType, linkView);
+            return fn.call(linkView, view, magnet, refPoint, opt, endType, linkView);
         }
-        return fn.apply(this, arguments);
+        return fn.apply(linkView, arguments);
     };
 }
 


### PR DESCRIPTION
## Summary
- Replace `this` references with the `linkView` parameter in `resolveRef()` wrapper for link anchor functions
- Link anchors (`connectionPerpendicular`, `connectionClosest`) can now be called directly as `anchor(view, magnet, ref, opt, endType, linkView)` without needing `.call(linkView, ...)`

## Test plan
- [ ] Verify link anchors work correctly when links connect to other links
- [ ] Verify `connectionPerpendicular` and `connectionClosest` produce same results as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)