### PR TITLE
feat(joint-core): predicate form for Cell.toJSON ignoreEmptyAttributes

### DIFF
--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -29,6 +29,7 @@ import {
 } from '../util/util.mjs';
 import { Model } from '../mvc/Model.mjs';
 import { cloneCells } from '../util/cloneCells.mjs';
+import { removeEmptyAttributes, removeAtTopLevelOnly } from '../util/removeEmptyAttributes.mjs';
 import { attributes } from './attributes/index.mjs';
 import * as g from '../g/index.mjs';
 import { config } from '../config/index.mjs';
@@ -42,31 +43,6 @@ const attributesMerger = function(a, b) {
         return cloneDeep(b);
     }
 };
-
-// Recursive predicate-driven removal. The predicate `(key, path) => boolean` is
-// invoked bottom-up for every empty `{}`; returning truthy drops the key. A
-// parent that becomes empty after its children are removed is itself a candidate.
-function removeEmptyAttributes(obj, predicate, path) {
-
-    for (const key in obj) {
-
-        const objValue = obj[key];
-        const isRealObject = isObject(objValue) && !Array.isArray(objValue);
-
-        if (!isRealObject) continue;
-
-        const childPath = path ? path.concat(key) : [key];
-        removeEmptyAttributes(objValue, predicate, childPath);
-
-        if (isEmpty(objValue) && predicate(key, childPath)) {
-            delete obj[key];
-        }
-    }
-}
-
-// Default predicate for `ignoreEmptyAttributes: true` — drops top-level empties
-// only, preserving the original (pre-recursive) behavior.
-const isTopLevelEmpty = (_key, path) => path.length === 1;
 
 export const Cell = Model.extend({
 
@@ -107,7 +83,7 @@ export const Cell = Model.extend({
         if (typeof ignoreEmptyAttributes === 'function') {
             removeEmptyPredicate = ignoreEmptyAttributes;
         } else if (ignoreEmptyAttributes) {
-            removeEmptyPredicate = isTopLevelEmpty;
+            removeEmptyPredicate = removeAtTopLevelOnly;
         }
 
         if (ignoreDefaults === false) {

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -43,9 +43,11 @@ const attributesMerger = function(a, b) {
     }
 };
 
-function removeEmptyAttributes(obj) {
+// Recursive predicate-driven removal. The predicate `(key, path) => boolean` is
+// invoked bottom-up for every empty `{}`; returning truthy drops the key. A
+// parent that becomes empty after its children are removed is itself a candidate.
+function removeEmptyAttributes(obj, predicate, path) {
 
-    // Remove toplevel empty attributes
     for (const key in obj) {
 
         const objValue = obj[key];
@@ -53,11 +55,18 @@ function removeEmptyAttributes(obj) {
 
         if (!isRealObject) continue;
 
-        if (isEmpty(objValue)) {
+        const childPath = path ? path.concat(key) : [key];
+        removeEmptyAttributes(objValue, predicate, childPath);
+
+        if (isEmpty(objValue) && predicate(key, childPath)) {
             delete obj[key];
         }
     }
 }
+
+// Default predicate for `ignoreEmptyAttributes: true` — drops top-level empties
+// only, preserving the original (pre-recursive) behavior.
+const isTopLevelEmpty = (_key, path) => path.length === 1;
 
 export const Cell = Model.extend({
 
@@ -88,13 +97,26 @@ export const Cell = Model.extend({
         const { ignoreDefaults, ignoreEmptyAttributes = false } = opt || {};
         const defaults = result(this.constructor.prototype, 'defaults');
 
+        // `ignoreEmptyAttributes`:
+        //  - `false` (default) — keep all empties.
+        //  - `true` — drop top-level empties only (sugar for the
+        //    `(key, path) => path.length === 1` predicate).
+        //  - `(key, path) => boolean` — recursive predicate; truthy drops the key
+        //    bottom-up (so a parent emptied by child removal is itself a candidate).
+        let removeEmptyPredicate = null;
+        if (typeof ignoreEmptyAttributes === 'function') {
+            removeEmptyPredicate = ignoreEmptyAttributes;
+        } else if (ignoreEmptyAttributes) {
+            removeEmptyPredicate = isTopLevelEmpty;
+        }
+
         if (ignoreDefaults === false) {
             // Return all attributes without omitting the defaults
             const finalAttributes = cloneDeep(this.attributes);
 
-            if (!ignoreEmptyAttributes) return finalAttributes;
-
-            removeEmptyAttributes(finalAttributes);
+            if (removeEmptyPredicate) {
+                removeEmptyAttributes(finalAttributes, removeEmptyPredicate);
+            }
 
             return finalAttributes;
         }
@@ -117,8 +139,8 @@ export const Cell = Model.extend({
         // Omit `id` and `type` attribute from the defaults since it should be always present
         const finalAttributes = objectDifference(attributes, omit(defaultAttributes, 'id', 'type'), { maxDepth: 4 });
 
-        if (ignoreEmptyAttributes) {
-            removeEmptyAttributes(finalAttributes);
+        if (removeEmptyPredicate) {
+            removeEmptyAttributes(finalAttributes, removeEmptyPredicate);
         }
 
         return finalAttributes;

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -3,7 +3,6 @@ import {
     result,
     merge,
     forIn,
-    isObject,
     isEqual,
     isString,
     cloneDeep,

--- a/packages/joint-core/src/dia/Cell.mjs
+++ b/packages/joint-core/src/dia/Cell.mjs
@@ -74,8 +74,9 @@ export const Cell = Model.extend({
 
         // `ignoreEmptyAttributes`:
         //  - `false` (default) — keep all empties.
-        //  - `true` — drop top-level empties only (sugar for the
-        //    `(key, path) => path.length === 1` predicate).
+        //  - `true` — drops top-level empties only, for backwards compatibility.
+        //    TODO(next major): `true` should drop all empties (recursive). Pass
+        //    `removeAtTopLevelOnly` explicitly to preserve the legacy behavior.
         //  - `(key, path) => boolean` — recursive predicate; truthy drops the key
         //    bottom-up (so a parent emptied by child removal is itself a candidate).
         let removeEmptyPredicate = null;

--- a/packages/joint-core/src/util/removeEmptyAttributes.mjs
+++ b/packages/joint-core/src/util/removeEmptyAttributes.mjs
@@ -1,0 +1,27 @@
+import { isObject, isEmpty } from './utilHelpers.mjs';
+
+// Recursive predicate-driven removal. The predicate `(key, path) => boolean` is
+// invoked bottom-up for every empty `{}` encountered; returning truthy drops the
+// key. A parent that becomes empty after its children are removed is itself a
+// candidate.
+export function removeEmptyAttributes(obj, predicate, path) {
+
+    for (const key in obj) {
+
+        const objValue = obj[key];
+        const isRealObject = isObject(objValue) && !Array.isArray(objValue);
+
+        if (!isRealObject) continue;
+
+        const childPath = path ? path.concat(key) : [key];
+        removeEmptyAttributes(objValue, predicate, childPath);
+
+        if (isEmpty(objValue) && predicate(key, childPath)) {
+            delete obj[key];
+        }
+    }
+}
+
+// Default predicate for `ignoreEmptyAttributes: true` — drops top-level
+// empties only, preserving the original (pre-recursive) behavior.
+export const removeAtTopLevelOnly = (_key, path) => path.length === 1;

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -809,7 +809,7 @@ QUnit.module('cell', function(hooks) {
                     size: { width: 100, height: 50 },
                     position: { x: 0, y: 0 },
                     foo: {},
-                    bar: { baz: {} },
+                    bar: { baz: {}},
                     extraDefault: { nested: 'value' }
                 }
             });

--- a/packages/joint-core/test/jointjs/cell.js
+++ b/packages/joint-core/test/jointjs/cell.js
@@ -797,6 +797,51 @@ QUnit.module('cell', function(hooks) {
                 size: {}
             });
         });
+
+        QUnit.test('`opt.ignoreEmptyAttributes` accepts a predicate `(key, path) => boolean`', function(assert) {
+            const El = joint.dia.Element.extend({
+                defaults: {
+                    type: 'test.Element',
+                    attrs: {
+                        text: { fill: 'red' },
+                        body: { stroke: 'black' }
+                    },
+                    size: { width: 100, height: 50 },
+                    position: { x: 0, y: 0 },
+                    foo: {},
+                    bar: { baz: {} },
+                    extraDefault: { nested: 'value' }
+                }
+            });
+
+            const el = new El({
+                id: 'el1',
+                attrs: {
+                    text: {
+                        textWrap: {}, // new key not in defaults — empty `{}` survives the diff
+                        fill: 'blue'  // overrides default
+                    }
+                }
+            });
+
+            // Drop every empty `{}` EXCEPT those at depth 3 inside `attrs`
+            // (e.g. `attrs.text.textWrap` should survive).
+            const result = el.toJSON({
+                ignoreDefaults: true,
+                ignoreEmptyAttributes: (key, path) => !(path[0] === 'attrs' && path.length === 3)
+            });
+
+            assert.deepEqual(result, {
+                id: 'el1',
+                type: 'test.Element',
+                attrs: {
+                    text: {
+                        textWrap: {},
+                        fill: 'blue'
+                    }
+                }
+            });
+        });
     });
 
     QUnit.module('relative vs absolute points', function() {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -614,7 +614,7 @@ export namespace Cell {
 
     interface ExportOptions {
         ignoreDefaults?: boolean | string[];
-        ignoreEmptyAttributes?: boolean;
+        ignoreEmptyAttributes?: boolean | ((key: string, path: string[]) => boolean);
     }
 
     type UnsetCallback<V> = (

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -612,9 +612,11 @@ export namespace Cell {
         mergeArrays?: boolean;
     }
 
+    type IgnoreEmptyAttributesCallback = (key: string, path: string[]) => boolean;
+
     interface ExportOptions {
         ignoreDefaults?: boolean | string[];
-        ignoreEmptyAttributes?: boolean | ((key: string, path: string[]) => boolean);
+        ignoreEmptyAttributes?: boolean | IgnoreEmptyAttributesCallback;
     }
 
     type UnsetCallback<V> = (


### PR DESCRIPTION
## Summary
- `Cell.toJSON({ ignoreEmptyAttributes })` now also accepts a predicate `(key: string, path: string[]) => boolean` for fine-grained control over which empty `{}` values are pruned from the serialized output.
- `true` keeps its existing top-level-only semantics — sugar for `(key, path) => path.length === 1`. No breaking change.
- Predicate is invoked bottom-up; a parent emptied by child removal is itself a candidate, so nested empties (e.g. `{ ports: { groups: {} } }`) are reachable when the predicate opts in.

## Motivation
The boolean form was all-or-nothing and only stripped top-level empties. There was no way to:
- Drop nested empties (`{ ports: { groups: {} } }` survived).
- Keep a known set of empties (e.g. an intentional `attrs.text.textWrap: {}`) while pruning the rest.

## Example
```js
cell.toJSON({
  ignoreDefaults: true,
  // keep empties at depth 3 inside `attrs`, drop everything else empty
  ignoreEmptyAttributes: (key, path) => !(path[0] === 'attrs' && path.length === 3),
});
```

## Test plan
- [x] New QUnit test in `test/jointjs/cell.js` covering the predicate form.
- [x] Existing `ignoreEmptyAttributes: true` tests still pass (1946 / 1946).
- [x] Type definition updated in `dia.d.ts` (`Cell.ExportOptions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)