### PR TITLE
types(dia.Paper): fix setDimensions arguments types

### DIFF
--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2117,7 +2117,7 @@ export class Paper extends mvc.View<Graph> {
 
     getModelById(id: Graph.CellRef): Cell;
 
-    setDimensions(width: Paper.Dimension, height: Paper.Dimension, data?: any): void;
+    setDimensions(width?: Paper.Dimension, height?: Paper.Dimension, data?: any): void;
 
     setInteractivity(value: any): void;
 


### PR DESCRIPTION
Fixed setDimension arguments types: both `width` and `height` may be optional.
