### PR TITLE
feat(joint-react): cell selectors + usePaper().wakeUp

### DIFF
--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
-import { useContext, useReducer, useLayoutEffect, useRef } from 'react';
+import { useCallback, useContext, useReducer, useLayoutEffect, useRef } from 'react';
 import { PaperStoreContext } from '../context';
 import type { PaperStore } from '../store';
 import { useGraphStore } from './use-graph-store';
@@ -156,11 +156,31 @@ export function usePaperStore(idOrOptions?: string | Optional): PaperStore | nul
  * }
  * ```
  */
-export function usePaper(): { paper: dia.Paper };
-export function usePaper(options: Optional): { paper: dia.Paper | null };
-export function usePaper(id: string): { paper: dia.Paper | null };
-export function usePaper(idOrOptions?: string | Optional): { paper: dia.Paper | null };
-export function usePaper(idOrOptions?: string | Optional): { paper: dia.Paper | null } {
+/** Imperative actions returned alongside the paper instance from {@link usePaper}. */
+interface UsePaperActions {
+  /**
+   * Trigger a render pass on the paper. Forwards to `paper.wakeUp()` —
+   * useful after mutations that don't go through React state (e.g. toggling
+   * a `cellVisibility` predicate that closes over external state). No-op
+   * when the paper isn't resolved yet.
+   * @see https://docs.jointjs.com/api/dia/Paper#wakeUp
+   */
+  readonly wakeUp: () => void;
+}
+
+export function usePaper(): { paper: dia.Paper } & UsePaperActions;
+export function usePaper(options: Optional): { paper: dia.Paper | null } & UsePaperActions;
+export function usePaper(id: string): { paper: dia.Paper | null } & UsePaperActions;
+export function usePaper(
+  idOrOptions?: string | Optional
+): { paper: dia.Paper | null } & UsePaperActions;
+export function usePaper(
+  idOrOptions?: string | Optional
+): { paper: dia.Paper | null } & UsePaperActions {
   const paperStore = usePaperStore(idOrOptions);
-  return { paper: (paperStore?.paper as dia.Paper | undefined) ?? null };
+  const paper = (paperStore?.paper as dia.Paper | undefined) ?? null;
+  const wakeUp = useCallback(() => {
+    paper?.wakeUp();
+  }, [paper]);
+  return { paper, wakeUp };
 }

--- a/packages/joint-react/src/selectors/__tests__/cell-selectors.test.ts
+++ b/packages/joint-react/src/selectors/__tests__/cell-selectors.test.ts
@@ -56,7 +56,7 @@ describe('cell-selectors', () => {
     expect(selectCellParent(child)).toBe('parent-1');
   });
 
-  it('selectCellParent returns undefined when no parent', () => {
-    expect(selectCellParent(element)).toBeUndefined();
+  it('selectCellParent returns null when no parent', () => {
+    expect(selectCellParent(element)).toBeNull();
   });
 });

--- a/packages/joint-react/src/selectors/cell-selectors.ts
+++ b/packages/joint-react/src/selectors/cell-selectors.ts
@@ -31,8 +31,8 @@ export function selectElementSize(element: Computed<ElementRecord>) {
  * Reads `element.angle`.
  * @param element
  */
-export function selectElementAngle(element: Computed<ElementRecord>) {
-  return element.angle;
+export function selectElementAngle(element: Computed<ElementRecord>): number {
+  return element.angle ?? 0;
 }
 
 /**
@@ -68,5 +68,21 @@ export const selectCellType = (cell: Computed<CellRecord>) => cell.type;
  * any cell can be embedded.
  * @param cell
  */
-export const selectCellParent = (cell: Computed<CellRecord>): CellId | undefined =>
-  cell.parent as CellId | undefined;
+export const selectCellParent = (cell: Computed<CellRecord>): CellId | null =>
+  cell.parent ?? null;
+
+/**
+ * Reads the `layer` field — name of the JointJS layer the cell renders into,
+ * or undefined when the cell uses the paper's default layer.
+ * @param cell
+ */
+export const selectCellLayer = (cell: Computed<CellRecord>): string | null =>
+  cell.layer ?? null;
+
+/**
+ * Reads the `z` field — JointJS z-index (paint order within a layer).
+ * Undefined when the cell hasn't been assigned an explicit z-index.
+ * @param cell
+ */
+export const selectCellZIndex = (cell: Computed<CellRecord>): number =>
+  cell.z ?? 0;

--- a/packages/joint-react/src/stories/examples/with-layers/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-layers/code.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { dia, shapes } from '@joint/core';
-import { type CellRecord, GraphProvider, useCell, Paper, ElementModel, LinkModel, HTMLHost, selectElementSize } from '@joint/react';
-import { useMemo, useRef, useState } from 'react';
+import { type CellRecord, GraphProvider, useCell, Paper, ElementModel, LinkModel, HTMLHost, selectElementSize, usePaper } from '@joint/react';
+import { useMemo, useState } from 'react';
 import { PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, SECONDARY } from 'storybook-config/theme';
 
 interface LayeredElementData {
@@ -131,7 +131,7 @@ interface MainProps {
 
 function Main({ hiddenLayers, toggleLayer }: Readonly<MainProps>) {
   const layers = ['background', 'main', 'foreground'];
-  const paperRef = useRef<dia.Paper | null>(null);
+  const { wakeUp } = usePaper('layers-paper');
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -142,7 +142,7 @@ function Main({ hiddenLayers, toggleLayer }: Readonly<MainProps>) {
             type="button"
             onClick={() => {
               toggleLayer(layerId);
-              paperRef.current?.wakeUp();
+              wakeUp();
             }}
             style={{
               padding: '8px 16px',
@@ -160,7 +160,7 @@ function Main({ hiddenLayers, toggleLayer }: Readonly<MainProps>) {
         ))}
       </div>
       <Paper
-        ref={paperRef}
+        id="layers-paper"
         height={300}
         className={PAPER_CLASSNAME}
         renderElement={RenderElement}


### PR DESCRIPTION
## Summary

Three small additions to the joint-react public surface:

- **New cell selectors** (`packages/joint-react/src/selectors/cell-selectors.ts`):
  - `selectCellLayer(cell): string | null` — layer name the cell renders into.
  - `selectCellZIndex(cell): number` — z-index (paint order) within the layer.
  - `selectCellParent(cell)` now returns `null` (instead of `undefined`) for top-level cells, matching the new style for missing fields.
- **`usePaper().wakeUp()`** — sync method exposed on the `usePaper()` hook return, forwards to `paper.wakeUp()`. Useful after mutations that don't go through React state (e.g. toggling external flags closed over by a `cellVisibility` predicate).
- **`with-layers` example** uses `usePaper('layers-paper').wakeUp()` instead of a `paperRef`, demonstrating the new pattern.
- Test updated for the `selectCellParent` `null` return.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn jest` — 831/831 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)