### PR TITLE
feat(dia.CellView): add computeNodeBoundingRect method

### DIFF
--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -802,33 +802,43 @@ export const CellView = View.extend({
                 // Measure the node bounding box using the paper's measureNode method.
                 metrics.boundingRect = measureNode(magnet, this);
             } else {
-                if (magnet instanceof HTMLElement) {
-                    if (magnet.checkVisibility()) {
-                        const clientRect = new Rect(magnet.getBoundingClientRect());
-                        const clientCenter = clientRect.center();
-                        const localCenter = this.paper.clientToLocalPoint(clientCenter);
-                        const ctm = this.getRootTranslateMatrix().multiply(this.getNodeRotateMatrix(magnet)).inverse();
-                        const preRotationCenter = V.transformPoint(localCenter, ctm);
-                        // get non-rotated bounding box dimensions
-                        const w = magnet.offsetWidth;
-                        const h = magnet.offsetHeight;
-                        metrics.boundingRect = new Rect(
-                            preRotationCenter.x - w / 2,
-                            preRotationCenter.y - h / 2,
-                            w,
-                            h
-                        );
-                    } else {
-                        console.warn('dia.CellView: A node is not part of the render tree — it may not be visible, or not attached to the DOM. Its bounding box cannot be measured, so anything that depends on its position will be incorrect. Ensure the node and its containing elements are visible and attached to the DOM, or provide a custom measureNode method in the paper options.');
-
-                        metrics.boundingRect = new Rect();
-                    }
-                } else {
-                    metrics.boundingRect = V(magnet).getBBox();
-                }
+                metrics.boundingRect = this.computeNodeBoundingRect(magnet);
             }
         }
         return new Rect(metrics.boundingRect);
+    },
+
+    /**
+     * Compute the pre-rotation bounding rectangle of a node in local coordinates.
+     * Unlike {@link getNodeBoundingRect}, the result is never cached and the
+     * paper's `measureNode` callback is not consulted.
+     *
+     * @param {SVGElement|HTMLElement} magnet - The node to measure.
+     * @returns {Rect} The axis-aligned bounding rectangle before rotation.
+     */
+    computeNodeBoundingRect: function(magnet) {
+        if (!magnet.checkVisibility()) {
+            console.warn('dia.CellView: A node is not part of the render tree — it may not be visible, or not attached to the DOM. Its bounding box cannot be measured, so anything that depends on its position will be incorrect. Ensure the node and its containing elements are visible and attached to the DOM, or provide a custom measureNode method in the paper options.');
+            return new Rect(0, 0, 0, 0);
+        }
+        if (magnet instanceof SVGElement) {
+            // SVG elements can be measured directly using their getBBox() method.
+            return V(magnet).getBBox();
+        }
+        const clientRect = new Rect(magnet.getBoundingClientRect());
+        const clientCenter = clientRect.center();
+        const localCenter = this.paper.clientToLocalPoint(clientCenter);
+        const ctm = this.getRootTranslateMatrix().multiply(this.getNodeRotateMatrix(magnet)).inverse();
+        const preRotationCenter = V.transformPoint(localCenter, ctm);
+        // get non-rotated bounding box dimensions
+        const w = magnet.offsetWidth;
+        const h = magnet.offsetHeight;
+        return new Rect(
+            preRotationCenter.x - w / 2,
+            preRotationCenter.y - h / 2,
+            w,
+            h
+        );
     },
 
     getNodeMatrix: function(magnet) {

--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -71,7 +71,7 @@ export const HighlighterView = mvc.View.extend({
             }
         } else if (nodeSelector) {
             el = V.toNode(nodeSelector);
-            if (!(el instanceof SVGElement) || !cellView.el.contains(el)) el = null;
+            if (!(el instanceof Element) || !cellView.el.contains(el)) el = null;
         }
         return el ? el : null;
     },

--- a/packages/joint-core/test/jointjs/cellView.js
+++ b/packages/joint-core/test/jointjs/cellView.js
@@ -708,6 +708,20 @@ QUnit.module('cellView', function(hooks) {
             assert.equal(rect.height, expected.height);
         });
 
+        QUnit.test('SVG magnet - invisible - returns a zero rect and produces a warning', function(assert) {
+            const magnet = cellView.el.querySelector('rect');
+            sinon.stub(magnet, 'checkVisibility').returns(false);
+            const warnStub = sinon.stub(console, 'warn');
+            const rect = cellView.getNodeBoundingRect(magnet);
+            assert.ok(rect instanceof g.Rect);
+            assert.equal(rect.x, 0);
+            assert.equal(rect.y, 0);
+            assert.equal(rect.width, 0);
+            assert.equal(rect.height, 0);
+            assert.ok(warnStub.calledOnce);
+            warnStub.restore();
+        });
+
         QUnit.test('measureNode option - delegates to the function', function(assert) {
             const magnet = cellView.el.querySelector('rect');
             const expected = { x: 5, y: 10, width: 50, height: 60 };

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1185,6 +1185,8 @@ export abstract class CellViewGeneric<T extends Cell> extends mvc.View<T, SVGEle
 
     getNodeBoundingRect(node: SVGElement): g.Rect;
 
+    computeNodeBoundingRect(node: SVGElement | HTMLElement): g.Rect;
+
     getBBox(opt?: { useModelGeometry?: boolean }): g.Rect;
 
     getNodeBBox(node: SVGElement): g.Rect;


### PR DESCRIPTION
## Summary
- Extract node measurement logic from `getNodeBoundingRect` into a public `computeNodeBoundingRect()` method on CellView
- Unlike `getNodeBoundingRect`, the result is never cached and the paper's `measureNode` callback is not consulted
- Adds `checkVisibility()` guard for SVG nodes (previously only checked for HTML nodes) — warns and returns a zero rect when the node is not in the render tree

## Test plan
- [x] Added SVG invisible node test mirroring existing HTML invisible tests
- [x] All 452 cellView client tests pass
- [x] TypeScript type tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)