### PR TITLE
feat(joint-core): originX/originY options for getFitToContentArea

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2329,6 +2329,10 @@ export const Paper = View.extend({
         const maxWidth = opt.maxWidth || Number.MAX_VALUE;
         const maxHeight = opt.maxHeight || Number.MAX_VALUE;
         const newOrigin = opt.allowNewOrigin;
+        // Shift the grid anchor so the first cell starts at (originX, originY)
+        // in paper-local coords. Default 0 reproduces the prior behavior.
+        const originX = opt.originX || 0;
+        const originY = opt.originY || 0;
 
         const area = ('contentArea' in opt) ? new Rect(opt.contentArea) : this.getContentArea(opt);
         const { sx, sy } = this.scale();
@@ -2336,6 +2340,10 @@ export const Paper = View.extend({
         area.y *= sy;
         area.width *= sx;
         area.height *= sy;
+        // Move the area into the origin-relative coordinate system.
+        // All grid math below then operates relative to (originX, originY).
+        area.x -= originX * sx;
+        area.y -= originY * sy;
 
         let calcWidth = Math.ceil((area.width + area.x) / gridWidth);
         let calcHeight = Math.ceil((area.height + area.y) / gridHeight);
@@ -2371,7 +2379,9 @@ export const Paper = View.extend({
         calcWidth = Math.min(calcWidth, maxWidth);
         calcHeight = Math.min(calcHeight, maxHeight);
 
-        return new Rect(-tx / sx, -ty / sy, calcWidth / sx, calcHeight / sy);
+        // Translate the returned rect back into the absolute coordinate
+        // system (undo the origin-relative shift applied to area.x/y).
+        return new Rect(-tx / sx + originX, -ty / sy + originY, calcWidth / sx, calcHeight / sy);
     },
 
     transformToFitContent: function(opt) {

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -885,6 +885,55 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             });
         });
 
+        QUnit.module('fitToContent() > options > originX / originY', function() {
+
+            QUnit.test('default origin (0, 0) — backward compatible', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    allowNewOrigin: 'any'
+                });
+                // Content spans (-100, -100) → (200, 300). Grid at 0:
+                //   Right edge rounds to 200, Bottom to 300.
+                //   New origin shifts negative content into view.
+                assert.deepEqual(area.toJSON(), { x: -100, y: -100, width: 300, height: 400 });
+            });
+
+            QUnit.test('non-zero origin shifts the grid anchor', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    allowNewOrigin: 'any',
+                    originX: 50,
+                    originY: 25
+                });
+                // Origin shifted by (50, 25): the returned rect's
+                // top-left moves by the same amount; dimensions are
+                // unchanged because content/grid relationship hasn't
+                // changed in origin-relative space.
+                assert.deepEqual(area.toJSON(), { x: -50, y: -75, width: 300, height: 400 });
+            });
+
+            QUnit.test('origin without allowNewOrigin still offsets the rect', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    originX: 50,
+                    originY: 25
+                });
+                // Without allowNewOrigin the negative content is
+                // ignored; rect origin = (originX, originY).
+                assert.deepEqual(area.x, 50);
+                assert.deepEqual(area.y, 25);
+            });
+        });
+
         QUnit.module('fitToContent() > options > useModelGeometry', function() {
 
             [0.5, 1, 2].forEach(function(scale) {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1840,6 +1840,12 @@ export namespace Paper {
         maxHeight?: number;
         useModelGeometry?: boolean;
         contentArea?: BBox;
+        /**
+         * Shifts the grid anchor so the first cell starts at
+         * (`originX`, `originY`) in paper-local coordinates. Default `0`.
+         */
+        originX?: number;
+        originY?: number;
     }
 
     interface EventMap {


### PR DESCRIPTION
## Summary
`paper.getFitToContentArea` (and therefore `paper.fitToContent`) hard-anchored its grid at `(0, 0)`: grid lines landed at `0, gridWidth, 2*gridWidth, …`.

New options `originX?: number`, `originY?: number` (default `0`, paper-local coords) shift the grid anchor so lines land at `originX + n*gridWidth, originY + m*gridHeight` instead. Backward compatible — omitting the opts reproduces today's behavior exactly.

## Implementation
- `Paper.mjs::getFitToContentArea` (`src/dia/Paper.mjs`):
  - Read `opt.originX` / `opt.originY` (default `0`).
  - After scaling `area.x` / `area.y` by `sx` / `sy`, subtract `originX * sx` / `originY * sy` so the existing grid math operates in origin-relative space.
  - Return the rect translated back into absolute coords: `new Rect(-tx/sx + originX, -ty/sy + originY, …)`.
- `Paper.fitToContent` inherits the feature automatically via the existing `opt` forwarding.
- Types updated in `types/dia.d.ts` (`FitToContentOptions`).
- New unit tests cover three combinations: default origin (regression), non-zero origin with `allowNewOrigin: 'any'`, and non-zero origin without `allowNewOrigin`.

## Motivation
Consumers wanting multi-page layouts where the first page starts at a non-zero offset (e.g. a sheet preset that doesn't start at the origin) currently have no way to express it. Used by the companion `@joint/react-plus` PaperScroller refactor that introduces `sheetX` / `sheetY` props.

## Test plan
- [ ] `yarn workspace @joint/core test-client` — confirms new tests pass, no regressions.
- [ ] Backward-compat: existing `fitToContent` / `getFitToContentArea` callers behave identically when `originX` / `originY` are omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
