### PR TITLE
fix(joint-react): propagate `interactive` prop changes via setInteractivity

### DIFF
--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -372,13 +372,14 @@ export function useCreatePortalPaper(
       validateEmbedding: validateEmbeddingCallback,
       validateUnembedding: validateUnembeddingCallback,
       cellVisibility: cellVisibilityCallback,
-      interactive: interactiveValue,
       ...paperOptions,
       ...linkRouting,
       ...escapeHatchOptions,
     });
 
     const { drawGrid, gridSize } = paperOptions;
+
+    paper.setInteractivity(interactiveValue);
 
     if (drawGrid !== undefined) {
       paper.setGrid(drawGrid);

--- a/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useId, useState } from 'react';
+import {
+  type CellRecord,
+  GraphProvider,
+  Paper,
+  useCells,
+  useGraph,
+  usePaperEvents,
+} from '@joint/react';
+import { type dia } from '@joint/core';
+import { BUTTON_CLASSNAME, PAPER_CLASSNAME } from 'storybook-config/theme';
+
+import '../index.css';
+
+// ============================================================================
+// Data
+// ============================================================================
+
+interface NodeData {
+  readonly label: string;
+}
+
+const SIZE = { width: 140, height: 50 };
+
+const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
+  { id: 'a', type: 'element', data: { label: 'Source' }, position: { x: 60, y: 60 }, size: SIZE },
+  { id: 'b', type: 'element', data: { label: 'Process' }, position: { x: 300, y: 60 }, size: SIZE },
+  { id: 'c', type: 'element', data: { label: 'Sink' }, position: { x: 540, y: 60 }, size: SIZE },
+  { id: 'a→b', type: 'link', source: { id: 'a' }, target: { id: 'b' }, style: { targetMarker: 'arrow' } },
+  { id: 'b→c', type: 'link', source: { id: 'b' }, target: { id: 'c' }, style: { targetMarker: 'arrow' } },
+];
+
+// ============================================================================
+// Controllers — different event wiring per mode
+// ============================================================================
+
+interface EditControllerProps {
+  readonly paperId: string;
+  readonly onSelect: (id: string | null) => void;
+}
+
+function EditController({ paperId, onSelect }: Readonly<EditControllerProps>) {
+  usePaperEvents(
+    paperId,
+    {
+      'element:pointerclick': (view: dia.ElementView) => onSelect(String(view.model.id)),
+      'blank:pointerclick': () => onSelect(null),
+    },
+    [onSelect]
+  );
+  return null;
+}
+
+interface ViewControllerProps {
+  readonly paperId: string;
+}
+
+function ViewController({ paperId }: Readonly<ViewControllerProps>) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  usePaperEvents(
+    paperId,
+    {
+      'element:mouseenter': (view: dia.ElementView) => {
+        const data = view.model.attributes.data as NodeData | undefined;
+        setHovered(data?.label ?? String(view.model.id));
+      },
+      'element:mouseleave': () => setHovered(null),
+    },
+    []
+  );
+  if (!hovered) return null;
+  return (
+    <div className="absolute top-2 right-2 px-3 py-1 rounded-md bg-white border border-gray-200 shadow-md text-xs font-medium text-gray-700 pointer-events-none">
+      Hovering: {hovered}
+    </div>
+  );
+}
+
+// ============================================================================
+// Property Editor — visible only in edit mode
+// ============================================================================
+
+interface PropertyEditorProps {
+  readonly selectedId: string | null;
+}
+
+function PropertyEditor({ selectedId }: Readonly<PropertyEditorProps>) {
+  const { setCell } = useGraph<CellRecord<NodeData>>();
+  const label = useCells<CellRecord<NodeData>, string>(
+    selectedId ?? '',
+    (cell) => (cell?.type === 'element' ? cell.data?.label ?? '' : '')
+  );
+
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!selectedId) return;
+      const next = event.target.value;
+      setCell(selectedId, (previous) => {
+        const element = previous as CellRecord<NodeData> & { readonly type: 'element' };
+        return { ...element, data: { ...element.data, label: next } };
+      });
+    },
+    [selectedId, setCell]
+  );
+
+  return (
+    <aside className="w-full bg-white border border-gray-200 rounded-lg shadow-md text-sm text-gray-800 overflow-hidden">
+      <header className="px-4 py-2 border-b border-gray-200 bg-gray-50 font-semibold text-gray-700">
+        Property Editor
+      </header>
+      <div className="p-4">
+        {selectedId ? (
+          <>
+            <label className="block mb-1 text-xs font-medium text-gray-500 uppercase tracking-wide">Label</label>
+            <input
+              value={label}
+              onChange={onChange}
+              className="w-full px-2 py-1.5 rounded border border-gray-300 bg-white text-sm text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+            <div className="mt-3 text-xs text-gray-400">id: {selectedId}</div>
+          </>
+        ) : (
+          <div className="text-gray-400 italic">Click an element to edit it.</div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+function Main() {
+  const paperId = useId();
+  const [editMode, setEditMode] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const toggleMode = useCallback(() => {
+    setEditMode((previous) => {
+      const next = !previous;
+      if (!next) setSelectedId(null);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={toggleMode} className={BUTTON_CLASSNAME}>
+          {editMode ? 'Edit mode' : 'View mode'}
+        </button>
+        <span className="text-xs opacity-70">
+          Toggle to switch <code>interactive</code> live. Edit: drag &amp; click to edit. View: read-only, hover for info.
+        </span>
+      </div>
+
+      <div className="flex">
+        <div className="flex-1 relative">
+          <Paper id={paperId} className={PAPER_CLASSNAME} interactive={editMode} />
+          {editMode ? (
+            <EditController paperId={paperId} onSelect={setSelectedId} />
+          ) : (
+            <ViewController paperId={paperId} />
+          )}
+        </div>
+        {editMode && (
+          <div className="w-64 shrink-0 ml-3">
+            <PropertyEditor selectedId={selectedId} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// App
+// ============================================================================
+
+export default function App() {
+  return (
+    <GraphProvider initialCells={initialCells}>
+      <Main />
+    </GraphProvider>
+  );
+}

--- a/packages/joint-react/src/stories/examples/with-dynamic-interactivity/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-interactivity/story.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../index.css';
+import Code from './code';
+import { makeRootDocumentation } from '../../utils/make-story';
+
+import CodeRaw from './code?raw';
+export type Story = StoryObj<typeof Code>;
+
+export default {
+  title: 'Examples/Dynamic Interactivity',
+  component: Code,
+  tags: ['example'],
+  parameters: makeRootDocumentation({
+    code: CodeRaw,
+  }),
+} satisfies Meta<typeof Code>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary

- After-mount changes to the `<Paper interactive={...}>` prop only mutated `paper.options.interactive` via `assignOptions`. Existing cell views were never notified, so they kept their pre-toggle interactivity until they re-rendered.
- Replace the option-only mutation with a direct `paper.setInteractivity(interactiveValue)` call in the reactive `useEffect`, mirroring the existing `setGrid` / `setGridSize` / `matrix` pattern. `setInteractivity` writes the option **and** fans out to live views (`invoke(this._views, 'setInteractivity', value)`).
- Adds a `Examples/Dynamic Interactivity` story that toggles between edit and view modes — different `usePaperEvents` controllers per mode, plus a property editor pane that only mounts in edit mode.

## Files

- `packages/joint-react/src/hooks/use-create-portal-paper.tsx` — drop `interactive` from `assignOptions`, call `paper.setInteractivity(interactiveValue)` next to the other setters.
- `packages/joint-react/src/stories/examples/with-dynamic-interactivity/{code,story}.tsx` — new story.

## Test plan

- [ ] Open `Examples/Dynamic Interactivity` story
- [ ] Confirm Edit mode → dragging an element works; clicking selects it; editing the label in the side pane updates the diagram live
- [ ] Toggle to View mode → existing elements stop being draggable immediately (no remount); hover shows the badge instead of selection
- [ ] Toggle back to Edit mode → drag and selection work again
- [ ] `yarn jest --testPathPatterns="paper"` — 85/85 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)