### PR TITLE
types(dia.Paper): add CellViewCallback type for elementView/linkView

### DIFF
--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1539,6 +1539,9 @@ export class LinkView<L extends Link = Link> extends CellViewGeneric<L> {
 
 export namespace Paper {
 
+    /** A callback that resolves which view class to use for a given model. Return `null` or `undefined` to use the default view. */
+    type CellViewCallback<V extends typeof CellViewGeneric<any>> = (model: InstanceType<V> extends CellViewGeneric<infer M> ? M : Cell, NSView: V | null) => V | null | undefined;
+
     interface GradientOptions {
         id?: string;
         type: 'linearGradient' | 'radialGradient';
@@ -1729,8 +1732,8 @@ export namespace Paper {
         moveThreshold?: number;
         magnetThreshold?: number | string;
         // views
-        elementView?: typeof ElementView<any> | ((element: Element) => typeof ElementView<any> | null | undefined);
-        linkView?: typeof LinkView<any> | ((link: Link) => typeof LinkView<any> | null | undefined);
+        elementView?: typeof ElementView<Element> | CellViewCallback<typeof ElementView<Element>>;
+        linkView?: typeof LinkView<Link> | CellViewCallback<typeof LinkView<Link>>;
         measureNode?: MeasureNodeCallback;
         // embedding
         embeddingMode?: boolean;


### PR DESCRIPTION
## Summary
- Add generic `Paper.CellViewCallback<V>` type that infers the model type from the view class
- Simplify `elementView` / `linkView` option signatures using the new type
- Change `ElementView<any>` / `LinkView<any>` to `ElementView<Element>` / `LinkView<Link>` for stricter typing (custom subclasses still accepted via covariance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)