### PR TITLE
feat(joint-core): Graph cell namespace and type constructor API

### DIFF
--- a/packages/joint-core/src/dia/CellCollection.mjs
+++ b/packages/joint-core/src/dia/CellCollection.mjs
@@ -12,6 +12,11 @@ export class CellCollection extends Collection {
 
     [CELL_COLLECTION_MARKER] = true;
 
+    /** @deprecated Use graph.getCellNamespace() instead. */
+    get cellNamespace() {
+        return this.layer?.collection?.cellNamespace ?? null;
+    }
+
     initialize(_models, opt) {
         this.layer = opt.layer;
     }

--- a/packages/joint-core/src/dia/CellCollection.mjs
+++ b/packages/joint-core/src/dia/CellCollection.mjs
@@ -26,16 +26,8 @@ export class CellCollection extends Collection {
     // based on their `type` attribute and the `cellNamespace` option.
     model(attrs, opt) {
 
-        const namespace = this.cellNamespace;
-
-        if (!namespace) {
-            throw new Error('dia.CellCollection: cellNamespace is required to instantiate a Cell from JSON.');
-        }
-
         const { type } = attrs;
-
-        // Find the model class based on the `type` attribute in the cell namespace
-        const ModelClass = util.getByPath(namespace, type, '.');
+        const ModelClass = this.layer.collection.getTypeConstructor(type);
         if (!ModelClass) {
             throw new Error(`dia.Graph: Could not find cell constructor for type: '${type}'. Make sure to add the constructor to 'cellNamespace'.`);
         }

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -747,14 +747,37 @@ export const Graph = Model.extend({
         return this.layerCollection.toArray();
     },
 
+    /**
+     * @public
+     * @description Returns the cell namespace used to resolve cell types.
+     */
     getCellNamespace() {
         return this.layerCollection.cellNamespace;
     },
 
+    /**
+     * @public
+     * @description Sets the cell namespace for the graph.
+     * Invalidates the type defaults cache.
+     */
+    setCellNamespace(namespace) {
+        this.layerCollection.cellNamespace = namespace;
+        this._typeDefaultsCache = {};
+    },
+
+    /**
+     * @public
+     * @description Returns the constructor for a given cell type string, or null.
+     */
     getTypeConstructor(type) {
         return this.layerCollection.getTypeConstructor(type);
     },
 
+    /**
+     * @public
+     * @description Returns frozen default attributes for a cell type.
+     * Results are cached per graph instance.
+     */
     getTypeDefaults(type) {
         if (!this._typeDefaultsCache) {
             this._typeDefaultsCache = {};

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -747,15 +747,25 @@ export const Graph = Model.extend({
         return this.layerCollection.toArray();
     },
 
+    getCellNamespace() {
+        return this.layerCollection.cellNamespace;
+    },
+
+    getTypeConstructor(type) {
+        if (!type) return null;
+        const Ctor = util.getByPath(this.getCellNamespace(), type, '.');
+        if (!Ctor || !Ctor.prototype) return null;
+        return Ctor;
+    },
+
     getTypeDefaults(type) {
-        if (!type) return {};
         if (!this._typeDefaultsCache) {
             this._typeDefaultsCache = {};
         }
         const cached = this._typeDefaultsCache[type];
         if (cached) return cached;
-        const Ctor = util.getByPath(this.layerCollection.cellNamespace, type, '.');
-        if (!Ctor || !Ctor.prototype) return {};
+        const Ctor = this.getTypeConstructor(type);
+        if (!Ctor) return {};
         const defaults = util.result(Ctor.prototype, 'defaults', {});
         Object.freeze(defaults);
         this._typeDefaultsCache[type] = defaults;

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -747,6 +747,21 @@ export const Graph = Model.extend({
         return this.layerCollection.toArray();
     },
 
+    getTypeDefaults(type) {
+        if (!type) return {};
+        if (!this._typeDefaultsCache) {
+            this._typeDefaultsCache = {};
+        }
+        const cached = this._typeDefaultsCache[type];
+        if (cached) return cached;
+        const Ctor = util.getByPath(this.layerCollection.cellNamespace, type, '.');
+        if (!Ctor || !Ctor.prototype) return {};
+        const defaults = util.result(Ctor.prototype, 'defaults', {});
+        Object.freeze(defaults);
+        this._typeDefaultsCache[type] = defaults;
+        return defaults;
+    },
+
     getCell: function(cellRef) {
         return this.layerCollection.getCell(cellRef);
     },

--- a/packages/joint-core/src/dia/Graph.mjs
+++ b/packages/joint-core/src/dia/Graph.mjs
@@ -752,10 +752,7 @@ export const Graph = Model.extend({
     },
 
     getTypeConstructor(type) {
-        if (!type) return null;
-        const Ctor = util.getByPath(this.getCellNamespace(), type, '.');
-        if (!Ctor || !Ctor.prototype) return null;
-        return Ctor;
+        return this.layerCollection.getTypeConstructor(type);
     },
 
     getTypeDefaults(type) {

--- a/packages/joint-core/src/dia/GraphLayerCollection.mjs
+++ b/packages/joint-core/src/dia/GraphLayerCollection.mjs
@@ -58,21 +58,13 @@ export const GraphLayerCollection = Collection.extend({
     // Override to set graph reference
     _addReference(layer, options) {
         Collection.prototype._addReference.call(this, layer, options);
-
-        // assign graph and cellNamespace references
-        // to the added layer
         layer.graph = this.graph;
-        layer.cellCollection.cellNamespace = this.cellNamespace;
     },
 
     // Override to remove graph reference
     _removeReference(layer, options) {
         Collection.prototype._removeReference.call(this, layer, options);
-
-        // remove graph and cellNamespace references
-        // from the removed layer
         layer.graph = null;
-        layer.cellCollection.cellNamespace = null;
     },
 
     /**

--- a/packages/joint-core/src/dia/GraphLayerCollection.mjs
+++ b/packages/joint-core/src/dia/GraphLayerCollection.mjs
@@ -209,8 +209,12 @@ export const GraphLayerCollection = Collection.extend({
      * @description Returns the constructor for a given cell type string, or null.
      */
     getTypeConstructor(type) {
+        const { cellNamespace } = this;
+        if (!cellNamespace) {
+            throw new Error('dia.Graph: cellNamespace is required to instantiate a Cell from JSON.');
+        }
         if (!type) return null;
-        const Ctor = util.getByPath(this.cellNamespace, type, '.');
+        const Ctor = util.getByPath(cellNamespace, type, '.');
         if (!Ctor || !Ctor.prototype) return null;
         return Ctor;
     },

--- a/packages/joint-core/src/dia/GraphLayerCollection.mjs
+++ b/packages/joint-core/src/dia/GraphLayerCollection.mjs
@@ -206,6 +206,17 @@ export const GraphLayerCollection = Collection.extend({
 
     /**
      * @public
+     * @description Returns the constructor for a given cell type string, or null.
+     */
+    getTypeConstructor(type) {
+        if (!type) return null;
+        const Ctor = util.getByPath(this.cellNamespace, type, '.');
+        if (!Ctor || !Ctor.prototype) return null;
+        return Ctor;
+    },
+
+    /**
+     * @public
      * @description Finds and returns a cell by its id from all layers.
      */
     getCell(cellRef) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -392,10 +392,9 @@ export const Paper = View.extend({
         // }
         defaultLink: function() {
             // Do not create hard dependency on the joint.shapes.standard namespace (by importing the standard.Link model directly)
-            const { cellNamespace } = this.model.layerCollection;
-            const ctor = getByPath(cellNamespace, ['standard', 'Link']);
-            if (!ctor) throw new Error('dia.Paper: no default link model found. Use `options.defaultLink` to specify a default link model.');
-            return new ctor();
+            const Ctor = this.model.getTypeConstructor('standard.Link');
+            if (!Ctor) throw new Error('dia.Paper: no default link model found. Use `options.defaultLink` to specify a default link model.');
+            return new Ctor();
         },
 
         // A connector that is used by links with no connector defined on the model.

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -4572,7 +4572,8 @@ QUnit.module('graph', function(hooks) {
         });
 
         QUnit.test('should throw when cellNamespace is not set', function(assert) {
-            var graph = new joint.dia.Graph({}, { cellNamespace: null });
+            var graph = this.graph;
+            graph.setCellNamespace(null);
             assert.throws(function() {
                 graph.getTypeConstructor('standard.Rectangle');
             }, /cellNamespace is required/);

--- a/packages/joint-core/test/jointjs/graph.js
+++ b/packages/joint-core/test/jointjs/graph.js
@@ -4522,4 +4522,83 @@ QUnit.module('graph', function(hooks) {
         });
     });
 
+    QUnit.module('getCellNamespace()', function() {
+
+        QUnit.test('should return the cell namespace', function(assert) {
+            var graph = this.graph;
+            assert.equal(graph.getCellNamespace(), joint.shapes);
+        });
+    });
+
+    QUnit.module('setCellNamespace()', function() {
+
+        QUnit.test('should set the cell namespace', function(assert) {
+            var graph = this.graph;
+            var customNamespace = { custom: { MyShape: joint.shapes.standard.Rectangle }};
+            graph.setCellNamespace(customNamespace);
+            assert.equal(graph.getCellNamespace(), customNamespace);
+        });
+
+        QUnit.test('should invalidate the type defaults cache', function(assert) {
+            var graph = this.graph;
+            var defaults1 = graph.getTypeDefaults('standard.Rectangle');
+            assert.ok(defaults1.type === 'standard.Rectangle');
+            // Change namespace to one without standard.Rectangle
+            graph.setCellNamespace({});
+            var defaults2 = graph.getTypeDefaults('standard.Rectangle');
+            assert.deepEqual(defaults2, {});
+        });
+    });
+
+    QUnit.module('getTypeConstructor()', function() {
+
+        QUnit.test('should return the constructor for a valid type', function(assert) {
+            var graph = this.graph;
+            var Ctor = graph.getTypeConstructor('standard.Rectangle');
+            assert.equal(Ctor, joint.shapes.standard.Rectangle);
+        });
+
+        QUnit.test('should return null for an unknown type', function(assert) {
+            var graph = this.graph;
+            var Ctor = graph.getTypeConstructor('nonexistent.Shape');
+            assert.equal(Ctor, null);
+        });
+
+        QUnit.test('should return null for empty type', function(assert) {
+            var graph = this.graph;
+            assert.equal(graph.getTypeConstructor(''), null);
+            assert.equal(graph.getTypeConstructor(null), null);
+            assert.equal(graph.getTypeConstructor(undefined), null);
+        });
+
+        QUnit.test('should throw when cellNamespace is not set', function(assert) {
+            var graph = new joint.dia.Graph({}, { cellNamespace: null });
+            assert.throws(function() {
+                graph.getTypeConstructor('standard.Rectangle');
+            }, /cellNamespace is required/);
+        });
+    });
+
+    QUnit.module('getTypeDefaults()', function() {
+
+        QUnit.test('should return frozen defaults for a valid type', function(assert) {
+            var graph = this.graph;
+            var defaults = graph.getTypeDefaults('standard.Rectangle');
+            assert.equal(defaults.type, 'standard.Rectangle');
+            assert.ok(Object.isFrozen(defaults));
+        });
+
+        QUnit.test('should cache the result', function(assert) {
+            var graph = this.graph;
+            var defaults1 = graph.getTypeDefaults('standard.Rectangle');
+            var defaults2 = graph.getTypeDefaults('standard.Rectangle');
+            assert.strictEqual(defaults1, defaults2);
+        });
+
+        QUnit.test('should return empty object for unknown type', function(assert) {
+            var graph = this.graph;
+            assert.deepEqual(graph.getTypeDefaults('nonexistent.Shape'), {});
+        });
+    });
+
 });

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -190,6 +190,8 @@ export namespace dia {
 
         insert(layer: Graph.LayerInit, beforeId: GraphLayer.ID | null, opt?: ObjectHash): void;
 
+        getTypeConstructor<T extends Cell = Cell>(type: string): Cell.Constructor<T> | null;
+
         getCell(cellRef: Graph.CellRef): Cell | undefined;
 
         getCells(): Cell[];

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -443,6 +443,10 @@ export namespace dia {
 
         getCellLayerId(cell: Graph.CellRef): GraphLayer.ID;
 
+        getCellNamespace(): Record<string, any>;
+
+        getTypeConstructor(type: string): Cell.Constructor<Cell> | null;
+
         getTypeDefaults(type: string): Cell.Attributes;
 
         getCell(id: Graph.CellRef): Cell;

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -174,7 +174,8 @@ export namespace dia {
 
     class CellCollection<C extends Cell = Cell> extends mvc.Collection<C> {
 
-        cellNamespace: any;
+        /** @deprecated Use graph.getCellNamespace() instead. */
+        readonly cellNamespace: any;
         layer: GraphLayer;
 
         minZIndex(): number;
@@ -446,6 +447,8 @@ export namespace dia {
         getCellLayerId(cell: Graph.CellRef): GraphLayer.ID;
 
         getCellNamespace(): Record<string, any>;
+
+        setCellNamespace(namespace: Record<string, any>): void;
 
         getTypeConstructor<T extends Cell = Cell>(type: string): Cell.Constructor<T> | null;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -445,7 +445,7 @@ export namespace dia {
 
         getCellNamespace(): Record<string, any>;
 
-        getTypeConstructor(type: string): Cell.Constructor<Cell> | null;
+        getTypeConstructor<T extends Cell = Cell>(type: string): Cell.Constructor<T> | null;
 
         getTypeDefaults(type: string): Cell.Attributes;
 

--- a/packages/joint-core/types/joint.d.ts
+++ b/packages/joint-core/types/joint.d.ts
@@ -443,6 +443,8 @@ export namespace dia {
 
         getCellLayerId(cell: Graph.CellRef): GraphLayer.ID;
 
+        getTypeDefaults(type: string): Cell.Attributes;
+
         getCell(id: Graph.CellRef): Cell;
 
         getElements(): Element[];


### PR DESCRIPTION
## Summary
- Add `graph.getCellNamespace()` / `graph.setCellNamespace(namespace)` — get/set the cell namespace, setter invalidates type defaults cache
- Add `graph.getTypeConstructor(type)` — resolve a cell type string (e.g. `'standard.Rectangle'`) to its constructor, generic typed `<T extends Cell>`
- Add `graph.getTypeDefaults(type)` — return frozen, cached default attributes for a cell type
- Add `graphLayerCollection.getTypeConstructor(type)` — single source of truth for constructor lookups, includes `cellNamespace` null guard
- Refactor `CellCollection.model()` to delegate to `layerCollection.getTypeConstructor()` instead of duplicating the lookup
- Refactor `Paper.defaultLink` to use `graph.getTypeConstructor('standard.Link')` instead of reaching into `layerCollection.cellNamespace`
- Deprecate `CellCollection.cellNamespace` property — now a getter that reads from `layerCollection.cellNamespace`
- Remove `cellNamespace` propagation from `GraphLayerCollection._addReference/_removeReference`
- Add QUnit tests for all new Graph methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)