### PR TITLE
fix(highlighters): support HTML elements in mask highlighter and node resolution

### DIFF
--- a/packages/joint-core/src/dia/HighlighterView.mjs
+++ b/packages/joint-core/src/dia/HighlighterView.mjs
@@ -71,7 +71,7 @@ export const HighlighterView = mvc.View.extend({
             }
         } else if (nodeSelector) {
             el = V.toNode(nodeSelector);
-            if (!(el instanceof SVGElement) || !cellView.el.contains(el)) el = null;
+            if (!(el instanceof Element) || !cellView.el.contains(el)) el = null;
         }
         return el ? el : null;
     },

--- a/packages/joint-core/src/highlighters/mask.mjs
+++ b/packages/joint-core/src/highlighters/mask.mjs
@@ -125,6 +125,7 @@ export const mask = HighlighterView.extend({
     getMaskShape(cellView, vel) {
         const { options, MASK_REPLACE_TAGS } = this;
         const { deep } = options;
+        if (!V.isSVGGraphicsElement(vel)) return null;
         const tagName = vel.tagName();
         let maskRoot;
         if (tagName === 'G') {

--- a/packages/joint-core/test/jointjs/dia/HighlighterView.js
+++ b/packages/joint-core/test/jointjs/dia/HighlighterView.js
@@ -645,6 +645,43 @@ QUnit.module('HighlighterView', function(hooks) {
             unhighlightSpy.restore();
         });
 
+        QUnit.test('Highlight element by an HTML node', function(assert) {
+
+            var highlightSpy = sinon.spy(joint.dia.HighlighterView.prototype, 'highlight');
+            var invalidSpy = sinon.spy();
+
+            paper.on('cell:highlight:invalid', invalidSpy);
+
+            var foElement = new joint.dia.Element({
+                type: 'foElement',
+                position: { x: 50, y: 30 },
+                size: { width: 100, height: 80 },
+                markup: joint.util.svg`
+                    <foreignObject @selector="fo" width="100" height="80">
+                        <div xmlns="http://www.w3.org/1999/xhtml" @selector="htmlBody" style="width:100%;height:100%;"></div>
+                    </foreignObject>
+                `
+            });
+            foElement.addTo(graph);
+            var foView = foElement.findView(paper);
+            var htmlNode = foView.el.querySelector('[joint-selector="htmlBody"]');
+
+            assert.ok(htmlNode instanceof HTMLElement, 'node is an HTMLElement');
+            assert.ok(foView.el.contains(htmlNode), 'node is inside the cell view');
+
+            var id = 'html-highlighter';
+            var highlighter = joint.dia.HighlighterView.add(foView, htmlNode, id);
+            assert.ok(highlighter instanceof joint.dia.HighlighterView);
+            assert.ok(highlightSpy.calledOnce);
+            assert.ok(highlightSpy.calledOnceWithExactly(foView, htmlNode));
+            assert.ok(invalidSpy.notCalled);
+
+            joint.dia.HighlighterView.remove(foView, id);
+            foElement.remove();
+
+            highlightSpy.restore();
+        });
+
         QUnit.test('Highlight element by a selector', function(assert) {
 
             var highlightSpy = sinon.spy(joint.dia.HighlighterView.prototype, 'highlight');
@@ -1173,6 +1210,39 @@ QUnit.module('HighlighterView', function(hooks) {
             joint.dia.HighlighterView.remove(elementView, id);
             assert.notEqual(elementView.el, highlighter.el.parentNode);
             assert.notOk(paper.isDefined(highlighter.getMaskId()));
+        });
+
+        QUnit.test('Highlight HTML element - falls back to rect mask', function(assert) {
+
+            var HighlighterView = joint.highlighters.mask;
+            var id = 'html-mask-highlighter';
+
+            var foElement = new joint.dia.Element({
+                type: 'foElement',
+                position: { x: 50, y: 30 },
+                size: { width: 100, height: 80 },
+                markup: joint.util.svg`
+                    <foreignObject @selector="fo" width="100" height="80">
+                        <div xmlns="http://www.w3.org/1999/xhtml" @selector="htmlBody" style="width:100%;height:100%;"></div>
+                    </foreignObject>
+                `
+            });
+            foElement.addTo(graph);
+            var foView = foElement.findView(paper);
+            var htmlNode = foView.el.querySelector('[joint-selector="htmlBody"]');
+
+            // Highlight
+            var highlighter = HighlighterView.add(foView, htmlNode, id);
+            assert.ok(highlighter instanceof HighlighterView);
+            assert.ok(paper.isDefined(highlighter.getMaskId()));
+            var maskEl = paper.svg.getElementById(highlighter.getMaskId());
+            assert.equal(maskEl.querySelectorAll('rect').length, 2, 'mask contains two rect elements');
+
+            // Unhighlight
+            joint.dia.HighlighterView.remove(foView, id);
+            assert.notOk(paper.isDefined(highlighter.getMaskId()));
+
+            foElement.remove();
         });
 
         QUnit.test('Purging the mask nodes', function(assert) {


### PR DESCRIPTION
## Summary
- Mask highlighter falls back to a `<rect/>` mask for HTML nodes (e.g. inside `foreignObject`), using `V.isSVGGraphicsElement()` check — same pattern as text/image elements
- `HighlighterView.findNode()` relaxed from `SVGElement` to `Element` so HTML nodes can be passed directly

## Test plan
- [x] Added test: highlighting an HTML node resolves correctly via `HighlighterView.add()`
- [x] Added test: mask highlighter creates rect-based mask for HTML elements
- [x] All existing highlighter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)