### PR TITLE
feat(joint-core, joint-react): split Cell.JSON/JSONInit + cell record type refactor

### DIFF
--- a/packages/joint-core/test/ts-exports/exports.test.js
+++ b/packages/joint-core/test/ts-exports/exports.test.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=exports.test.js.map

--- a/packages/joint-core/test/ts-exports/exports.test.js.map
+++ b/packages/joint-core/test/ts-exports/exports.test.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"exports.test.js","sourceRoot":"","sources":["exports.test.ts"],"names":[],"mappings":""}

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -290,7 +290,7 @@ export namespace Graph {
 
     type Cells = CellCollection;
 
-    type CellInit = Cell | Cell.JSON;
+    type CellInit = Cell | Cell.JSONInit;
 
     type CellRef = Cell | Cell.ID;
 
@@ -308,7 +308,7 @@ export namespace Graph {
         cells: Array<Cell.JSON>;
         layers?: Array<GraphLayer.Attributes>;
         defaultLayer?: string;
-        [key: string]: any;
+        [key: string]: unknown;
     }
 
     interface InsertLayerOptions extends Options {
@@ -474,9 +474,9 @@ export class Graph<A extends ObjectHash = Graph.Attributes, S = ModelSetOptions>
 
     getCommonAncestor(...cells: Cell[]): Element | undefined;
 
-    toJSON(opt?: { cellAttributes?: Cell.ExportOptions }): any;
+    toJSON(opt?: { cellAttributes?: Cell.ExportOptions }): Graph.JSON;
 
-    fromJSON(json: any, opt?: S): this;
+    fromJSON(json: Graph.JSON, opt?: S): this;
 
     clear(opt?: { [key: string]: any }): this;
 
@@ -552,22 +552,43 @@ export namespace Cell {
 
     type ID = string | number;
 
-    interface GenericAttributes<T> {
-        attrs?: T;
-        z?: number;
-        layer?: string;
-        parent?: string;
-        [key: string]: any;
-    }
-
     interface Selectors {
         [selector: string]: Nullable<attributes.SVGAttributes> | undefined;
     }
 
-    interface Attributes extends GenericAttributes<Selectors> {
+    /**
+     * An object that is passed to the constructor of a cell.
+     * It should not contain the `type` field
+     */
+    interface Attributes<S = Selectors> {
+        id?: ID;
+        attrs?: S;
+        z?: number;
+        layer?: string;
+        parent?: string;
+        /**
+         * @todo change to `unknown` (breaking change)
+         * See `/test/ts/toolsView.test.ts`
+         */
+        [key: string]: any;
     }
 
-    type JSON<K extends Selectors = Selectors, T extends GenericAttributes<K> = GenericAttributes<K>> = T & {
+    /** @deprecated use `Attributes` instead. */
+    interface GenericAttributes<T> extends Attributes<T> {}
+
+    /**
+     * When a cell is parsed from a JSON,
+     * only the `type` field is required to determine the constructor.
+     */
+    interface JSONInit<S = Selectors> extends Attributes<S> {
+        type: string;
+    }
+
+    /**
+     * The full JSON representation of a cell, as returned by `toJSON()`.
+     * The `id` and `type` attributes are always present.
+     */
+    type JSON<K extends Selectors = Selectors, T extends Attributes<K> = Attributes<K>> = T & {
         [attribute in keyof T]: T[attribute];
     } & {
         id: ID;
@@ -777,7 +798,7 @@ export class Cell<A extends ObjectHash = Cell.Attributes, S extends mvc.ModelSet
 
 export namespace Element {
 
-    interface GenericAttributes<T> extends Cell.GenericAttributes<T> {
+    interface Attributes<T = Cell.Selectors> extends Cell.Attributes<T> {
         markup?: string | MarkupJSON;
         position?: Point;
         size?: Size;
@@ -788,7 +809,10 @@ export namespace Element {
         };
     }
 
-    interface Attributes extends GenericAttributes<Cell.Selectors> {
+    /** @deprecated use `Attributes` instead. */
+    interface GenericAttributes<T> extends Attributes<T> {}
+
+    interface JSONInit<S = Cell.Selectors> extends Cell.JSONInit<S>, Attributes<S> {
     }
 
     interface ConstructorOptions extends Cell.ConstructorOptions {
@@ -979,7 +1003,7 @@ export namespace Link {
         y?: number;
     }
 
-    interface GenericAttributes<T> extends Cell.GenericAttributes<T> {
+    interface Attributes<S = Cell.Selectors> extends Cell.Attributes<S> {
         source?: EndJSON;
         target?: EndJSON;
         labels?: Label[];
@@ -988,7 +1012,10 @@ export namespace Link {
         connector?: connectors.Connector | connectors.ConnectorJSON;
     }
 
-    interface Attributes extends GenericAttributes<Cell.Selectors> {
+    /** @deprecated use `Attributes` instead. */
+    interface GenericAttributes<T> extends Attributes<T> {}
+
+    interface JSONInit<S = Cell.Selectors> extends Cell.JSONInit<S>, Attributes<S> {
     }
 
     interface LabelPosition {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -308,7 +308,7 @@ export namespace Graph {
         cells: Array<Cell.JSON>;
         layers?: Array<GraphLayer.Attributes>;
         defaultLayer?: string;
-        [key: string]: unknown;
+        [key: string]: any;
     }
 
     interface InsertLayerOptions extends Options {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -561,7 +561,6 @@ export namespace Cell {
      * It should not contain the `type` field
      */
     interface Attributes<S = Selectors> {
-        id?: ID;
         attrs?: S;
         z?: number;
         layer?: string;
@@ -570,7 +569,7 @@ export namespace Cell {
          * @todo change to `unknown` (breaking change)
          * See `/test/ts/toolsView.test.ts`
          */
-        [key: string]: any;
+        [customAttribute: string]: any;
     }
 
     /** @deprecated use `Attributes` instead. */
@@ -581,6 +580,7 @@ export namespace Cell {
      * only the `type` field is required to determine the constructor.
      */
     interface JSONInit<S = Selectors> extends Attributes<S> {
+        id?: ID;
         type: string;
     }
 

--- a/packages/joint-core/types/shapes-standard.d.ts
+++ b/packages/joint-core/types/shapes-standard.d.ts
@@ -9,7 +9,7 @@ export interface RectangleSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type RectangleAttributes = dia.Element.GenericAttributes<RectangleSelectors>;
+export type RectangleAttributes = dia.Element.Attributes<RectangleSelectors>;
 
 export class Rectangle extends dia.Element<RectangleAttributes> {
 }
@@ -20,7 +20,7 @@ export interface CircleSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type CircleAttributes = dia.Element.GenericAttributes<CircleSelectors>;
+export type CircleAttributes = dia.Element.Attributes<CircleSelectors>;
 
 export class Circle extends dia.Element<CircleAttributes> {
 }
@@ -31,7 +31,7 @@ export interface EllipseSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type EllipseAttributes = dia.Element.GenericAttributes<EllipseSelectors>;
+export type EllipseAttributes = dia.Element.Attributes<EllipseSelectors>;
 
 export class Ellipse extends dia.Element<EllipseAttributes> {
 }
@@ -42,7 +42,7 @@ export interface PathSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type PathAttributes = dia.Element.GenericAttributes<PathSelectors>;
+export type PathAttributes = dia.Element.Attributes<PathSelectors>;
 
 export class Path extends dia.Element<PathAttributes> {
 }
@@ -53,7 +53,7 @@ export interface PolygonSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type PolygonAttributes = dia.Element.GenericAttributes<PolygonSelectors>;
+export type PolygonAttributes = dia.Element.Attributes<PolygonSelectors>;
 
 export class Polygon extends dia.Element<PolygonAttributes> {
 }
@@ -64,7 +64,7 @@ export interface PolylineSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type PolylineAttributes = dia.Element.GenericAttributes<PolylineSelectors>;
+export type PolylineAttributes = dia.Element.Attributes<PolylineSelectors>;
 
 export class Polyline extends dia.Element<PolylineAttributes> {
 }
@@ -75,7 +75,7 @@ export interface ImageSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type ImageAttributes = dia.Element.GenericAttributes<ImageSelectors>;
+export type ImageAttributes = dia.Element.Attributes<ImageSelectors>;
 
 export class Image extends dia.Element<ImageAttributes> {
 }
@@ -88,7 +88,7 @@ export interface BorderedImageSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type BorderedImageAttributes = dia.Element.GenericAttributes<BorderedImageSelectors>;
+export type BorderedImageAttributes = dia.Element.Attributes<BorderedImageSelectors>;
 
 export class BorderedImage extends dia.Element<BorderedImageAttributes> {
 }
@@ -100,7 +100,7 @@ export interface EmbeddedImageSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type EmbeddedImageAttributes = dia.Element.GenericAttributes<EmbeddedImageSelectors>;
+export type EmbeddedImageAttributes = dia.Element.Attributes<EmbeddedImageSelectors>;
 
 export class EmbeddedImage extends dia.Element<EmbeddedImageAttributes> {
 }
@@ -113,7 +113,7 @@ export interface InscribedImageSelectors extends dia.Cell.Selectors {
     label?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type InscribedImageAttributes = dia.Element.GenericAttributes<InscribedImageSelectors>;
+export type InscribedImageAttributes = dia.Element.Attributes<InscribedImageSelectors>;
 
 export class InscribedImage extends dia.Element<InscribedImageAttributes> {
 }
@@ -126,7 +126,7 @@ export interface HeaderedRectangleSelectors extends dia.Cell.Selectors {
     bodyText?: Nullable<attributes.SVGTextAttributes>;
 }
 
-export type HeaderedRectangleAttributes = dia.Element.GenericAttributes<HeaderedRectangleSelectors>;
+export type HeaderedRectangleAttributes = dia.Element.Attributes<HeaderedRectangleSelectors>;
 
 export class HeaderedRectangle extends dia.Element<HeaderedRectangleAttributes> {
 }
@@ -141,7 +141,7 @@ export interface CylinderSelectors extends dia.Cell.Selectors {
     top?: Nullable<attributes.SVGEllipseAttributes>;
 }
 
-export type CylinderAttributes = dia.Element.GenericAttributes<CylinderSelectors>;
+export type CylinderAttributes = dia.Element.Attributes<CylinderSelectors>;
 
 export class Cylinder<S extends mvc.ModelSetOptions = dia.ModelSetOptions> extends dia.Element<CylinderAttributes, S> {
     topRy(): string | number;
@@ -158,7 +158,7 @@ export interface TextBlockSelectors extends dia.Cell.Selectors {
     }>;
 }
 
-export type TextBlockAttributes = dia.Element.GenericAttributes<TextBlockSelectors>;
+export type TextBlockAttributes = dia.Element.Attributes<TextBlockSelectors>;
 
 export class TextBlock extends dia.Element<TextBlockAttributes> {
 }
@@ -169,7 +169,7 @@ export interface LinkSelectors extends dia.Cell.Selectors {
     wrapper?: Nullable<attributes.SVGPathAttributes>;
 }
 
-export type LinkAttributes = dia.Link.GenericAttributes<LinkSelectors>;
+export type LinkAttributes = dia.Link.Attributes<LinkSelectors>;
 
 export class Link extends dia.Link<LinkAttributes> {
 }
@@ -180,7 +180,7 @@ export interface DoubleLinkSelectors extends dia.Cell.Selectors {
     outline?: Nullable<attributes.SVGPathAttributes>;
 }
 
-export type DoubleLinkAttributes = dia.Link.GenericAttributes<DoubleLinkSelectors>;
+export type DoubleLinkAttributes = dia.Link.Attributes<DoubleLinkSelectors>;
 
 export class DoubleLink extends dia.Link<DoubleLinkAttributes> {
 }
@@ -191,7 +191,7 @@ export interface ShadowLinkSelectors extends dia.Cell.Selectors {
     shadow?: Nullable<attributes.SVGPathAttributes>;
 }
 
-export type ShadowLinkAttributes = dia.Link.GenericAttributes<ShadowLinkSelectors>;
+export type ShadowLinkAttributes = dia.Link.Attributes<ShadowLinkSelectors>;
 
 export class ShadowLink extends dia.Link<ShadowLinkAttributes> {
 }

--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -4,12 +4,12 @@ import { useImperativeApi } from '../../hooks/use-imperative-api';
 import { GraphStoreContext } from '../../context';
 import { GraphStore } from '../../store';
 import type { IncrementalCellsChange } from '../../store/graph-view';
-import type { DiaElementRecord, DiaLinkRecord } from '../../types/cell.types';
+import type { ElementJSONInit, LinkJSONInit } from '../../types/cell.types';
 
 /** Cells array accepted by GraphProvider. */
 type ProviderCells<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > = ReadonlyArray<Element | Link>;
 
 /**
@@ -18,8 +18,8 @@ type ProviderCells<
  * @template LinkData - User data attached to each link record.
  */
 interface GraphProviderBaseProps<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   /**
    * Pre-existing JointJS graph instance to use. If omitted, GraphProvider
@@ -51,8 +51,8 @@ interface GraphProviderBaseProps<
  * @template LinkData - user data on each link
  */
 interface GraphProviderUncontrolledProps<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > extends GraphProviderBaseProps<Element, Link> {
   readonly initialCells?: ProviderCells<Element, Link>;
   readonly cells?: never;
@@ -67,8 +67,8 @@ interface GraphProviderUncontrolledProps<
  * @template LinkData - user data on each link
  */
 interface GraphProviderControlledProps<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > extends GraphProviderBaseProps<Element, Link> {
   readonly cells: ProviderCells<Element, Link>;
   readonly initialCells?: never;
@@ -91,8 +91,8 @@ interface GraphProviderControlledProps<
  * @template LinkData - User data attached to each link record.
  */
 export type GraphProviderProps<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > = GraphProviderUncontrolledProps<Element, Link> | GraphProviderControlledProps<Element, Link>;
 
 /**
@@ -103,8 +103,8 @@ export type GraphProviderProps<
  * re-binds the generics on read — the runtime instance is the same.
  */
 type GraphProviderBaseInternalProps = GraphProviderProps<
-  DiaElementRecord,
-  DiaLinkRecord
+  ElementJSONInit,
+  LinkJSONInit
 > & {
   ref?: React.Ref<dia.Graph | null>;
 };
@@ -136,7 +136,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
   const isControlled = cellsProperty !== undefined;
 
   const { isReady, ref } = useImperativeApi<
-    GraphStore<DiaElementRecord, DiaLinkRecord>,
+    GraphStore<ElementJSONInit, LinkJSONInit>,
     dia.Graph
   >(
     {
@@ -146,7 +146,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
         const graphStore =
           store ??
           (isControlled
-            ? new GraphStore<DiaElementRecord, DiaLinkRecord>({
+            ? new GraphStore<ElementJSONInit, LinkJSONInit>({
                 graph,
                 cellNamespace,
                 cellModel,
@@ -154,7 +154,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
                 onCellsChange,
                 onIncrementalCellsChange,
               })
-            : new GraphStore<DiaElementRecord, DiaLinkRecord>({
+            : new GraphStore<ElementJSONInit, LinkJSONInit>({
                 graph,
                 cellNamespace,
                 cellModel,
@@ -216,8 +216,8 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
  * @see GraphProviderProps for all available props
  */
 export const GraphProvider = GraphBase as <
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(
   props: GraphProviderProps<Element, Link> & {
     ref?: React.Ref<dia.Graph | null>;

--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -4,12 +4,12 @@ import { useImperativeApi } from '../../hooks/use-imperative-api';
 import { GraphStoreContext } from '../../context';
 import { GraphStore } from '../../store';
 import type { IncrementalCellsChange } from '../../store/graph-view';
-import type { DiaElementAttributes, DiaLinkAttributes } from '../../types/cell.types';
+import type { DiaElementRecord, DiaLinkRecord } from '../../types/cell.types';
 
 /** Cells array accepted by GraphProvider. */
 type ProviderCells<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > = ReadonlyArray<Element | Link>;
 
 /**
@@ -18,8 +18,8 @@ type ProviderCells<
  * @template LinkData - User data attached to each link record.
  */
 interface GraphProviderBaseProps<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   /**
    * Pre-existing JointJS graph instance to use. If omitted, GraphProvider
@@ -51,8 +51,8 @@ interface GraphProviderBaseProps<
  * @template LinkData - user data on each link
  */
 interface GraphProviderUncontrolledProps<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > extends GraphProviderBaseProps<Element, Link> {
   readonly initialCells?: ProviderCells<Element, Link>;
   readonly cells?: never;
@@ -67,8 +67,8 @@ interface GraphProviderUncontrolledProps<
  * @template LinkData - user data on each link
  */
 interface GraphProviderControlledProps<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > extends GraphProviderBaseProps<Element, Link> {
   readonly cells: ProviderCells<Element, Link>;
   readonly initialCells?: never;
@@ -91,8 +91,8 @@ interface GraphProviderControlledProps<
  * @template LinkData - User data attached to each link record.
  */
 export type GraphProviderProps<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > = GraphProviderUncontrolledProps<Element, Link> | GraphProviderControlledProps<Element, Link>;
 
 /**
@@ -103,8 +103,8 @@ export type GraphProviderProps<
  * re-binds the generics on read — the runtime instance is the same.
  */
 type GraphProviderBaseInternalProps = GraphProviderProps<
-  DiaElementAttributes,
-  DiaLinkAttributes
+  DiaElementRecord,
+  DiaLinkRecord
 > & {
   ref?: React.Ref<dia.Graph | null>;
 };
@@ -136,7 +136,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
   const isControlled = cellsProperty !== undefined;
 
   const { isReady, ref } = useImperativeApi<
-    GraphStore<DiaElementAttributes, DiaLinkAttributes>,
+    GraphStore<DiaElementRecord, DiaLinkRecord>,
     dia.Graph
   >(
     {
@@ -146,7 +146,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
         const graphStore =
           store ??
           (isControlled
-            ? new GraphStore<DiaElementAttributes, DiaLinkAttributes>({
+            ? new GraphStore<DiaElementRecord, DiaLinkRecord>({
                 graph,
                 cellNamespace,
                 cellModel,
@@ -154,7 +154,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
                 onCellsChange,
                 onIncrementalCellsChange,
               })
-            : new GraphStore<DiaElementAttributes, DiaLinkAttributes>({
+            : new GraphStore<DiaElementRecord, DiaLinkRecord>({
                 graph,
                 cellNamespace,
                 cellModel,
@@ -216,8 +216,8 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
  * @see GraphProviderProps for all available props
  */
 export const GraphProvider = GraphBase as <
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(
   props: GraphProviderProps<Element, Link> & {
     ref?: React.Ref<dia.Graph | null>;

--- a/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
@@ -12,7 +12,6 @@ import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type {
   CellRecord,
-  CellJSONInit,
   ElementRecord,
 } from '../../types/cell.types';
 
@@ -41,7 +40,7 @@ const baseCells: readonly CellRecord[] = [
 
 const wrapper = graphProviderWrapper({ initialCells: baseCells });
 
-const setCellAUpdater = (previous: CellJSONInit): CellRecord => {
+const setCellAUpdater = (previous: CellRecord<unknown, unknown, string, string>): CellRecord => {
   const element = previous as ElementRecord;
   return {
     ...element,
@@ -49,22 +48,22 @@ const setCellAUpdater = (previous: CellJSONInit): CellRecord => {
   } as CellRecord;
 };
 
-const passthroughUpdater = (previous: CellJSONInit) => previous as CellRecord;
+const passthroughUpdater = (previous: CellRecord<unknown, unknown, string, string>) => previous as CellRecord;
 
-const filterOutCellA = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
+const filterOutCellA = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
   previous.filter((cell) => cell.id !== 'a');
 
-const filterOutCellB = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
+const filterOutCellB = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
   previous.filter((cell) => cell.id !== 'b');
 
-const moveCellAFar = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
+const moveCellAFar = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
   previous.map((cell) => {
     if (cell.id !== 'a') return cell;
     const element = cell as ElementRecord;
     return {
       ...element,
       position: { x: 999, y: 999 },
-    } as CellJSONInit;
+    } as CellRecord<unknown, unknown, string, string>;
   });
 
 describe('use-cell-setters', () => {

--- a/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
@@ -11,6 +11,7 @@ import { useGraphStore } from '../use-graph-store';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type {
+  AnyCellRecord,
   CellRecord,
   ElementRecord,
 } from '../../types/cell.types';
@@ -40,7 +41,7 @@ const baseCells: readonly CellRecord[] = [
 
 const wrapper = graphProviderWrapper({ initialCells: baseCells });
 
-const setCellAUpdater = (previous: CellRecord<unknown, unknown, string, string>): CellRecord => {
+const setCellAUpdater = (previous: AnyCellRecord): CellRecord => {
   const element = previous as ElementRecord;
   return {
     ...element,
@@ -48,22 +49,22 @@ const setCellAUpdater = (previous: CellRecord<unknown, unknown, string, string>)
   } as CellRecord;
 };
 
-const passthroughUpdater = (previous: CellRecord<unknown, unknown, string, string>) => previous as CellRecord;
+const passthroughUpdater = (previous: AnyCellRecord) => previous as CellRecord;
 
-const filterOutCellA = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
+const filterOutCellA = (previous: readonly AnyCellRecord[]): readonly AnyCellRecord[] =>
   previous.filter((cell) => cell.id !== 'a');
 
-const filterOutCellB = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
+const filterOutCellB = (previous: readonly AnyCellRecord[]): readonly AnyCellRecord[] =>
   previous.filter((cell) => cell.id !== 'b');
 
-const moveCellAFar = (previous: ReadonlyArray<CellRecord<unknown, unknown, string, string>>): ReadonlyArray<CellRecord<unknown, unknown, string, string>> =>
+const moveCellAFar = (previous: readonly AnyCellRecord[]): readonly AnyCellRecord[] =>
   previous.map((cell) => {
     if (cell.id !== 'a') return cell;
     const element = cell as ElementRecord;
     return {
       ...element,
       position: { x: 999, y: 999 },
-    } as CellRecord<unknown, unknown, string, string>;
+    } as AnyCellRecord;
   });
 
 describe('use-cell-setters', () => {

--- a/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
@@ -12,7 +12,7 @@ import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type {
   CellRecord,
-  DiaCellAttributes,
+  DiaCellRecord,
   ElementRecord,
 } from '../../types/cell.types';
 
@@ -41,7 +41,7 @@ const baseCells: readonly CellRecord[] = [
 
 const wrapper = graphProviderWrapper({ initialCells: baseCells });
 
-const setCellAUpdater = (previous: DiaCellAttributes): CellRecord => {
+const setCellAUpdater = (previous: DiaCellRecord): CellRecord => {
   const element = previous as ElementRecord;
   return {
     ...element,
@@ -49,22 +49,22 @@ const setCellAUpdater = (previous: DiaCellAttributes): CellRecord => {
   } as CellRecord;
 };
 
-const passthroughUpdater = (previous: DiaCellAttributes) => previous as CellRecord;
+const passthroughUpdater = (previous: DiaCellRecord) => previous as CellRecord;
 
-const filterOutCellA = (previous: readonly DiaCellAttributes[]): readonly DiaCellAttributes[] =>
+const filterOutCellA = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
   previous.filter((cell) => cell.id !== 'a');
 
-const filterOutCellB = (previous: readonly DiaCellAttributes[]): readonly DiaCellAttributes[] =>
+const filterOutCellB = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
   previous.filter((cell) => cell.id !== 'b');
 
-const moveCellAFar = (previous: readonly DiaCellAttributes[]): readonly DiaCellAttributes[] =>
+const moveCellAFar = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
   previous.map((cell) => {
     if (cell.id !== 'a') return cell;
     const element = cell as ElementRecord;
     return {
       ...element,
       position: { x: 999, y: 999 },
-    } as DiaCellAttributes;
+    } as DiaCellRecord;
   });
 
 describe('use-cell-setters', () => {

--- a/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
@@ -12,7 +12,7 @@ import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type {
   CellRecord,
-  DiaCellRecord,
+  CellJSONInit,
   ElementRecord,
 } from '../../types/cell.types';
 
@@ -41,7 +41,7 @@ const baseCells: readonly CellRecord[] = [
 
 const wrapper = graphProviderWrapper({ initialCells: baseCells });
 
-const setCellAUpdater = (previous: DiaCellRecord): CellRecord => {
+const setCellAUpdater = (previous: CellJSONInit): CellRecord => {
   const element = previous as ElementRecord;
   return {
     ...element,
@@ -49,22 +49,22 @@ const setCellAUpdater = (previous: DiaCellRecord): CellRecord => {
   } as CellRecord;
 };
 
-const passthroughUpdater = (previous: DiaCellRecord) => previous as CellRecord;
+const passthroughUpdater = (previous: CellJSONInit) => previous as CellRecord;
 
-const filterOutCellA = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
+const filterOutCellA = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
   previous.filter((cell) => cell.id !== 'a');
 
-const filterOutCellB = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
+const filterOutCellB = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
   previous.filter((cell) => cell.id !== 'b');
 
-const moveCellAFar = (previous: readonly DiaCellRecord[]): readonly DiaCellRecord[] =>
+const moveCellAFar = (previous: readonly CellJSONInit[]): readonly CellJSONInit[] =>
   previous.map((cell) => {
     if (cell.id !== 'a') return cell;
     const element = cell as ElementRecord;
     return {
       ...element,
       position: { x: 999, y: 999 },
-    } as DiaCellRecord;
+    } as CellJSONInit;
   });
 
 describe('use-cell-setters', () => {

--- a/packages/joint-react/src/hooks/__tests__/use-cell.type.test.ts
+++ b/packages/joint-react/src/hooks/__tests__/use-cell.type.test.ts
@@ -25,7 +25,7 @@
 import { useCell } from '../use-cell';
 import { useCells } from '../use-cells';
 import type {
-  DiaElementRecord,
+  ElementJSONInit,
   CellId,
   Computed,
   ElementRecord,
@@ -140,7 +140,7 @@ if (false as boolean) {
   );
 
   // User-defined custom cell with literal type — narrowing works
-  interface MyCustomNode extends DiaElementRecord {
+  interface MyCustomNode extends ElementJSONInit {
     readonly id: CellId;
     readonly type: 'my-custom';
     readonly data: { readonly foo: string };
@@ -155,7 +155,7 @@ if (false as boolean) {
   );
 
   // Custom link-flavoured record narrows from union
-  interface MyCustomEdge extends DiaElementRecord {
+  interface MyCustomEdge extends ElementJSONInit {
     readonly id: CellId;
     readonly type: 'my-edge';
     readonly data: { readonly weight: number };

--- a/packages/joint-react/src/hooks/__tests__/use-cell.type.test.ts
+++ b/packages/joint-react/src/hooks/__tests__/use-cell.type.test.ts
@@ -25,7 +25,7 @@
 import { useCell } from '../use-cell';
 import { useCells } from '../use-cells';
 import type {
-  DiaElementAttributes,
+  DiaElementRecord,
   CellId,
   Computed,
   ElementRecord,
@@ -140,7 +140,7 @@ if (false as boolean) {
   );
 
   // User-defined custom cell with literal type — narrowing works
-  interface MyCustomNode extends DiaElementAttributes {
+  interface MyCustomNode extends DiaElementRecord {
     readonly id: CellId;
     readonly type: 'my-custom';
     readonly data: { readonly foo: string };
@@ -155,7 +155,7 @@ if (false as boolean) {
   );
 
   // Custom link-flavoured record narrows from union
-  interface MyCustomEdge extends DiaElementAttributes {
+  interface MyCustomEdge extends DiaElementRecord {
     readonly id: CellId;
     readonly type: 'my-edge';
     readonly data: { readonly weight: number };

--- a/packages/joint-react/src/hooks/__tests__/use-cells.type.test.ts
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.type.test.ts
@@ -26,7 +26,7 @@
  */
 import { useCells } from '../use-cells';
 import type {
-  DiaElementRecord,
+  ElementJSONInit,
   CellId,
   Computed,
   ElementRecord,
@@ -108,7 +108,7 @@ if (false as boolean) {
   );
 
   // User-defined custom cell with literal type — narrowing works
-  interface MyCustomNode extends DiaElementRecord {
+  interface MyCustomNode extends ElementJSONInit {
     readonly id: CellId;
     readonly type: 'my-custom';
     readonly data: { readonly foo: string };
@@ -122,7 +122,7 @@ if (false as boolean) {
   );
 
   // Custom link-flavoured record narrows from union
-  interface MyCustomEdge extends DiaElementRecord {
+  interface MyCustomEdge extends ElementJSONInit {
     readonly id: CellId;
     readonly type: 'my-edge';
     readonly data: { readonly weight: number };

--- a/packages/joint-react/src/hooks/__tests__/use-cells.type.test.ts
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.type.test.ts
@@ -1,5 +1,5 @@
- 
- 
+
+
 /* eslint-disable react-hooks/rules-of-hooks */
 /**
  * Type-only tests for `useCells`. The `expectType` helper forces TypeScript to
@@ -26,7 +26,7 @@
  */
 import { useCells } from '../use-cells';
 import type {
-  DiaElementAttributes,
+  DiaElementRecord,
   CellId,
   Computed,
   ElementRecord,
@@ -108,7 +108,7 @@ if (false as boolean) {
   );
 
   // User-defined custom cell with literal type — narrowing works
-  interface MyCustomNode extends DiaElementAttributes {
+  interface MyCustomNode extends DiaElementRecord {
     readonly id: CellId;
     readonly type: 'my-custom';
     readonly data: { readonly foo: string };
@@ -122,7 +122,7 @@ if (false as boolean) {
   );
 
   // Custom link-flavoured record narrows from union
-  interface MyCustomEdge extends DiaElementAttributes {
+  interface MyCustomEdge extends DiaElementRecord {
     readonly id: CellId;
     readonly type: 'my-edge';
     readonly data: { readonly weight: number };

--- a/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
@@ -5,7 +5,7 @@ import { useGraph } from '../use-graph';
 import { useGraphStore } from '../use-graph-store';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
-import type { CellRecord, ElementRecord } from '../../types/cell.types';
+import type { AnyCellRecord, CellRecord, ElementRecord } from '../../types/cell.types';
 
 const INITIAL: readonly CellRecord[] = [
   {
@@ -36,7 +36,7 @@ const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 
 // Hoisted so the nested-function-depth lint rule doesn't fire inside the
 // `await act(async () => { ... })` + `setCell(fn)` call stack.
-function shiftAXBy10(previous: CellRecord<unknown, unknown, string, string>): CellRecord<unknown, unknown, string, string> {
+function shiftAXBy10(previous: AnyCellRecord): AnyCellRecord {
   if (previous.id !== 'a') return { id: 'a', type: ELEMENT_MODEL_TYPE } as CellRecord;
   const element = previous as ElementRecord;
   return {
@@ -106,7 +106,7 @@ describe('useGraph', () => {
       const { result } = renderHook(() => useGraph(), { wrapper });
       await waitFor(() => expect(result.current).toBeDefined());
       await flush();
-      const updater = jest.fn((previous: CellRecord<unknown, unknown, string, string>) => {
+      const updater = jest.fn((previous: AnyCellRecord) => {
         const element = previous as ElementRecord;
         return {
           ...element,

--- a/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
@@ -197,7 +197,7 @@ describe('useGraph', () => {
       await waitFor(() => expect(result.current).toBeDefined());
       const json = result.current.exportToJSON();
       expect(json.cells).toHaveLength(3);
-      const ids = json.cells.map((c: { id: string }) => c.id).toSorted();
+      const ids = json.cells.map((c) => String(c.id)).toSorted((a, b) => a.localeCompare(b));
       expect(ids).toEqual(['a', 'b', 'l1']);
     });
 
@@ -215,7 +215,7 @@ describe('useGraph', () => {
         await flush();
       });
       const json = result.current.exportToJSON();
-      const cellD = json.cells.find((c: { id: string }) => c.id === 'd') as Record<string, unknown>;
+      const cellD = json.cells.find((c) => c.id === 'd') as Record<string, unknown>;
       expect(cellD).toBeDefined();
       expect(cellD.size).toBeUndefined();
       expect(cellD.data).toBeUndefined();
@@ -235,7 +235,7 @@ describe('useGraph', () => {
         await flush();
       });
       const json = result.current.exportToJSON();
-      const cellE = json.cells.find((c: { id: string }) => c.id === 'e') as {
+      const cellE = json.cells.find((c) => c.id === 'e') as {
         attrs?: { text?: { textWrap?: Record<string, unknown> } };
       };
       expect(cellE?.attrs?.text?.textWrap).toEqual({});
@@ -246,7 +246,7 @@ describe('useGraph', () => {
       const { result } = renderHook(() => useGraph(), { wrapper });
       await waitFor(() => expect(result.current).toBeDefined());
       const json = result.current.exportToJSON({ includeDefaults: true });
-      const cellA = json.cells.find((c: { id: string }) => c.id === 'a') as Record<string, unknown>;
+      const cellA = json.cells.find((c) => c.id === 'a') as Record<string, unknown>;
       expect(cellA.size).toEqual({ width: 10, height: 10 });
       expect(cellA.data).toEqual({});
     });

--- a/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
@@ -5,7 +5,7 @@ import { useGraph } from '../use-graph';
 import { useGraphStore } from '../use-graph-store';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
-import type { CellRecord, ElementRecord, CellJSONInit } from '../../types/cell.types';
+import type { CellRecord, ElementRecord } from '../../types/cell.types';
 
 const INITIAL: readonly CellRecord[] = [
   {
@@ -36,7 +36,7 @@ const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 
 // Hoisted so the nested-function-depth lint rule doesn't fire inside the
 // `await act(async () => { ... })` + `setCell(fn)` call stack.
-function shiftAXBy10(previous: CellJSONInit): CellJSONInit {
+function shiftAXBy10(previous: CellRecord<unknown, unknown, string, string>): CellRecord<unknown, unknown, string, string> {
   if (previous.id !== 'a') return { id: 'a', type: ELEMENT_MODEL_TYPE } as CellRecord;
   const element = previous as ElementRecord;
   return {
@@ -106,7 +106,7 @@ describe('useGraph', () => {
       const { result } = renderHook(() => useGraph(), { wrapper });
       await waitFor(() => expect(result.current).toBeDefined());
       await flush();
-      const updater = jest.fn((previous: CellJSONInit) => {
+      const updater = jest.fn((previous: CellRecord<unknown, unknown, string, string>) => {
         const element = previous as ElementRecord;
         return {
           ...element,

--- a/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
@@ -5,7 +5,7 @@ import { useGraph } from '../use-graph';
 import { useGraphStore } from '../use-graph-store';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
-import type { CellRecord, ElementRecord, DiaCellAttributes } from '../../types/cell.types';
+import type { CellRecord, ElementRecord, DiaCellRecord } from '../../types/cell.types';
 
 const INITIAL: readonly CellRecord[] = [
   {
@@ -36,7 +36,7 @@ const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 
 // Hoisted so the nested-function-depth lint rule doesn't fire inside the
 // `await act(async () => { ... })` + `setCell(fn)` call stack.
-function shiftAXBy10(previous: DiaCellAttributes): DiaCellAttributes {
+function shiftAXBy10(previous: DiaCellRecord): DiaCellRecord {
   if (previous.id !== 'a') return { id: 'a', type: ELEMENT_MODEL_TYPE } as CellRecord;
   const element = previous as ElementRecord;
   return {
@@ -106,7 +106,7 @@ describe('useGraph', () => {
       const { result } = renderHook(() => useGraph(), { wrapper });
       await waitFor(() => expect(result.current).toBeDefined());
       await flush();
-      const updater = jest.fn((previous: DiaCellAttributes) => {
+      const updater = jest.fn((previous: DiaCellRecord) => {
         const element = previous as ElementRecord;
         return {
           ...element,

--- a/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph.test.tsx
@@ -5,7 +5,7 @@ import { useGraph } from '../use-graph';
 import { useGraphStore } from '../use-graph-store';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
-import type { CellRecord, ElementRecord, DiaCellRecord } from '../../types/cell.types';
+import type { CellRecord, ElementRecord, CellJSONInit } from '../../types/cell.types';
 
 const INITIAL: readonly CellRecord[] = [
   {
@@ -36,7 +36,7 @@ const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 
 // Hoisted so the nested-function-depth lint rule doesn't fire inside the
 // `await act(async () => { ... })` + `setCell(fn)` call stack.
-function shiftAXBy10(previous: DiaCellRecord): DiaCellRecord {
+function shiftAXBy10(previous: CellJSONInit): CellJSONInit {
   if (previous.id !== 'a') return { id: 'a', type: ELEMENT_MODEL_TYPE } as CellRecord;
   const element = previous as ElementRecord;
   return {
@@ -106,7 +106,7 @@ describe('useGraph', () => {
       const { result } = renderHook(() => useGraph(), { wrapper });
       await waitFor(() => expect(result.current).toBeDefined());
       await flush();
-      const updater = jest.fn((previous: DiaCellRecord) => {
+      const updater = jest.fn((previous: CellJSONInit) => {
         const element = previous as ElementRecord;
         return {
           ...element,

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -3,8 +3,8 @@ import type { dia } from '@joint/core';
 import { useGraphStore } from './use-graph-store';
 import { mapCellToAttributes } from '../state/data-mapping';
 import type {
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -16,8 +16,8 @@ import type {
  * @template Link - link record shape
  */
 export type SetCellUpdater<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > = (previous: CellUnion<Element, Link>) => CellUnion<Element, Link>;
 
 /**
@@ -30,8 +30,8 @@ export type SetCellUpdater<
  * @template Link - link record shape
  */
 export interface SetCell<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > {
   (record: CellUnion<Element, Link>): void;
   (id: CellId, updater: SetCellUpdater<Element, Link>): void;
@@ -45,8 +45,8 @@ export interface SetCell<
  * @returns memoized setCell setter
  */
 export function useSetCell<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(): SetCell<Element, Link> {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;
@@ -94,7 +94,7 @@ export function useSetCell<
  * @param store - graph store used to read the previous record for the updater form
  * @returns resolved cell record
  */
-function resolveSetCellInput<Element extends DiaElementAttributes, Link extends DiaLinkAttributes>(
+function resolveSetCellInput<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
   argument1: CellUnion<Element, Link> | CellId,
   argument2: SetCellUpdater<Element, Link> | undefined,
   store: ReturnType<typeof useGraphStore<Element, Link>>
@@ -161,8 +161,8 @@ export function useRemoveCells() {
  * @returns memoized resetCells setter
  */
 export function useResetCells<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >() {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;
@@ -191,8 +191,8 @@ export function useResetCells<
  * @returns memoized updateCells setter
  */
 export function useUpdateCells<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >() {
   const store = useGraphStore<Element, Link>();
   return useCallback(

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -3,8 +3,8 @@ import type { dia } from '@joint/core';
 import { useGraphStore } from './use-graph-store';
 import { mapCellToAttributes } from '../state/data-mapping';
 import type {
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -16,8 +16,8 @@ import type {
  * @template Link - link record shape
  */
 export type SetCellUpdater<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > = (previous: CellUnion<Element, Link>) => CellUnion<Element, Link>;
 
 /**
@@ -30,8 +30,8 @@ export type SetCellUpdater<
  * @template Link - link record shape
  */
 export interface SetCell<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > {
   (record: CellUnion<Element, Link>): void;
   (id: CellId, updater: SetCellUpdater<Element, Link>): void;
@@ -45,8 +45,8 @@ export interface SetCell<
  * @returns memoized setCell setter
  */
 export function useSetCell<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(): SetCell<Element, Link> {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;
@@ -94,7 +94,7 @@ export function useSetCell<
  * @param store - graph store used to read the previous record for the updater form
  * @returns resolved cell record
  */
-function resolveSetCellInput<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
+function resolveSetCellInput<Element extends ElementJSONInit, Link extends LinkJSONInit>(
   argument1: CellUnion<Element, Link> | CellId,
   argument2: SetCellUpdater<Element, Link> | undefined,
   store: ReturnType<typeof useGraphStore<Element, Link>>
@@ -161,8 +161,8 @@ export function useRemoveCells() {
  * @returns memoized resetCells setter
  */
 export function useResetCells<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >() {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;
@@ -191,8 +191,8 @@ export function useResetCells<
  * @returns memoized updateCells setter
  */
 export function useUpdateCells<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >() {
   const store = useGraphStore<Element, Link>();
   return useCallback(

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -6,7 +6,6 @@ import type {
   ElementJSONInit,
   LinkJSONInit,
   CellId,
-  CellUnion,
 } from '../types/cell.types';
 /**
  * Updater function form for {@link SetCell}. Receives the current cell record
@@ -18,7 +17,7 @@ import type {
 export type SetCellUpdater<
   Element extends ElementJSONInit,
   Link extends LinkJSONInit,
-> = (previous: CellUnion<Element, Link>) => CellUnion<Element, Link>;
+> = (previous: Element | Link) => Element | Link;
 
 /**
  * Function returned by {@link useSetCell}. Two forms:
@@ -33,7 +32,7 @@ export interface SetCell<
   Element extends ElementJSONInit,
   Link extends LinkJSONInit,
 > {
-  (record: CellUnion<Element, Link>): void;
+  (record: Element | Link): void;
   (id: CellId, updater: SetCellUpdater<Element, Link>): void;
 }
 
@@ -52,7 +51,7 @@ export function useSetCell<
   const { graph } = store;
   const setCell = useCallback(
     (
-      argument1: CellUnion<Element, Link> | CellId,
+      argument1: Element | Link | CellId,
       argument2?: SetCellUpdater<Element, Link>
     ) => {
       const next = resolveSetCellInput(argument1, argument2, store);
@@ -95,11 +94,11 @@ export function useSetCell<
  * @returns resolved cell record
  */
 function resolveSetCellInput<Element extends ElementJSONInit, Link extends LinkJSONInit>(
-  argument1: CellUnion<Element, Link> | CellId,
+  argument1: Element | Link | CellId,
   argument2: SetCellUpdater<Element, Link> | undefined,
   store: ReturnType<typeof useGraphStore<Element, Link>>
-): CellUnion<Element, Link> {
-  if (argument2 === undefined) return argument1 as CellUnion<Element, Link>;
+): Element | Link {
+  if (argument2 === undefined) return argument1 as Element | Link;
   const id = argument1 as CellId;
   const previous = store.graphView.cells.get(id);
   if (!previous) {
@@ -169,10 +168,10 @@ export function useResetCells<
   return useCallback(
     (
       input:
-        | ReadonlyArray<CellUnion<Element, Link>>
+        | ReadonlyArray<Element | Link>
         | ((
-            previous: ReadonlyArray<CellUnion<Element, Link>>
-          ) => ReadonlyArray<CellUnion<Element, Link>>)
+            previous: ReadonlyArray<Element | Link>
+          ) => ReadonlyArray<Element | Link>)
     ) => {
       const current = store.graphView.cells.getAll();
       const next = typeof input === 'function' ? input(current) : input;
@@ -198,8 +197,8 @@ export function useUpdateCells<
   return useCallback(
     (
       updater: (
-        previous: ReadonlyArray<CellUnion<Element, Link>>
-      ) => ReadonlyArray<CellUnion<Element, Link>>
+        previous: ReadonlyArray<Element | Link>
+      ) => ReadonlyArray<Element | Link>
     ) => {
       const current = store.graphView.cells.getAll();
       store.applyControlled(updater(current));

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -176,7 +176,7 @@ export function useResetCells<
     ) => {
       const current = store.graphView.cells.getAll();
       const next = typeof input === 'function' ? input(current) : input;
-      const mapped: dia.Cell.JSON[] = next.map((cell) => mapCellToAttributes(cell, graph));
+      const mapped: dia.Cell.JSONInit[] = next.map((cell) => mapCellToAttributes(cell, graph));
       graph.resetCells(mapped);
     },
     [graph, store]

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { CellIdContext } from '../context';
 import { useCells } from './use-cells';
-import type { CellId, DiaCellRecord, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, CellJSONInit, CellRecord, Computed } from '../types/cell.types';
 
 /**
  * Read the current cell from the closest `CellIdContext` — the id is provided
@@ -14,7 +14,7 @@ import type { CellId, DiaCellRecord, CellRecord, Computed } from '../types/cell.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  */
-export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(): Cell;
+export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(): Cell;
 /**
  * Read a selected slice from the current cell (context-scoped). Re-renders
  * only when `isEqual(prev, next)` returns false.
@@ -26,7 +26,7 @@ export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(): Ce
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
+export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
@@ -40,7 +40,7 @@ export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
  * @param id - cell id to track
  * @returns the resolved cell record
  */
-export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(
+export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   id: CellId
 ): Cell;
@@ -55,12 +55,12 @@ export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
+export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
   id: CellId,
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
+export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
   argument1?: CellId | ((cell: Cell) => Selected),
   argument2?: ((cell: Cell) => Selected) | ((a: Selected, b: Selected) => boolean),
   argument3?: (a: Selected, b: Selected) => boolean

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { CellIdContext } from '../context';
 import { useCells } from './use-cells';
-import type { CellId, CellRecord, Computed } from '../types/cell.types';
+import type { AnyCellRecord, CellId, CellRecord, Computed } from '../types/cell.types';
 
 /**
  * Read the current cell from the closest `CellIdContext` — the id is provided
@@ -14,7 +14,7 @@ import type { CellId, CellRecord, Computed } from '../types/cell.types';
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  */
-export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed<CellRecord>>(): Cell;
+export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(): Cell;
 /**
  * Read a selected slice from the current cell (context-scoped). Re-renders
  * only when `isEqual(prev, next)` returns false.
@@ -26,7 +26,7 @@ export function useCell<Cell extends CellRecord<unknown, unknown, string, string
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
+export function useCell<Cell extends AnyCellRecord = Computed, Selected = Cell>(
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
@@ -40,7 +40,7 @@ export function useCell<Cell extends CellRecord<unknown, unknown, string, string
  * @param id - cell id to track
  * @returns the resolved cell record
  */
-export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed<CellRecord>>(
+export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   id: CellId
 ): Cell;
@@ -55,12 +55,12 @@ export function useCell<Cell extends CellRecord<unknown, unknown, string, string
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
+export function useCell<Cell extends AnyCellRecord = Computed, Selected = Cell>(
   id: CellId,
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
+export function useCell<Cell extends AnyCellRecord = Computed, Selected = Cell>(
   argument1?: CellId | ((cell: Cell) => Selected),
   argument2?: ((cell: Cell) => Selected) | ((a: Selected, b: Selected) => boolean),
   argument3?: (a: Selected, b: Selected) => boolean

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { CellIdContext } from '../context';
 import { useCells } from './use-cells';
-import type { CellId, CellJSONInit, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, CellRecord, Computed } from '../types/cell.types';
 
 /**
  * Read the current cell from the closest `CellIdContext` — the id is provided
@@ -14,7 +14,7 @@ import type { CellId, CellJSONInit, CellRecord, Computed } from '../types/cell.t
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  */
-export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(): Cell;
+export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed<CellRecord>>(): Cell;
 /**
  * Read a selected slice from the current cell (context-scoped). Re-renders
  * only when `isEqual(prev, next)` returns false.
@@ -26,7 +26,7 @@ export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(): Cel
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
+export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
@@ -40,7 +40,7 @@ export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
  * @param id - cell id to track
  * @returns the resolved cell record
  */
-export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(
+export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   id: CellId
 ): Cell;
@@ -55,12 +55,12 @@ export function useCell<Cell extends CellJSONInit = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
+export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
   id: CellId,
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCell<Cell extends CellJSONInit = Computed, Selected = Cell>(
+export function useCell<Cell extends CellRecord<unknown, unknown, string, string> = Computed, Selected = Cell>(
   argument1?: CellId | ((cell: Cell) => Selected),
   argument2?: ((cell: Cell) => Selected) | ((a: Selected, b: Selected) => boolean),
   argument3?: (a: Selected, b: Selected) => boolean

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 import { CellIdContext } from '../context';
 import { useCells } from './use-cells';
-import type { CellId, DiaCellAttributes, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, DiaCellRecord, CellRecord, Computed } from '../types/cell.types';
 
 /**
  * Read the current cell from the closest `CellIdContext` — the id is provided
@@ -14,7 +14,7 @@ import type { CellId, DiaCellAttributes, CellRecord, Computed } from '../types/c
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  */
-export function useCell<Cell extends DiaCellAttributes = Computed<CellRecord>>(): Cell;
+export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(): Cell;
 /**
  * Read a selected slice from the current cell (context-scoped). Re-renders
  * only when `isEqual(prev, next)` returns false.
@@ -26,7 +26,7 @@ export function useCell<Cell extends DiaCellAttributes = Computed<CellRecord>>()
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends DiaCellAttributes = Computed, Selected = Cell>(
+export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
@@ -40,7 +40,7 @@ export function useCell<Cell extends DiaCellAttributes = Computed, Selected = Ce
  * @param id - cell id to track
  * @returns the resolved cell record
  */
-export function useCell<Cell extends DiaCellAttributes = Computed<CellRecord>>(
+export function useCell<Cell extends DiaCellRecord = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   id: CellId
 ): Cell;
@@ -55,12 +55,12 @@ export function useCell<Cell extends DiaCellAttributes = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCell<Cell extends DiaCellAttributes = Computed, Selected = Cell>(
+export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
   id: CellId,
   selector: (cell: Cell) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCell<Cell extends DiaCellAttributes = Computed, Selected = Cell>(
+export function useCell<Cell extends DiaCellRecord = Computed, Selected = Cell>(
   argument1?: CellId | ((cell: Cell) => Selected),
   argument2?: ((cell: Cell) => Selected) | ((a: Selected, b: Selected) => boolean),
   argument3?: (a: Selected, b: Selected) => boolean

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -1,15 +1,8 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 import { useGraphStore } from './use-graph-store';
-import type { CellId, CellRecord, Computed } from '../types/cell.types';
+import type { AnyCellRecord, CellId, CellRecord, Computed } from '../types/cell.types';
 import type { ReadonlyContainer } from '../store/state-container';
-
-/**
- * Internal upper bound for any cell record this hook accepts as a constraint.
- * Equivalent to `CellRecord<unknown, unknown, string, string>` — the loose
- * variant where `type` is any string.
- */
-type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
 
 /** Union of all possible `useCells` return shapes (depends on argument form). */
 type UseCellsResult<Cell extends AnyCellRecord, Selected> =

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 import { useGraphStore } from './use-graph-store';
-import type { CellId, DiaCellRecord, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, CellJSONInit, CellRecord, Computed } from '../types/cell.types';
 import type { ReadonlyContainer } from '../store/state-container';
 
 /** Union of all possible `useCells` return shapes (depends on argument form). */
-type UseCellsResult<Cell extends DiaCellRecord, Selected> =
+type UseCellsResult<Cell extends CellJSONInit, Selected> =
   | readonly Cell[]
   | Cell
   | undefined
@@ -83,7 +83,7 @@ function arrayAwareEqual(a: unknown, b: unknown): boolean {
  * @param subscribedIds - cell ids to pick
  * @returns array of resolved cells in id order (missing ids omitted)
  */
-function pickCells<Cell extends DiaCellRecord>(
+function pickCells<Cell extends CellJSONInit>(
   container: ReadonlyContainer<Cell>,
   subscribedIds: readonly CellId[]
 ): readonly Cell[] {
@@ -105,7 +105,7 @@ function pickCells<Cell extends DiaCellRecord>(
  * @param cellSelector - selector for the single-id form (optional)
  * @returns selected value or raw cell / cells
  */
-function computeNext<Cell extends DiaCellRecord, Selected>(
+function computeNext<Cell extends CellJSONInit, Selected>(
   container: ReadonlyContainer<Cell>,
   targetId: CellId | undefined,
   subscribedIds: readonly CellId[] | undefined,
@@ -124,7 +124,7 @@ function computeNext<Cell extends DiaCellRecord, Selected>(
 }
 
 /** Normalised arguments after dispatching by the runtime call shape. */
-interface ParsedUseCellsArgs<Cell extends DiaCellRecord, Selected> {
+interface ParsedUseCellsArgs<Cell extends CellJSONInit, Selected> {
   readonly targetId: CellId | undefined;
   readonly ids: readonly CellId[] | undefined;
   readonly arraySelector: ((cells: readonly Cell[]) => Selected) | undefined;
@@ -140,7 +140,7 @@ interface ParsedUseCellsArgs<Cell extends DiaCellRecord, Selected> {
  * @param argument3 - third positional arg (isEqual when the form admits it)
  * @returns the normalised input
  */
-function parseUseCellsArgs<Cell extends DiaCellRecord, Selected>(
+function parseUseCellsArgs<Cell extends CellJSONInit, Selected>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)
@@ -206,14 +206,14 @@ function parseUseCellsArgs<Cell extends DiaCellRecord, Selected>(
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns readonly resolved cells array
  */
-export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(): readonly Cell[];
+export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(): readonly Cell[];
 /**
  * Subscribe to a single cell by id.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns current resolved cell, or undefined when missing
  */
-export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
+export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
   id: CellId
 ): Cell | undefined;
 /**
@@ -226,7 +226,7 @@ export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellRecord = Computed, Selected = Cell | undefined>(
+export function useCells<Cell extends CellJSONInit = Computed, Selected = Cell | undefined>(
   id: CellId,
   selector: (cell: Cell | undefined) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -244,7 +244,7 @@ export function useCells<Cell extends DiaCellRecord = Computed, Selected = Cell 
  * @param ids - cell ids to track
  * @returns array of resolved cells (only those that exist; missing ids are skipped)
  */
-export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
+export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   ids: readonly CellId[]
 ): readonly Cell[];
@@ -258,7 +258,7 @@ export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
   ids: readonly CellId[],
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -271,11 +271,11 @@ export function useCells<Cell extends DiaCellRecord = Computed, Selected = reado
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -1,11 +1,18 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 import { useGraphStore } from './use-graph-store';
-import type { CellId, CellJSONInit, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, CellRecord, Computed } from '../types/cell.types';
 import type { ReadonlyContainer } from '../store/state-container';
 
+/**
+ * Internal upper bound for any cell record this hook accepts as a constraint.
+ * Equivalent to `CellRecord<unknown, unknown, string, string>` — the loose
+ * variant where `type` is any string.
+ */
+type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
+
 /** Union of all possible `useCells` return shapes (depends on argument form). */
-type UseCellsResult<Cell extends CellJSONInit, Selected> =
+type UseCellsResult<Cell extends AnyCellRecord, Selected> =
   | readonly Cell[]
   | Cell
   | undefined
@@ -83,7 +90,7 @@ function arrayAwareEqual(a: unknown, b: unknown): boolean {
  * @param subscribedIds - cell ids to pick
  * @returns array of resolved cells in id order (missing ids omitted)
  */
-function pickCells<Cell extends CellJSONInit>(
+function pickCells<Cell extends AnyCellRecord>(
   container: ReadonlyContainer<Cell>,
   subscribedIds: readonly CellId[]
 ): readonly Cell[] {
@@ -105,7 +112,7 @@ function pickCells<Cell extends CellJSONInit>(
  * @param cellSelector - selector for the single-id form (optional)
  * @returns selected value or raw cell / cells
  */
-function computeNext<Cell extends CellJSONInit, Selected>(
+function computeNext<Cell extends AnyCellRecord, Selected>(
   container: ReadonlyContainer<Cell>,
   targetId: CellId | undefined,
   subscribedIds: readonly CellId[] | undefined,
@@ -124,7 +131,7 @@ function computeNext<Cell extends CellJSONInit, Selected>(
 }
 
 /** Normalised arguments after dispatching by the runtime call shape. */
-interface ParsedUseCellsArgs<Cell extends CellJSONInit, Selected> {
+interface ParsedUseCellsArgs<Cell extends AnyCellRecord, Selected> {
   readonly targetId: CellId | undefined;
   readonly ids: readonly CellId[] | undefined;
   readonly arraySelector: ((cells: readonly Cell[]) => Selected) | undefined;
@@ -140,7 +147,7 @@ interface ParsedUseCellsArgs<Cell extends CellJSONInit, Selected> {
  * @param argument3 - third positional arg (isEqual when the form admits it)
  * @returns the normalised input
  */
-function parseUseCellsArgs<Cell extends CellJSONInit, Selected>(
+function parseUseCellsArgs<Cell extends AnyCellRecord, Selected>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)
@@ -206,14 +213,14 @@ function parseUseCellsArgs<Cell extends CellJSONInit, Selected>(
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns readonly resolved cells array
  */
-export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(): readonly Cell[];
+export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(): readonly Cell[];
 /**
  * Subscribe to a single cell by id.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns current resolved cell, or undefined when missing
  */
-export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
+export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
   id: CellId
 ): Cell | undefined;
 /**
@@ -226,7 +233,7 @@ export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends CellJSONInit = Computed, Selected = Cell | undefined>(
+export function useCells<Cell extends AnyCellRecord = Computed, Selected = Cell | undefined>(
   id: CellId,
   selector: (cell: Cell | undefined) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -244,7 +251,7 @@ export function useCells<Cell extends CellJSONInit = Computed, Selected = Cell |
  * @param ids - cell ids to track
  * @returns array of resolved cells (only those that exist; missing ids are skipped)
  */
-export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
+export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   ids: readonly CellId[]
 ): readonly Cell[];
@@ -258,7 +265,7 @@ export function useCells<Cell extends CellJSONInit = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends AnyCellRecord = Computed, Selected = readonly Cell[]>(
   ids: readonly CellId[],
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -271,11 +278,11 @@ export function useCells<Cell extends CellJSONInit = Computed, Selected = readon
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends AnyCellRecord = Computed, Selected = readonly Cell[]>(
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCells<Cell extends CellJSONInit = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends AnyCellRecord = Computed, Selected = readonly Cell[]>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 import { useGraphStore } from './use-graph-store';
-import type { CellId, DiaCellAttributes, CellRecord, Computed } from '../types/cell.types';
+import type { CellId, DiaCellRecord, CellRecord, Computed } from '../types/cell.types';
 import type { ReadonlyContainer } from '../store/state-container';
 
 /** Union of all possible `useCells` return shapes (depends on argument form). */
-type UseCellsResult<Cell extends DiaCellAttributes, Selected> =
+type UseCellsResult<Cell extends DiaCellRecord, Selected> =
   | readonly Cell[]
   | Cell
   | undefined
@@ -83,7 +83,7 @@ function arrayAwareEqual(a: unknown, b: unknown): boolean {
  * @param subscribedIds - cell ids to pick
  * @returns array of resolved cells in id order (missing ids omitted)
  */
-function pickCells<Cell extends DiaCellAttributes>(
+function pickCells<Cell extends DiaCellRecord>(
   container: ReadonlyContainer<Cell>,
   subscribedIds: readonly CellId[]
 ): readonly Cell[] {
@@ -105,7 +105,7 @@ function pickCells<Cell extends DiaCellAttributes>(
  * @param cellSelector - selector for the single-id form (optional)
  * @returns selected value or raw cell / cells
  */
-function computeNext<Cell extends DiaCellAttributes, Selected>(
+function computeNext<Cell extends DiaCellRecord, Selected>(
   container: ReadonlyContainer<Cell>,
   targetId: CellId | undefined,
   subscribedIds: readonly CellId[] | undefined,
@@ -124,7 +124,7 @@ function computeNext<Cell extends DiaCellAttributes, Selected>(
 }
 
 /** Normalised arguments after dispatching by the runtime call shape. */
-interface ParsedUseCellsArgs<Cell extends DiaCellAttributes, Selected> {
+interface ParsedUseCellsArgs<Cell extends DiaCellRecord, Selected> {
   readonly targetId: CellId | undefined;
   readonly ids: readonly CellId[] | undefined;
   readonly arraySelector: ((cells: readonly Cell[]) => Selected) | undefined;
@@ -140,7 +140,7 @@ interface ParsedUseCellsArgs<Cell extends DiaCellAttributes, Selected> {
  * @param argument3 - third positional arg (isEqual when the form admits it)
  * @returns the normalised input
  */
-function parseUseCellsArgs<Cell extends DiaCellAttributes, Selected>(
+function parseUseCellsArgs<Cell extends DiaCellRecord, Selected>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)
@@ -206,14 +206,14 @@ function parseUseCellsArgs<Cell extends DiaCellAttributes, Selected>(
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns readonly resolved cells array
  */
-export function useCells<Cell extends DiaCellAttributes = Computed<CellRecord>>(): readonly Cell[];
+export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(): readonly Cell[];
 /**
  * Subscribe to a single cell by id.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns current resolved cell, or undefined when missing
  */
-export function useCells<Cell extends DiaCellAttributes = Computed<CellRecord>>(
+export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
   id: CellId
 ): Cell | undefined;
 /**
@@ -226,7 +226,7 @@ export function useCells<Cell extends DiaCellAttributes = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellAttributes = Computed, Selected = Cell | undefined>(
+export function useCells<Cell extends DiaCellRecord = Computed, Selected = Cell | undefined>(
   id: CellId,
   selector: (cell: Cell | undefined) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -244,7 +244,7 @@ export function useCells<Cell extends DiaCellAttributes = Computed, Selected = C
  * @param ids - cell ids to track
  * @returns array of resolved cells (only those that exist; missing ids are skipped)
  */
-export function useCells<Cell extends DiaCellAttributes = Computed<CellRecord>>(
+export function useCells<Cell extends DiaCellRecord = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   ids: readonly CellId[]
 ): readonly Cell[];
@@ -258,7 +258,7 @@ export function useCells<Cell extends DiaCellAttributes = Computed<CellRecord>>(
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellAttributes = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
   ids: readonly CellId[],
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
@@ -271,11 +271,11 @@ export function useCells<Cell extends DiaCellAttributes = Computed, Selected = r
  * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
  * @returns selected value
  */
-export function useCells<Cell extends DiaCellAttributes = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
   selector: (cells: readonly Cell[]) => Selected,
   isEqual?: (a: Selected, b: Selected) => boolean
 ): Selected;
-export function useCells<Cell extends DiaCellAttributes = Computed, Selected = readonly Cell[]>(
+export function useCells<Cell extends DiaCellRecord = Computed, Selected = readonly Cell[]>(
   argument1?: CellId | readonly CellId[] | ((cells: readonly Cell[]) => Selected),
   argument2?:
     | ((cells: readonly Cell[]) => Selected)

--- a/packages/joint-react/src/hooks/use-container-keys.ts
+++ b/packages/joint-react/src/hooks/use-container-keys.ts
@@ -4,8 +4,8 @@ import type { ReadonlyContainer } from '../store/state-container';
 import type {
   CellId,
   CellUnion,
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
 } from '../types/cell.types';
 
 /**
@@ -16,7 +16,7 @@ import type {
  * @internal
  */
 export function useContainerKeys<
-  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
+  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
 >(container: ReadonlyContainer<Cell>): CellId[] {
   const previousKeysRef = useRef<CellId[]>([]);
 

--- a/packages/joint-react/src/hooks/use-container-keys.ts
+++ b/packages/joint-react/src/hooks/use-container-keys.ts
@@ -4,8 +4,8 @@ import type { ReadonlyContainer } from '../store/state-container';
 import type {
   CellId,
   CellUnion,
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
 } from '../types/cell.types';
 
 /**
@@ -16,7 +16,7 @@ import type {
  * @internal
  */
 export function useContainerKeys<
-  Cell extends CellUnion<DiaElementAttributes, DiaLinkAttributes>,
+  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
 >(container: ReadonlyContainer<Cell>): CellId[] {
   const previousKeysRef = useRef<CellId[]>([]);
 

--- a/packages/joint-react/src/hooks/use-container-keys.ts
+++ b/packages/joint-react/src/hooks/use-container-keys.ts
@@ -3,9 +3,7 @@ import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-s
 import type { ReadonlyContainer } from '../store/state-container';
 import type {
   CellId,
-  CellUnion,
-  ElementJSONInit,
-  LinkJSONInit,
+  AnyCellRecord,
 } from '../types/cell.types';
 
 /**
@@ -16,7 +14,7 @@ import type {
  * @internal
  */
 export function useContainerKeys<
-  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
+  Cell extends AnyCellRecord,
 >(container: ReadonlyContainer<Cell>): CellId[] {
   const previousKeysRef = useRef<CellId[]>([]);
 

--- a/packages/joint-react/src/hooks/use-graph-store.ts
+++ b/packages/joint-react/src/hooks/use-graph-store.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { GraphStoreContext } from '../context';
 import type { GraphStore } from '../store';
-import type { DiaElementAttributes, DiaLinkAttributes } from '../types/cell.types';
+import type { DiaElementRecord, DiaLinkRecord } from '../types/cell.types';
 
 /**
  * Hook for accessing the `GraphStore` from a `GraphProvider`.
@@ -13,8 +13,8 @@ import type { DiaElementAttributes, DiaLinkAttributes } from '../types/cell.type
  * @throws {Error} If used outside of a `GraphProvider`.
  */
 export function useGraphStore<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(): GraphStore<Element, Link> {
   const store = useContext(GraphStoreContext);
   if (!store) {

--- a/packages/joint-react/src/hooks/use-graph-store.ts
+++ b/packages/joint-react/src/hooks/use-graph-store.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { GraphStoreContext } from '../context';
 import type { GraphStore } from '../store';
-import type { DiaElementRecord, DiaLinkRecord } from '../types/cell.types';
+import type { ElementJSONInit, LinkJSONInit } from '../types/cell.types';
 
 /**
  * Hook for accessing the `GraphStore` from a `GraphProvider`.
@@ -13,8 +13,8 @@ import type { DiaElementRecord, DiaLinkRecord } from '../types/cell.types';
  * @throws {Error} If used outside of a `GraphProvider`.
  */
 export function useGraphStore<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(): GraphStore<Element, Link> {
   const store = useContext(GraphStoreContext);
   if (!store) {

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -10,8 +10,8 @@ import {
   type SetCell,
 } from './use-cell-setters';
 import type {
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -29,8 +29,8 @@ import type {
  *                  `Computed<LinkRecord<MyData>>`)
  */
 export interface UseGraphResult<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   /** The JointJS graph instance. */
   readonly graph: dia.Graph;
@@ -118,8 +118,8 @@ export interface ExportToJSONOptions {
  * @returns the imperative API described by {@link UseGraphResult}
  */
 export function useGraph<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(): UseGraphResult<Element, Link> {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -10,8 +10,8 @@ import {
   type SetCell,
 } from './use-cell-setters';
 import type {
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -29,8 +29,8 @@ import type {
  *                  `Computed<LinkRecord<MyData>>`)
  */
 export interface UseGraphResult<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   /** The JointJS graph instance. */
   readonly graph: dia.Graph;
@@ -118,8 +118,8 @@ export interface ExportToJSONOptions {
  * @returns the imperative API described by {@link UseGraphResult}
  */
 export function useGraph<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(): UseGraphResult<Element, Link> {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -13,7 +13,6 @@ import type {
   ElementJSONInit,
   LinkJSONInit,
   CellId,
-  CellUnion,
 } from '../types/cell.types';
 
 /**
@@ -50,16 +49,16 @@ export interface UseGraphResult<
   /** Atomically replace the cell set. */
   readonly resetCells: (
     input:
-      | ReadonlyArray<CellUnion<Element, Link>>
+      | ReadonlyArray<Element | Link>
       | ((
-          previous: ReadonlyArray<CellUnion<Element, Link>>
-        ) => ReadonlyArray<CellUnion<Element, Link>>)
+          previous: ReadonlyArray<Element | Link>
+        ) => ReadonlyArray<Element | Link>)
   ) => void;
   /** Apply an updater to the current cells array. */
   readonly updateCells: (
     updater: (
-      previous: ReadonlyArray<CellUnion<Element, Link>>
-    ) => ReadonlyArray<CellUnion<Element, Link>>
+      previous: ReadonlyArray<Element | Link>
+    ) => ReadonlyArray<Element | Link>
   ) => void;
   /**
    * Predicate / type guard: true when the input resolves to an element cell.
@@ -67,14 +66,14 @@ export interface UseGraphResult<
    * so any `dia.Element` subclass (including custom shapes) is recognised,
    * not just our default `ElementModel`.
    */
-  readonly isElement: (input: CellUnion<Element, Link>) => input is Element;
+  readonly isElement: (input: Element | Link) => input is Element;
   /**
    * Predicate / type guard: true when the input resolves to a link cell.
    * Delegates to `GraphStore.isLink` — consults the graph's type registry so
    * any `dia.Link` subclass (including custom shapes) is recognised, not just
    * our default `LinkModel`.
    */
-  readonly isLink: (input: CellUnion<Element, Link>) => input is Link;
+  readonly isLink: (input: Element | Link) => input is Link;
   /**
    * Serialize the graph to a plain JSON object.
    *

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -174,6 +174,9 @@ export function usePaper(id: string): { paper: dia.Paper | null } & UsePaperActi
 export function usePaper(
   idOrOptions?: string | Optional
 ): { paper: dia.Paper | null } & UsePaperActions;
+/**
+ *
+ */
 export function usePaper(
   idOrOptions?: string | Optional
 ): { paper: dia.Paper | null } & UsePaperActions {

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -71,7 +71,6 @@ export type {
   ElementRecord,
   LinkRecord,
   Computed,
-  CellJSONInit,
 } from './types/cell.types';
 
 // Types — geometry / presets

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -71,9 +71,9 @@ export type {
   ElementRecord,
   LinkRecord,
   Computed,
-  DiaElementRecord as DiaElementAttributes,
-  DiaLinkRecord as DiaLinkAttributes,
-  DiaCellRecord as DiaCellAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
+  DiaCellRecord,
 } from './types/cell.types';
 
 // Types — geometry / presets

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -71,6 +71,7 @@ export type {
   ElementRecord,
   LinkRecord,
   Computed,
+  AnyCellRecord,
 } from './types/cell.types';
 
 // Types — geometry / presets

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -71,9 +71,7 @@ export type {
   ElementRecord,
   LinkRecord,
   Computed,
-  DiaElementRecord,
-  DiaLinkRecord,
-  DiaCellRecord,
+  CellJSONInit,
 } from './types/cell.types';
 
 // Types — geometry / presets

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -71,9 +71,9 @@ export type {
   ElementRecord,
   LinkRecord,
   Computed,
-  DiaElementAttributes,
-  DiaLinkAttributes,
-  DiaCellAttributes,
+  DiaElementRecord as DiaElementAttributes,
+  DiaLinkRecord as DiaLinkAttributes,
+  DiaCellRecord as DiaCellAttributes,
 } from './types/cell.types';
 
 // Types — geometry / presets

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -1,11 +1,23 @@
 import { util } from '@joint/core';
 import { elementPorts } from './element-ports';
 import type { dia } from '@joint/core';
-import type { ElementPort} from './element-ports';
+import type { ElementPort } from './element-ports';
 
-export interface ElementJSONInit extends dia.Element.JSONInit {
+/**
+ * Loose preset input — no `type` required. The preset transforms declarative
+ * fields (`portMap`) into native JointJS shapes; it does not depend on the
+ * cell discriminator.
+ */
+export interface ElementPresetAttributes extends dia.Element.Attributes {
   portMap?: Record<string, ElementPort>;
   portStyle?: Partial<ElementPort>;
+}
+
+/**
+ * Type-required variant used at the record / mapper boundary.
+ */
+export interface ElementJSONInit extends ElementPresetAttributes {
+  type: string;
 }
 
 /**
@@ -17,17 +29,12 @@ export interface ElementJSONInit extends dia.Element.JSONInit {
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function elementAttributes(element: ElementJSONInit): ElementJSONInit {
+export function elementAttributes(element: ElementPresetAttributes): dia.Element.Attributes {
   if (!util.isObject(element)) {
     throw new TypeError('Invalid element format: expected an object.');
   }
 
-  const { portMap, ports, type, ...rest } = element;
-
-  const attributes: ElementJSONInit = {
-    ...rest,
-    type,
-  };
+  const { portMap, ports, ...attributes } = element;
 
   if (portMap) {
     if (ports) {

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -1,6 +1,13 @@
 import { util } from '@joint/core';
-import type { DiaElementAttributes } from '../types/cell.types';
 import { elementPorts } from './element-ports';
+import type { dia } from '@joint/core';
+import type { ElementPort} from './element-ports';
+
+export interface ElementJSONInit extends dia.Element.JSONInit {
+  data?: unknown;
+  portMap?: Record<string, ElementPort>;
+  portStyle?: Partial<ElementPort>;
+}
 
 /**
  * Converts an `ElementAttributes` record to JointJS cell attributes.
@@ -11,14 +18,14 @@ import { elementPorts } from './element-ports';
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function elementAttributes(element: DiaElementAttributes): DiaElementAttributes {
+export function elementAttributes(element: ElementJSONInit): ElementJSONInit {
   if (!util.isObject(element)) {
     throw new TypeError('Invalid element format: expected an object.');
   }
 
   const { data = {}, portMap, ports, type, ...rest } = element;
 
-  const attributes: DiaElementAttributes = {
+  const attributes: ElementJSONInit = {
     ...rest,
     type,
     data,

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -4,7 +4,6 @@ import type { dia } from '@joint/core';
 import type { ElementPort} from './element-ports';
 
 export interface ElementJSONInit extends dia.Element.JSONInit {
-  data?: unknown;
   portMap?: Record<string, ElementPort>;
   portStyle?: Partial<ElementPort>;
 }
@@ -23,12 +22,11 @@ export function elementAttributes(element: ElementJSONInit): ElementJSONInit {
     throw new TypeError('Invalid element format: expected an object.');
   }
 
-  const { data = {}, portMap, ports, type, ...rest } = element;
+  const { portMap, ports, type, ...rest } = element;
 
   const attributes: ElementJSONInit = {
     ...rest,
     type,
-    data,
   };
 
   if (portMap) {

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -4,21 +4,20 @@ import type { dia } from '@joint/core';
 import type { ElementPort } from './element-ports';
 
 /**
- * Loose preset input — no `type` required. The preset transforms declarative
- * fields (`portMap`) into native JointJS shapes; it does not depend on the
- * cell discriminator.
+ * React-side declarative fields the preset adds on top of `dia.Element.Attributes`.
+ * Composed orthogonally into both `ElementAttributes` (preset input) and
+ * `ElementJSONInit` (record/mapper boundary).
  */
-export interface ElementPresetAttributes extends dia.Element.Attributes {
+export interface ElementPresetAttributes {
   portMap?: Record<string, ElementPort>;
   portStyle?: Partial<ElementPort>;
 }
 
 /**
- * Type-required variant used at the record / mapper boundary.
+ * Loose preset input — no `type` required. `dia.Element.Attributes` plus the
+ * React preset extras (`portMap`, `portStyle`).
  */
-export interface ElementJSONInit extends ElementPresetAttributes {
-  type: string;
-}
+export interface ElementAttributes extends dia.Element.Attributes, ElementPresetAttributes {}
 
 /**
  * Converts an `ElementAttributes` record to JointJS cell attributes.
@@ -29,7 +28,7 @@ export interface ElementJSONInit extends ElementPresetAttributes {
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function elementAttributes(element: ElementPresetAttributes): dia.Element.Attributes {
+export function elementAttributes(element: ElementAttributes): dia.Element.Attributes {
   if (!util.isObject(element)) {
     throw new TypeError('Invalid element format: expected an object.');
   }

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -7,7 +7,6 @@ import type { LinkLabel} from './link-labels';
 
 
 export interface LinkJSONInit extends dia.Link.JSONInit {
-  data?: unknown;
   style?: LinkStyle;
   labelMap?: Record<string, LinkLabel>;
   labelStyle?: Partial<LinkLabel>;
@@ -28,11 +27,10 @@ export function linkAttributes(link: LinkJSONInit): LinkJSONInit {
     throw new TypeError('Invalid link data: expected an object with link properties.');
   }
 
-  const { data = {}, type, style, labelMap, labels, ...rest } = link;
+  const { type, style, labelMap, labels, ...rest } = link;
   const attributes: LinkJSONInit = {
     ...rest,
     type,
-    data,
   };
 
   if (style) {

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -6,22 +6,21 @@ import type { LinkStyle } from './link-style';
 import type { LinkLabel } from './link-labels';
 
 /**
- * Loose preset input — no `type` required. The preset transforms declarative
- * fields (`style`, `labelMap`) into native JointJS shapes; it does not depend
- * on the cell discriminator.
+ * React-side declarative fields the preset adds on top of `dia.Link.Attributes`.
+ * Composed orthogonally into both `LinkAttributes` (preset input) and
+ * `LinkJSONInit` (record/mapper boundary).
  */
-export interface LinkPresetAttributes extends dia.Link.Attributes {
+export interface LinkPresetAttributes {
   style?: LinkStyle;
   labelMap?: Record<string, LinkLabel>;
   labelStyle?: Partial<LinkLabel>;
 }
 
 /**
- * Type-required variant used at the record / mapper boundary.
+ * Loose preset input — no `type` required. `dia.Link.Attributes` plus the
+ * React preset extras (`style`, `labelMap`, `labelStyle`).
  */
-export interface LinkJSONInit extends LinkPresetAttributes {
-  type: string;
-}
+export interface LinkAttributes extends dia.Link.Attributes, LinkPresetAttributes {}
 
 /**
  * Converts a `LinkAttributes` record to JointJS cell attributes.
@@ -33,7 +32,7 @@ export interface LinkJSONInit extends LinkPresetAttributes {
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function linkAttributes(link: LinkPresetAttributes): dia.Link.Attributes {
+export function linkAttributes(link: LinkAttributes): dia.Link.Attributes {
   if (!util.isObject(link)) {
     throw new TypeError('Invalid link data: expected an object with link properties.');
   }

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -3,13 +3,24 @@ import { linkLabels } from './link-labels';
 import { linkStyle } from './link-style';
 import type { dia } from '@joint/core';
 import type { LinkStyle } from './link-style';
-import type { LinkLabel} from './link-labels';
+import type { LinkLabel } from './link-labels';
 
-
-export interface LinkJSONInit extends dia.Link.JSONInit {
+/**
+ * Loose preset input — no `type` required. The preset transforms declarative
+ * fields (`style`, `labelMap`) into native JointJS shapes; it does not depend
+ * on the cell discriminator.
+ */
+export interface LinkPresetAttributes extends dia.Link.Attributes {
   style?: LinkStyle;
   labelMap?: Record<string, LinkLabel>;
   labelStyle?: Partial<LinkLabel>;
+}
+
+/**
+ * Type-required variant used at the record / mapper boundary.
+ */
+export interface LinkJSONInit extends LinkPresetAttributes {
+  type: string;
 }
 
 /**
@@ -22,16 +33,12 @@ export interface LinkJSONInit extends dia.Link.JSONInit {
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function linkAttributes(link: LinkJSONInit): LinkJSONInit {
+export function linkAttributes(link: LinkPresetAttributes): dia.Link.Attributes {
   if (!util.isObject(link)) {
     throw new TypeError('Invalid link data: expected an object with link properties.');
   }
 
-  const { type, style, labelMap, labels, ...rest } = link;
-  const attributes: LinkJSONInit = {
-    ...rest,
-    type,
-  };
+  const { style, labelMap, labels, ...attributes } = link;
 
   if (style) {
     attributes.attrs = linkStyle(style);

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -1,7 +1,17 @@
 import { util } from '@joint/core';
-import type { DiaLinkAttributes } from '../types/cell.types';
 import { linkLabels } from './link-labels';
 import { linkStyle } from './link-style';
+import type { dia } from '@joint/core';
+import type { LinkStyle } from './link-style';
+import type { LinkLabel} from './link-labels';
+
+
+export interface LinkJSONInit extends dia.Link.JSONInit {
+  data?: unknown;
+  style?: LinkStyle;
+  labelMap?: Record<string, LinkLabel>;
+  labelStyle?: Partial<LinkLabel>;
+}
 
 /**
  * Converts a `LinkAttributes` record to JointJS cell attributes.
@@ -13,13 +23,13 @@ import { linkStyle } from './link-style';
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
  */
-export function linkAttributes(link: DiaLinkAttributes): DiaLinkAttributes {
+export function linkAttributes(link: LinkJSONInit): LinkJSONInit {
   if (!util.isObject(link)) {
     throw new TypeError('Invalid link data: expected an object with link properties.');
   }
 
   const { data = {}, type, style, labelMap, labels, ...rest } = link;
-  const attributes: DiaLinkAttributes = {
+  const attributes: LinkJSONInit = {
     ...rest,
     type,
     data,

--- a/packages/joint-react/src/state/__tests__/data-mapper.test.ts
+++ b/packages/joint-react/src/state/__tests__/data-mapper.test.ts
@@ -130,9 +130,9 @@ describe('dataMapper', () => {
 
       const cellJson = mapElementToAttributes(element);
       expect(cellJson.ports).toBeDefined();
-      expect(cellJson.ports.groups.main).toBeDefined();
-      expect(cellJson.ports.items).toHaveLength(1);
-      expect(cellJson.ports.items[0].id).toBe('p1');
+      expect(cellJson.ports?.groups?.main).toBeDefined();
+      expect(cellJson.ports?.items).toHaveLength(1);
+      expect(cellJson.ports?.items?.[0].id).toBe('p1');
     });
 
     it('should convert port with label', () => {
@@ -148,9 +148,9 @@ describe('dataMapper', () => {
       };
 
       const cellJson = mapElementToAttributes(element);
-      const [port] = cellJson.ports.items;
+      const [port] = cellJson.ports!.items!;
       expect(port.label).toBeDefined();
-      expect(port.label.position.name).toBe('outside');
+      expect(port.label!.position!.name).toBe('outside');
       expect(port.attrs?.text?.text).toBe('Port A');
     });
 
@@ -167,7 +167,7 @@ describe('dataMapper', () => {
       };
 
       const cellJson = mapElementToAttributes(element);
-      const portMarkup = cellJson.ports.items[0].markup;
+      const portMarkup = cellJson.ports!.items![0].markup as dia.MarkupNodeJSON[];
       expect(portMarkup[0].tagName).toBe('rect');
     });
   });
@@ -256,8 +256,8 @@ describe('dataMapper', () => {
 
       const cellJson = mapLinkToAttributes(link);
       expect(cellJson.labels).toHaveLength(2);
-      expect(cellJson.labels[0]).toMatchObject({ id: 'lbl1', position: { distance: 0.3 } });
-      expect(cellJson.labels[1]).toMatchObject({
+      expect(cellJson.labels![0]).toMatchObject({ id: 'lbl1', position: { distance: 0.3 } });
+      expect(cellJson.labels![1]).toMatchObject({
         id: 'lbl2',
         position: { distance: 0.7, offset: 20 },
       });

--- a/packages/joint-react/src/state/data-mapping/__tests__/cell-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/cell-mapper.test.ts
@@ -3,7 +3,7 @@ import { mapCellToAttributes } from '../cell-mapper';
 import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../../models/link-model';
 import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
-import type { DiaElementAttributes, DiaLinkAttributes } from '../../../types/cell.types';
+import type { DiaElementRecord, DiaLinkRecord } from '../../../types/cell.types';
 
 function createGraph() {
   return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
@@ -18,7 +18,7 @@ describe('mapCellToAttributes', () => {
         type: ELEMENT_MODEL_TYPE,
         position: { x: 1, y: 2 },
         size: { width: 5, height: 6 },
-      } as DiaElementAttributes,
+      } as DiaElementRecord,
       graph,
     );
 
@@ -34,7 +34,7 @@ describe('mapCellToAttributes', () => {
         type: LINK_MODEL_TYPE,
         source: { id: 'a' },
         target: { id: 'b' },
-      } as DiaLinkAttributes,
+      } as DiaLinkRecord,
       graph,
     );
 
@@ -49,7 +49,7 @@ describe('mapCellToAttributes', () => {
         id: 'custom-1',
         type: 'totally.Unknown.Type',
         foo: 'bar',
-      } as unknown as DiaElementAttributes,
+      } as unknown as DiaElementRecord,
       graph,
     );
 
@@ -63,7 +63,7 @@ describe('mapCellToAttributes', () => {
   it('passes cells without id through verbatim when type is unknown', () => {
     const graph = createGraph();
     const result = mapCellToAttributes(
-      { type: 'totally.Unknown.Type' } as unknown as DiaElementAttributes,
+      { type: 'totally.Unknown.Type' } as unknown as DiaElementRecord,
       graph,
     );
     expect(result).toEqual({ type: 'totally.Unknown.Type' });
@@ -76,7 +76,7 @@ describe('mapCellToAttributes', () => {
         type: ELEMENT_MODEL_TYPE,
         position: { x: 0, y: 0 },
         size: { width: 1, height: 1 },
-      } as DiaElementAttributes,
+      } as DiaElementRecord,
       graph,
     );
     expect(result.type).toBe(ELEMENT_MODEL_TYPE);
@@ -90,7 +90,7 @@ describe('mapCellToAttributes', () => {
         type: LINK_MODEL_TYPE,
         source: { id: 'a' },
         target: { id: 'b' },
-      } as DiaLinkAttributes,
+      } as DiaLinkRecord,
       graph,
     );
     expect(result.type).toBe(LINK_MODEL_TYPE);

--- a/packages/joint-react/src/state/data-mapping/__tests__/cell-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/cell-mapper.test.ts
@@ -3,7 +3,7 @@ import { mapCellToAttributes } from '../cell-mapper';
 import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../../models/link-model';
 import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
-import type { DiaElementRecord, DiaLinkRecord } from '../../../types/cell.types';
+import type { ElementJSONInit, LinkJSONInit } from '../../../types/cell.types';
 
 function createGraph() {
   return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
@@ -18,7 +18,7 @@ describe('mapCellToAttributes', () => {
         type: ELEMENT_MODEL_TYPE,
         position: { x: 1, y: 2 },
         size: { width: 5, height: 6 },
-      } as DiaElementRecord,
+      } as ElementJSONInit,
       graph,
     );
 
@@ -34,7 +34,7 @@ describe('mapCellToAttributes', () => {
         type: LINK_MODEL_TYPE,
         source: { id: 'a' },
         target: { id: 'b' },
-      } as DiaLinkRecord,
+      } as LinkJSONInit,
       graph,
     );
 
@@ -49,7 +49,7 @@ describe('mapCellToAttributes', () => {
         id: 'custom-1',
         type: 'totally.Unknown.Type',
         foo: 'bar',
-      } as unknown as DiaElementRecord,
+      } as unknown as ElementJSONInit,
       graph,
     );
 
@@ -63,7 +63,7 @@ describe('mapCellToAttributes', () => {
   it('passes cells without id through verbatim when type is unknown', () => {
     const graph = createGraph();
     const result = mapCellToAttributes(
-      { type: 'totally.Unknown.Type' } as unknown as DiaElementRecord,
+      { type: 'totally.Unknown.Type' } as unknown as ElementJSONInit,
       graph,
     );
     expect(result).toEqual({ type: 'totally.Unknown.Type' });
@@ -76,7 +76,7 @@ describe('mapCellToAttributes', () => {
         type: ELEMENT_MODEL_TYPE,
         position: { x: 0, y: 0 },
         size: { width: 1, height: 1 },
-      } as DiaElementRecord,
+      } as ElementJSONInit,
       graph,
     );
     expect(result.type).toBe(ELEMENT_MODEL_TYPE);
@@ -90,7 +90,7 @@ describe('mapCellToAttributes', () => {
         type: LINK_MODEL_TYPE,
         source: { id: 'a' },
         target: { id: 'b' },
-      } as DiaLinkRecord,
+      } as LinkJSONInit,
       graph,
     );
     expect(result.type).toBe(LINK_MODEL_TYPE);

--- a/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
@@ -4,14 +4,14 @@ import {
   mapElementToAttributes,
 } from '../element-mapper';
 import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
-import type { DiaElementAttributes } from '../../../types/cell.types';
+import type { DiaElementRecord } from '../../../types/cell.types';
 
 describe('mapElementToAttributes', () => {
   it('defaults the type to ELEMENT_MODEL_TYPE when missing', () => {
     const result = mapElementToAttributes({
       position: { x: 0, y: 0 },
       size: { width: 1, height: 1 },
-    } as DiaElementAttributes);
+    } as DiaElementRecord);
     expect(result.type).toBe(ELEMENT_MODEL_TYPE);
   });
 
@@ -20,7 +20,7 @@ describe('mapElementToAttributes', () => {
       type: 'custom.Element',
       position: { x: 0, y: 0 },
       size: { width: 1, height: 1 },
-    } as unknown as DiaElementAttributes);
+    } as unknown as DiaElementRecord);
     expect(result.type).toBe('custom.Element');
   });
 });
@@ -28,7 +28,7 @@ describe('mapElementToAttributes', () => {
 describe('mapAttributesToElement', () => {
   it('returns ports as-is when no portMap is present', () => {
     const ports = { items: [{ id: 'p1' }] };
-    const result = mapAttributesToElement<DiaElementAttributes>({
+    const result = mapAttributesToElement<DiaElementRecord>({
       type: ELEMENT_MODEL_TYPE,
       ports,
     } as unknown as dia.Element.Attributes);
@@ -41,7 +41,7 @@ describe('mapAttributesToElement', () => {
 
   it('returns portMap when present and ignores native ports', () => {
     const portMap = { p1: { id: 'p1' } };
-    const result = mapAttributesToElement<DiaElementAttributes>({
+    const result = mapAttributesToElement<DiaElementRecord>({
       type: ELEMENT_MODEL_TYPE,
       portMap,
       ports: { items: [{ id: 'p1' }] },
@@ -52,7 +52,7 @@ describe('mapAttributesToElement', () => {
   });
 
   it('preserves a custom type', () => {
-    const result = mapAttributesToElement<DiaElementAttributes>({
+    const result = mapAttributesToElement<DiaElementRecord>({
       type: 'custom.Element',
     } as unknown as dia.Element.Attributes);
     expect(result.type).toBe('custom.Element');

--- a/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
@@ -7,14 +7,6 @@ import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
 import type { DiaElementRecord } from '../../../types/cell.types';
 
 describe('mapElementToAttributes', () => {
-  it('defaults the type to ELEMENT_MODEL_TYPE when missing', () => {
-    const result = mapElementToAttributes({
-      position: { x: 0, y: 0 },
-      size: { width: 1, height: 1 },
-    } as DiaElementRecord);
-    expect(result.type).toBe(ELEMENT_MODEL_TYPE);
-  });
-
   it('preserves a custom type when provided', () => {
     const result = mapElementToAttributes({
       type: 'custom.Element',
@@ -31,7 +23,7 @@ describe('mapAttributesToElement', () => {
     const result = mapAttributesToElement<DiaElementRecord>({
       type: ELEMENT_MODEL_TYPE,
       ports,
-    } as unknown as dia.Element.Attributes);
+    } as dia.Element.Attributes);
 
     expect(result.ports).toEqual(ports);
     expect(result).not.toHaveProperty('portMap');
@@ -45,7 +37,7 @@ describe('mapAttributesToElement', () => {
       type: ELEMENT_MODEL_TYPE,
       portMap,
       ports: { items: [{ id: 'p1' }] },
-    } as unknown as dia.Element.Attributes);
+    } as dia.Element.Attributes);
 
     expect(result.portMap).toEqual(portMap);
     expect(result).not.toHaveProperty('ports');
@@ -54,7 +46,7 @@ describe('mapAttributesToElement', () => {
   it('preserves a custom type', () => {
     const result = mapAttributesToElement<DiaElementRecord>({
       type: 'custom.Element',
-    } as unknown as dia.Element.Attributes);
+    } as dia.Element.Attributes);
     expect(result.type).toBe('custom.Element');
   });
 });

--- a/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
@@ -4,7 +4,7 @@ import {
   mapElementToAttributes,
 } from '../element-mapper';
 import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
-import type { DiaElementRecord } from '../../../types/cell.types';
+import type { ElementJSONInit } from '../../../types/cell.types';
 
 describe('mapElementToAttributes', () => {
   it('preserves a custom type when provided', () => {
@@ -12,7 +12,7 @@ describe('mapElementToAttributes', () => {
       type: 'custom.Element',
       position: { x: 0, y: 0 },
       size: { width: 1, height: 1 },
-    } as unknown as DiaElementRecord);
+    } as unknown as ElementJSONInit);
     expect(result.type).toBe('custom.Element');
   });
 });
@@ -20,7 +20,7 @@ describe('mapElementToAttributes', () => {
 describe('mapAttributesToElement', () => {
   it('returns ports as-is when no portMap is present', () => {
     const ports = { items: [{ id: 'p1' }] };
-    const result = mapAttributesToElement<DiaElementRecord>({
+    const result = mapAttributesToElement<ElementJSONInit>({
       type: ELEMENT_MODEL_TYPE,
       ports,
     } as dia.Element.Attributes);
@@ -33,7 +33,7 @@ describe('mapAttributesToElement', () => {
 
   it('returns portMap when present and ignores native ports', () => {
     const portMap = { p1: { id: 'p1' } };
-    const result = mapAttributesToElement<DiaElementRecord>({
+    const result = mapAttributesToElement<ElementJSONInit>({
       type: ELEMENT_MODEL_TYPE,
       portMap,
       ports: { items: [{ id: 'p1' }] },
@@ -44,7 +44,7 @@ describe('mapAttributesToElement', () => {
   });
 
   it('preserves a custom type', () => {
-    const result = mapAttributesToElement<DiaElementRecord>({
+    const result = mapAttributesToElement<ElementJSONInit>({
       type: 'custom.Element',
     } as dia.Element.Attributes);
     expect(result.type).toBe('custom.Element');

--- a/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/element-mapper.test.ts
@@ -27,8 +27,7 @@ describe('mapAttributesToElement', () => {
 
     expect(result.ports).toEqual(ports);
     expect(result).not.toHaveProperty('portMap');
-    // default type stripped
-    expect(result).not.toHaveProperty('type');
+    expect(result.type).toBe(ELEMENT_MODEL_TYPE);
   });
 
   it('returns portMap when present and ignores native ports', () => {

--- a/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
@@ -1,14 +1,14 @@
 import type { dia } from '@joint/core';
 import { mapAttributesToLink, mapLinkToAttributes } from '../link-mapper';
 import { LINK_MODEL_TYPE } from '../../../models/link-model';
-import type { DiaLinkAttributes } from '../../../types/cell.types';
+import type { DiaLinkRecord } from '../../../types/cell.types';
 
 describe('mapLinkToAttributes', () => {
   it('defaults the type to LINK_MODEL_TYPE when missing', () => {
     const result = mapLinkToAttributes({
       source: { id: 'a' },
       target: { id: 'b' },
-    } as DiaLinkAttributes);
+    } as DiaLinkRecord);
     expect(result.type).toBe(LINK_MODEL_TYPE);
   });
 
@@ -17,7 +17,7 @@ describe('mapLinkToAttributes', () => {
       type: 'custom.Link',
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as DiaLinkAttributes);
+    } as unknown as DiaLinkRecord);
     expect(result.type).toBe('custom.Link');
   });
 });

--- a/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
@@ -4,14 +4,6 @@ import { LINK_MODEL_TYPE } from '../../../models/link-model';
 import type { DiaLinkRecord } from '../../../types/cell.types';
 
 describe('mapLinkToAttributes', () => {
-  it('defaults the type to LINK_MODEL_TYPE when missing', () => {
-    const result = mapLinkToAttributes({
-      source: { id: 'a' },
-      target: { id: 'b' },
-    } as DiaLinkRecord);
-    expect(result.type).toBe(LINK_MODEL_TYPE);
-  });
-
   it('preserves a custom type', () => {
     const result = mapLinkToAttributes({
       type: 'custom.Link',
@@ -30,7 +22,7 @@ describe('mapAttributesToLink', () => {
       attrs: attributes,
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as dia.Link.Attributes);
+    } as dia.Link.Attributes);
 
     expect(result.attrs).toEqual(attributes);
     expect(result).not.toHaveProperty('style');
@@ -44,7 +36,7 @@ describe('mapAttributesToLink', () => {
       attrs: { line: { stroke: 'blue' } },
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as dia.Link.Attributes);
+    } as dia.Link.Attributes);
 
     expect(result.style).toEqual(style);
     expect(result).not.toHaveProperty('attrs');
@@ -59,7 +51,7 @@ describe('mapAttributesToLink', () => {
       labels,
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as dia.Link.Attributes);
+    } as dia.Link.Attributes);
 
     expect(result.labels).toEqual(labels);
     expect(result).not.toHaveProperty('labelMap');
@@ -79,7 +71,7 @@ describe('mapAttributesToLink', () => {
       labels,
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as dia.Link.Attributes);
+    } as dia.Link.Attributes);
 
     expect(result.labelMap?.a.position).toBe(0.7);
     expect(result.labelMap?.a.offset).toBe(9);

--- a/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
+++ b/packages/joint-react/src/state/data-mapping/__tests__/link-mapper.test.ts
@@ -1,7 +1,7 @@
 import type { dia } from '@joint/core';
 import { mapAttributesToLink, mapLinkToAttributes } from '../link-mapper';
 import { LINK_MODEL_TYPE } from '../../../models/link-model';
-import type { DiaLinkRecord } from '../../../types/cell.types';
+import type { LinkJSONInit } from '../../../types/cell.types';
 
 describe('mapLinkToAttributes', () => {
   it('preserves a custom type', () => {
@@ -9,7 +9,7 @@ describe('mapLinkToAttributes', () => {
       type: 'custom.Link',
       source: { id: 'a' },
       target: { id: 'b' },
-    } as unknown as DiaLinkRecord);
+    } as unknown as LinkJSONInit);
     expect(result.type).toBe('custom.Link');
   });
 });

--- a/packages/joint-react/src/state/data-mapping/cell-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/cell-mapper.ts
@@ -1,5 +1,5 @@
 import type { dia } from '@joint/core';
-import type { DiaElementAttributes, DiaLinkAttributes } from '../../types/cell.types';
+import type { DiaElementRecord, DiaLinkRecord } from '../../types/cell.types';
 import { isElementType, isLinkType } from '../../utils/cell-type';
 import { mapElementToAttributes } from './element-mapper';
 import { mapLinkToAttributes } from './link-mapper';
@@ -25,8 +25,8 @@ import { mapLinkToAttributes } from './link-mapper';
  * @returns JointJS cell attributes with `id` guaranteed
  */
 export function mapCellToAttributes<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(cell: Element | Link, graph: dia.Graph): dia.Cell.JSON {
   // `ElementAttributes` / `LinkAttributes` only declare `id`; the discriminator
   // `type` lives on `WithType` (which `ElementRecord` / `LinkRecord` extend).

--- a/packages/joint-react/src/state/data-mapping/cell-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/cell-mapper.ts
@@ -27,7 +27,7 @@ import { mapLinkToAttributes } from './link-mapper';
 export function mapCellToAttributes<
   Element extends DiaElementRecord = DiaElementRecord,
   Link extends DiaLinkRecord = DiaLinkRecord,
->(cell: Element | Link, graph: dia.Graph): dia.Cell.JSON {
+>(cell: Element | Link, graph: dia.Graph): dia.Cell.JSONInit {
   // `ElementAttributes` / `LinkAttributes` only declare `id`; the discriminator
   // `type` lives on `WithType` (which `ElementRecord` / `LinkRecord` extend).
   // Read it through a narrow cast so the index signature
@@ -45,5 +45,5 @@ export function mapCellToAttributes<
   }
   // fallback for unrecognized types: pass through verbatim (id may be omitted —
   // JointJS will assign one).
-  return { ...cell } as dia.Cell.JSON;
+  return { ...cell } as dia.Cell.JSONInit;
 }

--- a/packages/joint-react/src/state/data-mapping/cell-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/cell-mapper.ts
@@ -1,5 +1,5 @@
 import type { dia } from '@joint/core';
-import type { DiaElementRecord, DiaLinkRecord } from '../../types/cell.types';
+import type { ElementJSONInit, LinkJSONInit } from '../../types/cell.types';
 import { isElementType, isLinkType } from '../../utils/cell-type';
 import { mapElementToAttributes } from './element-mapper';
 import { mapLinkToAttributes } from './link-mapper';
@@ -25,8 +25,8 @@ import { mapLinkToAttributes } from './link-mapper';
  * @returns JointJS cell attributes with `id` guaranteed
  */
 export function mapCellToAttributes<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(cell: Element | Link, graph: dia.Graph): dia.Cell.JSONInit {
   // `ElementAttributes` / `LinkAttributes` only declare `id`; the discriminator
   // `type` lives on `WithType` (which `ElementRecord` / `LinkRecord` extend).

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -7,8 +7,8 @@ import { elementAttributes } from '../../presets/element-attributes';
  * Forward mapper using the React default element type.
  * @param element
  */
-export function mapElementToAttributes(element: DiaElementRecord): dia.Cell.JSON {
-  const attributes = elementAttributes(element) as dia.Cell.JSON;
+export function mapElementToAttributes(element: DiaElementRecord): dia.Element.JSONInit {
+  const attributes = elementAttributes(element) as dia.Element.JSONInit;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};
   return attributes;

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -1,5 +1,5 @@
 import { type dia } from '@joint/core';
-import type { DiaElementRecord, ElementRecord } from '../../types/cell.types';
+import type { ElementJSONInit, ElementRecord } from '../../types/cell.types';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { elementAttributes } from '../../presets/element-attributes';
 
@@ -7,7 +7,7 @@ import { elementAttributes } from '../../presets/element-attributes';
  * Forward mapper using the React default element type.
  * @param element
  */
-export function mapElementToAttributes(element: DiaElementRecord): dia.Element.JSONInit {
+export function mapElementToAttributes(element: ElementJSONInit): dia.Element.JSONInit {
   const attributes = elementAttributes(element) as dia.Element.JSONInit;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -11,8 +11,6 @@ export function mapElementToAttributes(element: DiaElementRecord): dia.Cell.JSON
   const attributes = elementAttributes(element) as dia.Cell.JSON;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};
-  // Default to React element model when caller omitted `type`.
-  attributes.type ??= ELEMENT_MODEL_TYPE;
   return attributes;
 }
 

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -1,17 +1,29 @@
 import { type dia } from '@joint/core';
 import type { ElementJSONInit, ElementRecord } from '../../types/cell.types';
-import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { elementAttributes } from '../../presets/element-attributes';
 
 /**
- * Forward mapper using the React default element type.
+ * Fill missing position/size/angle/data with framework defaults so the
+ * record satisfies `Computed<ElementRecord>`'s required-field contract.
+ * @param attributes
+ */
+function ensureDefaults(attributes: dia.Element.JSONInit): dia.Element.JSONInit {
+  const { position, size } = attributes;
+  attributes.position = { x: position?.x ?? 0, y: position?.y ?? 0 };
+  attributes.size = { width: size?.width ?? 0, height: size?.height ?? 0 };
+  attributes.angle ??= 0;
+  attributes.data ??= {};
+  return attributes;
+}
+
+/**
+ * Convert a React element record to JointJS-ready cell attributes —
+ * applies preset transforms (`portMap` → native `ports`) and fills
+ * framework defaults for `position` / `size` / `angle` / `data`.
  * @param element
  */
 export function mapElementToAttributes(element: ElementJSONInit): dia.Element.JSONInit {
-  const attributes = elementAttributes(element) as dia.Element.JSONInit;
-  // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
-  attributes.data ??= {};
-  return attributes;
+  return ensureDefaults(elementAttributes(element) as dia.Element.JSONInit);
 }
 
 /**
@@ -27,7 +39,6 @@ export function mapAttributesToElement<ElementData = unknown>(
   attributes: dia.Element.Attributes
 ): ElementRecord<ElementData> {
   const {
-    type,
     // Ports
     portMap,
     ports,
@@ -43,12 +54,7 @@ export function mapAttributesToElement<ElementData = unknown>(
     elementRecord.ports = ports;
   }
 
-  // Only a custom type should be included in the element record.
-  if (type && type !== ELEMENT_MODEL_TYPE) {
-    elementRecord.type = type;
-  }
-
-  return { ...elementRecord } as ElementRecord<ElementData>;
+  return elementRecord as ElementRecord<ElementData>;
 }
 
 /** Function signature that maps raw JointJS element attributes to an `ElementRecord`. */

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -1,5 +1,5 @@
 import { type dia } from '@joint/core';
-import type { DiaElementAttributes, ElementRecord } from '../../types/cell.types';
+import type { DiaElementRecord, ElementRecord } from '../../types/cell.types';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { elementAttributes } from '../../presets/element-attributes';
 
@@ -7,8 +7,12 @@ import { elementAttributes } from '../../presets/element-attributes';
  * Forward mapper using the React default element type.
  * @param element
  */
-export function mapElementToAttributes(element: DiaElementAttributes): dia.Cell.JSON {
+export function mapElementToAttributes(element: DiaElementRecord): dia.Cell.JSON {
   const attributes = elementAttributes(element) as dia.Cell.JSON;
+  // Ensure `data` is always present to avoid JointJS warnings about missing connection data. See `ElementModel.defaults()`.
+  if (!attributes.data) attributes.data = {};
+
+  // @todo: no longer required or change elementAttributes
   if (!attributes.type) attributes.type = ELEMENT_MODEL_TYPE;
   return attributes;
 }
@@ -22,7 +26,7 @@ export function mapElementToAttributes(element: DiaElementAttributes): dia.Cell.
  * 1:1 mapping — no `presentation` wrapper.
  * @param attributes
  */
-export function mapAttributesToElement<ElementData extends DiaElementAttributes>(
+export function mapAttributesToElement<ElementData extends DiaElementRecord>(
   attributes: dia.Element.Attributes
 ): ElementRecord<ElementData> {
   const {
@@ -51,7 +55,7 @@ export function mapAttributesToElement<ElementData extends DiaElementAttributes>
 }
 
 /** Function signature that maps raw JointJS element attributes to an `ElementRecord`. */
-export type MapAttributesToElement<ElementData extends DiaElementAttributes> =
+export type MapAttributesToElement<ElementData extends DiaElementRecord> =
   typeof mapAttributesToElement<ElementData>;
 
 /** Function signature that maps an `ElementRecord` back to JointJS element attributes. */

--- a/packages/joint-react/src/state/data-mapping/element-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/element-mapper.ts
@@ -9,11 +9,10 @@ import { elementAttributes } from '../../presets/element-attributes';
  */
 export function mapElementToAttributes(element: DiaElementRecord): dia.Cell.JSON {
   const attributes = elementAttributes(element) as dia.Cell.JSON;
-  // Ensure `data` is always present to avoid JointJS warnings about missing connection data. See `ElementModel.defaults()`.
-  if (!attributes.data) attributes.data = {};
-
-  // @todo: no longer required or change elementAttributes
-  if (!attributes.type) attributes.type = ELEMENT_MODEL_TYPE;
+  // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
+  attributes.data ??= {};
+  // Default to React element model when caller omitted `type`.
+  attributes.type ??= ELEMENT_MODEL_TYPE;
   return attributes;
 }
 
@@ -26,7 +25,7 @@ export function mapElementToAttributes(element: DiaElementRecord): dia.Cell.JSON
  * 1:1 mapping — no `presentation` wrapper.
  * @param attributes
  */
-export function mapAttributesToElement<ElementData extends DiaElementRecord>(
+export function mapAttributesToElement<ElementData = unknown>(
   attributes: dia.Element.Attributes
 ): ElementRecord<ElementData> {
   const {
@@ -55,7 +54,7 @@ export function mapAttributesToElement<ElementData extends DiaElementRecord>(
 }
 
 /** Function signature that maps raw JointJS element attributes to an `ElementRecord`. */
-export type MapAttributesToElement<ElementData extends DiaElementRecord> =
+export type MapAttributesToElement<ElementData = unknown> =
   typeof mapAttributesToElement<ElementData>;
 
 /** Function signature that maps an `ElementRecord` back to JointJS element attributes. */

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -1,5 +1,5 @@
 import { type dia } from '@joint/core';
-import type { DiaLinkRecord, LinkRecord } from '../../types/cell.types';
+import type { LinkJSONInit, LinkRecord } from '../../types/cell.types';
 import { linkAttributes } from '../../presets/link-attributes';
 import { mergeLabelsFromAttributes } from './convert-labels-reverse';
 
@@ -7,7 +7,7 @@ import { mergeLabelsFromAttributes } from './convert-labels-reverse';
  * Forward mapper using the React default link type.
  * @param link
  */
-export function mapLinkToAttributes(link: DiaLinkRecord): dia.Link.JSONInit {
+export function mapLinkToAttributes(link: LinkJSONInit): dia.Link.JSONInit {
   const attributes = linkAttributes(link) as dia.Link.JSONInit;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -7,8 +7,8 @@ import { mergeLabelsFromAttributes } from './convert-labels-reverse';
  * Forward mapper using the React default link type.
  * @param link
  */
-export function mapLinkToAttributes(link: DiaLinkRecord): dia.Cell.JSON {
-  const attributes = linkAttributes(link) as dia.Cell.JSON;
+export function mapLinkToAttributes(link: DiaLinkRecord): dia.Link.JSONInit {
+  const attributes = linkAttributes(link) as dia.Link.JSONInit;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};
   return attributes;

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -4,14 +4,22 @@ import { linkAttributes } from '../../presets/link-attributes';
 import { mergeLabelsFromAttributes } from './convert-labels-reverse';
 
 /**
- * Forward mapper using the React default link type.
+ * Fill missing `data` with `{}` so reading hooks can rely on
+ * `Computed<LinkRecord>`'s required `data` field.
+ */
+function ensureDefaults(attributes: dia.Link.JSONInit): dia.Link.JSONInit {
+  attributes.data ??= {};
+  return attributes;
+}
+
+/**
+ * Convert a React link record to JointJS-ready cell attributes —
+ * applies preset transforms (`style` → native `attrs`, `labelMap` → native
+ * `labels`) and fills framework default for `data`.
  * @param link
  */
 export function mapLinkToAttributes(link: LinkJSONInit): dia.Link.JSONInit {
-  const attributes = linkAttributes(link) as dia.Link.JSONInit;
-  // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
-  attributes.data ??= {};
-  return attributes;
+  return ensureDefaults(linkAttributes(link) as dia.Link.JSONInit);
 }
 
 /**
@@ -52,7 +60,7 @@ export function mapAttributesToLink<LinkData = unknown>(
     linkRecord.labels = labels;
   }
 
-  return { ...linkRecord } as LinkRecord<LinkData>;
+  return linkRecord as LinkRecord<LinkData>;
 }
 
 /** Function signature that maps raw JointJS link attributes to a `LinkRecord`. */

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -10,11 +10,10 @@ import { mergeLabelsFromAttributes } from './convert-labels-reverse';
  */
 export function mapLinkToAttributes(link: DiaLinkRecord): dia.Cell.JSON {
   const attributes = linkAttributes(link) as dia.Cell.JSON;
-  if (!attributes.data) attributes.data = {};
-  // Ensure `data` is always present to avoid JointJS warnings about missing connection data. See `LinkModel.defaults()`.
-
-  // @todo: no longer required or change linkAttributes
-  if (!attributes.type) attributes.type = LINK_MODEL_TYPE;
+  // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
+  attributes.data ??= {};
+  // Default to React link model when caller omitted `type`.
+  attributes.type ??= LINK_MODEL_TYPE;
   return attributes;
 }
 

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -1,5 +1,5 @@
 import { type dia } from '@joint/core';
-import type { DiaLinkAttributes, LinkRecord } from '../../types/cell.types';
+import type { DiaLinkRecord, LinkRecord } from '../../types/cell.types';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import { linkAttributes } from '../../presets/link-attributes';
 import { mergeLabelsFromAttributes } from './convert-labels-reverse';
@@ -8,8 +8,12 @@ import { mergeLabelsFromAttributes } from './convert-labels-reverse';
  * Forward mapper using the React default link type.
  * @param link
  */
-export function mapLinkToAttributes(link: DiaLinkAttributes): dia.Cell.JSON {
+export function mapLinkToAttributes(link: DiaLinkRecord): dia.Cell.JSON {
   const attributes = linkAttributes(link) as dia.Cell.JSON;
+  if (!attributes.data) attributes.data = {};
+  // Ensure `data` is always present to avoid JointJS warnings about missing connection data. See `LinkModel.defaults()`.
+
+  // @todo: no longer required or change linkAttributes
   if (!attributes.type) attributes.type = LINK_MODEL_TYPE;
   return attributes;
 }
@@ -28,8 +32,6 @@ export function mapAttributesToLink<LinkData = unknown>(
   attributes: dia.Link.Attributes
 ): LinkRecord<LinkData> {
   const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    id,
     // Labels
     labelMap,
     labels,

--- a/packages/joint-react/src/state/data-mapping/link-mapper.ts
+++ b/packages/joint-react/src/state/data-mapping/link-mapper.ts
@@ -1,6 +1,5 @@
 import { type dia } from '@joint/core';
 import type { DiaLinkRecord, LinkRecord } from '../../types/cell.types';
-import { LINK_MODEL_TYPE } from '../../models/link-model';
 import { linkAttributes } from '../../presets/link-attributes';
 import { mergeLabelsFromAttributes } from './convert-labels-reverse';
 
@@ -12,8 +11,6 @@ export function mapLinkToAttributes(link: DiaLinkRecord): dia.Cell.JSON {
   const attributes = linkAttributes(link) as dia.Cell.JSON;
   // `data` is a @joint/react concept — defaulted here, not in framework-neutral presets.
   attributes.data ??= {};
-  // Default to React link model when caller omitted `type`.
-  attributes.type ??= LINK_MODEL_TYPE;
   return attributes;
 }
 

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -13,7 +13,7 @@
 import type { dia } from '@joint/core';
 import type { CellId } from '../types/cell.types';
 import type { ElementLayout } from '../types/cell.types';
-import type { DiaElementAttributes } from '../types/cell.types';
+import type { DiaElementRecord } from '../types/cell.types';
 
 const DEFAULT_OBSERVER_OPTIONS: ResizeObserverOptions = { box: 'border-box' };
 // Epsilon value to avoid jitter due to sub-pixel rendering
@@ -66,7 +66,7 @@ interface ObservedElement {
   isMeasured: boolean;
 }
 
- 
+
 function identityTransform(options: TransformOptions) {
   const { width, height, x, y } = options;
   return { width, height, x, y };
@@ -82,7 +82,7 @@ interface Options {
     id: CellId
   ) => ElementLayoutOptionalXY & { element: dia.Element; angle: number };
   /** Function to get the elements from the container */
-  readonly getElements: () => Map<CellId, DiaElementAttributes>;
+  readonly getElements: () => Map<CellId, DiaElementRecord>;
   /** Callback function called when a batch of elements needs to be updated */
   readonly onBatchUpdate: (data: Record<CellId, ElementLayoutOptionalXY>) => void;
 }
@@ -128,7 +128,7 @@ interface ProcessSizeChangeOptions {
   readonly measuredHeight: number;
   readonly observedElement: ObservedElement;
   readonly getCellTransform: Options['getCellTransform'];
-  readonly elements: Map<CellId, DiaElementAttributes>;
+  readonly elements: Map<CellId, DiaElementRecord>;
   readonly mutableLayouts: Record<CellId, ElementLayoutOptionalXY>;
 }
 
@@ -215,20 +215,20 @@ export function createElementsSizeObserver(options: Options): GraphStoreObserver
   // Maps only the active DOM node to its ObservedElement for O(1) lookup in the ResizeObserver callback.
   const activeObservedElementByDomNode = new WeakMap<HTMLElement | SVGElement, ObservedElement>();
 
-   
+
   /** Returns the active (last) element from the stack, or `undefined` if empty. */
   function getActiveElement(stack: readonly ObservedElement[]): ObservedElement | undefined {
     return stack.at(-1);
   }
 
-   
+
   /** Starts observing the given element and registers it in the active DOM node lookup. */
   function activateElement(observedElement: ObservedElement) {
     observer.observe(observedElement.node, resizeObserverOptions);
     activeObservedElementByDomNode.set(observedElement.node, observedElement);
   }
 
-   
+
   /** Stops observing the given element and removes it from the active DOM node lookup. */
   function deactivateElement(observedElement: ObservedElement) {
     observer.unobserve(observedElement.node);

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -13,7 +13,7 @@
 import type { dia } from '@joint/core';
 import type { CellId } from '../types/cell.types';
 import type { ElementLayout } from '../types/cell.types';
-import type { DiaElementRecord } from '../types/cell.types';
+import type { ElementJSONInit } from '../types/cell.types';
 
 const DEFAULT_OBSERVER_OPTIONS: ResizeObserverOptions = { box: 'border-box' };
 // Epsilon value to avoid jitter due to sub-pixel rendering
@@ -82,7 +82,7 @@ interface Options {
     id: CellId
   ) => ElementLayoutOptionalXY & { element: dia.Element; angle: number };
   /** Function to get the elements from the container */
-  readonly getElements: () => Map<CellId, DiaElementRecord>;
+  readonly getElements: () => Map<CellId, ElementJSONInit>;
   /** Callback function called when a batch of elements needs to be updated */
   readonly onBatchUpdate: (data: Record<CellId, ElementLayoutOptionalXY>) => void;
 }
@@ -128,7 +128,7 @@ interface ProcessSizeChangeOptions {
   readonly measuredHeight: number;
   readonly observedElement: ObservedElement;
   readonly getCellTransform: Options['getCellTransform'];
-  readonly elements: Map<CellId, DiaElementRecord>;
+  readonly elements: Map<CellId, ElementJSONInit>;
   readonly mutableLayouts: Record<CellId, ElementLayoutOptionalXY>;
 }
 

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -1,7 +1,7 @@
 import { mvc, type dia } from '@joint/core';
 import type { IncrementalChange } from '../state/incremental.types';
 import { simpleScheduler } from '../utils/scheduler';
-import type { DiaElementAttributes, DiaLinkAttributes, CellId } from '../types/cell.types';
+import type { DiaElementRecord, DiaLinkRecord, CellId } from '../types/cell.types';
 import { mapCellToAttributes } from '../state/data-mapping';
 
 /** Custom graph event signalling a layout-only update (position/size/angle change). */
@@ -17,8 +17,8 @@ export const LAYOUT_UPDATE_EVENT = 'layout:update';
  *  - anything else → passed through as raw attributes
  */
 export interface UpdateGraphOptions<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   /** Cell records to sync. If omitted, the current graph cells are preserved untouched. */
   readonly cells?: ReadonlyArray<Element | Link>;
@@ -185,8 +185,8 @@ export function graphChanges(options: Options) {
     },
 
     updateGraph<
-      Element extends DiaElementAttributes = DiaElementAttributes,
-      Link extends DiaLinkAttributes = DiaLinkAttributes,
+      Element extends DiaElementRecord = DiaElementRecord,
+      Link extends DiaLinkRecord = DiaLinkRecord,
     >(update: UpdateGraphOptions<Element, Link>): UpdateGraphResult {
       const { cells, flag } = update;
       if (!isSyncedWithReact) {

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -198,7 +198,7 @@ export function graphChanges(options: Options) {
       }
 
       const cellIds: CellId[] = [];
-      const cellsToSync: dia.Cell.JSON[] = [];
+      const cellsToSync: dia.Cell.JSONInit[] = [];
 
       for (const cell of cells) {
         // Cells without an id are valid input — JointJS will assign one — but

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -1,7 +1,7 @@
 import { mvc, type dia } from '@joint/core';
 import type { IncrementalChange } from '../state/incremental.types';
 import { simpleScheduler } from '../utils/scheduler';
-import type { DiaElementRecord, DiaLinkRecord, CellId } from '../types/cell.types';
+import type { ElementJSONInit, LinkJSONInit, CellId } from '../types/cell.types';
 import { mapCellToAttributes } from '../state/data-mapping';
 
 /** Custom graph event signalling a layout-only update (position/size/angle change). */
@@ -17,8 +17,8 @@ export const LAYOUT_UPDATE_EVENT = 'layout:update';
  *  - anything else → passed through as raw attributes
  */
 export interface UpdateGraphOptions<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   /** Cell records to sync. If omitted, the current graph cells are preserved untouched. */
   readonly cells?: ReadonlyArray<Element | Link>;
@@ -185,8 +185,8 @@ export function graphChanges(options: Options) {
     },
 
     updateGraph<
-      Element extends DiaElementRecord = DiaElementRecord,
-      Link extends DiaLinkRecord = DiaLinkRecord,
+      Element extends ElementJSONInit = ElementJSONInit,
+      Link extends LinkJSONInit = LinkJSONInit,
     >(update: UpdateGraphOptions<Element, Link>): UpdateGraphResult {
       const { cells, flag } = update;
       if (!isSyncedWithReact) {

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -1,7 +1,7 @@
 import { dia, shapes } from '@joint/core';
 import type {
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -57,8 +57,8 @@ export interface GraphStoreInternalSnapshot {
  * being passed together.
  */
 interface GraphStoreOptionsBase<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   readonly graph?: dia.Graph;
   readonly cellNamespace?: unknown;
@@ -68,8 +68,8 @@ interface GraphStoreOptionsBase<
 
 /** Uncontrolled mode: parent provides only seed data. */
 interface GraphStoreOptionsUncontrolled<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > extends GraphStoreOptionsBase<Element, Link> {
   readonly initialCells?: ReadonlyArray<Element | Link>;
   readonly cells?: never;
@@ -78,8 +78,8 @@ interface GraphStoreOptionsUncontrolled<
 
 /** Controlled mode: parent is the source of truth; store applies snapshots. */
 interface GraphStoreOptionsControlled<
-  Element extends DiaElementAttributes,
-  Link extends DiaLinkAttributes,
+  Element extends DiaElementRecord,
+  Link extends DiaLinkRecord,
 > extends GraphStoreOptionsBase<Element, Link> {
   readonly cells: ReadonlyArray<Element | Link>;
   readonly initialCells?: never;
@@ -91,16 +91,16 @@ interface GraphStoreOptionsControlled<
  * or controlled (`cells` + `onCellsChange`).
  */
 export type GraphStoreOptions<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > = GraphStoreOptionsUncontrolled<Element, Link> | GraphStoreOptionsControlled<Element, Link>;
 
 /**
  * Central store for managing graph state, synchronization, and paper instances.
  */
 export class GraphStore<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   public readonly internalState: Atom<GraphStoreInternalSnapshot>;
   public readonly measureState: Atom<number> = createAtom(0);
@@ -112,8 +112,8 @@ export class GraphStore<
   public readonly graphView: GraphView<Element, Link>;
 
   public getGraphView<
-    E extends DiaElementAttributes = DiaElementAttributes,
-    L extends DiaLinkAttributes = DiaLinkAttributes,
+    E extends DiaElementRecord = DiaElementRecord,
+    L extends DiaLinkRecord = DiaLinkRecord,
   >(): GraphView<E, L> {
     return this.graphView as unknown as GraphView<E, L>;
   }
@@ -175,7 +175,7 @@ export class GraphStore<
         // The observer only cares about element-typed cells. Build a Map on
         // demand from the unified cells container — cold path, called only
         // when the ResizeObserver fires.
-        const map = new Map<CellId, DiaElementAttributes>();
+        const map = new Map<CellId, DiaElementRecord>();
         for (const cell of this.graphView.cells.getAll()) {
           if (cell.id === undefined) continue;
           if (this.isElement(cell)) {

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -1,7 +1,7 @@
 import { dia, shapes } from '@joint/core';
 import type {
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -57,8 +57,8 @@ export interface GraphStoreInternalSnapshot {
  * being passed together.
  */
 interface GraphStoreOptionsBase<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   readonly graph?: dia.Graph;
   readonly cellNamespace?: unknown;
@@ -68,8 +68,8 @@ interface GraphStoreOptionsBase<
 
 /** Uncontrolled mode: parent provides only seed data. */
 interface GraphStoreOptionsUncontrolled<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > extends GraphStoreOptionsBase<Element, Link> {
   readonly initialCells?: ReadonlyArray<Element | Link>;
   readonly cells?: never;
@@ -78,8 +78,8 @@ interface GraphStoreOptionsUncontrolled<
 
 /** Controlled mode: parent is the source of truth; store applies snapshots. */
 interface GraphStoreOptionsControlled<
-  Element extends DiaElementRecord,
-  Link extends DiaLinkRecord,
+  Element extends ElementJSONInit,
+  Link extends LinkJSONInit,
 > extends GraphStoreOptionsBase<Element, Link> {
   readonly cells: ReadonlyArray<Element | Link>;
   readonly initialCells?: never;
@@ -91,16 +91,16 @@ interface GraphStoreOptionsControlled<
  * or controlled (`cells` + `onCellsChange`).
  */
 export type GraphStoreOptions<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > = GraphStoreOptionsUncontrolled<Element, Link> | GraphStoreOptionsControlled<Element, Link>;
 
 /**
  * Central store for managing graph state, synchronization, and paper instances.
  */
 export class GraphStore<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   public readonly internalState: Atom<GraphStoreInternalSnapshot>;
   public readonly measureState: Atom<number> = createAtom(0);
@@ -112,8 +112,8 @@ export class GraphStore<
   public readonly graphView: GraphView<Element, Link>;
 
   public getGraphView<
-    E extends DiaElementRecord = DiaElementRecord,
-    L extends DiaLinkRecord = DiaLinkRecord,
+    E extends ElementJSONInit = ElementJSONInit,
+    L extends LinkJSONInit = LinkJSONInit,
   >(): GraphView<E, L> {
     return this.graphView as unknown as GraphView<E, L>;
   }
@@ -175,7 +175,7 @@ export class GraphStore<
         // The observer only cares about element-typed cells. Build a Map on
         // demand from the unified cells container — cold path, called only
         // when the ResizeObserver fires.
-        const map = new Map<CellId, DiaElementRecord>();
+        const map = new Map<CellId, ElementJSONInit>();
         for (const cell of this.graphView.cells.getAll()) {
           if (cell.id === undefined) continue;
           if (this.isElement(cell)) {

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -3,7 +3,6 @@ import type {
   ElementJSONInit,
   LinkJSONInit,
   CellId,
-  CellUnion,
 } from '../types/cell.types';
 import type { AddPaperOptions } from './paper-store';
 
@@ -260,7 +259,7 @@ export class GraphStore<
    * with the react-origin flag set.
    * @param cells - new cells snapshot from the parent
    */
-  public applyControlled(cells: ReadonlyArray<CellUnion<Element, Link>>) {
+  public applyControlled(cells: ReadonlyArray<Element | Link>) {
     this.graphView.updateGraph({ cells, flag: 'updateFromReact' });
   }
 
@@ -290,7 +289,7 @@ export class GraphStore<
    * @param cell - cell record, cell id, or type name
    * @returns `true` when the resolved type extends `dia.Link`
    */
-  public isLink = (cell: CellUnion<Element, Link>): cell is Link => {
+  public isLink = (cell: Element | Link): cell is Link => {
     const cellType = (cell as { readonly type?: string }).type;
     return cellType !== undefined && isLinkType(cellType, this.graph);
   };

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -5,7 +5,6 @@ import type {
   ElementJSONInit,
   LinkJSONInit,
   CellId,
-  CellUnion,
 } from '../types/cell.types';
 import { mapAttributesToElement, mapAttributesToLink } from '../state/data-mapping';
 import { graphChanges, type UpdateGraphOptions } from './graph-changes';
@@ -19,8 +18,8 @@ export interface IncrementalCellsChange<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
-  readonly added: Map<CellId, CellUnion<Element, Link>>;
-  readonly changed: Map<CellId, CellUnion<Element, Link>>;
+  readonly added: Map<CellId, Element | Link>;
+  readonly changed: Map<CellId, Element | Link>;
   readonly removed: Set<CellId>;
 }
 
@@ -51,10 +50,10 @@ interface GraphViewState<
  * @param next - freshly mapped record from the graph
  * @returns merged record; may be `previous` itself when nothing changed
  */
-function mergeCellUnion<Element extends ElementJSONInit, Link extends LinkJSONInit>(
-  previous: CellUnion<Element, Link> | undefined,
-  next: CellUnion<Element, Link>
-): CellUnion<Element, Link> {
+function mergeCellRecord<Element extends ElementJSONInit, Link extends LinkJSONInit>(
+  previous: Element | Link | undefined,
+  next: Element | Link
+): Element | Link {
   if (!previous) return next;
 
   const previousData = previous.data as object | undefined;
@@ -100,7 +99,7 @@ function mergeCellUnion<Element extends ElementJSONInit, Link extends LinkJSONIn
     data: mergedData,
     position: mergedPosition,
     size: mergedSize,
-  } as CellUnion<Element, Link>;
+  } as Element | Link;
 }
 
 /**
@@ -113,9 +112,9 @@ function mergeCellUnion<Element extends ElementJSONInit, Link extends LinkJSONIn
  * @param cell - graph cell
  * @returns CellRecord suitable for the cells container
  */
-function toCellUnion<Element extends ElementJSONInit, Link extends LinkJSONInit>(
+function toCellRecord<Element extends ElementJSONInit, Link extends LinkJSONInit>(
   cell: dia.Cell
-): CellUnion<Element, Link> {
+): Element | Link {
   if (cell.isElement()) {
     const record = mapAttributesToElement(cell.attributes);
     const previousPosition = record.position;
@@ -149,7 +148,7 @@ function toCellUnion<Element extends ElementJSONInit, Link extends LinkJSONInit>
     };
     return withDefaults as Link;
   }
-  return { ...cell.attributes, id: cell.id } as CellUnion<Element, Link>;
+  return { ...cell.attributes, id: cell.id } as Element | Link;
 }
 
 export function graphView<
@@ -158,11 +157,11 @@ export function graphView<
 >(options: GraphViewState<Element, Link>) {
   const { graph, onIncrementalChange, onElementsSizeChange } = options;
 
-  const cells = createContainer<CellUnion<Element, Link>>('Cells');
+  const cells = createContainer<Element | Link>('Cells');
 
   const trackChanges = onIncrementalChange !== undefined;
-  const added = trackChanges ? new Map<CellId, CellUnion<Element, Link>>() : undefined;
-  const changed = trackChanges ? new Map<CellId, CellUnion<Element, Link>>() : undefined;
+  const added = trackChanges ? new Map<CellId, Element | Link>() : undefined;
+  const changed = trackChanges ? new Map<CellId, Element | Link>() : undefined;
   const removed = trackChanges ? new Set<CellId>() : undefined;
 
   /**
@@ -173,12 +172,12 @@ export function graphView<
    * @param cell - graph cell
    * @returns the merged record (may be the previous reference when unchanged)
    */
-  function writeCell(cell: dia.Cell): CellUnion<Element, Link> {
+  function writeCell(cell: dia.Cell): Element | Link {
     cells.set(cell.id, (previous) => {
-      const next = toCellUnion<Element, Link>(cell);
-      return mergeCellUnion<Element, Link>(previous, next);
+      const next = toCellRecord<Element, Link>(cell);
+      return mergeCellRecord<Element, Link>(previous, next);
     });
-    return cells.get(cell.id) as CellUnion<Element, Link>;
+    return cells.get(cell.id) as Element | Link;
   }
 
   const graphChangesController = graphChanges({

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -2,8 +2,8 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import { type dia } from '@joint/core';
 import type {
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -16,8 +16,8 @@ import { LINK_MODEL_TYPE } from '../models/link-model';
 
 /** Incremental change set emitted by graphView after container commits. */
 export interface IncrementalCellsChange<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   readonly added: Map<CellId, CellUnion<Element, Link>>;
   readonly changed: Map<CellId, CellUnion<Element, Link>>;
@@ -25,8 +25,8 @@ export interface IncrementalCellsChange<
 }
 
 interface GraphViewState<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > {
   readonly graph: dia.Graph;
   readonly onIncrementalChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
@@ -51,7 +51,7 @@ interface GraphViewState<
  * @param next - freshly mapped record from the graph
  * @returns merged record; may be `previous` itself when nothing changed
  */
-function mergeCellUnion<Element extends DiaElementAttributes, Link extends DiaLinkAttributes>(
+function mergeCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
   previous: CellUnion<Element, Link> | undefined,
   next: CellUnion<Element, Link>
 ): CellUnion<Element, Link> {
@@ -59,10 +59,10 @@ function mergeCellUnion<Element extends DiaElementAttributes, Link extends DiaLi
 
   const previousData = previous.data as object | undefined;
   const nextData = next.data as object | undefined;
-  const previousPosition = (previous as DiaElementAttributes).position;
-  const nextPosition = (next as DiaElementAttributes).position;
-  const previousSize = (previous as DiaElementAttributes).size;
-  const nextSize = (next as DiaElementAttributes).size;
+  const previousPosition = (previous as DiaElementRecord).position;
+  const nextPosition = (next as DiaElementRecord).position;
+  const previousSize = (previous as DiaElementRecord).size;
+  const nextSize = (next as DiaElementRecord).size;
 
   const mergedData = isShallowEqual(previousData, nextData) ? previousData : nextData;
   const mergedPosition = isPositionEqual(previousPosition, nextPosition)
@@ -113,7 +113,7 @@ function mergeCellUnion<Element extends DiaElementAttributes, Link extends DiaLi
  * @param cell - graph cell
  * @returns CellRecord suitable for the cells container
  */
-function toCellUnion<Element extends DiaElementAttributes, Link extends DiaLinkAttributes>(
+function toCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
   cell: dia.Cell
 ): CellUnion<Element, Link> {
   if (cell.isElement()) {
@@ -153,8 +153,8 @@ function toCellUnion<Element extends DiaElementAttributes, Link extends DiaLinkA
 }
 
 export function graphView<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 >(options: GraphViewState<Element, Link>) {
   const { graph, onIncrementalChange, onElementsSizeChange } = options;
 
@@ -303,6 +303,6 @@ export function graphView<
 }
 
 export type GraphView<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends DiaElementRecord = DiaElementRecord,
+  Link extends DiaLinkRecord = DiaLinkRecord,
 > = ReturnType<typeof graphView<Element, Link>>;

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -10,8 +10,6 @@ import { mapAttributesToElement, mapAttributesToLink } from '../state/data-mappi
 import { graphChanges, type UpdateGraphOptions } from './graph-changes';
 import { asReadonlyContainer, createContainer } from './state-container';
 import { isShallowEqual, isPositionEqual, isSizeEqual } from '../utils/selector-utils';
-import { ELEMENT_MODEL_TYPE } from '../models/element-model';
-import { LINK_MODEL_TYPE } from '../models/link-model';
 
 /** Incremental change set emitted by graphView after container commits. */
 export interface IncrementalCellsChange<
@@ -115,40 +113,9 @@ function mergeCellRecord<Element extends ElementJSONInit, Link extends LinkJSONI
 function toCellRecord<Element extends ElementJSONInit, Link extends LinkJSONInit>(
   cell: dia.Cell
 ): Element | Link {
-  if (cell.isElement()) {
-    const record = mapAttributesToElement(cell.attributes);
-    const previousPosition = record.position;
-    const previousSize = record.size;
-    const withDefaults = {
-      ...record,
-      id: cell.id,
-      type: record.type ?? ELEMENT_MODEL_TYPE,
-      position: {
-        x: previousPosition?.x ?? 0,
-        y: previousPosition?.y ?? 0,
-      },
-      size: {
-        width: previousSize?.width ?? 0,
-        height: previousSize?.height ?? 0,
-      },
-      angle: record.angle ?? 0,
-      data: record.data ?? {},
-    };
-    return withDefaults as Element;
-  }
-  if (cell.isLink()) {
-    const record = mapAttributesToLink(cell.attributes);
-    const withDefaults = {
-      ...record,
-      id: cell.id,
-      type: record.type ?? LINK_MODEL_TYPE,
-      source: record.source ?? {},
-      target: record.target ?? {},
-      data: record.data ?? {},
-    };
-    return withDefaults as Link;
-  }
-  return { ...cell.attributes, id: cell.id } as Element | Link;
+  return cell.isElement()
+    ? mapAttributesToElement(cell.attributes) as Element
+    : mapAttributesToLink(cell.attributes) as Link;
 }
 
 export function graphView<

--- a/packages/joint-react/src/store/graph-view.ts
+++ b/packages/joint-react/src/store/graph-view.ts
@@ -2,8 +2,8 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import { type dia } from '@joint/core';
 import type {
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
   CellId,
   CellUnion,
 } from '../types/cell.types';
@@ -16,8 +16,8 @@ import { LINK_MODEL_TYPE } from '../models/link-model';
 
 /** Incremental change set emitted by graphView after container commits. */
 export interface IncrementalCellsChange<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   readonly added: Map<CellId, CellUnion<Element, Link>>;
   readonly changed: Map<CellId, CellUnion<Element, Link>>;
@@ -25,8 +25,8 @@ export interface IncrementalCellsChange<
 }
 
 interface GraphViewState<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > {
   readonly graph: dia.Graph;
   readonly onIncrementalChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
@@ -51,7 +51,7 @@ interface GraphViewState<
  * @param next - freshly mapped record from the graph
  * @returns merged record; may be `previous` itself when nothing changed
  */
-function mergeCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
+function mergeCellUnion<Element extends ElementJSONInit, Link extends LinkJSONInit>(
   previous: CellUnion<Element, Link> | undefined,
   next: CellUnion<Element, Link>
 ): CellUnion<Element, Link> {
@@ -59,10 +59,10 @@ function mergeCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRe
 
   const previousData = previous.data as object | undefined;
   const nextData = next.data as object | undefined;
-  const previousPosition = (previous as DiaElementRecord).position;
-  const nextPosition = (next as DiaElementRecord).position;
-  const previousSize = (previous as DiaElementRecord).size;
-  const nextSize = (next as DiaElementRecord).size;
+  const previousPosition = (previous as ElementJSONInit).position;
+  const nextPosition = (next as ElementJSONInit).position;
+  const previousSize = (previous as ElementJSONInit).size;
+  const nextSize = (next as ElementJSONInit).size;
 
   const mergedData = isShallowEqual(previousData, nextData) ? previousData : nextData;
   const mergedPosition = isPositionEqual(previousPosition, nextPosition)
@@ -113,7 +113,7 @@ function mergeCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRe
  * @param cell - graph cell
  * @returns CellRecord suitable for the cells container
  */
-function toCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRecord>(
+function toCellUnion<Element extends ElementJSONInit, Link extends LinkJSONInit>(
   cell: dia.Cell
 ): CellUnion<Element, Link> {
   if (cell.isElement()) {
@@ -153,8 +153,8 @@ function toCellUnion<Element extends DiaElementRecord, Link extends DiaLinkRecor
 }
 
 export function graphView<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 >(options: GraphViewState<Element, Link>) {
   const { graph, onIncrementalChange, onElementsSizeChange } = options;
 
@@ -303,6 +303,6 @@ export function graphView<
 }
 
 export type GraphView<
-  Element extends DiaElementRecord = DiaElementRecord,
-  Link extends DiaLinkRecord = DiaLinkRecord,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > = ReturnType<typeof graphView<Element, Link>>;

--- a/packages/joint-react/src/store/state-container.ts
+++ b/packages/joint-react/src/store/state-container.ts
@@ -4,8 +4,8 @@ import { isStrictEqual } from '../utils/selector-utils';
 import type {
   CellId,
   CellUnion,
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
 } from '../types/cell.types';
 
 /** Update payload accepted by container setters: a new value or a previous-state updater. */
@@ -22,7 +22,7 @@ export function getValue<T>(previous: T | undefined, updater: Update<T>): T | un
 
 /** Read-only view of a cell container — supports reads, lookups, and subscriptions. */
 export interface ReadonlyContainer<
-  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
+  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
 > {
   getVersion: () => number;
   getAll: () => readonly Cell[];
@@ -35,7 +35,7 @@ export interface ReadonlyContainer<
 }
 
 /** Mutable cell container — extends {@link ReadonlyContainer} with set/delete/reset operations. */
-export interface Container<Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>>
+export interface Container<Cell extends CellUnion<ElementJSONInit, LinkJSONInit>>
   extends ReadonlyContainer<Cell> {
   set: (id: CellId, update: Update<Cell>) => void;
   delete: (id: CellId) => void;
@@ -48,7 +48,7 @@ export interface Container<Cell extends CellUnion<DiaElementRecord, DiaLinkRecor
  * @param container
  */
 export function asReadonlyContainer<
-  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
+  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
 >(container: Container<Cell>): ReadonlyContainer<Cell> {
   return {
     get: container.get,
@@ -72,7 +72,7 @@ export function asReadonlyContainer<
  * @param _name - optional label for debugging
  */
 export function createContainer<
-  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
+  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
 >(_name?: string): Container<Cell> {
   const items: Cell[] = [];
   const indexById = new Map<CellId, number>();

--- a/packages/joint-react/src/store/state-container.ts
+++ b/packages/joint-react/src/store/state-container.ts
@@ -4,8 +4,8 @@ import { isStrictEqual } from '../utils/selector-utils';
 import type {
   CellId,
   CellUnion,
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
 } from '../types/cell.types';
 
 /** Update payload accepted by container setters: a new value or a previous-state updater. */
@@ -22,7 +22,7 @@ export function getValue<T>(previous: T | undefined, updater: Update<T>): T | un
 
 /** Read-only view of a cell container — supports reads, lookups, and subscriptions. */
 export interface ReadonlyContainer<
-  Cell extends CellUnion<DiaElementAttributes, DiaLinkAttributes>,
+  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
 > {
   getVersion: () => number;
   getAll: () => readonly Cell[];
@@ -35,7 +35,7 @@ export interface ReadonlyContainer<
 }
 
 /** Mutable cell container — extends {@link ReadonlyContainer} with set/delete/reset operations. */
-export interface Container<Cell extends CellUnion<DiaElementAttributes, DiaLinkAttributes>>
+export interface Container<Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>>
   extends ReadonlyContainer<Cell> {
   set: (id: CellId, update: Update<Cell>) => void;
   delete: (id: CellId) => void;
@@ -48,7 +48,7 @@ export interface Container<Cell extends CellUnion<DiaElementAttributes, DiaLinkA
  * @param container
  */
 export function asReadonlyContainer<
-  Cell extends CellUnion<DiaElementAttributes, DiaLinkAttributes>,
+  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
 >(container: Container<Cell>): ReadonlyContainer<Cell> {
   return {
     get: container.get,
@@ -72,7 +72,7 @@ export function asReadonlyContainer<
  * @param _name - optional label for debugging
  */
 export function createContainer<
-  Cell extends CellUnion<DiaElementAttributes, DiaLinkAttributes>,
+  Cell extends CellUnion<DiaElementRecord, DiaLinkRecord>,
 >(_name?: string): Container<Cell> {
   const items: Cell[] = [];
   const indexById = new Map<CellId, number>();

--- a/packages/joint-react/src/store/state-container.ts
+++ b/packages/joint-react/src/store/state-container.ts
@@ -3,9 +3,7 @@ import { simpleScheduler } from '../utils/scheduler';
 import { isStrictEqual } from '../utils/selector-utils';
 import type {
   CellId,
-  CellUnion,
-  ElementJSONInit,
-  LinkJSONInit,
+  AnyCellRecord,
 } from '../types/cell.types';
 
 /** Update payload accepted by container setters: a new value or a previous-state updater. */
@@ -22,7 +20,7 @@ export function getValue<T>(previous: T | undefined, updater: Update<T>): T | un
 
 /** Read-only view of a cell container — supports reads, lookups, and subscriptions. */
 export interface ReadonlyContainer<
-  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
+  Cell extends AnyCellRecord,
 > {
   getVersion: () => number;
   getAll: () => readonly Cell[];
@@ -35,7 +33,7 @@ export interface ReadonlyContainer<
 }
 
 /** Mutable cell container — extends {@link ReadonlyContainer} with set/delete/reset operations. */
-export interface Container<Cell extends CellUnion<ElementJSONInit, LinkJSONInit>>
+export interface Container<Cell extends AnyCellRecord>
   extends ReadonlyContainer<Cell> {
   set: (id: CellId, update: Update<Cell>) => void;
   delete: (id: CellId) => void;
@@ -48,7 +46,7 @@ export interface Container<Cell extends CellUnion<ElementJSONInit, LinkJSONInit>
  * @param container
  */
 export function asReadonlyContainer<
-  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
+  Cell extends AnyCellRecord,
 >(container: Container<Cell>): ReadonlyContainer<Cell> {
   return {
     get: container.get,
@@ -72,7 +70,7 @@ export function asReadonlyContainer<
  * @param _name - optional label for debugging
  */
 export function createContainer<
-  Cell extends CellUnion<ElementJSONInit, LinkJSONInit>,
+  Cell extends AnyCellRecord,
 >(_name?: string): Container<Cell> {
   const items: Cell[] = [];
   const indexById = new Map<CellId, number>();

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import '../index.css';
-import { GraphProvider, Paper, type CellJSONInit } from '@joint/react';
+import { GraphProvider, Paper, type CellRecord } from '@joint/react';
 
 const SECONDARY = '#6366f1';
 
-const initialCells: readonly CellJSONInit[] = [
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
   // Row 1: Basic shapes
   {
     id: 'rectangle',
@@ -202,7 +202,7 @@ const initialCells: readonly CellJSONInit[] = [
     attrs: { line: { stroke: PRIMARY }, shadow: { stroke: '#9ca3af' } },
     labels: [{ attrs: { text: { text: 'ShadowLink' } } }],
   },
-] satisfies CellJSONInit[];
+] satisfies Array<CellRecord<unknown, unknown, string, string>>;
 
 function Main() {
   return (

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import '../index.css';
-import { GraphProvider, Paper, type DiaCellAttributes } from '@joint/react';
+import { GraphProvider, Paper, type DiaCellRecord } from '@joint/react';
 
 const SECONDARY = '#6366f1';
 
-const initialCells: readonly DiaCellAttributes[] = [
+const initialCells: readonly DiaCellRecord[] = [
   // Row 1: Basic shapes
   {
     id: 'rectangle',
@@ -202,7 +202,7 @@ const initialCells: readonly DiaCellAttributes[] = [
     attrs: { line: { stroke: PRIMARY }, shadow: { stroke: '#9ca3af' } },
     labels: [{ attrs: { text: { text: 'ShadowLink' } } }],
   },
-] satisfies DiaCellAttributes[];
+] satisfies DiaCellRecord[];
 
 function Main() {
   return (

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
@@ -5,7 +5,10 @@ import { GraphProvider, Paper, type CellRecord } from '@joint/react';
 
 const SECONDARY = '#6366f1';
 
-const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
+type ElementType = 'standard.Rectangle' | 'standard.Circle' | 'standard.Ellipse' | 'standard.Cylinder' | 'standard.Path' | 'standard.Polygon' | 'standard.Polyline' | 'standard.TextBlock' | 'standard.HeaderedRectangle' | 'standard.Image' | 'standard.BorderedImage' | 'standard.EmbeddedImage' | 'standard.InscribedImage';
+type LinkType = 'standard.Link' | 'standard.DoubleLink' | 'standard.ShadowLink';
+
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, ElementType, LinkType>> = [
   // Row 1: Basic shapes
   {
     id: 'rectangle',
@@ -202,7 +205,7 @@ const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> 
     attrs: { line: { stroke: PRIMARY }, shadow: { stroke: '#9ca3af' } },
     labels: [{ attrs: { text: { text: 'ShadowLink' } } }],
   },
-] satisfies Array<CellRecord<unknown, unknown, string, string>>;
+];
 
 function Main() {
   return (

--- a/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-build-in-shapes/code.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import '../index.css';
-import { GraphProvider, Paper, type DiaCellRecord } from '@joint/react';
+import { GraphProvider, Paper, type CellJSONInit } from '@joint/react';
 
 const SECONDARY = '#6366f1';
 
-const initialCells: readonly DiaCellRecord[] = [
+const initialCells: readonly CellJSONInit[] = [
   // Row 1: Basic shapes
   {
     id: 'rectangle',
@@ -202,7 +202,7 @@ const initialCells: readonly DiaCellRecord[] = [
     attrs: { line: { stroke: PRIMARY }, shadow: { stroke: '#9ca3af' } },
     labels: [{ attrs: { text: { text: 'ShadowLink' } } }],
   },
-] satisfies DiaCellRecord[];
+] satisfies CellJSONInit[];
 
 function Main() {
   return (

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -2,7 +2,7 @@ import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import { shapes, dia } from '@joint/core';
 import '../index.css';
 import {
-  type CellJSONInit,
+  type CellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -36,7 +36,7 @@ interface ElementData {
 // Data
 // ============================================================================
 
-const initialCells: readonly CellJSONInit[] = [
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
   {
     id: 'node-1',
     position: { x: 70, y: 100 },

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -2,7 +2,7 @@ import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import { shapes, dia } from '@joint/core';
 import '../index.css';
 import {
-  type DiaCellRecord,
+  type CellJSONInit,
   GraphProvider,
   useCell,
   Paper,
@@ -36,7 +36,7 @@ interface ElementData {
 // Data
 // ============================================================================
 
-const initialCells: readonly DiaCellRecord[] = [
+const initialCells: readonly CellJSONInit[] = [
   {
     id: 'node-1',
     position: { x: 70, y: 100 },

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -2,7 +2,7 @@ import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import { shapes, dia } from '@joint/core';
 import '../index.css';
 import {
-  type DiaCellAttributes,
+  type DiaCellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -36,7 +36,7 @@ interface ElementData {
 // Data
 // ============================================================================
 
-const initialCells: readonly DiaCellAttributes[] = [
+const initialCells: readonly DiaCellRecord[] = [
   {
     id: 'node-1',
     position: { x: 70, y: 100 },

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -36,7 +36,7 @@ interface ElementData {
 // Data
 // ============================================================================
 
-const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
+const initialCells: ReadonlyArray<CellRecord<ElementData, unknown, 'MyElementModel', 'standard.Link'>> = [
   {
     id: 'node-1',
     position: { x: 70, y: 100 },

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -1,13 +1,13 @@
+import type {
+  ElementRecord,
+  LinkRecord} from '@joint/react';
 import {
-  type CellRecord,
   GraphProvider,
   Paper,
   HTMLBox,
   ElementModel,
   LinkModel,
-  useGraph,
-  ElementRecord,
-  LinkRecord,
+  useGraph
 } from '@joint/react';
 import {
   elementAttributes,
@@ -104,7 +104,7 @@ type CustomCellRecord =
   ElementRecord<unknown, 'PortsElement' | 'PortMapElement'> |
   LinkRecord<unknown, 'LabelsLink' | 'LabelMapLink'>;
 
-const initialCells: ReadonlyArray<CustomCellRecord> = [
+const initialCells: readonly CustomCellRecord[] = [
   {
     id: 'a',
     type: 'PortsElement',

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -1,5 +1,5 @@
 import {
-  type DiaCellRecord,
+  type CellJSONInit,
   GraphProvider,
   Paper,
   HTMLBox,
@@ -98,7 +98,7 @@ interface NodeData {
   readonly label: string;
 }
 
-const initialCells: readonly DiaCellRecord[] = [
+const initialCells: readonly CellJSONInit[] = [
   {
     id: 'a',
     type: 'PortsElement',

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -1,5 +1,5 @@
 import {
-  type DiaCellAttributes,
+  type DiaCellRecord,
   GraphProvider,
   Paper,
   HTMLBox,
@@ -98,7 +98,7 @@ interface NodeData {
   readonly label: string;
 }
 
-const initialCells: readonly DiaCellAttributes[] = [
+const initialCells: readonly DiaCellRecord[] = [
   {
     id: 'a',
     type: 'PortsElement',

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -1,5 +1,5 @@
 import {
-  type CellJSONInit,
+  type CellRecord,
   GraphProvider,
   Paper,
   HTMLBox,
@@ -98,7 +98,7 @@ interface NodeData {
   readonly label: string;
 }
 
-const initialCells: readonly CellJSONInit[] = [
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
   {
     id: 'a',
     type: 'PortsElement',

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -6,6 +6,8 @@ import {
   ElementModel,
   LinkModel,
   useGraph,
+  ElementRecord,
+  LinkRecord,
 } from '@joint/react';
 import {
   elementAttributes,
@@ -98,7 +100,11 @@ interface NodeData {
   readonly label: string;
 }
 
-const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
+type CustomCellRecord =
+  ElementRecord<unknown, 'PortsElement' | 'PortMapElement'> |
+  LinkRecord<unknown, 'LabelsLink' | 'LabelMapLink'>;
+
+const initialCells: ReadonlyArray<CustomCellRecord> = [
   {
     id: 'a',
     type: 'PortsElement',

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
@@ -10,7 +10,7 @@ import {
 import '../index.css';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
-const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
+const initialCells: CellRecord[] = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import {
-  type DiaCellRecord,
+  type CellJSONInit,
   GraphProvider,
   useCell,
   Paper,
@@ -10,7 +10,7 @@ import {
 import '../index.css';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
-const initialCells: readonly DiaCellRecord[] = [
+const initialCells: readonly CellJSONInit[] = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import {
-  type DiaCellAttributes,
+  type DiaCellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -10,7 +10,7 @@ import {
 import '../index.css';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
-const initialCells: readonly DiaCellAttributes[] = [
+const initialCells: readonly DiaCellRecord[] = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
+++ b/packages/joint-react/src/stories/examples/with-node-update/code-with-svg.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import {
-  type CellJSONInit,
+  type CellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -10,7 +10,7 @@ import {
 import '../index.css';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
-const initialCells: readonly CellJSONInit[] = [
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -46,7 +46,13 @@ const PAPER_PROPS: PaperProps = {
 // Data
 // ============================================================================
 
-const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
+const initialCells: ReadonlyArray<
+  CellRecord<
+    ElementUserData,
+    unknown,
+    'element' | 'standard.Cylinder',
+    'link' | 'standard.ShadowLink'>
+> = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -3,7 +3,7 @@
 import '../index.css';
 import { dia, highlighters } from '@joint/core';
 import {
-  type CellJSONInit,
+  type CellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -46,7 +46,7 @@ const PAPER_PROPS: PaperProps = {
 // Data
 // ============================================================================
 
-const initialCells: readonly CellJSONInit[] = [
+const initialCells: ReadonlyArray<CellRecord<unknown, unknown, string, string>> = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -3,7 +3,7 @@
 import '../index.css';
 import { dia, highlighters } from '@joint/core';
 import {
-  type DiaCellRecord,
+  type CellJSONInit,
   GraphProvider,
   useCell,
   Paper,
@@ -46,7 +46,7 @@ const PAPER_PROPS: PaperProps = {
 // Data
 // ============================================================================
 
-const initialCells: readonly DiaCellRecord[] = [
+const initialCells: readonly CellJSONInit[] = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -3,7 +3,7 @@
 import '../index.css';
 import { dia, highlighters } from '@joint/core';
 import {
-  type DiaCellAttributes,
+  type DiaCellRecord,
   GraphProvider,
   useCell,
   Paper,
@@ -46,7 +46,7 @@ const PAPER_PROPS: PaperProps = {
 // Data
 // ============================================================================
 
-const initialCells: readonly DiaCellAttributes[] = [
+const initialCells: readonly DiaCellRecord[] = [
   {
     id: '1',
     type: 'element',

--- a/packages/joint-react/src/types/__tests__/cell-types-shape.test.ts
+++ b/packages/joint-react/src/types/__tests__/cell-types-shape.test.ts
@@ -2,8 +2,8 @@ import type {
   ElementRecord,
   LinkRecord,
   Computed,
-  DiaElementAttributes,
-  DiaLinkAttributes,
+  DiaElementRecord,
+  DiaLinkRecord,
 } from '../cell.types';
 
 describe('cell.types shape', () => {
@@ -56,9 +56,9 @@ describe('cell.types shape', () => {
   });
 
   it('Base records accept any extra fields (index signature)', () => {
-    const b: DiaElementAttributes = { type: 'custom', anything: 1 };
+    const b: DiaElementRecord = { type: 'custom', anything: 1 };
     expect(b.anything).toBe(1);
-    const l: DiaLinkAttributes = { type: 'custom', extra: 'x' };
+    const l: DiaLinkRecord = { type: 'custom', extra: 'x' };
     expect(l.extra).toBe('x');
   });
 });

--- a/packages/joint-react/src/types/__tests__/cell-types-shape.test.ts
+++ b/packages/joint-react/src/types/__tests__/cell-types-shape.test.ts
@@ -2,8 +2,8 @@ import type {
   ElementRecord,
   LinkRecord,
   Computed,
-  DiaElementRecord,
-  DiaLinkRecord,
+  ElementJSONInit,
+  LinkJSONInit,
 } from '../cell.types';
 
 describe('cell.types shape', () => {
@@ -56,9 +56,9 @@ describe('cell.types shape', () => {
   });
 
   it('Base records accept any extra fields (index signature)', () => {
-    const b: DiaElementRecord = { type: 'custom', anything: 1 };
+    const b: ElementJSONInit = { type: 'custom', anything: 1 };
     expect(b.anything).toBe(1);
-    const l: DiaLinkRecord = { type: 'custom', extra: 'x' };
+    const l: LinkJSONInit = { type: 'custom', extra: 'x' };
     expect(l.extra).toBe('x');
   });
 });

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -95,18 +95,6 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
   'id' | 'type' | 'source' | 'target' | 'data'
 >;
 /**
- * Structural upper bound for any cell record from joint-react's perspective —
- * `ElementJSONInit | LinkJSONInit`. Useful where you need a heterogeneous
- * loose union (e.g. `initialCells` arrays mixing built-in shape types).
- *
- * For custom `type` literals, parametrize the record at the call site:
- *   `LinkRecord<MyData, 'custom.MyLink'>`
- *   `ElementRecord<MyData, 'standard.Rectangle'>`
- * Then build the union: `MyElementRecord | MyLinkRecord`.
- */
-export type CellJSONInit = ElementJSONInit | LinkJSONInit;
-
-/**
  * Discriminated union over the React default `type` literals:
  * - `type === 'element'` → {@link ElementRecord}
  * - `type === 'link'`    → {@link LinkRecord}
@@ -115,9 +103,14 @@ export type CellJSONInit = ElementJSONInit | LinkJSONInit;
  * mixed built-in shape arrays with typed data, build the union manually:
  * `ElementRecord<MyData, 'standard.Rectangle'> | LinkRecord<MyData, 'standard.Link'>`.
  */
-export type CellRecord<ElementData = unknown, LinkData = unknown> =
-  | ElementRecord<ElementData, typeof ELEMENT_MODEL_TYPE>
-  | LinkRecord<LinkData, typeof LINK_MODEL_TYPE>;
+export type CellRecord<
+  ElementData = unknown,
+  LinkData = unknown,
+  ElementType extends string = typeof ELEMENT_MODEL_TYPE,
+  LinkType extends string = typeof LINK_MODEL_TYPE,
+> =
+  | ElementRecord<ElementData, ElementType>
+  | LinkRecord<LinkData, LinkType>;
 
 /**
  * Union of the records this `useGraph` instance accepts as cell input —

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -1,12 +1,20 @@
 import type {
   Cell as DiaCell,
+  Element as DiaElement,
+  Link as DiaLink,
   Point as DiaPoint,
   Size as DiaSize,
 } from '@joint/core/dia';
 import type { ELEMENT_MODEL_TYPE } from '../models/element-model';
 import type { LINK_MODEL_TYPE } from '../models/link-model';
-import type { LinkJSONInit } from '../presets/link-attributes';
-import type { ElementJSONInit } from '../presets/element-attributes';
+import type { LinkPresetAttributes } from '../presets/link-attributes';
+import type { ElementPresetAttributes } from '../presets/element-attributes';
+
+/** `dia.Element.JSONInit` (id?, type, visual attrs) + React preset extras. */
+export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttributes {}
+
+/** `dia.Link.JSONInit` (id?, type, visual attrs) + React preset extras. */
+export interface LinkJSONInit extends DiaLink.JSONInit, LinkPresetAttributes {}
 
 type PickRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /** Known cell type names. */

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -5,8 +5,8 @@ import type {
 } from '@joint/core/dia';
 import type { ELEMENT_MODEL_TYPE } from '../models/element-model';
 import type { LINK_MODEL_TYPE } from '../models/link-model';
-import { LinkJSONInit } from '../presets/link-attributes';
-import { ElementJSONInit } from '../presets/element-attributes';
+import type { LinkJSONInit } from '../presets/link-attributes';
+import type { ElementJSONInit } from '../presets/element-attributes';
 
 type PickRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /** Known cell type names. */
@@ -65,7 +65,7 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
 /**
  * Structural upper bound for any cell record. Use as the constraint when
  * defining custom cell types with non-`'element'` / non-`'link'` `type`
- * literals — extend either {@link DiaElementAttributes} or {@link DiaLinkAttributes}
+ * literals — extend either {@link DiaElementRecord} or {@link DiaLinkRecord}
  * (or this union) and pick your own `type` literal:
  * ```ts
  * interface MyCustomNode extends ElementAttributes {
@@ -76,10 +76,14 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
  * ```
  */
 
-export type DiaElementAttributes = ElementJSONInit;
-export type DiaLinkAttributes = LinkJSONInit;
+export interface DiaElementRecord extends ElementJSONInit {
+  data?: unknown;
+}
+export interface DiaLinkRecord extends LinkJSONInit {
+  data?: unknown;
+}
 
-export type DiaCellAttributes = ElementJSONInit | LinkJSONInit;
+export type DiaCellRecord = DiaElementRecord | DiaLinkRecord;
 
 /**
  * Discriminated union over the `type` literal:

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -68,7 +68,7 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
  * literals — extend either {@link DiaElementRecord} or {@link DiaLinkRecord}
  * (or this union) and pick your own `type` literal:
  * ```ts
- * interface MyCustomNode extends ElementAttributes {
+ * interface MyCustomNode extends DiaElementRecord {
  *   readonly type: 'my-node';
  *   readonly data: MyData;
  * }

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -1,23 +1,17 @@
 import type {
   Cell as DiaCell,
-  Element as DiaElement,
-  Link as DiaLink,
   Point as DiaPoint,
   Size as DiaSize,
 } from '@joint/core/dia';
 import type { ELEMENT_MODEL_TYPE } from '../models/element-model';
 import type { LINK_MODEL_TYPE } from '../models/link-model';
-import type { ElementPort } from '../presets/element-ports';
-import type { LinkStyle } from '../presets/link-style';
-import type { LinkLabel } from '../presets/link-labels';
+import { LinkJSONInit } from '../presets/link-attributes';
+import { ElementJSONInit } from '../presets/element-attributes';
 
 type PickRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /** Known cell type names. */
 type KnownCellType = typeof ELEMENT_MODEL_TYPE | typeof LINK_MODEL_TYPE;
 
-interface WithOptionalId {
-  readonly id?: DiaCell.ID;
-}
 interface WithType<Type extends string = KnownCellType> {
   readonly type: Type;
 }
@@ -26,26 +20,8 @@ type WithData<Data = unknown> = unknown extends Data
   ? { readonly data?: unknown }
   : { readonly data: Data };
 
-/**
- * Structural upper bound for any element-like cell.
- *
- * - Extends {@link WithOptionalId} and passes through JointJS `dia.Element.Attributes`
- *   (minus `id`, `type`, `position`, `size`, `angle` which we narrow below).
- * - Narrows `position` / `size` / `angle` to the React-side aliases.
- * - Allows arbitrary extra fields via the index signature so callers can
- *   attach custom data without losing type safety on known fields.
- */
-export interface DiaElementAttributes
-  extends WithOptionalId,
-    WithData,
-    WithType<string>,
-    DiaElement.Attributes {
-  portMap?: Record<string, ElementPort>;
-  portStyle?: Partial<ElementPort>;
-}
-
 /** Element-flavored cell; narrowed when `type === ELEMENT_MODEL_TYPE`. */
-export type ElementRecord<ElementData = unknown> = DiaElementAttributes &
+export type ElementRecord<ElementData = unknown> = ElementJSONInit &
   WithType<typeof ELEMENT_MODEL_TYPE> &
   WithData<ElementData>;
 
@@ -66,27 +42,8 @@ type InternalElementRecord<ElementData = unknown> = PickRequired<
   'id' | 'type' | 'position' | 'size' | 'angle' | 'data'
 >;
 
-/**
- * Structural upper bound for any link-like cell.
- *
- * - Extends {@link WithOptionalId} and passes through JointJS `dia.Link.Attributes`
- *   (minus `id`, `type`, `source`, `target` which we narrow below).
- * - Narrows `source` / `target` to `dia.Link.EndJSON`.
- * - Allows arbitrary extra fields via the index signature so callers can
- *   attach custom data without losing type safety on known fields.
- */
-export interface DiaLinkAttributes
-  extends WithOptionalId,
-    WithType<string>,
-    WithData,
-    DiaLink.Attributes {
-  style?: LinkStyle;
-  labelMap?: Record<string, LinkLabel>;
-  labelStyle?: Partial<LinkLabel>;
-}
-
 /** Link-flavored cell; narrowed when `type === LINK_MODEL_TYPE`. */
-export type LinkRecord<LinkData = unknown> = DiaLinkAttributes &
+export type LinkRecord<LinkData = unknown> = LinkJSONInit &
   WithType<typeof LINK_MODEL_TYPE> &
   WithData<LinkData>;
 
@@ -118,7 +75,11 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
  * type AppCell = CellRecord | MyCustomNode;
  * ```
  */
-export type DiaCellAttributes = DiaElementAttributes | DiaLinkAttributes;
+
+export type DiaElementAttributes = ElementJSONInit;
+export type DiaLinkAttributes = LinkJSONInit;
+
+export type DiaCellAttributes = ElementJSONInit | LinkJSONInit;
 
 /**
  * Discriminated union over the `type` literal:
@@ -142,8 +103,8 @@ export type CellRecord<ElementData = unknown, LinkData = unknown> =
  * @template Link - link record shape
  */
 export type CellUnion<
-  Element extends DiaElementAttributes = DiaElementAttributes,
-  Link extends DiaLinkAttributes = DiaLinkAttributes,
+  Element extends ElementJSONInit = ElementJSONInit,
+  Link extends LinkJSONInit = LinkJSONInit,
 > = Element | Link;
 /**
  * Resolves any input cell shape to its internal store form — the variant with
@@ -179,9 +140,9 @@ export type Computed<T = CellRecord> =
     ? InternalElementRecord<ElementData>
     : T extends LinkRecord<infer LinkData>
       ? InternalLinkRecord<LinkData>
-      : T extends DiaElementAttributes
+      : T extends ElementJSONInit
         ? InternalElementRecord<T['data']>
-        : T extends DiaLinkAttributes
+        : T extends LinkJSONInit
           ? InternalLinkRecord<T['data']>
           : T;
 

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -113,6 +113,14 @@ export type CellRecord<
   | LinkRecord<LinkData, LinkType>;
 
 /**
+ * Loose alias of `CellRecord` — `data` is `unknown`, `type` is any string.
+ * Use when you don't care about React-default `'element'` / `'link'`
+ * discrimination (e.g. `initialCells` arrays mixing built-in shape types,
+ * generic upper bounds in custom hooks).
+ */
+export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
+
+/**
  * Union of the records this `useGraph` instance accepts as cell input —
  * either a typed `Element` or `Link` record. To support custom cell types,
  * extend the union at the call site (e.g. `useGraph<MyElement | MyCustom, MyLink>`).

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -10,11 +10,25 @@ import type { LINK_MODEL_TYPE } from '../models/link-model';
 import type { LinkPresetAttributes } from '../presets/link-attributes';
 import type { ElementPresetAttributes } from '../presets/element-attributes';
 
-/** `dia.Element.JSONInit` (id?, type, visual attrs) + React preset extras. */
-export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttributes {}
+/**
+ * `dia.Element.JSONInit` (id?, type, visual attrs) + React preset extras
+ * + an explicit `data?: unknown` declaration that narrows the
+ * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
+ * the upper-bound layer.
+ */
+export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttributes {
+  data?: unknown;
+}
 
-/** `dia.Link.JSONInit` (id?, type, visual attrs) + React preset extras. */
-export interface LinkJSONInit extends DiaLink.JSONInit, LinkPresetAttributes {}
+/**
+ * `dia.Link.JSONInit` (id?, type, visual attrs) + React preset extras
+ * + an explicit `data?: unknown` declaration that narrows the
+ * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
+ * the upper-bound layer.
+ */
+export interface LinkJSONInit extends DiaLink.JSONInit, LinkPresetAttributes {
+  data?: unknown;
+}
 
 type PickRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /** Known cell type names. */
@@ -28,10 +42,15 @@ type WithData<Data = unknown> = unknown extends Data
   ? { readonly data?: unknown }
   : { readonly data: Data };
 
-/** Element-flavored cell; narrowed when `type === ELEMENT_MODEL_TYPE`. */
-export type ElementRecord<ElementData = unknown> = ElementJSONInit &
-  WithType<typeof ELEMENT_MODEL_TYPE> &
-  WithData<ElementData>;
+/**
+ * Element-flavored cell; default `Type = typeof ELEMENT_MODEL_TYPE` so
+ * `cell.type === 'element'` narrows. Override `Type` (e.g.
+ * `'standard.Rectangle'`) for built-in or custom shapes.
+ */
+export type ElementRecord<
+  ElementData = unknown,
+  Type extends string = typeof ELEMENT_MODEL_TYPE,
+> = ElementJSONInit & WithType<Type> & WithData<ElementData>;
 
 /**
  * Internal element record shape — what the store holds after JointJS /
@@ -50,10 +69,15 @@ type InternalElementRecord<ElementData = unknown> = PickRequired<
   'id' | 'type' | 'position' | 'size' | 'angle' | 'data'
 >;
 
-/** Link-flavored cell; narrowed when `type === LINK_MODEL_TYPE`. */
-export type LinkRecord<LinkData = unknown> = LinkJSONInit &
-  WithType<typeof LINK_MODEL_TYPE> &
-  WithData<LinkData>;
+/**
+ * Link-flavored cell; default `Type = typeof LINK_MODEL_TYPE` so
+ * `cell.type === 'link'` narrows. Override `Type` (e.g. `'standard.Link'`)
+ * for built-in or custom shapes.
+ */
+export type LinkRecord<
+  LinkData = unknown,
+  Type extends string = typeof LINK_MODEL_TYPE,
+> = LinkJSONInit & WithType<Type> & WithData<LinkData>;
 
 /**
  * Internal link record shape — what the store holds after JointJS /
@@ -71,41 +95,29 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
   'id' | 'type' | 'source' | 'target' | 'data'
 >;
 /**
- * Structural upper bound for any cell record. Use as the constraint when
- * defining custom cell types with non-`'element'` / non-`'link'` `type`
- * literals — extend either {@link DiaElementRecord} or {@link DiaLinkRecord}
- * (or this union) and pick your own `type` literal:
- * ```ts
- * interface MyCustomNode extends DiaElementRecord {
- *   readonly type: 'my-node';
- *   readonly data: MyData;
- * }
- * type AppCell = CellRecord | MyCustomNode;
- * ```
+ * Structural upper bound for any cell record from joint-react's perspective —
+ * `ElementJSONInit | LinkJSONInit`. Useful where you need a heterogeneous
+ * loose union (e.g. `initialCells` arrays mixing built-in shape types).
+ *
+ * For custom `type` literals, parametrize the record at the call site:
+ *   `LinkRecord<MyData, 'custom.MyLink'>`
+ *   `ElementRecord<MyData, 'standard.Rectangle'>`
+ * Then build the union: `MyElementRecord | MyLinkRecord`.
  */
-
-export interface DiaElementRecord extends ElementJSONInit {
-  data?: unknown;
-}
-export interface DiaLinkRecord extends LinkJSONInit {
-  data?: unknown;
-}
-
-export type DiaCellRecord = DiaElementRecord | DiaLinkRecord;
+export type CellJSONInit = ElementJSONInit | LinkJSONInit;
 
 /**
- * Discriminated union over the `type` literal:
+ * Discriminated union over the React default `type` literals:
  * - `type === 'element'` → {@link ElementRecord}
  * - `type === 'link'`    → {@link LinkRecord}
  *
- * For custom `type` literals, extend the union explicitly:
- * `CellRecord | MyCustomRecord`. The default union excludes a catch-all
- * "any string" branch on purpose so `if (cell.type === 'element')` narrows
- * correctly.
+ * `cell.type === 'element'` narrows correctly inside arrays / hooks. For
+ * mixed built-in shape arrays with typed data, build the union manually:
+ * `ElementRecord<MyData, 'standard.Rectangle'> | LinkRecord<MyData, 'standard.Link'>`.
  */
 export type CellRecord<ElementData = unknown, LinkData = unknown> =
-  | ElementRecord<ElementData>
-  | LinkRecord<LinkData>;
+  | ElementRecord<ElementData, typeof ELEMENT_MODEL_TYPE>
+  | LinkRecord<LinkData, typeof LINK_MODEL_TYPE>;
 
 /**
  * Union of the records this `useGraph` instance accepts as cell input —

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -121,17 +121,6 @@ export type CellRecord<
 export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
 
 /**
- * Union of the records this `useGraph` instance accepts as cell input —
- * either a typed `Element` or `Link` record. To support custom cell types,
- * extend the union at the call site (e.g. `useGraph<MyElement | MyCustom, MyLink>`).
- * @template Element - element record shape
- * @template Link - link record shape
- */
-export type CellUnion<
-  Element extends ElementJSONInit = ElementJSONInit,
-  Link extends LinkJSONInit = LinkJSONInit,
-> = Element | Link;
-/**
  * Resolves any input cell shape to its internal store form — the variant with
  * framework-populated fields (`id`, `position`, `size`, `angle`, `data` for
  * elements; `id`, `source`, `target`, `data` for links) required.

--- a/packages/joint-react/src/utils/__tests__/get-cell.test.ts
+++ b/packages/joint-react/src/utils/__tests__/get-cell.test.ts
@@ -39,7 +39,6 @@ describe('graph-state-selectors link mapping', () => {
       // User data is in the data field
       expect(link.data).toMatchObject({ key: 'value' });
       // Internal JointJS properties are not mapped back
-      expect(link).not.toHaveProperty('id');
       expect(link).not.toHaveProperty('markup');
       expect(link).not.toHaveProperty('defaultLabel');
     });


### PR DESCRIPTION
## Summary

### `@joint/core` (`packages/joint-core/types/dia.d.ts`)
- Split `Cell.JSON` (output of `toJSON`, requires `id` + `type`) from new `Cell.JSONInit` (constructor input, requires only `type`); same split for `Element` / `Link`.
- Move `id?` from `Cell.Attributes` to `Cell.JSONInit`. `Cell.Attributes` now represents visual canvas attrs only.
- Deprecate `GenericAttributes<T>` in favour of `Attributes<T>` (kept as empty `interface … extends Attributes<T>` to preserve declaration-merging).
- Tighten `Graph.toJSON()` return from `any` → `Graph.JSON`; `Graph.fromJSON(json: Graph.JSON, …)`.
- `Graph.JSON` index signature `any` → `unknown`.
- Index sig key `[key: string]` → `[customAttribute: string]` for clarity.
- Update `shapes-standard.d.ts` to use `Element.Attributes` / `Link.Attributes`.

### `@joint/react` (cell record type system overhaul)

**Public types:**
- Parametrize `ElementRecord<Data, Type>` and `LinkRecord<Data, Type>` over the `type` literal. Defaults (`'element'` / `'link'`) preserve narrowing.
- Parametrize `CellRecord<EData, LData, EType, LType>` — defaults narrow to React literals; override for built-in/custom shapes.
- Add `AnyCellRecord` ergonomic alias = `CellRecord<unknown, unknown, string, string>`.
- Add `Computed<T>` distributive utility for read-side narrowing.

**Renames (breaking):**
- `DiaElementAttributes` → removed (use `ElementRecord<Data, Type>`)
- `DiaLinkAttributes` → removed (use `LinkRecord<Data, Type>`)
- `DiaCellAttributes` → removed (use `CellRecord<...>` or `AnyCellRecord`)
- `DiaElementRecord` / `DiaLinkRecord` / `DiaCellRecord` → removed (intermediate naming dropped)
- `CellJSONInit` → removed (use `AnyCellRecord` or `ElementRecord | LinkRecord`)
- `CellUnion<E, L>` → removed (was tautological alias for `E | L`)

**Preset reorganization:**
- `presets/element-attributes.ts` exports `ElementPresetAttributes` (extras trait: `portMap`, `portStyle`) and `ElementAttributes` (`dia.Element.Attributes` + extras).
- Same pattern for link: `LinkPresetAttributes` + `LinkAttributes`.
- `ElementJSONInit` / `LinkJSONInit` moved to `types/cell.types.ts` (extends `dia.*.JSONInit` + `*PresetAttributes` + `data?: unknown`).
- Preset functions return `dia.Element.Attributes` / `dia.Link.Attributes` (JointJS-native). Loose `data` defaulting moved from preset → mappers (`@joint/react`-only concept).

**Mappers (`state/data-mapping/`):**
- `mapElementToAttributes(element: ElementJSONInit): dia.Element.JSONInit` (was `Cell.JSON`).
- `mapLinkToAttributes(link: LinkJSONInit): dia.Link.JSONInit`.
- `mapCellToAttributes(...): dia.Cell.JSONInit`.
- Fix generic constraint on `mapAttributesToElement<ElementData = unknown>` (was wrongly `extends DiaElementRecord`).
- Fix `data` default — `attributes.data ??= {}` (was `if (!attributes.data)` — broken for scalar payloads `0`/`''`/`false`).
- Drop dead `type` fallback on mappers (TS guarantees presence; routing skips when missing).

**Internal renames:**
- `mergeCellUnion` → `mergeCellRecord` (private to `graph-view.ts`).
- `toCellUnion` → `toCellRecord` (private to `graph-view.ts`).

## Migration guide for downstream

| Old | New |
|---|---|
| `DiaCellAttributes` | `AnyCellRecord` |
| `DiaElementRecord` | `ElementRecord<Data, Type>` (typed) or `ElementJSONInit` (upper bound, internal) |
| `CellJSONInit` | `AnyCellRecord` |
| `LinkJSONInit` (was full input) | `LinkRecord<Data, Type>` (record-layer) or `LinkAttributes` (preset input) |

## Test plan
- [ ] `yarn test-ts` passes (joint-core)
- [ ] `yarn workspace @joint/core run lint` passes
- [ ] `yarn workspace @joint/react run typecheck` passes
- [ ] `yarn workspace @joint/react run lint` passes
- [ ] `yarn workspace @joint/react run jest` (80 suites, 829 tests)
- [ ] `yarn workspace @joint/react run build` (cjs + esm)
- [ ] Verify declaration-merging on `dia.Element.GenericAttributes<T>` still compiles
- [ ] Verify storybook builds and built-in shape stories render

🤖 Generated with [Claude Code](https://claude.com/claude-code)