### PR TITLE
fix(joint-react): add onElementsSizeChange handling for element size updates in graphChanges

### DIFF
--- a/packages/joint-react/src/store/__tests__/graph-changes.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-changes.test.ts
@@ -369,6 +369,83 @@ describe('graphChanges', () => {
     });
   });
 
+  describe('onElementsSizeChange', () => {
+    function setupWithSize() {
+      const graph = createGraph();
+      const onChanges = jest.fn();
+      const onElementsSizeChange = jest.fn();
+      const controller = graphChanges({
+        graph,
+        onChanges,
+        onElementsSizeChange,
+      });
+      return { graph, onChanges, onElementsSizeChange, controller };
+    }
+
+    it('fires for each element when resetCells seeds cells with sizes', () => {
+      const { graph, onElementsSizeChange } = setupWithSize();
+      graph.resetCells([
+        {
+          id: 'a',
+          type: 'element',
+          position: { x: 0, y: 0 },
+          size: { width: 100, height: 50 },
+        },
+        {
+          id: 'b',
+          type: 'element',
+          position: { x: 200, y: 0 },
+          size: { width: 80, height: 40 },
+        },
+        {
+          id: 'l1',
+          type: 'standard.Link',
+          source: { id: 'a' },
+          target: { id: 'b' },
+        },
+      ]);
+
+      const elementCalls = onElementsSizeChange.mock.calls.filter(
+        ([id]) => id === 'a' || id === 'b'
+      );
+      expect(elementCalls).toHaveLength(2);
+      expect(elementCalls).toEqual(
+        expect.arrayContaining([
+          ['a', { width: 100, height: 50 }],
+          ['b', { width: 80, height: 40 }],
+        ])
+      );
+    });
+
+    it('does not fire for links on reset', () => {
+      const { graph, onElementsSizeChange } = setupWithSize();
+      graph.resetCells([
+        {
+          id: 'a',
+          type: 'element',
+          position: { x: 0, y: 0 },
+          size: { width: 100, height: 50 },
+        },
+        {
+          id: 'b',
+          type: 'element',
+          position: { x: 200, y: 0 },
+          size: { width: 80, height: 40 },
+        },
+        {
+          id: 'l1',
+          type: 'standard.Link',
+          source: { id: 'a' },
+          target: { id: 'b' },
+        },
+      ]);
+
+      for (const [id] of onElementsSizeChange.mock.calls) {
+        expect(id).not.toBe('l1');
+      }
+    });
+  });
+
   describe('destroy', () => {
     it('stops listening to graph events', () => {
       const { graph, onChanges, controller } = setup();

--- a/packages/joint-react/src/store/__tests__/graph-store.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-store.test.ts
@@ -61,6 +61,37 @@ describe('GraphStore', () => {
       store.destroy(true);
     });
 
+    it('bumps measureState after initialCells seed (so useNodesMeasuredEffect can fire isInitial)', async () => {
+      const initialCells: readonly CellRecord[] = [
+        {
+          id: 'a',
+          type: ELEMENT_MODEL_TYPE,
+          position: { x: 0, y: 0 },
+          size: { width: 100, height: 50 },
+        } as CellRecord,
+      ];
+      const store = new GraphStore({ initialCells });
+      // simpleScheduler defers the measureState bump to a microtask.
+      await flush();
+      expect(store.measureState.get()).toBeGreaterThan(0);
+      store.destroy(false);
+    });
+
+    it('does not bump measureState when initialCells contain only links or zero-sized elements', async () => {
+      const initialCells: readonly CellRecord[] = [
+        {
+          id: 'zero',
+          type: ELEMENT_MODEL_TYPE,
+          position: { x: 0, y: 0 },
+          size: { width: 0, height: 0 },
+        } as CellRecord,
+      ];
+      const store = new GraphStore({ initialCells });
+      await flush();
+      expect(store.measureState.get()).toBe(0);
+      store.destroy(false);
+    });
+
     it('accepts a controlled cells prop and mirrors it into the graph', () => {
       const cells: readonly CellRecord[] = [
         {

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -138,6 +138,13 @@ export function graphChanges(options: Options) {
       changes.clear();
       for (const cell of collection.models) {
         changes.set(cell.id, { type: 'add', data: cell });
+        // `reset` suppresses per-cell `add` events, so size notifications
+        // for seed elements never reach `onElementsSizeChange` via the
+        // `add` listener. Mirror that path here so initial-measurement
+        // gating (e.g. `useNodesMeasuredEffect`) fires for seed cells.
+        if (onElementsSizeChange && cell.isElement()) {
+          onElementsSizeChange(cell.id, (cell as dia.Element).size());
+        }
       }
       // Bypass the simpleScheduler wrapper used for normal cell events.
       // `reset` is a one-shot bulk operation and callers (e.g. GraphStore


### PR DESCRIPTION
Implement onElementsSizeChange to notify size updates for elements when resetting cells in the graph. This change enhances the responsiveness of the graph to size changes, ensuring that size notifications are correctly fired for elements while ignoring links. Additionally, it updates the measureState behavior in the GraphStore to reflect initial cell sizes appropriately.

