### PR TITLE
fix(joint-core): emit `'resize'` when host element CSS size changes

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2321,6 +2321,13 @@ export const Paper = View.extend({
 
         this._elementResizeObserver = new ResizeObserver(() => {
             if (!this.el || !this._elementResizeObserver) return;
+            // Re-read via getComputedSize() rather than the ResizeObserverEntry
+            // payload. `clientWidth/clientHeight` (the non-numeric branch of
+            // getComputedSize) is the padding box minus scrollbar — none of
+            // `contentBoxSize` / `borderBoxSize` / `contentRect` match exactly
+            // once the host has padding or border. Re-reading keeps the size
+            // we emit identical to every other `getComputedSize()` caller; the
+            // cost is one DOM read in a post-layout callback.
             const next = this.getComputedSize();
             const prev = this._lastObservedSize;
             if (prev && prev.width === next.width && prev.height === next.height) return;

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2283,11 +2283,6 @@ export const Paper = View.extend({
         this._setDimensions();
         const computedSize = this.getComputedSize();
         this.trigger('resize', computedSize.width, computedSize.height, data);
-        // Prime the observer dedup state so the next ResizeObserver callback
-        // (triggered by the CSS write inside `_setDimensions`) doesn't re-emit.
-        if (this._elementResizeObserver) {
-            this._lastObservedSize = { width: computedSize.width, height: computedSize.height };
-        }
         // Re-evaluate observer attachment in case the user toggled between
         // explicit-size and CSS-relative modes.
         this._stopObservingElementSize();

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -323,11 +323,6 @@ export const Paper = View.extend({
 
         width: 800,
         height: 600,
-        // Track host-element CSS size changes via ResizeObserver and re-emit
-        // 'resize' so downstream listeners (grid, scroller, rulers) follow
-        // CSS-relative sizing (`null`/`'100%'`/etc.). No-op when both `width`
-        // and `height` are numeric — `setDimensions()` is the size authority then.
-        autoResizePaper: true,
         gridSize: 1,
         // Whether or not to draw the grid lines on the paper's DOM element.
         // e.g drawGrid: true, drawGrid: { color: 'red', thickness: 2 }
@@ -2316,7 +2311,6 @@ export const Paper = View.extend({
 
     _startObservingElementSize: function() {
         if (this._elementResizeObserver) return;
-        if (!this.options.autoResizePaper) return;
         if (typeof ResizeObserver === 'undefined') return;
         const { width, height } = this.options;
         // Explicit-size mode: `setDimensions()` is the sole source of 'resize'.

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -323,6 +323,11 @@ export const Paper = View.extend({
 
         width: 800,
         height: 600,
+        // Track host-element CSS size changes via ResizeObserver and re-emit
+        // 'resize' so downstream listeners (grid, scroller, rulers) follow
+        // CSS-relative sizing (`null`/`'100%'`/etc.). No-op when both `width`
+        // and `height` are numeric — `setDimensions()` is the size authority then.
+        autoResizePaper: true,
         gridSize: 1,
         // Whether or not to draw the grid lines on the paper's DOM element.
         // e.g drawGrid: true, drawGrid: { color: 'red', thickness: 2 }
@@ -668,6 +673,7 @@ export const Paper = View.extend({
         this.cloneOptions();
         this.render();
         this._setDimensions();
+        this._startObservingElementSize();
         this.startListening();
 
         // Mouse wheel events buffer
@@ -2253,6 +2259,7 @@ export const Paper = View.extend({
 
     onRemove: function() {
 
+        this._stopObservingElementSize();
         this.freeze();
         this._updates.disabled = true;
         //clean up all DOM elements/views to prevent memory leaks
@@ -2281,6 +2288,15 @@ export const Paper = View.extend({
         this._setDimensions();
         const computedSize = this.getComputedSize();
         this.trigger('resize', computedSize.width, computedSize.height, data);
+        // Prime the observer dedup state so the next ResizeObserver callback
+        // (triggered by the CSS write inside `_setDimensions`) doesn't re-emit.
+        if (this._elementResizeObserver) {
+            this._lastObservedSize = { width: computedSize.width, height: computedSize.height };
+        }
+        // Re-evaluate observer attachment in case the user toggled between
+        // explicit-size and CSS-relative modes.
+        this._stopObservingElementSize();
+        this._startObservingElementSize();
     },
 
     _setDimensions: function() {
@@ -2293,6 +2309,41 @@ export const Paper = View.extend({
             width: (w === null) ? '' : w,
             height: (h === null) ? '' : h
         });
+    },
+
+    _elementResizeObserver: null,
+    _lastObservedSize: null,
+
+    _startObservingElementSize: function() {
+        if (this._elementResizeObserver) return;
+        if (!this.options.autoResizePaper) return;
+        if (typeof ResizeObserver === 'undefined') return;
+        const { width, height } = this.options;
+        // Explicit-size mode: `setDimensions()` is the sole source of 'resize'.
+        if (isNumber(width) && isNumber(height)) return;
+
+        const size = this.getComputedSize();
+        this._lastObservedSize = { width: size.width, height: size.height };
+
+        this._elementResizeObserver = new ResizeObserver(() => {
+            if (!this.el || !this._elementResizeObserver) return;
+            const next = this.getComputedSize();
+            const prev = this._lastObservedSize;
+            if (prev && prev.width === next.width && prev.height === next.height) return;
+            this._lastObservedSize = { width: next.width, height: next.height };
+            // The host already has its CSS-driven size; do not call
+            // `_setDimensions()` here — writing px values back would clobber CSS.
+            this.trigger('resize', next.width, next.height, { source: 'observer' });
+        });
+        this._elementResizeObserver.observe(this.el);
+    },
+
+    _stopObservingElementSize: function() {
+        if (this._elementResizeObserver) {
+            this._elementResizeObserver.disconnect();
+            this._elementResizeObserver = null;
+        }
+        this._lastObservedSize = null;
     },
 
     // Expand/shrink the paper to fit the content.

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -95,6 +95,100 @@ QUnit.module('paper', function(hooks) {
             resizeCbSpy.resetHistory();
         });
 
+        QUnit.module('autoResizePaper', function() {
+
+            // Waits for the ResizeObserver to deliver its async callback.
+            // Two rAFs cover the spec's "delivered before the next paint" plus
+            // browser implementation slack.
+            function afterResizeObserverDelivery(callback) {
+                requestAnimationFrame(function() {
+                    requestAnimationFrame(callback);
+                });
+            }
+
+            QUnit.test('fires resize when host CSS size changes', function(assert) {
+                var done = assert.async();
+                var paper = this.paper;
+                // '100%' / '100%' makes the paper fill the container while
+                // keeping options non-numeric (i.e. observer-eligible).
+                $container.css({ width: '200px', height: '100px' });
+                paper.setDimensions('100%', '100%');
+                var spy = sinon.spy();
+                paper.on('resize', spy);
+                afterResizeObserverDelivery(function() {
+                    spy.resetHistory();
+                    $container.css({ width: '300px', height: '150px' });
+                    afterResizeObserverDelivery(function() {
+                        assert.ok(spy.called, 'resize fires for host size change');
+                        var args = spy.lastCall.args;
+                        assert.equal(args[0], 300, 'width reports host clientWidth');
+                        assert.equal(args[1], 150, 'height reports host clientHeight');
+                        assert.deepEqual(args[2], { source: 'observer' }, 'data carries observer source');
+                        done();
+                    });
+                });
+            });
+
+            QUnit.test('numeric dimensions skip the observer', function(assert) {
+                var done = assert.async();
+                var paper = this.paper;
+                paper.setDimensions(200, 100);
+                var spy = sinon.spy();
+                paper.on('resize', spy);
+                $container.css({ width: '500px', height: '500px' });
+                afterResizeObserverDelivery(function() {
+                    assert.ok(spy.notCalled, 'host CSS resize ignored in explicit-size mode');
+                    done();
+                });
+            });
+
+            QUnit.test('false disables the observer', function(assert) {
+                var done = assert.async();
+                var paperEl = document.createElement('div');
+                $container.append(paperEl);
+                var paper = new joint.dia.Paper({
+                    el: paperEl,
+                    model: new joint.dia.Graph,
+                    width: '100%',
+                    height: '100%',
+                    autoResizePaper: false
+                });
+                var spy = sinon.spy();
+                paper.on('resize', spy);
+                $container.css({ width: '321px', height: '123px' });
+                afterResizeObserverDelivery(function() {
+                    assert.ok(spy.notCalled, 'observer is not attached when autoResizePaper=false');
+                    paper.remove();
+                    done();
+                });
+            });
+
+            QUnit.test('disconnects on paper.remove()', function(assert) {
+                var paperEl = document.createElement('div');
+                $container.append(paperEl);
+                var paper = new joint.dia.Paper({
+                    el: paperEl,
+                    model: new joint.dia.Graph,
+                    width: '100%',
+                    height: '100%'
+                });
+                assert.ok(paper._elementResizeObserver, 'observer attached on init');
+                var disconnectSpy = sinon.spy(paper._elementResizeObserver, 'disconnect');
+                paper.remove();
+                assert.ok(disconnectSpy.calledOnce, 'disconnect called exactly once on remove');
+                assert.notOk(paper._elementResizeObserver, 'observer reference cleared');
+            });
+
+            QUnit.test('toggling between fixed and CSS-relative dimensions attaches/detaches observer', function(assert) {
+                var paper = this.paper;
+                assert.notOk(paper._elementResizeObserver, 'no observer with default numeric dims');
+                paper.setDimensions('100%', '100%');
+                assert.ok(paper._elementResizeObserver, 'observer attached after switching to CSS-relative');
+                paper.setDimensions(100, 100);
+                assert.notOk(paper._elementResizeObserver, 'observer detached when both dims numeric again');
+            });
+        });
+
     });
 
     QUnit.test('paper.addCell() number of sort()', function(assert) {

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -142,27 +142,6 @@ QUnit.module('paper', function(hooks) {
                 });
             });
 
-            QUnit.test('false disables the observer', function(assert) {
-                var done = assert.async();
-                var paperEl = document.createElement('div');
-                $container.append(paperEl);
-                var paper = new joint.dia.Paper({
-                    el: paperEl,
-                    model: new joint.dia.Graph,
-                    width: '100%',
-                    height: '100%',
-                    autoResizePaper: false
-                });
-                var spy = sinon.spy();
-                paper.on('resize', spy);
-                $container.css({ width: '321px', height: '123px' });
-                afterResizeObserverDelivery(function() {
-                    assert.ok(spy.notCalled, 'observer is not attached when autoResizePaper=false');
-                    paper.remove();
-                    done();
-                });
-            });
-
             QUnit.test('disconnects on paper.remove()', function(assert) {
                 var paperEl = document.createElement('div');
                 $container.append(paperEl);

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1736,6 +1736,7 @@ export namespace Paper {
         // appearance
         width?: Dimension;
         height?: Dimension;
+        autoResizePaper?: boolean;
         drawGrid?: boolean | GridOptions | GridOptions[];
         drawGridSize?: number | null;
         background?: BackgroundOptions;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1736,7 +1736,6 @@ export namespace Paper {
         // appearance
         width?: Dimension;
         height?: Dimension;
-        autoResizePaper?: boolean;
         drawGrid?: boolean | GridOptions | GridOptions[];
         drawGridSize?: number | null;
         background?: BackgroundOptions;


### PR DESCRIPTION
## Summary

`dia.Paper` now attaches a `ResizeObserver` to its host `<div>` and re-emits the existing `'resize'` event when the host's computed size changes. Downstream subscribers — `GridLayerView`, `PaperScroller`, rulers, the React host — automatically follow CSS-relative sizing (`width: null` / `'100%'` / flex / container queries) without manual `setDimensions()` calls.

The observer self-skips when both `options.width` and `options.height` are numeric, so the existing explicit-size contract is preserved. Auto-emitted events carry `{ source: 'observer' }` as the `data` argument so listeners doing expensive work can short-circuit on it.

## Motivation

`Paper#getComputedSize()` already falls back to `el.clientWidth` / `el.clientHeight` when `options.width`/`height` are non-numeric, so CSS-relative sizing *works* — but JointJS never learns when the host actually changes size. The `'resize'` event only fired from explicit `setDimensions()` calls, leaving `GridLayerView` and other size-aware consumers stale on flex resizes, window resizes, sidebar toggles, container queries, etc.

`@joint/react` makes this especially visible: it already forces `width: undefined` / `height: undefined` on every Paper, so every React paper is in CSS-relative mode. This change automatically lights up grid / scroller / rulers across the entire React surface with no other code changes required.

## Flow

```
┌─────────────────────────────┐
│ host <div> CSS size changes │
└─────────────┬───────────────┘
              ▼
   ┌────────────────────────┐        ┌──────────────────────────────┐
   │  ResizeObserver        │──────▶ │ Paper observer callback      │
   │  (owned by Paper)      │        │ • getComputedSize()          │
   └────────────────────────┘        │ • dedup vs _lastObservedSize │
                                     │ • trigger('resize', w, h,    │
                                     │         { source:'observer'})│
                                     └─────────────┬────────────────┘
                                                   ▼
                              GridLayerView.updateGrid /
                              PaperScroller / rulers /
                              user `paper.on('resize', …)`
```

`setDimensions()` keeps its own direct `trigger('resize', …)` for the explicit-API path; both code paths feed `_lastObservedSize`, so observer + setDimensions never double-fire.

## Changes

- `packages/joint-core/src/dia/Paper.mjs`
  - New private methods `_startObservingElementSize` / `_stopObservingElementSize` and dedup state `_lastObservedSize`.
  - Wired into `init()`, `onRemove()`, and `setDimensions()` (re-evaluates observer attachment when toggling between explicit and CSS-relative modes).
- `packages/joint-core/test/jointjs/paper.js` — five new QUnit tests covering fire / skip / teardown / toggle paths.

## Test plan

- [ ] `yarn workspace @joint/core test` — full QUnit + Mocha suite green.
- [ ] `yarn workspace @joint/core run test-ts` — TS pass.
- [ ] Live: in any story with CSS-relative sizing (e.g. `@joint/react` storybook → *Examples / Dynamic Interactivity*), add `drawGrid={{ name: 'dot' }}` and confirm the grid follows window resize and sidebar toggles.
- [ ] Regression: open a demo using numeric `width`/`height`. Confirm no extra `'resize'` events fire on window resize.
- [ ] Cleanup: mount / unmount under React StrictMode and confirm `ResizeObserver#disconnect` is called exactly once per unmount.
