### PR TITLE
feat(joint-react): controlled/uncontrolled split via initialElements/initialLinks

### DIFF
--- a/packages/joint-react/README.md
+++ b/packages/joint-react/README.md
@@ -1,87 +1,82 @@
-<div style="display:flex;align-items:center;background:#131E29;padding:1.25rem 1rem;margin-bottom:1.25rem;">
-  <img src="https://cdn.prod.website-files.com/63061d4ee85b5a18644f221c/633045c1d726c7116dcbe582_JJS_logo.svg" alt="JointJS Logo" height="40" style="margin-right:1rem;display:inline-block;" />
-</div>
+<p align="center">
+  <img src="https://cdn.prod.website-files.com/63061d4ee85b5a18644f221c/633045c1d726c7116dcbe582_JJS_logo.svg" alt="JointJS" height="56" />
+</p>
 
-# @joint/react
+<h1 align="center">@joint/react</h1>
 
-**React-first diagramming.** Build flowcharts, workflows, network maps, mind maps — any graph‑based UI — with an idiomatic React API on top of JointJS. Type‑safe, customizable, and production‑ready.
+<p align="center">
+  <strong>React-first diagramming.</strong> Build flowcharts, workflows, network maps, and graph UIs with an idiomatic React API on top of JointJS.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@joint/react"><img src="https://img.shields.io/npm/v/@joint/react?style=flat-square&color=0EA5E9" alt="npm" /></a>
+  <a href="https://www.npmjs.com/package/@joint/react"><img src="https://img.shields.io/npm/types/@joint/react?style=flat-square&color=3178C6" alt="types" /></a>
+  <a href="https://bundlephobia.com/package/@joint/react"><img src="https://img.shields.io/bundlephobia/minzip/@joint/react?style=flat-square&color=8B5CF6" alt="bundle" /></a>
+  <a href="https://www.npmjs.com/package/@joint/react"><img src="https://img.shields.io/npm/dm/@joint/react?style=flat-square&color=F59E0B" alt="downloads" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/npm/l/@joint/react?style=flat-square&color=10B981" alt="license" /></a>
+</p>
 
 ---
 
-## ✨ Highlights
+## Why @joint/react
 
-- **API** — Components and hooks, no imperative glue required.
-- **TypeScript by default** — Written in TypeScript with full type definitions
-- **Custom rendering** — SVG or real HTML with an overlay.
-- **Interactive** — Dragging, connecting, selection, events.
-- **Composable** — Multiple views per diagram / graph (e.g., canvas + minimap).
+| | |
+|--|--|
+| **🧩 Component API** | Compose `<GraphProvider>` and `<Paper>` — no imperative glue. |
+| **🛡️ Strict TypeScript** | First-class types for elements, links, hooks, refs. |
+| **🎨 Render anything** | SVG, `<foreignObject>`, or real HTML overlay. |
+| **⚡ Reactive hooks** | `useElements`, `useLinks`, `useGraph` with stable selectors. |
+| **🔁 Controlled or not** | Per-stream control: elements and links are independent. |
+| **🧠 Battle-tested core** | Powered by JointJS — production diagrams since 2013. |
 
 ---
 
-## 📦 Installation
+## Install
 
-### npm
 ```bash
-npm install @joint/react
-```
-
-### yarn
-```bash
-yarn add @joint/react
-```
-
-### bun
-```bash
+npm i @joint/react        # or
+pnpm add @joint/react     # or
+yarn add @joint/react     # or
 bun add @joint/react
 ```
 
-> Requires React 16.8+ and a modern browser (Chrome, Firefox, Safari, Edge).
+> Requires React **18+** and a modern browser.
 
 ---
 
-## 🧭 Core Ideas
-
-- **Elements (nodes)** and **links (edges)** are plain objects stored in a `Record<string, Data>` where the key is the ID.
-- The **`GraphProvider`** component provides the graph context; **`Paper`** renders it.
-- Use hooks like `useElements`, `useLinks`, `useGraph`, `usePaper` for reading/updating state.
-
----
-
-## 🚀 Quick Start (TypeScript)
-
-Elements and links are stored in a `Record<string, Data>` where the key is the ID.
+## 60-second example
 
 ```tsx
-import React from 'react'
-import { GraphProvider } from '@joint/react'
+import { GraphProvider, Paper, type ElementRecord, type LinkRecord } from '@joint/react'
 
-const elements = {
-  'node1': { label: 'Start', x: 100, y: 50, width: 120, height: 60 },
-  'node2': { label: 'End',   x: 100, y: 200, width: 120, height: 60 },
-} as const
+type NodeData = { label: string }
 
-const links = {
-  'link1': { source: 'node1', target: 'node2' },
-} as const
+const initialElements: Record<string, ElementRecord<NodeData>> = {
+  start: {
+    data: { label: 'Start' },
+    position: { x: 100, y: 60 },
+    size: { width: 120, height: 60 },
+  },
+  end: {
+    data: { label: 'End' },
+    position: { x: 100, y: 220 },
+    size: { width: 120, height: 60 },
+  },
+}
 
-// Narrow element type straight from the record:
-type Element = typeof elements[keyof typeof elements]
+const initialLinks: Record<string, LinkRecord> = {
+  flow: { source: { id: 'start' }, target: { id: 'end' } },
+}
 
-export default function App() {
+export default function Flow() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Paper
-        
         height={360}
         useHTMLOverlay
-        renderElement={(el: Element) => (
-          <div style={{
-            padding: 10,
-            border: '2px solid #3498db',
-            borderRadius: 8,
-            background: '#fff'
-          }}>
-            {el.label}
+        renderElement={(data: NodeData) => (
+          <div className="px-4 py-2 rounded-lg border border-blue-500 bg-white shadow">
+            {data.label}
           </div>
         )}
       />
@@ -92,28 +87,99 @@ export default function App() {
 
 ---
 
-## 🧩 Idiomatic Patterns & Examples
+## Core ideas
+
+- **Elements (nodes)** carry `data`, `position`, and `size`. **Links (edges)** carry `data`, `source`, and `target`. Both are stored in a `Record<string, …>` keyed by ID.
+- **`renderElement`** / **`renderLink`** receive only the `data` field — your custom payload. Layout (position, size) is read via `useElementSize` / `useElementPosition` inside the renderer.
+- The **`GraphProvider`** component provides the graph context; **`Paper`** renders it.
+- Elements and links are **independent streams** — each can be *controlled* or *uncontrolled* independently.
+- Hooks like `useElements`, `useLinks`, `useGraph`, and `usePaper` read state from anywhere under the provider.
+
+---
+
+## Quick Start (TypeScript)
+
+```tsx
+import React from 'react'
+import {
+  GraphProvider,
+  Paper,
+  useElementSize,
+  type ElementRecord,
+  type LinkRecord,
+} from '@joint/react'
+
+type NodeData = { label: string }
+
+const initialElements: Record<string, ElementRecord<NodeData>> = {
+  node1: {
+    data: { label: 'Start' },
+    position: { x: 100, y: 50 },
+    size: { width: 120, height: 60 },
+  },
+  node2: {
+    data: { label: 'End' },
+    position: { x: 100, y: 200 },
+    size: { width: 120, height: 60 },
+  },
+}
+
+const initialLinks: Record<string, LinkRecord> = {
+  link1: { source: { id: 'node1' }, target: { id: 'node2' } },
+}
+
+function RenderNode({ label }: NodeData) {
+  const { width, height } = useElementSize()
+  return (
+    <foreignObject width={width} height={height}>
+      <div style={{
+        padding: 10,
+        border: '2px solid #3498db',
+        borderRadius: 8,
+        background: '#fff',
+      }}>
+        {label}
+      </div>
+    </foreignObject>
+  )
+}
+
+export default function App() {
+  return (
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
+      <Paper height={360} renderElement={RenderNode} />
+    </GraphProvider>
+  )
+}
+```
+
+---
+
+## Idiomatic Patterns & Examples
 
 ### 1) Multiple views (canvas + minimap)
+
 Share one diagram across views. Give each view a stable `id`.
 
 ```tsx
 import React from 'react'
-import { GraphProvider } from '@joint/react'
+import { GraphProvider, Paper, type ElementRecord, type LinkRecord } from '@joint/react'
 
-const elements = {
-  'a': { label: 'A', x: 40,  y: 60,  width: 80, height: 40 },
-  'b': { label: 'B', x: 260, y: 180, width: 80, height: 40 },
-} as const
+type NodeData = { label: string }
 
-const links = {
-  'a-b': { source: 'a', target: 'b' },
-} as const
+const initialElements: Record<string, ElementRecord<NodeData>> = {
+  a: { data: { label: 'A' }, position: { x: 40,  y: 60  }, size: { width: 80, height: 40 } },
+  b: { data: { label: 'B' }, position: { x: 260, y: 180 }, size: { width: 80, height: 40 } },
+}
+
+const initialLinks: Record<string, LinkRecord> = {
+  'a-b': { source: { id: 'a' }, target: { id: 'b' } },
+}
 
 export function MultiView() {
   return (
-    <GraphProvider elements={elements} links={links}>
-      <Paper id="main"  height={420} />
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
+      <Paper id="main" height={420} />
       <div style={{ position: 'absolute', right: 16, bottom: 16 }}>
         <Paper id="mini" width={180} height={120} interactive={false} scale={0.25} />
       </div>
@@ -123,24 +189,30 @@ export function MultiView() {
 ```
 
 ### 2) SVG vs real HTML nodes
+
 SVG with `<foreignObject>` keeps everything in one tree; `useHTMLOverlay` renders real HTML above the SVG for full CSS support.
 
 ```tsx
+import { Paper, useElementSize } from '@joint/react'
+
 // ForeignObject (SVG)
-<Paper
-  renderElement={({ width, height, label }) => (
+function SvgNode({ label }: { label: string }) {
+  const { width, height } = useElementSize()
+  return (
     <foreignObject width={width} height={height}>
       <div style={{ display: 'grid', placeItems: 'center', height: '100%', background: '#eee' }}>
         {label}
       </div>
     </foreignObject>
-  )}
-/>
+  )
+}
+
+<Paper renderElement={SvgNode} />
 
 // HTML overlay (React portal outside SVG)
 <Paper
   useHTMLOverlay
-  renderElement={({ label }) => (
+  renderElement={({ label }: { label: string }) => (
     <div style={{ padding: 8, borderRadius: 8, background: 'white', boxShadow: '0 1px 4px rgba(0,0,0,.15)' }}>
       {label}
     </div>
@@ -149,39 +221,41 @@ SVG with `<foreignObject>` keeps everything in one tree; `useHTMLOverlay` render
 ```
 
 ### 3) Events & interactions
-Subscribe to pointer events on elements/links.
+
+Subscribe to pointer events on elements/links via `Paper` props.
 
 ```tsx
 <Paper
-  onElementPointerClick={(el) => console.log('Clicked:', el.id)}
+  onElementPointerClick={({ cellView }) => console.log('Clicked:', cellView.model.id)}
   onBlankPointerDown={() => console.log('Canvas mousedown')}
 />
 ```
 
 ### 4) Controlled updates (React state drives the graph)
-Pass `elements/links` + `onElementsChange/onLinksChange` to keep React in charge.
 
-**React-controlled mode** gives you full control over graph state, enabling features like undo/redo, persistence, and integration with other React state management.
+Elements and links are **independent streams** — control either, both, or neither.
 
 ```tsx
 import React, { useState } from 'react'
-import { GraphProvider } from '@joint/react'
+import { GraphProvider, Paper, type ElementRecord, type LinkRecord } from '@joint/react'
 
-const initialElements = {
-  'n1': { label: 'Item', x: 60, y: 60, width: 100, height: 40 },
-} as const
-
-const initialLinks = {} as const
+type NodeData = { label: string }
 
 export function Controlled() {
-  const [els, setEls] = useState<Record<string, typeof initialElements[keyof typeof initialElements]>>({ ...initialElements })
-  const [lns, setLns] = useState<Record<string, never>>({ ...initialLinks })
+  const [els, setEls] = useState<Record<string, ElementRecord<NodeData>>>({
+    n1: {
+      data: { label: 'Item' },
+      position: { x: 60, y: 60 },
+      size: { width: 100, height: 40 },
+    },
+  })
+  const [lns, setLns] = useState<Record<string, LinkRecord>>({})
 
   return (
     <GraphProvider
       elements={els}
-      links={lns}
       onElementsChange={setEls}
+      links={lns}
       onLinksChange={setLns}
     >
       <Paper height={320} />
@@ -190,26 +264,56 @@ export function Controlled() {
 }
 ```
 
+**Mixed mode.** Control just elements while letting JointJS own the links — or vice versa.
+
+```tsx
+<GraphProvider
+  elements={els}              // controlled
+  onElementsChange={setEls}
+  initialLinks={initialLinks} // uncontrolled
+>
+  <Paper height={320} />
+</GraphProvider>
+```
+
+**Notifications in uncontrolled mode.** `onElementsChange` and `onLinksChange` fire in *both* modes. In uncontrolled mode they are notification-only — your state is never pushed back to the graph.
+
+```tsx
+<GraphProvider
+  initialElements={initialElements}
+  onElementsChange={(els) => analytics.track('graph:update', els)}
+>
+  <Paper />
+</GraphProvider>
+```
+
 ### 5) Incremental change mode (Redux, Zustand, etc.)
-Use `onIncrementalChange` to get granular change events for integration with external stores.
+
+`onIncrementalChange` is orthogonal to controlled/uncontrolled — it fires in any mode with granular `added` / `changed` / `removed` sets.
 
 ```tsx
 import React from 'react'
-import { GraphProvider, type IncrementalStateChanges } from '@joint/react'
+import { GraphProvider, Paper, type ElementRecord, type IncrementalContainerChanges } from '@joint/react'
 
-const initialElements = {
-  'n1': { label: 'Item', x: 60, y: 60, width: 100, height: 40 },
-} as const
+type NodeData = { label: string }
+
+const initialElements: Record<string, ElementRecord<NodeData>> = {
+  n1: {
+    data: { label: 'Item' },
+    position: { x: 60, y: 60 },
+    size: { width: 100, height: 40 },
+  },
+}
 
 export function IncrementalExample() {
-  const handleChange = (changes: IncrementalStateChanges) => {
+  const handleChange = (changes: IncrementalContainerChanges<NodeData>) => {
     // Dispatch granular changes to your external store
     console.log('Changes:', changes)
   }
 
   return (
     <GraphProvider
-      elements={initialElements}
+      initialElements={initialElements}
       onIncrementalChange={handleChange}
     >
       <Paper height={320} />
@@ -219,33 +323,35 @@ export function IncrementalExample() {
 ```
 
 ### 6) Programmatic cell manipulation
-Use the `useCellActions` hook to programmatically add, update, and remove cells.
+
+Use the `useSetElement`, `useSetLink`, `useRemoveElement`, and `useRemoveLink` hooks to programmatically add, update, and remove cells.
 
 ```tsx
-import { useCellActions } from '@joint/react'
+import { useSetElement, useRemoveElement, type ElementRecord } from '@joint/react'
 
-function MyComponent() {
-  const { set, remove } = useCellActions()
+type NodeData = { label: string }
+
+function CellActions() {
+  const setElement = useSetElement<NodeData>()
+  const removeElement = useRemoveElement()
 
   const addNode = () => {
-    set('new-node', {
-      x: 100,
-      y: 100,
-      width: 120,
-      height: 60,
-      label: 'New Node'
-    })
+    setElement('new-node', {
+      data: { label: 'New Node' },
+      position: { x: 100, y: 100 },
+      size: { width: 120, height: 60 },
+    } satisfies ElementRecord<NodeData>)
   }
 
   const updateNode = () => {
-    set('new-node', (prev) => ({
+    setElement('new-node', (prev) => ({
       ...prev,
-      label: 'Updated'
+      data: { label: 'Updated' },
     }))
   }
 
   const deleteNode = () => {
-    remove('new-node')
+    removeElement('new-node')
   }
 
   return (
@@ -258,22 +364,24 @@ function MyComponent() {
 }
 ```
 
-### 7) Imperative access (ref) for one‑off actions
+### 7) Imperative access (ref) for one-off actions
+
 Useful for `fitToContent`, scaling, exporting.
 
 ```tsx
 import React, { useEffect, useRef } from 'react'
-import type { PaperContext } from '@joint/react'
+import type { dia } from '@joint/core'
+import { GraphProvider, Paper } from '@joint/react'
 
 export function FitOnMount() {
-  const ref = useRef<PaperContext | null>(null)
+  const paperRef = useRef<dia.Paper | null>(null)
   useEffect(() => {
-    ref.current?.paper.fitToContent({ padding: 20 })
+    paperRef.current?.fitToContent({ padding: 20 })
   }, [])
 
   return (
-    <GraphProvider elements={elements} links={links}>
-      <Paper ref={ref} />
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
+      <Paper ref={paperRef} />
     </GraphProvider>
   )
 }
@@ -281,41 +389,40 @@ export function FitOnMount() {
 
 ---
 
+## Best practices
 
-## 🧠 Best Practices
-
-- **Type elements from data**: `type Element = typeof elements[keyof typeof elements]` — reuse data as your source of truth.
+- **Type your data**: declare a `type NodeData = { … }` and use `ElementRecord<NodeData>` so `renderElement` is typed end-to-end.
 - **Memoize renderers & handlers**: `useCallback` to minimize re-renders.
-- **Keep overlay HTML lightweight**: Prefer simple layout; avoid heavy transforms/animations in `<foreignObject>` (Safari can be picky).
+- **Keep overlay HTML lightweight**: prefer simple layout; avoid heavy transforms/animations in `<foreignObject>` (Safari can be picky).
 - **Give each view a stable `id`** when rendering multiple `Paper` instances.
-- **Prefer declarative first**: Reach for hooks/props; use imperative APIs (refs/graph methods) for targeted operations only.
+- **Prefer declarative first**: reach for hooks/props; use imperative APIs (refs/graph methods) for targeted operations only.
+- **Accessing component instances via refs**: `Paper` forwards a ref to the underlying JointJS `dia.Paper` instance. `GraphProvider` forwards a ref to the underlying `dia.Graph`.
+- **Choose the right mode**: default to uncontrolled (`initialElements` / `initialLinks`). Switch to controlled (`elements` + `onElementsChange`) only when React must own the source of truth — e.g. for undo/redo, persistence, or multi-store integration. Mix per stream as needed. Use `onIncrementalChange` for granular external-store sync (Redux, Zustand).
+- **Use selectors efficiently**: when using `useElements` or `useLinks`, provide custom selectors and equality functions to minimize re-renders.
+- **Batch updates**: the library automatically batches updates, but be mindful of rapid state changes in controlled mode.
 - **Test in Safari early** when using `<foreignObject>`; fall back to `useHTMLOverlay` if needed.
-- **Accessing component instances via refs**: Any component that accepts a `ref` (such as `Paper` or `GraphProvider`) exposes its instance/context via the ref. For `Paper`, the instance (including the underlying JointJS Paper) can be accessed via the `paperCtx` property on the ref object.
-- **Choose the right mode**: Use uncontrolled mode for simple cases, React-controlled (`onElementsChange`/`onLinksChange`) for full state control, and incremental-controlled (`onIncrementalChange`) for integration with Redux/Zustand.
-- **Use selectors efficiently**: When using `useElements` or `useLinks`, provide custom selectors and equality functions to minimize re-renders.
-- **Batch updates**: The library automatically batches updates, but be mindful of rapid state changes in controlled mode.
-
----
 
 > **Tip:** You can pass an existing JointJS `dia.Graph` into `GraphProvider` if you need to integrate with external data lifecycles or share a graph across multiple providers.
 
 ---
 
-## 🐞 Notes & caveats
+## Notes & caveats
 
-- **`<foreignObject>` CSS** — Avoid `position` (non‑static), `transform`, `transition`, and certain `-webkit-*` properties inside SVG foreign objects; some browsers (esp. Safari) may flicker or misrender. Consider `useHTMLOverlay` for complex HTML.
-- **Performance** — Favor memoized renderers, avoid heavy component trees inside `renderElement`.
-- **Flicker** — Rapid port/size changes can cause transient flickers while elements measure; we’re improving defaults.
-
----
-
-## 🔗 Further reading
-
-- API Reference & Guides: https://react.jointjs.com/api/index.html  
-- Storybook & Examples: https://react.jointjs.com/learn/?path=/docs/introduction--docs
+- **`<foreignObject>` CSS** — avoid `position` (non-static), `transform`, `transition`, and certain `-webkit-*` properties inside SVG foreign objects; some browsers (especially Safari) may flicker or misrender. Consider `useHTMLOverlay` for complex HTML.
+- **Performance** — favor memoized renderers, avoid heavy component trees inside `renderElement`.
+- **Flicker** — rapid port/size changes can cause transient flickers while elements measure; we're improving defaults.
 
 ---
 
-## 📝 License
+## Resources
+
+- 📚 **Docs** — https://react.jointjs.com/api/index.html
+- 🧪 **Storybook** — https://react.jointjs.com/learn/?path=/docs/introduction--docs
+- 🐛 **Issues** — https://github.com/clientIO/joint/issues
+- 📰 **Releases** — https://github.com/clientIO/joint/releases
+
+---
+
+## License
 
 MIT

--- a/packages/joint-react/src/components/graph/__tests__/graph-provider-mixed-mode.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/graph-provider-mixed-mode.test.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable sonarjs/no-identical-functions */
+import React, { useState } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { GraphProvider } from '../graph-provider';
+import { useElements, useLinks } from '../../../hooks';
+import type { ElementRecord, LinkRecord } from '../../../types/data-types';
+
+const INITIAL_ELEMENT_E1: ElementRecord = { size: { width: 10, height: 10 } };
+const INITIAL_ELEMENT_E2: ElementRecord = { size: { width: 20, height: 20 } };
+const INITIAL_ELEMENTS_E1E2: Record<string, ElementRecord> = {
+  e1: { size: { width: 10, height: 10 } },
+  e2: { size: { width: 10, height: 10 } },
+};
+const INITIAL_LINKS_L1: Record<string, LinkRecord> = { l1: { source: 'e1', target: 'e1' } };
+const LINK_L1: LinkRecord = { source: 'e1', target: 'e2' };
+
+describe('GraphProvider mixed mode', () => {
+  it('controlled elements + uncontrolled links: links survive an elements update', async () => {
+    let elementCount = 0;
+    let linkCount = 0;
+    function Probe() {
+      elementCount = useElements((items) => items.size);
+      linkCount = useLinks((items) => items.size);
+      return null;
+    }
+
+    let externalSetElements!: (next: Record<string, ElementRecord>) => void;
+    function App() {
+      const [elements, setElements] = useState<Record<string, ElementRecord>>({
+        e1: INITIAL_ELEMENT_E1,
+      });
+      externalSetElements = setElements;
+      return (
+        <GraphProvider
+          elements={elements}
+          onElementsChange={setElements}
+          initialLinks={INITIAL_LINKS_L1}
+        >
+          <Probe />
+        </GraphProvider>
+      );
+    }
+
+    render(<App />);
+    await waitFor(() => expect(elementCount).toBe(1));
+    expect(linkCount).toBe(1);
+
+    act(() => {
+      externalSetElements({
+        e1: INITIAL_ELEMENT_E1,
+        e2: INITIAL_ELEMENT_E2,
+      });
+    });
+
+    await waitFor(() => expect(elementCount).toBe(2));
+    expect(linkCount).toBe(1);
+  });
+
+  it('uncontrolled elements + controlled links: elements survive a links update', async () => {
+    let elementCount = 0;
+    let linkCount = 0;
+    function Probe() {
+      elementCount = useElements((items) => items.size);
+      linkCount = useLinks((items) => items.size);
+      return null;
+    }
+
+    let externalSetLinks!: (next: Record<string, LinkRecord>) => void;
+    function App() {
+      const [links, setLinks] = useState<Record<string, LinkRecord>>({});
+      externalSetLinks = setLinks;
+      return (
+        <GraphProvider
+          initialElements={INITIAL_ELEMENTS_E1E2}
+          links={links}
+          onLinksChange={setLinks}
+        >
+          <Probe />
+        </GraphProvider>
+      );
+    }
+
+    render(<App />);
+    await waitFor(() => expect(elementCount).toBe(2));
+    expect(linkCount).toBe(0);
+
+    act(() => {
+      externalSetLinks({ l1: LINK_L1 });
+    });
+
+    await waitFor(() => expect(linkCount).toBe(1));
+    expect(elementCount).toBe(2);
+  });
+});

--- a/packages/joint-react/src/components/graph/__tests__/graph-provider-uncontrolled-notifications.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/graph-provider-uncontrolled-notifications.test.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useRef } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { GraphProvider } from '../graph-provider';
+import { useGraph } from '../../../hooks';
+import type { ElementRecord } from '../../../types/data-types';
+
+const INITIAL_ELEMENTS: Record<string, ElementRecord> = {
+  e1: { size: { width: 10, height: 10 } },
+};
+
+describe('GraphProvider uncontrolled notifications', () => {
+  it('fires onElementsChange in uncontrolled mode without React→graph push', async () => {
+    const elementSnapshots: Array<Record<string, ElementRecord>> = [];
+
+    let graphRef!: ReturnType<typeof useGraph>;
+    function Probe() {
+      graphRef = useGraph();
+      return null;
+    }
+
+    function App() {
+      const snapshotsRef = useRef(elementSnapshots);
+      const handleElementsChange = useCallback(
+        (els: Record<string, ElementRecord>) => {
+          snapshotsRef.current.push(els);
+        },
+        []
+      );
+
+      return (
+        <GraphProvider initialElements={INITIAL_ELEMENTS} onElementsChange={handleElementsChange}>
+          <Probe />
+        </GraphProvider>
+      );
+    }
+
+    render(<App />);
+
+    // Wait for graphRef to be populated
+    await waitFor(() => expect(graphRef).toBeDefined());
+
+    const snapshotCountBefore = elementSnapshots.length;
+
+    act(() => {
+      graphRef.graph.addCell({
+        id: 'e2',
+        type: 'standard.Rectangle',
+        position: { x: 30, y: 30 },
+        size: { width: 20, height: 20 },
+      });
+    });
+
+    await waitFor(() => {
+      expect(elementSnapshots.length).toBeGreaterThan(snapshotCountBefore);
+      const last = elementSnapshots.at(-1);
+      expect(last && Object.keys(last)).toContain('e2');
+    });
+  });
+});

--- a/packages/joint-react/src/components/graph/graph-provider.stories.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.stories.tsx
@@ -20,24 +20,33 @@ const meta: Meta<typeof GraphProvider> = {
   tags: ['component'],
   parameters: makeRootDocumentation({
     description: `
-The **GraphProvider** component provides a shared Graph context for all its descendants. It manages the graph state (elements and links) and makes it available to child components through React context.
+The **GraphProvider** component provides a shared Graph context for all its descendants.
+
+**Modes (per stream — elements and links are independent):**
+- **Uncontrolled:** Pass \`initialElements\` / \`initialLinks\`. JointJS owns the data after mount.
+- **Controlled:** Pass \`elements\` + \`onElementsChange\` (and/or \`links\` + \`onLinksChange\`). React owns the data; the graph stays in sync.
+- **Mixed:** Any combination — e.g. controlled elements + uncontrolled links — is supported.
+
+**Notifications:**
+- \`onElementsChange\` / \`onLinksChange\` fire in both modes. In uncontrolled mode they are notification-only.
+- \`onIncrementalChange\` is orthogonal; fires in any mode with granular added/changed/removed sets.
 
 **Key Features:**
-- Manages graph state (elements and links)
-- Provides context for hooks like \`useElement\`, \`useLinks\`, \`useElements\`
-- Supports multiple Paper instances within the same provider
-- Handles graph updates and subscriptions efficiently
+- Manages graph state for elements and links.
+- Provides context for hooks like \`useElement\`, \`useLinks\`, \`useElements\`.
+- Supports multiple Paper instances within the same provider.
+- Handles graph updates and subscriptions efficiently.
     `,
     usage: `
 \`\`\`tsx
 import { GraphProvider, Paper } from '@joint/react';
 
-const elements = {
+const initialElements = {
   '1': { x: 100, y: 100, width: 100, height: 50 },
   '2': { x: 250, y: 200, width: 100, height: 50 },
 };
 
-const links = {
+const initialLinks = {
   'l1': { source: '1', target: '2' },
 };
 
@@ -47,7 +56,7 @@ function RenderElement() {
 
 function MyDiagram() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Paper renderElement={RenderElement} />
     </GraphProvider>
   );
@@ -55,15 +64,18 @@ function MyDiagram() {
 \`\`\`
     `,
     props: `
-- **elements**: Record of element objects keyed by ID (required)
-- **links**: Record of link objects keyed by ID (required)
-- **children**: React nodes (typically Paper components)
-- **onChange**: Callback fired when graph state changes
+- **initialElements** / **initialLinks**: uncontrolled record of cells (used on mount; JointJS owns the data after).
+- **elements** / **links**: controlled record of cells (each pairs with its onChange callback).
+- **onElementsChange** / **onLinksChange**: notification in uncontrolled mode; required write-back in controlled mode.
+- **onIncrementalChange**: granular add/change/remove sets — works in any mode.
+- **graph**: optional pre-built JointJS \`dia.Graph\` instance.
+- **store**: optional pre-built \`GraphStore\` instance.
+- **children**: React nodes (typically Paper components).
     `,
     apiURL: API_URL,
     code: `import { GraphProvider, Paper } from '@joint/react'
 
-<GraphProvider elements={elements} links={links}>
+<GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
   <Paper renderElement={RenderElement} />
 </GraphProvider>
     `,
@@ -99,8 +111,8 @@ function RenderHTMLElement() {
 
 export const Default: Story = {
   args: {
-    elements: testElements,
-    links: testLinks,
+    initialElements: testElements,
+    initialLinks: testLinks,
     children: <Paper className={PAPER_CLASSNAME} renderElement={RenderHTMLElement} />,
   },
   parameters: {
@@ -125,8 +137,8 @@ function Component() {
 
 export const ConditionalRender: Story = {
   args: {
-    elements: testElements,
-    links: testLinks,
+    initialElements: testElements,
+    initialLinks: testLinks,
     children: <Component />,
   },
   parameters: {

--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -3,91 +3,138 @@ import type { CellId } from '../../types/cell-id';
 import React, { useLayoutEffect, type Dispatch, type SetStateAction } from 'react';
 import { useImperativeApi } from '../../hooks/use-imperative-api';
 import { GraphStoreContext } from '../../context';
-import { GraphStore } from '../../store';
+import { GraphStore, type GraphStoreOptions } from '../../store';
 import type { IncrementalContainerChanges } from '../../store/graph-view';
 import type { ElementRecord, LinkRecord } from '../../types/data-types';
 
+type ElementsRecord<ElementData extends object> = Record<CellId, ElementRecord<ElementData>>;
+type LinksRecord<LinkData extends object> = Record<CellId, LinkRecord<LinkData>>;
+
 /**
- * Props for the GraphProvider component.
- * @template Element - The type of elements in the graph
- * @template Link - The type of links in the graph
+ * Props common to every GraphProvider mode.
+ * @template ElementData - User data attached to each element.
+ * @template LinkData - User data attached to each link.
  */
-export interface GraphProviderProps<
+interface GraphProviderBaseProps<
   ElementData extends object = Record<string, unknown>,
   LinkData extends object = Record<string, unknown>,
 > {
   /**
-   * Graph instance to use. If not provided, a new graph instance will be created.
+   * Pre-existing JointJS graph instance to use. If omitted, GraphProvider
+   * creates a fresh `new dia.Graph(...)`.
    * @see https://docs.jointjs.com/api/dia/Graph
-   * @default new dia.Graph({}, { cellNamespace: shapes })
    */
   readonly graph?: dia.Graph;
-  /**
-   * React children to render inside the GraphProvider.
-   */
+  /** React children rendered inside the provider — typically a `<Paper />`. */
   readonly children?: React.ReactNode;
   /**
-   * Namespace for cell models.
-   * @default `{ ...shapes, ElementModel, LinkModel }`
+   * Cell namespace passed through to `new dia.Graph`. Defaults to JointJS
+   * built-in shapes plus the `@joint/react` ElementModel and LinkModel.
    */
   readonly cellNamespace?: unknown;
-  /**
-   * Custom cell model to use as the base class for all cells in the graph.
-   */
+  /** Custom cell model used as the base class for all cells in the graph. */
   readonly cellModel?: typeof dia.Cell;
-
-  /**
-   * Pre-created GraphStore instance to use.
-   */
+  /** Pre-built `GraphStore` instance. When provided, GraphProvider does not own its lifecycle. */
   readonly store?: GraphStore<ElementData, LinkData>;
-
   /**
-   * When enabled, graph state updates are deferred during JointJS batch operations
-   * (e.g. drag) and flushed once the batch completes. Disabled by default — each
-   * graph change triggers an immediate state update.
+   * Defer state updates during JointJS batch operations (e.g. drag) and flush
+   * them after `batch:stop`. Off by default — every change triggers an
+   * immediate React update.
    * @default false
    */
   readonly enableBatchUpdates?: boolean;
-
   /**
-   * Elements (nodes) to be added to the graph as a Record keyed by cell ID.
-   *
-   * **Controlled mode:** When `onElementsChange` or `onIncrementalChange` is provided, this prop controls the elements.
-   *
-   * **Uncontrolled mode:** If neither is provided, this is only used for initial elements.
-   */
-  readonly elements?: Record<CellId, ElementRecord<ElementData>>;
-
-  /**
-   * Links (edges) to be added to the graph as a Record keyed by cell ID.
-   *
-   * **Controlled mode:** When `onLinksChange` or `onIncrementalChange` is provided, this prop controls the links.
-   *
-   * **Uncontrolled mode:** If neither is provided, this is only used for initial links.
-   */
-  readonly links?: Record<CellId, LinkRecord<LinkData>>;
-
-  /**
-   * Callback triggered when elements (nodes) change in the graph.
-   * Enables React-controlled mode for elements.
-   */
-  readonly onElementsChange?: Dispatch<SetStateAction<Record<CellId, ElementRecord<ElementData>>>>;
-
-  /**
-   * Callback triggered when links (edges) change in the graph.
-   * Enables React-controlled mode for links.
-   */
-  readonly onLinksChange?: Dispatch<SetStateAction<Record<CellId, LinkRecord<LinkData>>>>;
-
-  /**
-   * Callback triggered with granular incremental change information when graph state changes.
-   * Enables incremental-controlled mode. Can be used with external stores (Redux, Zustand, etc.).
+   * Notification fired with granular `added` / `changed` / `removed` sets
+   * after each commit. Independent of controlled/uncontrolled mode — fires
+   * in either. Wire up to external stores (Redux, Zustand, etc.).
    */
   readonly onIncrementalChange?: (
     changes: IncrementalContainerChanges<ElementData, LinkData>
   ) => void;
 }
 
+/**
+ * Elements-stream props. Either `elements` (controlled) or `initialElements`
+ * (uncontrolled) — the discriminated union forbids passing both.
+ */
+type GraphProviderElementsProps<ElementData extends object> =
+  | {
+      /**
+       * Controlled elements record keyed by cell ID. Pair with `onElementsChange`
+       * to write changes back to React state.
+       */
+      readonly elements: ElementsRecord<ElementData>;
+      readonly initialElements?: never;
+      /**
+       * Fires whenever elements change. In controlled mode (when `elements` is
+       * provided), consumers MUST update their state from this callback for the
+       * graph to reflect new data.
+       */
+      readonly onElementsChange?: Dispatch<SetStateAction<ElementsRecord<ElementData>>>;
+    }
+  | {
+      readonly elements?: never;
+      /**
+       * Uncontrolled initial elements record. Used only on mount; subsequent
+       * changes from React are ignored. JointJS drives the graph from here.
+       */
+      readonly initialElements?: ElementsRecord<ElementData>;
+      /**
+       * Fires whenever elements change. In uncontrolled mode this is a
+       * notification only — React state is NOT pushed back to the graph.
+       */
+      readonly onElementsChange?: (elements: ElementsRecord<ElementData>) => void;
+    };
+
+/**
+ * Links-stream props. Either `links` (controlled) or `initialLinks`
+ * (uncontrolled) — the discriminated union forbids passing both.
+ */
+type GraphProviderLinksProps<LinkData extends object> =
+  | {
+      /**
+       * Controlled links record keyed by cell ID. Pair with `onLinksChange`
+       * to write changes back to React state.
+       */
+      readonly links: LinksRecord<LinkData>;
+      readonly initialLinks?: never;
+      /** Fires whenever links change. In controlled mode, consumers MUST update state. */
+      readonly onLinksChange?: Dispatch<SetStateAction<LinksRecord<LinkData>>>;
+    }
+  | {
+      readonly links?: never;
+      /** Uncontrolled initial links record. Used only on mount. */
+      readonly initialLinks?: LinksRecord<LinkData>;
+      /** Notification-only callback — React state is NOT pushed back to the graph. */
+      readonly onLinksChange?: (links: LinksRecord<LinkData>) => void;
+    };
+
+/**
+ * Props for `GraphProvider`. Elements and links are independent streams —
+ * any combination of controlled/uncontrolled is valid.
+ *
+ * **Modes (per stream):**
+ * - **Uncontrolled:** Pass `initialElements` / `initialLinks`. JointJS owns the graph.
+ *   `onElementsChange` / `onLinksChange` may still be passed as notifications.
+ * - **Controlled:** Pass `elements` / `links` and `onElementsChange` / `onLinksChange`.
+ *   React owns the data; the graph is kept in sync from React state.
+ *
+ * Mixed (e.g. controlled elements + uncontrolled links) is fully supported.
+ * @template ElementData - User data attached to each element record.
+ * @template LinkData - User data attached to each link record.
+ */
+export type GraphProviderProps<
+  ElementData extends object = Record<string, unknown>,
+  LinkData extends object = Record<string, unknown>,
+> = GraphProviderBaseProps<ElementData, LinkData> &
+  GraphProviderElementsProps<ElementData> &
+  GraphProviderLinksProps<LinkData>;
+
+/**
+ * Internal generic base component for GraphProvider.
+ * @param props - GraphProvider props including optional forwarded ref.
+ * @returns The rendered graph context provider or null while loading.
+ */
 function GraphBase<
   ElementData extends object = Record<string, unknown>,
   LinkData extends object = Record<string, unknown>,
@@ -95,17 +142,24 @@ function GraphBase<
   const {
     children,
     store,
-    elements,
-    links,
+    onIncrementalChange,
     onElementsChange,
     onLinksChange,
-    onIncrementalChange,
     ref: forwardedRef,
     ...rest
-  } = props;
+  } = props as GraphProviderBaseProps<ElementData, LinkData> & {
+    elements?: ElementsRecord<ElementData>;
+    initialElements?: ElementsRecord<ElementData>;
+    links?: LinksRecord<LinkData>;
+    initialLinks?: LinksRecord<LinkData>;
+    onElementsChange?: GraphStoreOptions<ElementData, LinkData>['onElementsChange'];
+    onLinksChange?: GraphStoreOptions<ElementData, LinkData>['onLinksChange'];
+    ref?: React.Ref<dia.Graph | null>;
+  };
 
-  const isControlledMode =
-    Boolean(onIncrementalChange) || Boolean(onElementsChange) || Boolean(onLinksChange);
+  const { elements, links, initialElements, initialLinks } = rest;
+  const isElementsControlled = elements !== undefined;
+  const isLinksControlled = links !== undefined;
 
   const { isReady, ref } = useImperativeApi<GraphStore<ElementData, LinkData>, dia.Graph>(
     {
@@ -115,19 +169,25 @@ function GraphBase<
         const graphStore =
           store ??
           new GraphStore<ElementData, LinkData>({
-            ...rest,
-            initialElements: elements,
-            initialLinks: links,
+            graph: rest.graph,
+            cellNamespace: rest.cellNamespace,
+            cellModel: rest.cellModel,
+            initialElements: isElementsControlled ? elements : initialElements,
+            initialLinks: isLinksControlled ? links : initialLinks,
             onIncrementalChange,
-            onElementsChange,
-            onLinksChange,
+            onElementsChange: onElementsChange as GraphStoreOptions<
+              ElementData,
+              LinkData
+            >['onElementsChange'],
+            onLinksChange: onLinksChange as GraphStoreOptions<
+              ElementData,
+              LinkData
+            >['onLinksChange'],
           });
 
         return {
           cleanup() {
-            if (store) {
-              return;
-            }
+            if (store) return;
             graphStore.destroy(!!rest.graph);
           },
           instance: graphStore,
@@ -138,13 +198,20 @@ function GraphBase<
   );
 
   useLayoutEffect(() => {
-    if (!isControlledMode || !isReady || !ref.current) return;
+    if (!isElementsControlled || !isReady || !ref.current) return;
     ref.current.graphView.updateGraph({
       elements: elements ?? {},
+      flag: 'updateFromReact',
+    });
+  }, [elements, isElementsControlled, isReady, ref]);
+
+  useLayoutEffect(() => {
+    if (!isLinksControlled || !isReady || !ref.current) return;
+    ref.current.graphView.updateGraph({
       links: links ?? {},
       flag: 'updateFromReact',
     });
-  }, [elements, links, isControlledMode, isReady, ref]);
+  }, [links, isLinksControlled, isReady, ref]);
 
   if (!isReady) {
     return null;
@@ -156,16 +223,16 @@ function GraphBase<
 /**
  * GraphProvider is the main component that provides graph context to its children.
  *
- * **Three modes of operation:**
+ * **Modes of operation (per stream — elements and links are independent):**
  *
- * 1. **Uncontrolled mode** (default):
+ * 1. **Uncontrolled mode** (default): JointJS owns the graph after mount.
  * ```tsx
- * <GraphProvider elements={initialElements} links={initialLinks}>
+ * <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
  *   <Paper />
  * </GraphProvider>
  * ```
  *
- * 2. **React-controlled mode:**
+ * 2. **React-controlled mode:** React owns the data and pushes updates to the graph.
  * ```tsx
  * const [elements, setElements] = useState({});
  * const [links, setLinks] = useState({});
@@ -180,7 +247,18 @@ function GraphBase<
  * </GraphProvider>
  * ```
  *
- * 3. **Incremental-controlled mode:**
+ * 3. **Mixed mode:** controlled elements + uncontrolled links (or vice versa).
+ * ```tsx
+ * <GraphProvider
+ *   elements={elements}
+ *   onElementsChange={setElements}
+ *   initialLinks={initialLinks}
+ * >
+ *   <Paper />
+ * </GraphProvider>
+ * ```
+ *
+ * 4. **Incremental-controlled mode:**
  * ```tsx
  * <GraphProvider onIncrementalChange={(changes) => dispatch(changes)}>
  *   <Paper />

--- a/packages/joint-react/src/components/html-host.tsx
+++ b/packages/joint-react/src/components/html-host.tsx
@@ -14,7 +14,6 @@ import { useElementSize } from '../hooks';
  *
  * Does **not** apply any default theme class. For themed styling via
  * `--jj-box-*` CSS variables, use {@link DefaultHTMLHost} instead.
- *
  * @example
  * ```tsx
  * <Paper renderElement={({ label }) => (
@@ -37,6 +36,11 @@ interface HTMLFrameProps extends Omit<HTMLHostProps, 'useModelGeometry'> {
 /**
  * Shared rendering primitive: a `<div>` inside a `<foreignObject>`.
  * Forces static positioning to work around Safari foreignObject quirks.
+ * @param root0
+ * @param root0.nodeRef
+ * @param root0.width
+ * @param root0.height
+ * @param root0.style
  */
 function HTMLFrame({ nodeRef, width, height, style, ...rest }: Readonly<HTMLFrameProps>) {
   // Force static positioning — Safari mispositions foreignObject children with position: relative or backdrop-filter.
@@ -66,6 +70,8 @@ export function HTMLHost(props: Readonly<HTMLHostProps> = {}) {
 /**
  * Internal component that uses the element's size from the model.
  * Rendered when `useModelGeometry` is set.
+ * @param root0
+ * @param root0.style
  */
 function StaticHTMLFrame({ style, ...rest }: Readonly<HTMLAttributes<HTMLDivElement>>) {
   const { width, height } = useElementSize();
@@ -82,6 +88,8 @@ function StaticHTMLFrame({ style, ...rest }: Readonly<HTMLAttributes<HTMLDivElem
 /**
  * Internal component that measures its DOM node and syncs the size to the graph element.
  * Rendered by default when `useModelGeometry` is not set.
+ * @param root0
+ * @param root0.style
  */
 function MeasuredHTMLFrame({ style, ...rest }: Readonly<HTMLAttributes<HTMLDivElement>>) {
   const nodeRef = useRef<HTMLDivElement>(null);

--- a/packages/joint-react/src/components/paper/__tests__/graph-provider.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/graph-provider.test.tsx
@@ -55,7 +55,7 @@ describe('graph', () => {
       return null;
     }
     render(
-      <GraphProvider elements={elements} links={{ link1: link }}>
+      <GraphProvider initialElements={elements} initialLinks={{ link1: link }}>
         <TestComponent />
       </GraphProvider>
     );
@@ -115,7 +115,7 @@ describe('graph', () => {
       return null;
     }
     render(
-      <GraphProvider elements={elements}>
+      <GraphProvider initialElements={elements}>
         <TestComponent />
       </GraphProvider>
     );
@@ -250,7 +250,7 @@ describe('graph', () => {
       return null;
     }
     render(
-      <GraphProvider elements={elements} links={{ link1: link }}>
+      <GraphProvider initialElements={elements} initialLinks={{ link1: link }}>
         <TestComponent />
       </GraphProvider>
     );
@@ -424,7 +424,7 @@ describe('graph', () => {
     }
 
     render(
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <TestComponent />
       </GraphProvider>
     );
@@ -492,7 +492,7 @@ describe('graph', () => {
       const renderLink = useCallback(() => <CaptureLinkDataUpdated />, []);
 
       return (
-        <GraphProvider elements={elements} links={links} onLinksChange={setLinks}>
+        <GraphProvider initialElements={elements} links={links} onLinksChange={setLinks}>
           <Paper
             width={100}
             height={100}

--- a/packages/joint-react/src/components/paper/__tests__/paper-html-overlay-links.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-html-overlay-links.test.tsx
@@ -29,7 +29,7 @@ const links: Record<string, LinkRecord> = {
 describe('Paper with useHTMLOverlay and links', () => {
   it('renders links when useHTMLOverlay is enabled', async () => {
     const { container } = render(
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestElementRenderer />}
@@ -65,7 +65,7 @@ describe('Paper with useHTMLOverlay and links', () => {
 
   it('renders placeholder rect in SVG element when useHTMLOverlay is enabled', async () => {
     const { container } = render(
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestElementRenderer />}
@@ -113,7 +113,7 @@ describe('Paper with useHTMLOverlay and links', () => {
     };
 
     const { container } = render(
-      <GraphProvider elements={initialElements}>
+      <GraphProvider initialElements={initialElements}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestElementRenderer />}
@@ -176,7 +176,7 @@ describe('Paper with useHTMLOverlay and links', () => {
     }
 
     const { container } = render(
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestElementRenderer />}

--- a/packages/joint-react/src/components/paper/__tests__/paper-link-flickering.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-link-flickering.test.tsx
@@ -107,7 +107,7 @@ function checkLinkPathsNotAtOrigin(container: HTMLElement): boolean {
 describe('Paper link flickering prevention', () => {
   it('INVARIANT: links should not have paths before element content is rendered (SVG mode)', async () => {
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           renderElement={() => <TestFlickerElementSvg />}
         />
@@ -156,7 +156,7 @@ describe('Paper link flickering prevention', () => {
 
   it('INVARIANT: links should not have paths before element content is rendered (HTML overlay mode)', async () => {
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestFlickerElement />}
@@ -202,7 +202,7 @@ describe('Paper link flickering prevention', () => {
     // 3. The measureNode fix is applied (verified by other passing tests)
 
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestFlickerElement />}
@@ -238,7 +238,7 @@ describe('Paper link flickering prevention', () => {
 
   it('link paths should have correct coordinates (not at origin 0,0)', async () => {
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestFlickerElement />}
@@ -279,7 +279,7 @@ describe('Paper link flickering prevention', () => {
 
   it('should maintain consistency during initial render (no state changes)', async () => {
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestFlickerElement />}
@@ -319,7 +319,7 @@ describe('Paper link flickering prevention', () => {
     const startTime = performance.now();
 
     const { container } = render(
-      <GraphProvider elements={TEST_ELEMENTS} links={TEST_LINKS}>
+      <GraphProvider initialElements={TEST_ELEMENTS} initialLinks={TEST_LINKS}>
         <Paper
           useHTMLOverlay
           renderElement={() => <TestFlickerElement />}

--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -14,6 +14,7 @@ import type { ElementsMeasuredEvent } from '../../../types/event.types';
 import type { ElementRecord, LinkRecord } from '../../../types/data-types';
 import { GraphProvider } from '../../graph/graph-provider';
 import { Paper } from '../paper';
+import type { DefaultLinkContext } from '../paper.types';
 import { LinkModel, LINK_MODEL_TYPE } from '../../../models/link-model';
 import { PortalPaper } from '../../../models/portal-paper';
 import { ElementModel } from '../../../models/element-model';
@@ -77,7 +78,7 @@ const PROP_HEIGHT = 180;
 type DefaultLinkProperty =
   | dia.Link
   | Partial<LinkRecord>
-  | ((cellView: dia.CellView, magnet: SVGElement) => dia.Link | Partial<LinkRecord>);
+  | ((context: DefaultLinkContext) => dia.Link | Partial<LinkRecord>);
 
 type PortDragElementView = dia.ElementView & {
   findPortNode: (portId: string, selector?: string) => SVGElement | null;
@@ -293,7 +294,7 @@ async function renderPortDragPaper(defaultLink?: DefaultLinkProperty) {
 
   await act(async () => {
     render(
-      <GraphProvider elements={getPortDragElements()}>
+      <GraphProvider initialElements={getPortDragElements()}>
         <Paper
           ref={ref}
           defaultLink={defaultLink}
@@ -383,7 +384,7 @@ describe('Paper Component', () => {
     const PAPER_ID = 'test-measured';
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <MeasuredListener paperId={PAPER_ID} callback={onMeasuredMock} />
           <Paper
             id={PAPER_ID}
@@ -406,7 +407,7 @@ describe('Paper Component', () => {
   it('renders elements correctly with useHTMLOverlay enabled', async () => {
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper useHTMLOverlay renderElement={() => <TestLabelElement />} />
         </GraphProvider>
       );
@@ -460,7 +461,7 @@ describe('Paper Component', () => {
   it('applies default clickThreshold and custom clickThreshold', async () => {
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -470,7 +471,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper clickThreshold={20} renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -482,7 +483,7 @@ describe('Paper Component', () => {
   it('applies scale to the Paper', async () => {
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper scale={2} renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -500,7 +501,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <MeasuredListener paperId={PAPER_ID} callback={onMeasuredMock} />
           <Paper id={PAPER_ID} renderElement={() => <div>Test</div>} />
         </GraphProvider>
@@ -524,7 +525,7 @@ describe('Paper Component', () => {
         }, 100);
       }, []);
       return (
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           {isReady && (
             <>
               <MeasuredListener paperId={PAPER_ID} callback={onMeasuredMock} />
@@ -549,7 +550,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -580,7 +581,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
           <CapturePaperRef paperRef={ref} />
         </GraphProvider>
@@ -612,7 +613,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <PaperWithEffectRefCapture />
         </GraphProvider>
       );
@@ -643,7 +644,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={{}}>
+        <GraphProvider initialElements={{}}>
           <PaperWithEffectRefCapture />
         </GraphProvider>
       );
@@ -664,7 +665,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={{}}>
+        <GraphProvider initialElements={{}}>
           <Paper ref={ref} />
         </GraphProvider>
       );
@@ -698,7 +699,7 @@ describe('Paper Component', () => {
     function Component() {
       const ref = useRef<dia.Paper | null>(null);
       return (
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
           <ChangeScale paperRef={ref} />
         </GraphProvider>
@@ -738,7 +739,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
           <ChangeScale />
         </GraphProvider>
@@ -848,7 +849,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={view1Ref} renderElement={() => <div>Test</div>} />
           <Paper ref={view2Ref} renderElement={() => <div>Test</div>} />
         </GraphProvider>
@@ -870,7 +871,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -892,7 +893,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper
             ref={ref}
             defaultConnectionPoint={{ name: 'boundary' }}
@@ -916,7 +917,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} width="100%" renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -934,7 +935,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} height="100%" renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -952,7 +953,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} width="100%" height="100%" renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -970,7 +971,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper
             ref={ref}
             className="custom-paper-class flowchart-paper"
@@ -1007,7 +1008,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper
             ref={ref}
             style={{ width: '640px', height: '360px' }}
@@ -1040,7 +1041,7 @@ describe('Paper Component', () => {
     try {
       await act(async () => {
         render(
-          <GraphProvider elements={elements}>
+          <GraphProvider initialElements={elements}>
             <Paper
               ref={ref}
               className="paper-host-sized-by-class"
@@ -1076,7 +1077,7 @@ describe('Paper Component', () => {
     try {
       await act(async () => {
         render(
-          <GraphProvider elements={elements}>
+          <GraphProvider initialElements={elements}>
             <Paper
               ref={ref}
               className="paper-host-size-conflict"
@@ -1113,7 +1114,7 @@ describe('Paper Component', () => {
     try {
       await act(async () => {
         render(
-          <GraphProvider elements={elements}>
+          <GraphProvider initialElements={elements}>
             <Paper
               ref={ref}
               className="paper-host-size-priority"
@@ -1149,7 +1150,7 @@ describe('Paper Component', () => {
 
       await act(async () => {
         render(
-          <GraphProvider elements={elements}>
+          <GraphProvider initialElements={elements}>
             <Paper
               ref={ref}
               className={withClassName ? CUSTOM_PAPER_CLASSNAME : undefined}
@@ -1201,7 +1202,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} width="100%" height="100%" renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -1220,7 +1221,7 @@ describe('Paper Component', () => {
 
     await act(async () => {
       render(
-        <GraphProvider elements={elements}>
+        <GraphProvider initialElements={elements}>
           <Paper ref={ref} renderElement={() => <div>Test</div>} />
         </GraphProvider>
       );
@@ -1238,8 +1239,18 @@ describe('Paper Component', () => {
       magnet: SVGElement
     ) => dia.Link;
 
+    const paper = ref.current!;
+    const graph = paper.model;
+    const sourceCell = graph.getCells()[0];
+    const cellView = {
+      model: sourceCell,
+      paper,
+      el: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+      findAttribute: () => null,
+    } as unknown as dia.CellView;
+
     const createdLink = defaultLinkFactory(
-      {} as dia.CellView,
+      cellView,
       document.createElementNS('http://www.w3.org/2000/svg', 'circle')
     );
     expect(createdLink).toBeInstanceOf(CustomNamespaceLinkModel);
@@ -1300,7 +1311,7 @@ describe('Paper Component', () => {
 
     it('supports defaultLink as a callback returning a dia.Link when dragging between ports', async () => {
       const defaultLinkCallback = jest.fn(
-        (_cellView: dia.CellView, _magnet: SVGElement): dia.Link =>
+        (_context: DefaultLinkContext): dia.Link =>
           new shapes.standard.Link({
             attrs: {
               line: {
@@ -1321,9 +1332,9 @@ describe('Paper Component', () => {
       if (!firstCall) {
         throw new Error('Expected defaultLink callback to be called at least once.');
       }
-      const [calledCellView, calledMagnet] = firstCall;
-      expect(calledCellView.model.id).toBe(SOURCE_ELEMENT_ID);
-      expect(calledMagnet.getAttribute('port')).toBe(SOURCE_PORT_ID);
+      const [calledContext] = firstCall;
+      expect(calledContext.source.id).toBe(SOURCE_ELEMENT_ID);
+      expect(calledContext.source.port).toBe(SOURCE_PORT_ID);
       expect(createdLink).toBeInstanceOf(shapes.standard.Link);
       expect(createdLink.attr(['line', 'stroke'])).toBe('#abcdef');
       expect(createdLink.getSourceCell()?.id).toBe(SOURCE_ELEMENT_ID);
@@ -1378,7 +1389,7 @@ describe('Paper Component', () => {
 
     it('supports defaultLink callback returning LinkRecord when dragging between ports', async () => {
       const defaultLinkCallback = jest.fn(
-        (_cellView: dia.CellView, _magnet: SVGElement): Partial<LinkRecord> => ({
+        (_context: DefaultLinkContext): Partial<LinkRecord> => ({
           data: { customProperty: 'callback-flat-link-default' },
           style: {
             color: '#22aa55',
@@ -1511,7 +1522,7 @@ describe('Paper Component', () => {
 
         return (
           <GraphProvider
-            elements={{
+            initialElements={{
               'el-1': {
                 data: { label: 'Visible Node' },
                 size: { width: 100, height: 50 },
@@ -1608,7 +1619,7 @@ describe('Paper Component', () => {
     it('useLink provides layout with sourceX/sourceY/targetX/targetY on initial load', async () => {
       await act(async () => {
         render(
-          <GraphProvider elements={testElements} links={testLinks}>
+          <GraphProvider initialElements={testElements} initialLinks={testLinks}>
             <Paper
               height={400}
               renderElement={() => <rect width={100} height={50} />}

--- a/packages/joint-react/src/components/paper/paper.stories.tsx
+++ b/packages/joint-react/src/components/paper/paper.stories.tsx
@@ -55,7 +55,7 @@ function RenderElement() {
 
 function MyDiagram() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Paper
         renderElement={RenderElement}
         height={600}
@@ -81,7 +81,7 @@ function RenderElement() {
   return <rect rx={10} ry={10} width={size?.width} height={size?.height} fill="blue" />;
 }
 
-<GraphProvider elements={elements} links={links}>
+<GraphProvider initialElements={elements} initialLinks={links}>
   <Paper renderElement={RenderElement} height={600} />
 </GraphProvider>
     `,

--- a/packages/joint-react/src/hooks/__tests__/use-create-features.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-create-features.test.tsx
@@ -26,7 +26,7 @@ function renderTestElement() {
 
 function createPaperWrapper(paperId = 'test-paper') {
   return ({ children }: { children: ReactNode }) => (
-    <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+    <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
       <Paper id={paperId} width={100} height={100} renderElement={renderTestElement}>
         {children}
       </Paper>
@@ -36,7 +36,7 @@ function createPaperWrapper(paperId = 'test-paper') {
 
 function createGraphWrapper() {
   return ({ children }: { children: ReactNode }) => (
-    <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+    <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
       {children}
     </GraphProvider>
   );
@@ -450,7 +450,7 @@ describe('FeaturesProvider', () => {
     }
 
     render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <Paper id="feat-paper" width={100} height={100} renderElement={renderTestElement}>
           <FeaturesProvider target="paper" id="scroller" onAddFeature={onAddFeature}>
             <CaptureFeatures />
@@ -481,7 +481,7 @@ describe('FeaturesProvider', () => {
     }
 
     render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <FeaturesProvider target="graph" id="command-manager" onAddFeature={onAddFeature}>
           <CaptureFeatures />
         </FeaturesProvider>

--- a/packages/joint-react/src/hooks/__tests__/use-create-react-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-create-react-paper.test.tsx
@@ -14,7 +14,7 @@ function renderTestElement() {
 
 function createGraphWrapper() {
   return ({ children }: { children: ReactNode }) => (
-    <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+    <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
       {children}
     </GraphProvider>
   );
@@ -295,7 +295,7 @@ describe('use-create-portal-paper', () => {
     };
 
     render(
-      <GraphProvider elements={initialElements} links={initialLinks}>
+      <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
         <RenderCountHost onRenderCount={onRenderCount} />
       </GraphProvider>
     );

--- a/packages/joint-react/src/hooks/__tests__/use-link.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-link.test.tsx
@@ -91,7 +91,7 @@ describe('useLink', () => {
 
     // After move, layout.d should update to match the new native link path
     await waitFor(() => {
-      const layout = result.current.layout;
+      const {layout} = result.current;
       expect(layout).toBeDefined();
       expect(layout!.d).not.toBe('');
       // The path must have changed from the initial position

--- a/packages/joint-react/src/hooks/__tests__/use-nodes-measured-effect.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-nodes-measured-effect.test.tsx
@@ -53,7 +53,7 @@ describe('useNodesMeasuredEffect', () => {
     const callback = jest.fn();
 
     render(
-      <GraphProvider elements={ELEMENTS_WITH_SIZE}>
+      <GraphProvider initialElements={ELEMENTS_WITH_SIZE}>
         <Listener callback={callback} />
         <Paper id={PAPER_ID} renderElement={RenderElement} />
       </GraphProvider>
@@ -85,7 +85,7 @@ describe('useNodesMeasuredEffect', () => {
     });
 
     render(
-      <GraphProvider elements={ELEMENTS_WITHOUT_SIZE}>
+      <GraphProvider initialElements={ELEMENTS_WITHOUT_SIZE}>
         <Listener callback={callback} />
         <Paper id={PAPER_ID} renderElement={RenderMeasuredElement} />
       </GraphProvider>

--- a/packages/joint-react/src/hooks/__tests__/use-paper-events.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper-events.test.tsx
@@ -99,7 +99,7 @@ const PAPER_EVENT_ARGS: {
 
 function createPaperWrapper(paperId: string) {
   return ({ children }: { children: ReactNode }) => (
-    <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+    <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
       <Paper id={paperId} width={100} height={100} renderElement={renderTestElement}>
         {children}
       </Paper>
@@ -362,7 +362,7 @@ describe('use-paper-events', () => {
     const paperHolder = { current: null as dia.Paper | null };
 
     render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <UsePaperEventsWithPaperIdPattern onCustomEvent={onCustomEvent} paperHolder={paperHolder} />
       </GraphProvider>
     );
@@ -417,7 +417,7 @@ describe('use-paper-events', () => {
 
     function Wrapper() {
       return (
-        <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+        <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
           <TestComponent />
         </GraphProvider>
       );
@@ -442,7 +442,7 @@ describe('use-paper-events', () => {
     }
 
     const { unmount } = render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <TestComponent />
         <PaperExtractor />
       </GraphProvider>

--- a/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
@@ -16,7 +16,7 @@ function renderTestElement() {
 
 function createPaperWrapper(paperId = 'paper-under-test') {
   return ({ children }: { children: ReactNode }) => (
-    <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+    <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
       <Paper id={paperId} width={100} height={100} renderElement={renderTestElement}>
         {children}
       </Paper>
@@ -26,8 +26,8 @@ function createPaperWrapper(paperId = 'paper-under-test') {
 
 describe('use-paper', () => {
   const graphWrapper = graphProviderWrapper({
-    elements: EMPTY_ELEMENTS,
-    links: EMPTY_LINKS,
+    initialElements: EMPTY_ELEMENTS,
+    initialLinks: EMPTY_LINKS,
   });
 
   it('returns paper instance from Paper context', async () => {
@@ -134,7 +134,7 @@ describe('useResolvePaperId', () => {
     }
 
     render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <TestComponent />
       </GraphProvider>
     );
@@ -163,7 +163,7 @@ describe('useResolvePaperId', () => {
     }
 
     render(
-      <GraphProvider elements={EMPTY_ELEMENTS} links={EMPTY_LINKS}>
+      <GraphProvider initialElements={EMPTY_ELEMENTS} initialLinks={EMPTY_LINKS}>
         <TestComponent />
       </GraphProvider>
     );

--- a/packages/joint-react/src/hooks/use-are-elements-measured.ts
+++ b/packages/joint-react/src/hooks/use-are-elements-measured.ts
@@ -1,6 +1,9 @@
 import { useGraphStore } from './use-graph-store';
 import { useSyncExternalStore } from 'react';
 
+/**
+ *
+ */
 export function useAreElementsMeasured() {
   const { measureState } = useGraphStore();
   return useSyncExternalStore(

--- a/packages/joint-react/src/hooks/use-container-items.ts
+++ b/packages/joint-react/src/hooks/use-container-items.ts
@@ -23,7 +23,8 @@ function areMapsShallowEqual<R>(a: Map<string, R>, b: Map<string, R>): boolean {
  * - **Map mode** (`ids?`): returns all/filtered items as a stable Map. Per-ID subscription for IDs.
  * - **Map mode with transform** (`ids?, mapItem`): same, but applies `mapItem` to each value.
  * - **Selector mode** (`selector, isEqual?`): applies selector to full Map, custom equality.
- *
+ * @param container
+ * @param ids
  * @internal
  */
 export function useContainerItems<T>(

--- a/packages/joint-react/src/hooks/use-element.ts
+++ b/packages/joint-react/src/hooks/use-element.ts
@@ -9,7 +9,6 @@ import type { ElementWithLayout } from '../types/data-types';
  * Use it only inside `renderElement` or components rendered from within.
  *
  * Returns element data with guaranteed position, size, and angle.
- *
  * @example
  * ```tsx
  * const element = useElement();

--- a/packages/joint-react/src/hooks/use-elements.ts
+++ b/packages/joint-react/src/hooks/use-elements.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/unified-signatures */
+ 
 import { useMemo } from 'react';
 import type { CellId } from '../types/cell-id';
 import { useGraphStore } from './use-graph-store';
@@ -17,7 +17,6 @@ import type { ElementWithLayout } from '../types/data-types';
  * - **No args**: returns all elements as a stable `Map`.
  * - **IDs**: returns a filtered subset.
  * - **Selector**: applies a selector over the full `Map`.
- *
  * @group Hooks
  */
 export function useElements<T extends object = Record<string, unknown>>(): Map<

--- a/packages/joint-react/src/hooks/use-link.ts
+++ b/packages/joint-react/src/hooks/use-link.ts
@@ -22,7 +22,6 @@ export type ResolvedLink<D extends object = Record<string, unknown>> = LinkRecor
  * Returns link data with the current paper's layout resolved
  * (source/target coordinates and SVG path).
  * @experimental
- *
  * @example
  * ```tsx
  * const link = useLink();

--- a/packages/joint-react/src/hooks/use-links-data.ts
+++ b/packages/joint-react/src/hooks/use-links-data.ts
@@ -13,7 +13,6 @@ import { useContainerItems } from './use-container-items';
  * - **No args**: returns all links as a stable `Map`.
  * - **IDs**: returns a filtered subset.
  * - **Selector**: applies a selector over the full `Map`.
- *
  * @group Hooks
  */
 export function useLinksData<D extends object = Record<string, unknown>>(): Map<CellId, LinkRecord<D>>;

--- a/packages/joint-react/src/hooks/use-links.ts
+++ b/packages/joint-react/src/hooks/use-links.ts
@@ -16,7 +16,6 @@ import { useContainerItems } from './use-container-items';
  * - **No args**: returns all links as a stable `Map`.
  * - **IDs**: returns a filtered subset.
  * - **Selector**: applies a selector over the full `Map`.
- *
  * @group Hooks
  */
 export function useLinks<T extends object = Record<string, unknown>>(): Map<CellId, LinkRecord<T>>;

--- a/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
+++ b/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
@@ -84,6 +84,9 @@ export function useNodesMeasuredEffect(
     if (!paperStore) return;
     const { paper } = paperStore;
 
+    /**
+     *
+     */
     function handleChanges() {
       const value = measureState.get();
       const isMeasured = value > 0;

--- a/packages/joint-react/src/models/__tests__/link-model.test.ts
+++ b/packages/joint-react/src/models/__tests__/link-model.test.ts
@@ -9,6 +9,7 @@ describe('LinkModel', () => {
         {
           tagName: 'path',
           selector: 'wrapper',
+          className: 'jj-link-wrapper',
           attributes: {
             fill: 'none',
             cursor: 'pointer',
@@ -18,6 +19,7 @@ describe('LinkModel', () => {
         {
           tagName: 'path',
           selector: 'line',
+          className: 'jj-link-line',
           attributes: {
             fill: 'none',
             pointerEvents: 'none',

--- a/packages/joint-react/src/presets/anchors.ts
+++ b/packages/joint-react/src/presets/anchors.ts
@@ -5,6 +5,12 @@ import { getMarkerLength, MODEL_GEOMETRY_OPTIONS } from './utils';
 /**
  * Anchor that uses `center` with model geometry for the root element and ports,
  * and plain `center` (DOM-measured) for custom magnets.
+ * @param elementView
+ * @param magnet
+ * @param ref
+ * @param _
+ * @param endType
+ * @param linkView
  */
 export const centerAnchor: anchors.Anchor = (
   elementView, magnet, ref, _, endType, linkView
@@ -18,6 +24,12 @@ export const centerAnchor: anchors.Anchor = (
 /**
  * Anchor that uses `perpendicular` with model geometry for the root element and ports,
  * and plain `perpendicular` (DOM-measured) for custom magnets.
+ * @param elementView
+ * @param magnet
+ * @param ref
+ * @param _
+ * @param endType
+ * @param linkView
  */
 export const perpendicularAnchor: anchors.Anchor = (
   elementView, magnet, ref, _, endType, linkView
@@ -36,9 +48,10 @@ export type LinkMode = 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 
  * - Root element → `midSide` with model geometry and the given `mode`.
  * - Port magnet → a specific side of the port bbox, with optional padding.
  * - Other magnets → `midSide` (DOM-based)
-* @param mode - The `midSide` mode. Default: `'auto'`.
+ * @param mode - The `midSide` mode. Default: `'auto'`.
  * @param sourceOffset - Padding for source end (px). Default: `0`.
  * @param targetOffset - Padding for target end (px). Default: `0`.
+ * @param markerSelector
  */
 export function midSideAnchor(mode: LinkMode = 'auto', sourceOffset = 0, targetOffset = 0, markerSelector = 'line'): anchors.Anchor {
   return (elementView, magnet, ref, _, endType, linkView) => {

--- a/packages/joint-react/src/presets/can-connect.ts
+++ b/packages/joint-react/src/presets/can-connect.ts
@@ -98,6 +98,11 @@ function endMatches(
 /**
  * Returns `true` if a duplicate link already exists between the two ends
  * (ignoring the link currently being validated).
+ * @param sourceView
+ * @param sourceNode
+ * @param targetView
+ * @param targetNode
+ * @param linkView
  */
 function hasDuplicateLink(
   sourceView: dia.CellView, sourceNode: SVGElement | undefined,

--- a/packages/joint-react/src/presets/can-embed.ts
+++ b/packages/joint-react/src/presets/can-embed.ts
@@ -22,6 +22,10 @@ export interface ValidateUnembeddingContext {
   readonly graph: dia.Graph;
 }
 
+/**
+ *
+ * @param view
+ */
 function toEmbeddingInfo(view: dia.ElementView) {
   return { id: view.model.id, model: view.model } as const;
 }
@@ -30,10 +34,8 @@ function toEmbeddingInfo(view: dia.ElementView) {
  * Creates a JointJS-native `validateEmbedding` function.
  * Converts positional `(childView, parentView)` args into a structured
  * `{ child, parent, paper, graph }` context for the validate callback.
- *
  * @param validate - Optional custom validation. Defaults to `() => true`.
  * @returns A JointJS-compatible `validateEmbedding` function.
- *
  * @example
  * ```ts
  * paper.options.validateEmbedding = canEmbed(
@@ -58,10 +60,8 @@ export function canEmbed(validate?: (context: ValidateEmbeddingContext) => boole
  * Creates a JointJS-native `validateUnembedding` function.
  * Converts the positional `(childView)` arg into a structured
  * `{ child, paper, graph }` context for the validate callback.
- *
  * @param validate - Optional custom validation. Defaults to `() => true`.
  * @returns A JointJS-compatible `validateUnembedding` function.
- *
  * @example
  * ```ts
  * paper.options.validateUnembedding = canUnembed(

--- a/packages/joint-react/src/presets/connection-points.ts
+++ b/packages/joint-react/src/presets/connection-points.ts
@@ -9,6 +9,12 @@ import { BOUNDARY_OPTIONS, EMPTY_OPTIONS, getMarkerLength, MODEL_GEOMETRY_OPTION
  * - Default port magnets (elements with a `port` attribute)
  *
  * Uses `boundary` for custom sub-elements registered via `selectorRef`.
+ * @param endPathSegmentLine
+ * @param endView
+ * @param endMagnet
+ * @param _opt
+ * @param endType
+ * @param linkView
  */
 export const boundaryPoint: connectionPoints.ConnectionPoint = (
   endPathSegmentLine,
@@ -29,6 +35,12 @@ export const boundaryPoint: connectionPoints.ConnectionPoint = (
  * For ports: returns the anchor (already at port edge via smartAnchor).
  * For root element: returns the anchor (already on boundary via midSide).
  * For custom magnets: uses `rectangle` with model geometry.
+ * @param endPathSegmentLine
+ * @param endView
+ * @param endMagnet
+ * @param _opt
+ * @param endType
+ * @param linkView
  */
 export const anchorPoint: connectionPoints.ConnectionPoint = (
   endPathSegmentLine,
@@ -47,6 +59,10 @@ export const anchorPoint: connectionPoints.ConnectionPoint = (
 
 /**
  * Wraps a connection point function and applies per-end offsets to the result.
+ * @param cp
+ * @param sourceOffset
+ * @param targetOffset
+ * @param markerSelector
  */
 export function withOffsets(
   cp: connectionPoints.ConnectionPoint,

--- a/packages/joint-react/src/presets/connectors.ts
+++ b/packages/joint-react/src/presets/connectors.ts
@@ -1,12 +1,22 @@
 import type { routers, connectors as connectorTypes } from '@joint/core';
 import { connectors as connectorFns, routers as routerFns } from '@joint/core';
 
-/** Creates a right-angle router with `useVertices: true`. */
+/**
+ * Creates a right-angle router with `useVertices: true`.
+ * @param margin
+ */
 export function rightAngleRouter(margin = 20): routers.Router {
   return (vertices, _args, linkView) => routerFns.rightAngle(vertices, { useVertices: true, margin }, linkView);
 }
 
-/** Curve connector with outwards tangent direction. */
+/**
+ * Curve connector with outwards tangent direction.
+ * @param sourcePoint
+ * @param targetPoint
+ * @param routePoints
+ * @param _args
+ * @param linkView
+ */
 export const outwardsCurveConnector: connectorTypes.Connector = (sourcePoint, targetPoint, routePoints, _args, linkView) =>
   connectorFns.curve(sourcePoint, targetPoint, routePoints, {
     sourceDirection: connectorFns.curve.TangentDirections.OUTWARDS,

--- a/packages/joint-react/src/presets/link-labels.ts
+++ b/packages/joint-react/src/presets/link-labels.ts
@@ -54,7 +54,7 @@ const defaultLabelStyle = {
 
 /**
  * Creates a JointJS link label from simplified options.
- *
+ * @param label
  * @example
  * ```ts
  * linkLabel({ text: 'Hello', color: '#333', position: 0.5 })
@@ -153,7 +153,8 @@ export function linkLabel(label: LinkLabel): dia.Link.Label {
 
 /**
  * Converts a record of simplified LinkLabel definitions to an array of JointJS labels.
- *
+ * @param labels
+ * @param labelStyle
  * @example
  * ```ts
  * linkLabels({ main: { text: 'Hello', fontSize: 12 } })

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -55,6 +55,7 @@ export interface LinkRoutingStraightOptions extends BaseLinkOptions {
 /**
  * Straight-line links between elements.
  * The shortest path with no routing — a single line from source to target.
+ * @param options
  */
 export function linkRoutingStraight(options: LinkRoutingStraightOptions = {}): LinkRouting {
   const { sourceOffset = 0, targetOffset = 0, cornerType = 'point', cornerRadius = 0, perpendicular = false, markerSelector } = options;
@@ -81,6 +82,7 @@ export interface LinkRoutingOrthogonalOptions extends BaseLinkOptions {
 /**
  * Orthogonal (right-angle) links between elements.
  * Routes links with horizontal and vertical segments only, avoiding element overlap.
+ * @param options
  */
 export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}): LinkRouting {
   const {
@@ -123,6 +125,7 @@ export interface LinkRoutingSmoothOptions extends BaseLinkOptions {}
 /**
  * Smooth curved links between elements.
  * Renders links as bezier curves for a softer, more organic look.
+ * @param options
  */
 export function linkRoutingSmooth(options: LinkRoutingSmoothOptions = {}): LinkRouting {
   const { mode, sourceOffset = 0, targetOffset = 0, straightWhenDisconnected = true, markerSelector } = options;

--- a/packages/joint-react/src/presets/link-view.ts
+++ b/packages/joint-react/src/presets/link-view.ts
@@ -23,9 +23,9 @@ export class LinkView extends dia.LinkView {
     this.el.classList.remove(LINK_CONNECTING_CLASS, LINK_SNAPPED_CN);
   }
 
-  _snapArrowhead(evt: dia.Event, x: number, y: number) {
+  _snapArrowhead(event_: dia.Event, x: number, y: number) {
     // @ts-expect-error Protected method override
-    const isSnapped = super._snapArrowhead(evt, x, y);
+    const isSnapped = super._snapArrowhead(event_, x, y);
     this.el.classList.toggle(LINK_CONNECTING_CLASS, !isSnapped);
     this.el.classList.toggle(LINK_SNAPPED_CN, !!isSnapped);
     return isSnapped;

--- a/packages/joint-react/src/presets/wrappers.ts
+++ b/packages/joint-react/src/presets/wrappers.ts
@@ -1,9 +1,10 @@
-import type { routers, connectors as connectorTypes } from '@joint/core';
-import { anchors, connectionPoints, connectors as connectorFns, g } from '@joint/core';
+import type { routers, connectors as connectorTypes , anchors, connectionPoints} from '@joint/core';
+import { connectors as connectorFns, g } from '@joint/core';
 
 /**
  * Wraps a router so it falls back to straight-line routing when either end
  * of the link is not connected to an element.
+ * @param router
  */
 export function straightRouterUntilConnected(router: routers.Router): routers.Router {
   return (vertices, args, linkView) => {
@@ -21,10 +22,11 @@ export function straightRouterUntilConnected(router: routers.Router): routers.Ro
 /**
  * Wraps a connector so it falls back to the `straight` connector when either end
  * of the link is not connected to an element.
+ * @param connector
  */
 export function straightConnectorUntilConnected(connector: connectorTypes.Connector): connectorTypes.Connector {
   return (sourcePoint, targetPoint, routePoints, args, linkView) => {
-    if (!linkView || !linkView.model.getSourceCell() || !linkView.model.getTargetCell()) {
+    if (!linkView?.model.getSourceCell() || !linkView.model.getTargetCell()) {
       return connectorFns.straight(sourcePoint, targetPoint, routePoints, {}, linkView);
     }
     return connector(sourcePoint, targetPoint, routePoints, args, linkView);
@@ -33,6 +35,8 @@ export function straightConnectorUntilConnected(connector: connectorTypes.Connec
 
 /**
  * Wraps an anchor — uses `connected` when both ends are attached, `disconnected` otherwise.
+ * @param connected
+ * @param disconnected
  */
 export function anchorWhenConnected(connected: anchors.Anchor, disconnected: anchors.Anchor): anchors.Anchor {
   return (elementView, magnet, ref, opt, endType, linkView) => {
@@ -46,6 +50,8 @@ export function anchorWhenConnected(connected: anchors.Anchor, disconnected: anc
 
 /**
  * Wraps a connection point — uses `connected` when both ends are attached, `disconnected` otherwise.
+ * @param connected
+ * @param disconnected
  */
 export function connectionPointWhenConnected(connected: connectionPoints.ConnectionPoint, disconnected: connectionPoints.ConnectionPoint): connectionPoints.ConnectionPoint {
   return (endPathSegmentLine, endView, endMagnet, opt, endType, linkView) => {

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -4,7 +4,10 @@ import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { elementAttributes } from '../../presets/element-attributes';
 import type { CellAttributes } from './index';
 
-/** Forward mapper using the React default element type. */
+/**
+ * Forward mapper using the React default element type.
+ * @param element
+ */
 export function mapElementToAttributes<ElementData extends object = Record<string, unknown>>(
   element: ElementRecord<ElementData>
 ): CellAttributes {
@@ -20,6 +23,7 @@ export function mapElementToAttributes<ElementData extends object = Record<strin
  * - No `portMap` → return `ports` as-is.
  *
  * 1:1 mapping — no `presentation` wrapper.
+ * @param attributes
  */
 export function mapAttributesToElement<ElementData extends object = Record<string, unknown>>(
   attributes: dia.Element.Attributes

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -5,7 +5,10 @@ import { linkAttributes } from '../../presets/link-attributes';
 import { mergeLabelsFromAttributes } from './convert-labels-reverse';
 import type { CellAttributes } from '.';
 
-/** Forward mapper using the React default link type. */
+/**
+ * Forward mapper using the React default link type.
+ * @param link
+ */
 export function mapLinkToAttributes<LinkData extends object = Record<string, unknown>>(
   link: LinkRecord<LinkData>
 ): CellAttributes {
@@ -22,6 +25,7 @@ export function mapLinkToAttributes<LinkData extends object = Record<string, unk
  * - No `labelMap` → return `labels` as-is.
  *
  * 1:1 mapping — no `presentation` wrapper.
+ * @param attributes
  */
 export function mapAttributesToLink<LinkData extends object = Record<string, unknown>>(
   attributes: dia.Link.Attributes

--- a/packages/joint-react/src/store/__tests__/graph-changes.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-changes.test.ts
@@ -46,7 +46,7 @@ describe('graphChanges', () => {
       await flush();
 
       expect(onChanges).toHaveBeenCalled();
-      const { changes } = onChanges.mock.calls[0][0];
+      const [[{ changes }]] = onChanges.mock.calls;
       expect(changes.get('el-1')).toEqual(expect.objectContaining({ type: 'add' }));
     });
 
@@ -61,7 +61,7 @@ describe('graphChanges', () => {
       await flush();
 
       expect(onChanges).toHaveBeenCalled();
-      const lastCall = onChanges.mock.calls.at(-1)[0];
+      const [lastCall] = onChanges.mock.calls.at(-1) ?? [];
       expect(lastCall.changes.get('el-1')).toEqual(expect.objectContaining({ type: 'change' }));
     });
 
@@ -75,7 +75,7 @@ describe('graphChanges', () => {
       await flush();
 
       expect(onChanges).toHaveBeenCalled();
-      const lastCall = onChanges.mock.calls.at(-1)[0];
+      const [lastCall] = onChanges.mock.calls.at(-1) ?? [];
       expect(lastCall.changes.get('el-1')).toEqual(expect.objectContaining({ type: 'remove' }));
     });
 
@@ -90,7 +90,7 @@ describe('graphChanges', () => {
       await flush();
 
       expect(onChanges).toHaveBeenCalled();
-      const lastCall = onChanges.mock.calls.at(-1)[0];
+      const [lastCall] = onChanges.mock.calls.at(-1) ?? [];
       expect(lastCall.changes.get('link-1')).toEqual(expect.objectContaining({ type: 'add' }));
     });
 
@@ -111,7 +111,7 @@ describe('graphChanges', () => {
       await flush();
 
       expect(onChanges).toHaveBeenCalled();
-      const lastCall = onChanges.mock.calls.at(-1)[0];
+      const [lastCall] = onChanges.mock.calls.at(-1) ?? [];
       expect(lastCall.changes.get('el-2')).toEqual(expect.objectContaining({ type: 'add' }));
       // old element should not be in changes (reset clears the map first)
       expect(lastCall.changes.has('el-1')).toBe(false);
@@ -160,8 +160,7 @@ describe('graphChanges', () => {
 
       // batch:stop still fires onChanges, but it should not contain a 'remove' entry for el-1
       // because the remove event itself was filtered by isUpdateFromReact
-      for (const call of onChanges.mock.calls) {
-        const { changes } = call[0];
+      for (const [{ changes }] of onChanges.mock.calls) {
         const change = changes.get('el-1');
         expect(change?.type).not.toBe('remove');
       }
@@ -174,7 +173,7 @@ describe('graphChanges', () => {
       addElement(graph, 'el-1');
       await flush();
 
-      const { isInsideBatch } = onChanges.mock.calls[0][0];
+      const [[{ isInsideBatch }]] = onChanges.mock.calls;
       expect(isInsideBatch).toBe(false);
     });
 
@@ -186,7 +185,7 @@ describe('graphChanges', () => {
       await flush();
 
       // During batch, onChanges is still called but with isInsideBatch=true
-      const duringBatch = onChanges.mock.calls[0][0];
+      const [[duringBatch]] = onChanges.mock.calls;
       expect(duringBatch.isInsideBatch).toBe(true);
 
       onChanges.mockClear();
@@ -195,7 +194,7 @@ describe('graphChanges', () => {
 
       // On batch stop, onChanges is called again with isInsideBatch=false
       expect(onChanges).toHaveBeenCalled();
-      const afterBatch = onChanges.mock.calls.at(-1)[0];
+      const [afterBatch] = onChanges.mock.calls.at(-1) ?? [];
       expect(afterBatch.isInsideBatch).toBe(false);
     });
 
@@ -208,7 +207,7 @@ describe('graphChanges', () => {
 
       // batch:stop always fires onChanges with the current (empty) changes map
       expect(onChanges).toHaveBeenCalled();
-      const { changes, isInsideBatch } = onChanges.mock.calls.at(-1)[0];
+      const [{ changes, isInsideBatch }] = onChanges.mock.calls.at(-1) ?? [];
       expect(changes.size).toBe(0);
       expect(isInsideBatch).toBe(false);
     });
@@ -231,7 +230,7 @@ describe('graphChanges', () => {
       await flush();
       // Outer stop should trigger
       expect(onChanges).toHaveBeenCalled();
-      const { isInsideBatch } = onChanges.mock.calls.at(-1)[0];
+      const [{ isInsideBatch }] = onChanges.mock.calls.at(-1) ?? [];
       expect(isInsideBatch).toBe(false);
     });
   });
@@ -292,5 +291,61 @@ describe('graphChanges', () => {
 
       expect(onChanges).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('updateGraph partial sync', () => {
+  it('preserves existing element cells when only links are provided', () => {
+    const graph = createGraph();
+    graph.addCells([
+      { id: 'e1', type: 'ElementModel', position: { x: 0, y: 0 }, size: { width: 10, height: 10 } },
+    ]);
+    const controller = graphChanges({ graph, onChanges: () => {} });
+
+    controller.updateGraph({ links: {}, flag: 'updateFromReact' });
+
+    expect(graph.getCell('e1')).toBeDefined();
+    controller.destroy();
+  });
+
+  it('preserves existing link cells when only elements are provided', () => {
+    const graph = createGraph();
+    graph.addCells([
+      { id: 'e1', type: 'ElementModel', position: { x: 0, y: 0 }, size: { width: 10, height: 10 } },
+      { id: 'e2', type: 'ElementModel', position: { x: 50, y: 50 }, size: { width: 10, height: 10 } },
+      { id: 'l1', type: 'standard.Link', source: { id: 'e1' }, target: { id: 'e2' } },
+    ]);
+    const controller = graphChanges({ graph, onChanges: () => {} });
+
+    controller.updateGraph({
+      elements: {
+        e1: { position: { x: 0, y: 0 }, size: { width: 10, height: 10 } },
+        e2: { position: { x: 50, y: 50 }, size: { width: 10, height: 10 } },
+      },
+      flag: 'updateFromReact',
+    });
+
+    expect(graph.getCell('l1')).toBeDefined();
+    controller.destroy();
+  });
+
+  it('removes missing link cells when links stream is provided', () => {
+    const graph = createGraph();
+    graph.addCells([
+      { id: 'e1', type: 'ElementModel', position: { x: 0, y: 0 }, size: { width: 10, height: 10 } },
+      { id: 'e2', type: 'ElementModel', position: { x: 50, y: 50 }, size: { width: 10, height: 10 } },
+      { id: 'l1', type: 'standard.Link', source: { id: 'e1' }, target: { id: 'e2' } },
+      { id: 'l2', type: 'standard.Link', source: { id: 'e2' }, target: { id: 'e1' } },
+    ]);
+    const controller = graphChanges({ graph, onChanges: () => {} });
+
+    controller.updateGraph({
+      links: { l1: { source: 'e1', target: 'e2' } },
+      flag: 'updateFromReact',
+    });
+
+    expect(graph.getCell('l1')).toBeDefined();
+    expect(graph.getCell('l2')).toBeUndefined();
+    controller.destroy();
   });
 });

--- a/packages/joint-react/src/store/__tests__/graph-view.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-view.test.ts
@@ -888,3 +888,38 @@ describe('graphView', () => {
     });
   });
 });
+
+describe('updateGraph partial sync', () => {
+  it('updates only links container when called with links only', () => {
+    const graph = createGraph();
+    graph.addCells([
+      { id: 'e1', type: 'ElementModel', position: { x: 0, y: 0 }, size: { width: 10, height: 10 } },
+    ]);
+    const view = graphView({ graph });
+    view.syncFromGraph();
+
+    view.updateGraph({
+      links: { l1: { source: 'e1', target: 'e1' } },
+      flag: 'updateFromReact',
+    });
+
+    expect(view.elements.get('e1')).toBeDefined();
+    expect(view.links.get('l1')).toBeDefined();
+    view.destroy();
+  });
+
+  it('updates only elements container when called with elements only', () => {
+    const graph = createGraph();
+    const view = graphView({ graph });
+    view.syncFromGraph();
+
+    view.updateGraph({
+      elements: { e1: { position: { x: 0, y: 0 }, size: { width: 10, height: 10 } } },
+      flag: 'updateFromReact',
+    });
+
+    expect(view.elements.get('e1')).toBeDefined();
+    expect(view.links.getSize()).toBe(0);
+    view.destroy();
+  });
+});

--- a/packages/joint-react/src/store/__tests__/graph-view.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-view.test.ts
@@ -813,6 +813,65 @@ describe('graphView', () => {
     });
   });
 
+  describe('embedding — parent attribute reactivity', () => {
+    it('reflects parent after embed', async () => {
+      const { graph, view } = setup();
+      addElement(graph, 'parent-1', 0, 0, 400, 300);
+      addElement(graph, 'child-1', 50, 50, 100, 50);
+      await flush();
+
+      const parent = graph.getCell('parent-1') as dia.Element;
+      const child = graph.getCell('child-1') as dia.Element;
+      parent.embed(child);
+      await flush();
+
+      expect(view.elements.get('child-1')).toEqual(
+        expect.objectContaining({ parent: 'parent-1' })
+      );
+    });
+
+    it('removes parent from element record after unembed', async () => {
+      const { graph, view } = setup();
+      addElement(graph, 'parent-1', 0, 0, 400, 300);
+      addElement(graph, 'child-1', 50, 50, 100, 50);
+      await flush();
+
+      const parent = graph.getCell('parent-1') as dia.Element;
+      const child = graph.getCell('child-1') as dia.Element;
+      parent.embed(child);
+      await flush();
+
+      expect(view.elements.get('child-1')?.parent).toBe('parent-1');
+
+      parent.unembed(child);
+      await flush();
+
+      // After unembed, `parent` must be gone from the element record
+      expect(view.elements.get('child-1')?.parent).toBeUndefined();
+    });
+
+    it('reflects embeds array on parent after embed/unembed', async () => {
+      const { graph, view } = setup();
+      addElement(graph, 'parent-1', 0, 0, 400, 300);
+      addElement(graph, 'child-1', 50, 50, 100, 50);
+      await flush();
+
+      const parent = graph.getCell('parent-1') as dia.Element;
+      const child = graph.getCell('child-1') as dia.Element;
+      parent.embed(child);
+      await flush();
+
+      expect(view.elements.get('parent-1')?.embeds).toEqual(['child-1']);
+
+      parent.unembed(child);
+      await flush();
+
+      // After unembed, `embeds` should no longer contain child-1 (either empty or undefined)
+      const embedsAfter = view.elements.get('parent-1')?.embeds as string[] | undefined;
+      expect(embedsAfter === undefined || embedsAfter.length === 0).toBe(true);
+    });
+  });
+
   describe('isUpdateFromReact filtering', () => {
     it('ignores changes with isUpdateFromReact flag', async () => {
       const { graph, view } = setup();

--- a/packages/joint-react/src/store/__tests__/paper-store.test.ts
+++ b/packages/joint-react/src/store/__tests__/paper-store.test.ts
@@ -232,7 +232,14 @@ describe('PaperStore', () => {
       portMagnet.getBBox = jest.fn(() => ({ x: -5, y: -5, width: 10, height: 10 }) as DOMRect);
 
       const element = new dia.Element({ size: { width: 200, height: 100 } });
-      const cellView = { el: rootNode, model: element } as unknown as dia.CellView;
+      const cellView = {
+        el: rootNode,
+        model: element,
+        computeNodeBoundingRect: (node: SVGGraphicsElement) => {
+          const bbox = node.getBBox();
+          return { x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height };
+        },
+      } as unknown as dia.CellView;
 
       const result = measureNode!(portMagnet as SVGGraphicsElement, cellView);
 

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -11,8 +11,10 @@ export interface UpdateGraphOptions<
   ElementData extends object = Record<string, unknown>,
   LinkData extends object = Record<string, unknown>,
 > {
-  readonly elements: Record<string, ElementRecord<ElementData>>;
-  readonly links: Record<string, LinkRecord<LinkData>>;
+  /** Element records to sync. If omitted, existing element cells are preserved untouched. */
+  readonly elements?: Record<string, ElementRecord<ElementData>>;
+  /** Link records to sync. If omitted, existing link cells are preserved untouched. */
+  readonly links?: Record<string, LinkRecord<LinkData>>;
   readonly flag?: 'updateFromReact';
 }
 
@@ -21,7 +23,9 @@ export interface UpdateGraphOptions<
  * Returned so callers can iterate them once instead of re-walking the user record.
  */
 export interface UpdateGraphResult {
+  /** Empty when the corresponding stream was omitted from the update. */
   readonly elementIds: readonly string[];
+  /** Empty when the corresponding stream was omitted from the update. */
   readonly linkIds: readonly string[];
 }
 
@@ -43,6 +47,8 @@ interface JointJSEventOptions {
 /**
  * Sets up listeners for JointJS graph mutations and translates them into incremental change events.
  * Batching is always on: layout changes are immediate, data changes fire on batch:stop.
+ * @param options - Graph listener configuration.
+ * @returns Controller exposing updateGraph and destroy.
  */
 export function graphChanges(options: Options) {
   const { graph, onElementsSizeChange } = options;
@@ -51,6 +57,10 @@ export function graphChanges(options: Options) {
   let batchDepth = 0;
   let isSyncedWithReact = true;
 
+  /**
+   * Schedules onChanges to fire on next tick.
+   * @param data - Change options to pass to the handler.
+   */
   function onChanges(data: OnChangeOptions) {
     simpleScheduler(() => {
       options.onChanges(data);
@@ -59,6 +69,7 @@ export function graphChanges(options: Options) {
 
   /**
    * Returns true when inside a batch operation.
+   * @returns true when inside a JointJS batch operation.
    */
   function isInsideBatch() {
     return batchDepth > 0;
@@ -66,6 +77,8 @@ export function graphChanges(options: Options) {
 
   /**
    * Records a cell change and notifies the change handler.
+   * @param cell - The cell that changed.
+   * @param type - Kind of change.
    */
   function onCellEvent(cell: dia.Cell, type: 'change' | 'add' | 'remove') {
     changes.set(String(cell.id), { type, data: cell });
@@ -168,22 +181,37 @@ export function graphChanges(options: Options) {
 
       const elementIds: string[] = [];
       const linkIds: string[] = [];
-      const graphElements: dia.Cell.JSON[] = Object.entries(elements).map(([id, element]) => {
-        const cellAttributes = mapElementToAttributes(element);
-        cellAttributes.id = id;
-        elementIds.push(id);
-        return cellAttributes as dia.Cell.JSON;
-      });
-      const graphLinks: dia.Cell.JSON[] = Object.entries(links).map(([id, link]) => {
-        const cellAttributes = mapLinkToAttributes(link);
-        cellAttributes.id = id;
-        linkIds.push(id);
-        return cellAttributes as dia.Cell.JSON;
-      });
+      const cellsToSync: dia.Cell.JSON[] = [];
+
+      if (elements) {
+        for (const [id, element] of Object.entries(elements)) {
+          const cellAttributes = mapElementToAttributes(element);
+          cellAttributes.id = id;
+          elementIds.push(id);
+          cellsToSync.push(cellAttributes as dia.Cell.JSON);
+        }
+      } else {
+        // Preserve untouched element cells by re-emitting their current JSON.
+        for (const cell of graph.getElements()) {
+          cellsToSync.push(cell.toJSON());
+        }
+      }
+
+      if (links) {
+        for (const [id, link] of Object.entries(links)) {
+          const cellAttributes = mapLinkToAttributes(link);
+          cellAttributes.id = id;
+          linkIds.push(id);
+          cellsToSync.push(cellAttributes as dia.Cell.JSON);
+        }
+      } else {
+        for (const cell of graph.getLinks()) {
+          cellsToSync.push(cell.toJSON());
+        }
+      }
 
       graph.startBatch('updateFromReact');
-
-      graph.syncCells([...graphElements, ...graphLinks], {
+      graph.syncCells(cellsToSync, {
         remove: true,
         isUpdateFromReact: flag === 'updateFromReact',
       });

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -94,7 +94,7 @@ export function graphView<
                 // Use `rest` as the source of truth — `mapAttributesToElement`
                 // returns the complete current attribute set, so spreading
                 // `previous` would re-introduce keys that JointJS has unset
-                // (e.g. `parent` after an unembed).
+                // (e.g. `parent` after an embed is undone).
                 const newItem = {
                   ...rest,
                   data: isShallowEqual(previousUserData, userData) ? previousUserData : userData,
@@ -223,61 +223,61 @@ export function graphView<
       // We still need to refresh the containers so hooks see the new data —
       // and we MUST read it from the graph, not from the raw user input,
       // because Backbone preserves attributes that the user did not specify
-      // (e.g. a measured `size` that came from a ResizeObserver). Reading
-      // from the user record would wipe those preserved attributes from the
-      // container while leaving them on the graph cell, putting hooks and
-      // the cell models out of sync.
+      // (e.g. a measured `size` that came from a ResizeObserver).
+      // Only refresh the streams that were actually synced — if `update.elements`
+      // is omitted, element cells and the elements container are untouched here.
       if (update.flag !== 'updateFromReact') {
         return;
       }
 
-      const userElementIds = new Set(elementIds);
-      const userLinkIds = new Set(linkIds);
-
       let hasElementChange = false;
       let hasLinkChange = false;
 
-      for (const id of elementIds) {
-        const cell = graph.getCell(id);
-        if (!cell?.isElement()) continue;
-        elements.set(id, (previous) => {
-          const next = mapAttributesToElement(cell.attributes) as ElementWithLayout<ElementData>;
-          if (!previous) return next;
-          const { data: nextUserData, position, size, ...rest } = next;
-          const {
-            data: previousUserData,
-            position: previousPosition,
-            size: previousSize,
-          } = previous;
-          return {
-            ...rest,
-            data: isShallowEqual(previousUserData, nextUserData) ? previousUserData : nextUserData,
-            position: isPositionEqual(previousPosition, position) ? previousPosition : position,
-            size: isSizeEqual(previousSize, size) ? previousSize : size,
-          };
-        });
-        hasElementChange = true;
-      }
-
-      for (const id of linkIds) {
-        const cell = graph.getCell(id);
-        if (!cell?.isLink()) continue;
-        const linkData = mapAttributesToLink<LinkData>(cell.attributes);
-        links.set(id, linkData);
-        hasLinkChange = true;
-      }
-
-      // Remove elements/links that are no longer in the user state
-      for (const [id] of elements.getFull()) {
-        if (!userElementIds.has(id)) {
-          elements.delete(id);
+      if (update.elements !== undefined) {
+        const userElementIds = new Set(elementIds);
+        for (const id of elementIds) {
+          const cell = graph.getCell(id);
+          if (!cell?.isElement()) continue;
+          elements.set(id, (previous) => {
+            const next = mapAttributesToElement(cell.attributes) as ElementWithLayout<ElementData>;
+            if (!previous) return next;
+            const { data: nextUserData, position, size, ...rest } = next;
+            const {
+              data: previousUserData,
+              position: previousPosition,
+              size: previousSize,
+            } = previous;
+            return {
+              ...rest,
+              data: isShallowEqual(previousUserData, nextUserData) ? previousUserData : nextUserData,
+              position: isPositionEqual(previousPosition, position) ? previousPosition : position,
+              size: isSizeEqual(previousSize, size) ? previousSize : size,
+            };
+          });
           hasElementChange = true;
         }
+        for (const [id] of elements.getFull()) {
+          if (!userElementIds.has(id)) {
+            elements.delete(id);
+            hasElementChange = true;
+          }
+        }
       }
-      for (const [id] of links.getFull()) {
-        if (!userLinkIds.has(id)) {
-          links.delete(id);
+
+      if (update.links !== undefined) {
+        const userLinkIds = new Set(linkIds);
+        for (const id of linkIds) {
+          const cell = graph.getCell(id);
+          if (!cell?.isLink()) continue;
+          const linkData = mapAttributesToLink<LinkData>(cell.attributes);
+          links.set(id, linkData);
           hasLinkChange = true;
+        }
+        for (const [id] of links.getFull()) {
+          if (!userLinkIds.has(id)) {
+            links.delete(id);
+            hasLinkChange = true;
+          }
         }
       }
 

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -91,8 +91,11 @@ export function graphView<
                   position: previousPosition,
                   size: previousSize,
                 } = previous;
+                // Use `rest` as the source of truth — `mapAttributesToElement`
+                // returns the complete current attribute set, so spreading
+                // `previous` would re-introduce keys that JointJS has unset
+                // (e.g. `parent` after an unembed).
                 const newItem = {
-                  ...previous,
                   ...rest,
                   data: isShallowEqual(previousUserData, userData) ? previousUserData : userData,
                   position: isPositionEqual(previousPosition, position)
@@ -247,7 +250,6 @@ export function graphView<
             size: previousSize,
           } = previous;
           return {
-            ...previous,
             ...rest,
             data: isShallowEqual(previousUserData, nextUserData) ? previousUserData : nextUserData,
             position: isPositionEqual(previousPosition, position) ? previousPosition : position,

--- a/packages/joint-react/src/store/paper-store.ts
+++ b/packages/joint-react/src/store/paper-store.ts
@@ -161,6 +161,7 @@ export class PaperStore {
   /**
    * Flushes pending link changes via setPaperViews so React re-reads correct link layout.
    * Called from afterRender when JointJS has finished rendering.
+   * @param graphStore
    */
   private flushPendingLinkChanges(graphStore: GraphStore): void {
     simpleScheduler(() => {

--- a/packages/joint-react/src/store/state-container.ts
+++ b/packages/joint-react/src/store/state-container.ts
@@ -46,6 +46,7 @@ export function asReadonlyContainer<T>(container: Container<T>): ReadonlyContain
 
 /**
  * Creates a keyed container with per-id subscriptions and batched change notifications.
+ * @param _name
  */
 export function createContainer<T>(_name?: string): Container<T> {
   const container = new Map<string, T>();

--- a/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
+++ b/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
@@ -536,7 +536,7 @@ export default function App() {
         className="hidden"
         onChange={handleFileChosen}
       />
-      <GraphProvider<NodeData> key={reloadKey} elements={initialElements} links={initialLinks}>
+      <GraphProvider<NodeData> key={reloadKey} initialElements={initialElements} initialLinks={initialLinks}>
         <InnerShell onLoadFile={handleLoadClick} />
       </GraphProvider>
     </div>

--- a/packages/joint-react/src/stories/demos/collaboration/code.tsx
+++ b/packages/joint-react/src/stories/demos/collaboration/code.tsx
@@ -947,8 +947,8 @@ function GraphWithRedux() {
         }}
       >
         <GraphProvider
-          elements={themedElements}
-          links={themedLinks}
+          initialElements={themedElements}
+          initialLinks={themedLinks}
           onIncrementalChange={handleIncrementalChange}
         >
           <Paper

--- a/packages/joint-react/src/stories/demos/flowchart/code.tsx
+++ b/packages/joint-react/src/stories/demos/flowchart/code.tsx
@@ -526,7 +526,7 @@ export default function App() {
   const [isLight, setIsLight] = useState(false);
   return (
     <div className={`flowchart-wrapper${isLight ? ' light-theme' : ''}`}>
-      <GraphProvider elements={flowchartNodes} links={flowchartLinks}>
+      <GraphProvider initialElements={flowchartNodes} initialLinks={flowchartLinks}>
         <Main />
       </GraphProvider>
       <ThemeSwitch onClick={() => setIsLight((v) => !v)} />

--- a/packages/joint-react/src/stories/demos/introduction-demo/code.tsx
+++ b/packages/joint-react/src/stories/demos/introduction-demo/code.tsx
@@ -530,7 +530,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/demos/investment-calculator/code.tsx
+++ b/packages/joint-react/src/stories/demos/investment-calculator/code.tsx
@@ -644,7 +644,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider<ShapeData> elements={initialElements} links={initialLinks}>
+    <GraphProvider<ShapeData> initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
+++ b/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
@@ -155,7 +155,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={elements}>
+    <GraphProvider initialElements={elements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/demos/saasflow/code.tsx
+++ b/packages/joint-react/src/stories/demos/saasflow/code.tsx
@@ -478,8 +478,8 @@ function Main() {
 
   return (
     <GraphProvider<SaasNodeData>
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Paper
         ref={paperRef}

--- a/packages/joint-react/src/stories/examples/markup-selectors-html/code.tsx
+++ b/packages/joint-react/src/stories/examples/markup-selectors-html/code.tsx
@@ -139,7 +139,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/markup-selectors/code.tsx
+++ b/packages/joint-react/src/stories/examples/markup-selectors/code.tsx
@@ -192,7 +192,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
@@ -115,7 +115,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
@@ -198,8 +198,8 @@ function Main() {
 export default function App() {
   return (
     <GraphProvider
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/story.tsx
@@ -36,7 +36,7 @@ const mapDataToElementAttributes = ({
 
 // Pass to GraphProvider
 <GraphProvider
-  elements={elements}
+  initialElements={elements}
   mapDataToElementAttributes={mapDataToElementAttributes}
 >
   <Paper />

--- a/packages/joint-react/src/stories/examples/with-card/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-card/code.tsx
@@ -76,7 +76,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-cell-actions/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-actions/code.tsx
@@ -594,7 +594,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -178,8 +178,8 @@ export default function App() {
   return (
     <GraphProvider
       graph={graph}
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
@@ -443,7 +443,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-collapsible-subtrees/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-collapsible-subtrees/code.tsx
@@ -732,7 +732,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-containers/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-containers/code.tsx
@@ -125,7 +125,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links-classname.tsx
@@ -27,7 +27,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider links={initialEdges} elements={initialElements}>
+    <GraphProvider initialLinks={initialEdges} initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-link/code-with-create-links.tsx
@@ -25,7 +25,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider links={initialEdges} elements={initialElements}>
+    <GraphProvider initialLinks={initialEdges} initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-custom-link/code-with-dia-links.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-link/code-with-dia-links.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
-/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+ 
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import type { dia } from '@joint/core';
 import { shapes, util } from '@joint/core';
@@ -83,8 +83,8 @@ const links: Record<string, LinkRecord> = {
 export default function App() {
   return (
     <GraphProvider
-      links={links as Record<string, LinkRecord>}
-      elements={initialElements}
+      initialLinks={links as Record<string, LinkRecord>}
+      initialElements={initialElements}
       cellNamespace={{ LinkModel }}
     >
       <Main />

--- a/packages/joint-react/src/stories/examples/with-custom-mapper/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-custom-mapper/code.tsx
@@ -111,8 +111,8 @@ function Main() {
 export default function App() {
   return (
     <GraphProvider
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-data-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-data-defaults/code.tsx
@@ -171,7 +171,7 @@ function Diagram() {
       >
         {alternate ? '\u25A0 Square ports' : '\u25CF Round ports'}
       </button>
-      <GraphProvider<ElementData> elements={initialElements} links={initialLinks}>
+      <GraphProvider<ElementData> initialElements={initialElements} initialLinks={initialLinks}>
         <ThemeUpdater color={color} portShape={portShape} />
         <Paper
           className={PAPER_CLASSNAME}

--- a/packages/joint-react/src/stories/examples/with-default-element/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-default-element/code.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useMemo, useRef } from 'react';
-import { GraphProvider, Paper, HTMLBox, type ElementRecord, type LinkRecord } from '@joint/react';
+import { useState, useCallback, useMemo, useRef, memo } from 'react';
+import { GraphProvider, Paper, HTMLBox, type ElementRecord, type LinkRecord, type LinkMarkerName } from '@joint/react';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
 // Base theme — provides --jj-* CSS variable defaults (including element styles)
@@ -61,7 +61,7 @@ const initialElements: Record<string, ElementRecord<Data>> = {
 };
 
 const TOOLBAR_STYLE = { marginBottom: 8, display: 'flex', gap: 8, alignItems: 'center' } as const;
-const DEFAULT_LINK = { style: { targetMarker: 'arrow' } };
+const DEFAULT_LINK = { style: { targetMarker: 'arrow' as LinkMarkerName } };
 
 
 const initialLinks: Record<string, LinkRecord> = {
@@ -82,13 +82,14 @@ const initialLinks: Record<string, LinkRecord> = {
   },
 };
 
-function RenderElement({ label, width, height }: Readonly<Data>) {
+const RenderElement = memo(function RenderElement({ label, width, height }: Readonly<Data>) {
+  const boxStyle = useMemo(() => ({ width, height }), [width, height]);
   return (
-    <HTMLBox style={{ width, height }}>
+    <HTMLBox style={boxStyle}>
       {label}
     </HTMLBox>
   );
-}
+});
 
 export default function App() {
   const [isDark, setIsDark] = useState(false);
@@ -127,7 +128,7 @@ export default function App() {
           {isDark ? '\u2600\uFE0F Light' : '\uD83C\uDF19 Dark'}
         </button>
       </div>
-      <GraphProvider elements={initialElements} links={initialLinks}>
+      <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
         <Paper
           className={PAPER_CLASSNAME}
           height={240}

--- a/packages/joint-react/src/stories/examples/with-default-link/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-default-link/code.tsx
@@ -63,7 +63,7 @@ function RenderElement(data: Readonly<{ label: string }>) {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Paper
         renderElement={RenderElement}
         className={PAPER_CLASSNAME}

--- a/packages/joint-react/src/stories/examples/with-dynamic-status-icons/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-status-icons/code.tsx
@@ -256,7 +256,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
@@ -786,7 +786,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -137,8 +137,8 @@ export default function App() {
 
   return (
     <GraphProvider
-      elements={elements}
-      links={links}
+      initialElements={elements}
+      initialLinks={links}
       cellNamespace={{ PortsElement, PortMapElement, LabelsLink, LabelMapLink }}
     >
       <Paper

--- a/packages/joint-react/src/stories/examples/with-element-ports-groups/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-ports-groups/code.tsx
@@ -77,7 +77,7 @@ function RenderElement({ label }: { label: string }) {
 
 export default function App() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Paper
         className={PAPER_CLASSNAME}
         height={380}

--- a/packages/joint-react/src/stories/examples/with-element-ports-native/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-ports-native/code.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+ 
 import { PAPER_CLASSNAME, PAPER_STYLE } from 'storybook-config/theme';
 import type { dia } from '@joint/core';
 import '../index.css';
@@ -205,8 +205,8 @@ function Main() {
 export default function App() {
   return (
     <GraphProvider<NativeElementUserData>
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-element-ports-native/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-ports-native/story.tsx
@@ -41,7 +41,7 @@ const renderElement = useCallback(
   [],
 );
 
-<GraphProvider elements={elements}>
+<GraphProvider initialElements={elements}>
   <Paper renderElement={renderElement} />
 </GraphProvider>
 \`\`\`

--- a/packages/joint-react/src/stories/examples/with-element-ports/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-ports/code.tsx
@@ -429,8 +429,8 @@ function Main() {
 export default function App() {
   return (
     <GraphProvider
-      elements={initialElements}
-      links={initialLinks}
+      initialElements={initialElements}
+      initialLinks={initialLinks}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-embedding/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-embedding/code.tsx
@@ -172,7 +172,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
@@ -441,7 +441,7 @@ function Main() {
 // ----------------------------------------------------------------------------
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+ 
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import {
@@ -317,7 +317,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
@@ -132,7 +132,7 @@ export interface AppProps {
 
 export default function App({ variant = 'mask' }: Readonly<AppProps>) {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main variant={variant} />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-intersection/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-intersection/code.tsx
@@ -46,7 +46,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-layers/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-layers/code.tsx
@@ -244,7 +244,7 @@ export default function App() {
   };
 
   return (
-    <GraphProvider graph={graph} elements={elements} links={links}>
+    <GraphProvider graph={graph} initialElements={elements} initialLinks={links}>
       <Main hiddenLayers={hiddenLayers} toggleLayer={toggleLayer} />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-layers/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-layers/story.tsx
@@ -38,7 +38,7 @@ const graph = useMemo(() => {
   return g;
 }, []);
 
-<GraphProvider graph={graph} elements={elements} links={links}>
+<GraphProvider graph={graph} initialElements={elements} initialLinks={links}>
   ...
 </GraphProvider>
 \`\`\`

--- a/packages/joint-react/src/stories/examples/with-link-labels/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-labels/code.tsx
@@ -90,7 +90,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-link-markers/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-markers/code.tsx
@@ -86,8 +86,8 @@ const elements: Record<string, ElementRecord> = {
 function buildLinks(scale: number): Record<string, LinkRecord> {
   const result: Record<string, LinkRecord> = {};
   for (const entry of MARKER_ENTRIES) {
-    const [name, factory, extraOpts] = entry;
-    const marker = factory({ scale, ...extraOpts });
+    const [name, factory, extraOptions] = entry;
+    const marker = factory({ scale, ...extraOptions });
     result[name] = {
       source: { id: 'left', port: name },
       target: { id: 'right', port: name },
@@ -119,12 +119,12 @@ export default function App() {
 
   const handleScaleChange = (newScale: number) => {
     setScale(newScale);
-    setLinkState((prev) => {
-      const next = { ...prev };
+    setLinkState((previous) => {
+      const next = { ...previous };
       for (const entry of MARKER_ENTRIES) {
-        const [name, factory, extraOpts] = entry;
-        const marker = factory({ scale: newScale, ...extraOpts });
-        next[name] = { ...prev[name], style: { ...prev[name]?.style, sourceMarker: marker, targetMarker: marker } };
+        const [name, factory, extraOptions] = entry;
+        const marker = factory({ scale: newScale, ...extraOptions });
+        next[name] = { ...previous[name], style: { ...previous[name]?.style, sourceMarker: marker, targetMarker: marker } };
       }
       return next;
     });

--- a/packages/joint-react/src/stories/examples/with-link-routing/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-routing/code.tsx
@@ -315,7 +315,7 @@ function PresetPicker() {
 export default function App() {
   return (
     <div>
-      <GraphProvider elements={initialElements} links={initialLinks}>
+      <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
         <PresetPicker />
       </GraphProvider>
     </div>

--- a/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
@@ -121,7 +121,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-list-node/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-list-node/code.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+ 
 /* eslint-disable @eslint-react/no-array-index-key */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 
@@ -142,7 +142,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-minimap/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-minimap/code.tsx
@@ -87,7 +87,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-node-update/code-add-remove-node.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-add-remove-node.tsx
@@ -104,7 +104,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-color.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-color.tsx
@@ -64,7 +64,7 @@ function Main() {
 
 export default function WithColor() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
-/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+ 
 import { GraphProvider, Paper, useElementSize, type ElementRecord, type LinkRecord } from '@joint/react';
 import '../index.css';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
@@ -43,7 +43,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-node-update/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code.tsx
@@ -67,7 +67,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -339,8 +339,8 @@ function Main() {
 export default function App() {
   return (
     <GraphProvider
-      elements={elements}
-      links={links}
+      initialElements={elements}
+      initialLinks={links}
     >
       <Main />
     </GraphProvider>

--- a/packages/joint-react/src/stories/examples/with-portal-selector/docs.mdx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/docs.mdx
@@ -28,8 +28,8 @@ The `mapDataToElementAttributes` and `mapDataToLinkAttributes` props allow you t
 
 ```tsx
 <GraphProvider
-  elements={elements}
-  links={links}
+  initialElements={elements}
+  initialLinks={links}
   mapDataToElementAttributes={({ data }) => {
     const { jjType, color } = data;
     // For custom JointJS types, override the type

--- a/packages/joint-react/src/stories/examples/with-proximity-link/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-proximity-link/code.tsx
@@ -91,7 +91,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements}>
+    <GraphProvider initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-render-link/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-render-link/code.tsx
@@ -86,7 +86,7 @@ export default function App() {
   const [useLinkModels, setUseLinkModels] = useState(true);
 
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <div className="flex flex-col gap-2">
         <button
           type="button"

--- a/packages/joint-react/src/stories/examples/with-resizable-node/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-resizable-node/code.tsx
@@ -88,7 +88,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-rotable-node/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-rotable-node/code.tsx
@@ -110,7 +110,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-shape-animations/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-shape-animations/code.tsx
@@ -410,7 +410,7 @@ function Main() {
 // ----------------------------------------------------------------------------
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialLinks}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/examples/with-svg-node/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-svg-node/code.tsx
@@ -93,7 +93,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider elements={initialElements} links={initialEdges}>
+    <GraphProvider initialElements={initialElements} initialLinks={initialEdges}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-redux.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-redux.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable sonarjs/cognitive-complexity */
+ 
 /* eslint-disable @typescript-eslint/no-dynamic-delete */
 /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
 /* eslint-disable sonarjs/pseudo-random */

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-html-renderer.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-html-renderer.tsx
@@ -113,7 +113,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider links={initialEdges} elements={initialElements}>
+    <GraphProvider initialLinks={initialEdges} initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-html.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-html.tsx
@@ -38,7 +38,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider links={initialEdges} elements={initialElements}>
+    <GraphProvider initialLinks={initialEdges} initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-svg.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-svg.tsx
@@ -36,7 +36,7 @@ function Main() {
 
 export default function App() {
   return (
-    <GraphProvider links={initialEdges} elements={initialElements}>
+    <GraphProvider initialLinks={initialEdges} initialElements={initialElements}>
       <Main />
     </GraphProvider>
   );

--- a/packages/joint-react/src/stories/tutorials/step-by-step/docs.mdx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/docs.mdx
@@ -70,7 +70,7 @@ Wrap your app with the `GraphProvider` component to provide the graph context to
 ```tsx
 import { GraphProvider } from '@joint/react';
 
-<GraphProvider elements={elements} links={links}>
+<GraphProvider initialElements={elements} initialLinks={links}>
   {/* Add Paper or other components here */}
 </GraphProvider>
 ```
@@ -164,7 +164,7 @@ const mapDataToElementAttributes = ({
   ...(data.ports && { ports: data.ports }),
 });
 
-<GraphProvider elements={elements} mapDataToElementAttributes={mapDataToElementAttributes}>
+<GraphProvider initialElements={elements} mapDataToElementAttributes={mapDataToElementAttributes}>
   <Paper />
 </GraphProvider>;
 ```
@@ -387,7 +387,7 @@ ${CodeControlledModePeerJS}
 The graph manages its own state internally. Use this for simple, read-only diagrams.
 
 ```tsx
-<GraphProvider elements={initialElements} links={initialLinks}>
+<GraphProvider initialElements={initialElements} initialLinks={initialLinks}>
   <Paper />
 </GraphProvider>
 ```
@@ -513,7 +513,7 @@ const elements = {
 
 export function MultiViews() {
   return (
-    <GraphProvider elements={elements}>
+    <GraphProvider initialElements={elements}>
       {/* Main interactive canvas */}
       <Paper id="main" width={800} height={500} />
 
@@ -561,7 +561,7 @@ function FitToContent() {
 
 export function WithHook() {
   return (
-    <GraphProvider elements={elements}>
+    <GraphProvider initialElements={elements}>
       <Paper id="main" />
       <FitToContent />
     </GraphProvider>
@@ -588,7 +588,7 @@ export function WithRef() {
   }, []);
 
   return (
-    <GraphProvider elements={elements}>
+    <GraphProvider initialElements={elements}>
       <Paper id="zoomed" ref={paperRef} />
     </GraphProvider>
   );
@@ -604,7 +604,7 @@ export function WithRef() {
 ```tsx
 function GraphWithMinimap() {
   return (
-    <GraphProvider elements={elements} links={links}>
+    <GraphProvider initialElements={elements} initialLinks={links}>
       <Paper id="main"  height={400} />
       <div style={{ position: 'absolute', right: 16, bottom: 16 }}>
         <Paper id="mini" width={180} height={120} interactive={false} scale={0.2} />
@@ -620,10 +620,10 @@ function GraphWithMinimap() {
 function EditorWithPreview() {
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 16 }}>
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <Paper id="editable" />
       </GraphProvider>
-      <GraphProvider elements={elements} links={links}>
+      <GraphProvider initialElements={elements} initialLinks={links}>
         <Paper id="preview" interactive={false} />
       </GraphProvider>
     </div>
@@ -642,7 +642,7 @@ const renderElement = ({ label }) => (
 
 function HtmlNodes() {
   return (
-    <GraphProvider elements={elements}>
+    <GraphProvider initialElements={elements}>
       <Paper useHTMLOverlay renderElement={renderElement} />
     </GraphProvider>
   );

--- a/packages/joint-react/src/types/data-types.ts
+++ b/packages/joint-react/src/types/data-types.ts
@@ -1,10 +1,10 @@
 import type { dia } from '@joint/core';
-import type { ElementPort, PortShape } from '../presets/element-ports';
+import type { ElementPort,  } from '../presets/element-ports';
 import type { LinkStyle } from '../presets/link-style';
 import type { LinkLabel } from '../presets/link-labels';
 import type { ElementPosition, ElementSize } from './cell-data';
 
-export type { ElementPort, PortShape, LinkStyle, LinkLabel };
+
 
 // ── Element Types ─────────────────────────────────────────────────────────────
 
@@ -63,3 +63,7 @@ export type ElementWithLayout<E extends object = Record<string, unknown>> = Elem
   size: Required<ElementSize>;
   angle: number;
 };
+
+export {type PortShape, type ElementPort} from '../presets/element-ports';
+export {type LinkStyle} from '../presets/link-style';
+export {type LinkLabel} from '../presets/link-labels';

--- a/packages/joint-react/src/utils/selector-utils.ts
+++ b/packages/joint-react/src/utils/selector-utils.ts
@@ -1,12 +1,14 @@
 import type { ElementPosition, ElementSize } from '../types/cell-data';
 
-// eslint-disable-next-line unicorn/prevent-abbreviations
+ 
 export const isStrictEqual = Object.is;
 export const identitySelector = <T>(item: T) => item;
 
 /**
  * Shallow-compares two objects by their own enumerable keys.
  * Returns true if both have the same keys with strictly equal values.
+ * @param a
+ * @param b
  */
 export function isShallowEqual(
   a: object | undefined,
@@ -14,23 +16,33 @@ export function isShallowEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  const objA = a as Record<string, unknown>;
-  const objB = b as Record<string, unknown>;
-  const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
+  const objectA = a as Record<string, unknown>;
+  const objectB = b as Record<string, unknown>;
+  const keysA = Object.keys(objectA);
+  const keysB = Object.keys(objectB);
   if (keysA.length !== keysB.length) return false;
   for (const key of keysA) {
-    if (objA[key] !== objB[key]) return false;
+    if (objectA[key] !== objectB[key]) return false;
   }
   return true;
 }
 
+/**
+ *
+ * @param a
+ * @param b
+ */
 export function isSizeEqual(a?: ElementSize, b?: ElementSize): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return a.width === b.width && a.height === b.height;
 }
 
+/**
+ *
+ * @param a
+ * @param b
+ */
 export function isPositionEqual(a?: ElementPosition, b?: ElementPosition): boolean {
   if (a === b) return true;
   if (!a || !b) return false;

--- a/packages/joint-react/src/utils/test-wrappers.tsx
+++ b/packages/joint-react/src/utils/test-wrappers.tsx
@@ -58,13 +58,13 @@ export function paperRenderElementWrapper(options: Options): React.JSXElementCon
 
 export const simpleRenderElementWrapper = paperRenderElementWrapper({
   graphProviderProps: {
-    elements: {
+    initialElements: {
       '1': {
         data: undefined,
         size: { width: 97, height: 99 },
       },
     },
-    links: {
+    initialLinks: {
       '3': {
         source: { id: '1' },
         target: { id: '2' },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [x] If applicable, there are new or updated @types
* [x] If applicable, documentation has been updated
-->

## Description

Refactors `GraphProvider` to separate controlled and uncontrolled modes with a TS-enforced discriminated union, and makes the two streams (elements and links) independent.

**Public API change:**
- Uncontrolled (default): `initialElements` / `initialLinks`. JointJS owns the data after mount.
- Controlled: `elements` + `onElementsChange` (and/or `links` + `onLinksChange`). React owns the data; the graph stays in sync.
- Mixed mode: any combination (e.g. controlled elements + uncontrolled links) is fully supported.
- Passing both `elements` and `initialElements` (or both `links` and `initialLinks`) is a TypeScript compile error.

**Internals:**
- `graphView.updateGraph` and `graphChanges.updateGraph` now accept partial input. When only `elements` is provided, link cells are preserved untouched (and vice versa). New tests lock in the "touched stream removes missing cells, untouched stream is preserved" contract.
- `GraphBase` detects controlled mode per stream (`isElementsControlled` / `isLinksControlled`) and splits the previous single `useLayoutEffect` into two stream-specific effects.
- `onElementsChange` / `onLinksChange` fire in both modes; in uncontrolled mode they are notification-only (React state is not pushed back to the graph).
- `onIncrementalChange` is orthogonal — it works in any mode.

**Migration:**
- ~50 stories / tests / MDX examples migrated from `elements=` / `links=` → `initialElements=` / `initialLinks=` where they were already uncontrolled. Controlled callers (`elements` + `onElementsChange`) are untouched.
- `graph-provider.stories.tsx` docs strings updated to reflect the new API surface.
- Package `README.md` modernized (badges, hero, feature grid, 60-second example, mixed-mode docs) and brought in line with the correct `data` / `position` / `size` record shape.

**Tests:**
- Added `graph-provider-mixed-mode.test.tsx` (2 tests) — controlled elements + uncontrolled links, and vice versa.
- Added `graph-provider-uncontrolled-notifications.test.tsx` (1 test) — verifies `onElementsChange` fires in uncontrolled mode without React→graph push.
- Added 3 `updateGraph partial sync` tests in `graph-changes.test.ts` and 2 in `graph-view.test.ts`.
- Fixed 3 pre-existing test failures uncovered along the way (`link-model` markup expectation, `paper-store` `computeNodeBoundingRect` mock, `paper.test.tsx` defaultLink signature).

All 532 tests pass. \`yarn typecheck\` clean.

## Motivation and Context

The previous `GraphProvider` API overloaded a single `elements` prop to mean "initial value" or "controlled value" depending on whether *any* callback (even one for links) was present. This was surprising — and the old `useLayoutEffect` always pushed both streams to the graph, which meant mixing controlled elements with uncontrolled links was impossible without wiping the uncontrolled side.

This refactor makes intent explicit at the prop level, lifts the limitation on mixed mode, and aligns the API with React's `value`/`defaultValue` convention.

### Screenshots (if appropriate):

N/A — API/types/docs change only.