### PR TITLE
fix(joint-react): register paper features synchronously during render

### DIFF
--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/esm/presets/index.js",
       "require": "./dist/cjs/presets/index.js"
     },
+    "./stories": {
+      "types": "./dist/types/stories.d.ts",
+      "import": "./dist/esm/stories.js",
+      "require": "./dist/cjs/stories.js"
+    },
     "./src/*": "./src/*",
     "./scripts/*": "./scripts/*.ts",
     "./css/*": "./src/css/*"

--- a/packages/joint-react/rollup.config.ts
+++ b/packages/joint-react/rollup.config.ts
@@ -1,7 +1,7 @@
 import { createRollupConfig } from './scripts/create-rollup-config';
 
 export default createRollupConfig({
-  entries: ['src/index.ts', 'src/internal.ts', 'src/presets/index.ts'],
+  entries: ['src/index.ts', 'src/internal.ts', 'src/presets/index.ts', 'src/stories.ts'],
   external: [
     'react',
     'react-dom',

--- a/packages/joint-react/src/hooks/use-create-features.ts
+++ b/packages/joint-react/src/hooks/use-create-features.ts
@@ -277,11 +277,6 @@ export function useCreateFeature<T>(
   const graphCtx = useContext(GraphFeaturesContext);
   const featureContext = (isPaperTarget ? paperCtx : graphCtx) ?? featuresRef.current;
 
-  // Paper-specific: deferred registration when paper is not yet mounted
-  if (isPaperTarget && !featureContext.features.has(id) && !paperStore) {
-    featureContext.features.set(id, onAddFeature);
-  }
-
   const asChildren = !!paperStore;
 
   // Guard: skip onUpdateFeature on initial mount — it must only fire on dependency changes
@@ -289,11 +284,38 @@ export function useCreateFeature<T>(
   // Holds the created feature to survive strict-mode cleanup/re-mount without re-calling onAddFeature
   const featureRef = useRef<Feature | null>(null);
 
+  // Paper-specific registration paths:
+  //  - Paper not yet mounted: defer via `featureContext` so Paper's mount
+  //    effect picks up the feature before it sets `isReady=true`.
+  //  - Paper already mounted (this hook is being called from inside
+  //    `<Paper>`'s subtree): register synchronously during render so the
+  //    feature is visible to sibling consumers reading `paperStore.features`
+  //    in the same commit. Without this, a `<Stencil>` sibling that creates
+  //    its underlying instance in `useImperativeApi`'s onLoad sees an empty
+  //    feature snapshot and never picks up the inside-Paper-registered
+  //    feature.
+  if (isPaperTarget && !featureContext.features.has(id) && !featureRef.current) {
+    if (paperStore) {
+      const feature = createAndRegisterFeature(
+        target,
+        onAddFeature,
+        graphStore,
+        paperStore,
+        true
+      );
+      featureRef.current = feature;
+      registerFeature(target, graphStore, paperStore, feature);
+    } else {
+      featureContext.features.set(id, onAddFeature);
+    }
+  }
+
   // Create and register the feature (fires onAddFeature exactly once)
   useLayoutEffect(() => {
     if (isPaperTarget && !paperStore) return;
 
     // Re-register cached feature if it was removed by strict-mode cleanup
+    // OR if it was already created during render (inside-Paper case).
     if (featureRef.current) {
       registerFeature(target, graphStore, paperStore, featureRef.current);
       setForwardRef(forwardedRef, featureRef.current.instance);

--- a/packages/joint-react/src/hooks/use-create-features.ts
+++ b/packages/joint-react/src/hooks/use-create-features.ts
@@ -257,8 +257,25 @@ export function useCreateFeature<T>(
   const isPaperTarget = target === 'paper';
   const graphStore = useGraphStore();
   // Always called — returns null when no PaperStoreContext is above
-  const paperStore = usePaperStore(OPTIONAL);
+  const contextPaperStore = usePaperStore(OPTIONAL);
   const featuresRef = useRef<FeaturesContext>({ features: new Map() });
+
+  // When the hook is called OUTSIDE a Paper subtree (e.g. PaperScroller wraps
+  // Paper, so PaperScroller sits above PaperStoreContext), the deferred-queue
+  // path creates the feature inside some paperStore but `useCreateFeature`
+  // can't see that paperStore via context. Scan the graphStore's papers map
+  // for the one whose features bag contains our id, so update/load paths
+  // still have a paperStore to operate on.
+  const fallbackPaperStore = useInternalData((snapshot) => {
+    if (!isPaperTarget) return null;
+    if (contextPaperStore) return null;
+    for (const paperId of Object.keys(snapshot.papers)) {
+      const ps = graphStore.getPaperStore(paperId);
+      if (ps?.features[id]) return ps;
+    }
+    return null;
+  });
+  const paperStore = contextPaperStore ?? fallbackPaperStore;
 
   // Subscribe to paper feature changes (resolves paper feature instances)
   const paperFeatureInstance = useInternalData(() => {
@@ -320,6 +337,19 @@ export function useCreateFeature<T>(
       registerFeature(target, graphStore, paperStore, featureRef.current);
       setForwardRef(forwardedRef, featureRef.current.instance);
       return () => unregisterFeature(target, graphStore, paperStore, featureRef.current!.id);
+    }
+
+    // Adopt a feature that was already registered by the deferred-queue path
+    // (e.g. PaperScroller wraps Paper — Paper's mount picks up the deferred
+    // onAddFeature and registers the feature in its paperStore). Without
+    // adoption, the create-effect would call onAddFeature again here once
+    // the fallback paperStore lookup resolves, creating a duplicate
+    // instance.
+    const existing = resolveExistingFeature(target, graphStore, paperStore, id);
+    if (existing) {
+      featureRef.current = existing;
+      setForwardRef(forwardedRef, existing.instance);
+      return;
     }
 
     const feature = createAndRegisterFeature(target, onAddFeature, graphStore, paperStore, asChildren);

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -358,6 +358,13 @@ export function useCreatePortalPaper(
     if (!paperStore) return;
     if (!paper) return;
 
+    // `width` and `height` are managed by `paper.setDimensions()` only —
+    // see the dedicated useEffect below. They must NOT go through
+    // `assignOptions` (that would write `paper.options.width` directly,
+    // bypassing the DOM update and tripping `setDimensions`'s early-exit
+    // guard the next time it's called).
+    const { width: _w, height: _h, ...paperOptionsWithoutDimensions } = paperOptions;
+
     assignOptions(paper.options, {
       defaultLink: defaultLinkCallback,
       validateConnection: validateConnectionCallback,
@@ -366,7 +373,7 @@ export function useCreatePortalPaper(
       validateUnembedding: validateUnembeddingCallback,
       cellVisibility: cellVisibilityCallback,
       interactive: interactiveValue,
-      ...paperOptions,
+      ...paperOptionsWithoutDimensions,
       ...linkRouting,
       ...escapeHatchOptions,
     });
@@ -397,6 +404,20 @@ export function useCreatePortalPaper(
     paperStore,
     transform,
   ]);
+
+  // Sync paper dimensions when the `width` / `height` props on `<Paper>`
+  // change. Going through `setDimensions` (rather than mutating
+  // `paper.options.width/height` directly via assignOptions) keeps DOM CSS
+  // in lockstep with `paper.options` — features like `<PaperScroller>`
+  // that mutate `paper.options.width` via `setDimensions(...)` later won't
+  // hit the early-exit guard because of a stale options value.
+  const paperWidthProp = paperOptions.width;
+  const paperHeightProp = paperOptions.height;
+  useEffect(() => {
+    if (!paper) return;
+    if (paperWidthProp === undefined && paperHeightProp === undefined) return;
+    paper.setDimensions(paperWidthProp, paperHeightProp);
+  }, [paper, paperWidthProp, paperHeightProp]);
 
   const elements = useMemo(() => {
     if (!hasRenderElement) {

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -63,6 +63,7 @@ export { resolvePaper, resolvePaperId } from './types';
 // Constants
 export { ELEMENT_MODEL_TYPE, PORTAL_SELECTOR } from './models/element-model';
 export { LINK_MODEL_TYPE } from './models/link-model';
+export { OPTIONAL } from './types';
 
 // Internal Selectors
 export {

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -85,6 +85,8 @@ export interface LinkRoutingOrthogonalOptions extends BaseLinkOptions {
   readonly cornerRadius?: number;
   /** Minimum distance (in px) the link keeps from elements when routing. */
   readonly margin?: number;
+  /** Minimum length (in px) of each link segment. Default: `margin / 4`. */
+  readonly minPathMargin?: number;
 }
 
 /**

--- a/packages/joint-react/src/stories.ts
+++ b/packages/joint-react/src/stories.ts
@@ -1,0 +1,5 @@
+// @joint/react/stories — Storybook helpers shared across @joint/react and
+// @joint/react-plus story files. Not part of the runtime public API.
+
+export { makeRootDocumentation, makeStory } from './stories/utils/make-story';
+export { getAPILink } from './stories/utils/get-api-documentation-link';


### PR DESCRIPTION
## Summary

Fixes a class of bugs where features registered by hooks called inside a `<Paper>` subtree, or through a wrapping component (e.g. `<PaperScroller>` wrapping `<Paper>`), were not visible to sibling consumers in the same render pass. Adds adjacent fixes that surfaced while validating the main change.

## Changes

### 1. Synchronous render-phase feature registration (`use-create-features.ts`)

Previously `useCreateFeature` deferred registration to `useLayoutEffect`. When a feature-registering component (e.g. `<Snaplines />`) mounted **inside** `<Paper>`, sibling consumers reading `usePaperFeatures(paperId)` in the same render captured an empty snapshot in their `onLoad` / imperative-API closures and never picked up the feature.

Fix: when `target === 'paper'` AND a `paperStore` is reachable AND the feature isn't already cached, register synchronously during render via `createAndRegisterFeature` + `registerFeature`. Mirrors the existing render-phase `featureContext.features.set(...)` path used when no `paperStore` exists. The `featureRef.current` guard in the existing useLayoutEffect re-register branch keeps `onAddFeature` firing exactly once.

### 2. Fallback paperStore lookup (`use-create-features.ts`)

When the hook is called **outside** a Paper subtree (e.g. `<PaperScroller>` wraps `<Paper>`, so the scroller sits above `PaperStoreContext`), `usePaperStore(OPTIONAL)` returns `null`. The deferred-queue path may have already registered the feature inside some `paperStore`, but `useCreateFeature` can't see it via context.

Fix: scan `graphStore.papers` for a paperStore whose `features` bag contains our `id`, fall back to it. Update / load paths now have a `paperStore` to operate on regardless of where the hook is mounted.

### 3. Existing-feature adoption (`use-create-features.ts`)

When the fallback paperStore resolves and a feature was already created via the deferred-queue path, the create-effect would have called `onAddFeature` again, producing duplicates. Adoption path: `resolveExistingFeature(...)` — if a feature with `id` already exists, store it in `featureRef.current` and skip creation.

### 4. `<Paper>` width/height routed through `setDimensions` (`use-create-portal-paper.tsx`)

`width` and `height` were spread into `assignOptions(paper.options, ...)`, which mutated `paper.options.width/height` directly and bypassed the DOM update. Worse, it tripped `setDimensions`'s early-exit guard the next time it ran (e.g. `<PaperScroller>` calling `paper.setDimensions(...)` after the prop change).

Fix: strip `width`/`height` out of the assignOptions spread and add a dedicated `useEffect` that calls `paper.setDimensions(width, height)`. Keeps DOM CSS and `paper.options` in lockstep.

### 5. `minPathMargin` option in `LinkRoutingOrthogonal` preset (`presets/link-routing.ts`)

Surfaces the new `minPathMargin` option from the `rightAngle` router (joint-core #3266) on the orthogonal preset typings.

### 6. New `@joint/react/stories` subpath export

Adds a stories utility entry point so `@joint/react-plus` story files can reuse `makeRootDocumentation`, `makeStory`, and `getAPILink` without reaching into `src/`. Not part of the runtime public API.

- `package.json` — `./stories` exports map entry
- `rollup.config.ts` — `src/stories.ts` added to entries
- `src/stories.ts` (new) — re-exports
- `src/internal.ts` — exposes `OPTIONAL` constant for downstream consumers

## Test plan

- [x] `yarn jest --testPathPatterns="features|use-create"` (43/43 pass)
- [x] `yarn typecheck` (no new errors)
- [ ] Manual: `<Snaplines />` mounted as child of `<Paper>` is detected by sibling `<Stencil />` (validated downstream in joint-plus)
- [ ] Manual: `<PaperScroller>` wrapping `<Paper>` — feature registration / update / unmount paths all hit the same `paperStore`
- [ ] Manual: changing `width`/`height` props on `<Paper>` resizes the DOM, and `<PaperScroller>` `setDimensions` calls afterwards still work