### PR TITLE
fix(react): correct presets export paths

### DIFF
--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -32,9 +32,9 @@
       "require": "./dist/cjs/internal.js"
     },
     "./presets": {
-      "types": "./dist/types/presets.d.ts",
-      "import": "./dist/esm/presets.js",
-      "require": "./dist/cjs/presets.js"
+      "types": "./dist/types/presets/index.d.ts",
+      "import": "./dist/esm/presets/index.js",
+      "require": "./dist/cjs/presets/index.js"
     },
     "./src/*": "./src/*",
     "./scripts/*": "./scripts/*.ts",


### PR DESCRIPTION
## Summary

Corrects the `@joint/react/presets` package export paths so they match the files emitted by the current preserved-module build.

## Why

The package metadata pointed `./presets` at top-level `dist/*/presets.*` files, but the build emits the presets barrel as `dist/*/presets/index.*`. This made the subpath export resolve to missing files.

## Changes

- Updates the `./presets` export in `packages/joint-react/package.json`
- Points `types`, `import`, and `require` to the generated `presets/index.*` files

## Verification

- `yarn workspace @joint/react build`
- `yarn workspace @joint/react typecheck`
- Verified the configured `./presets` export targets exist after build