### PR TITLE
feat(joint-core, joint-react): PointerEvents drag survival + capture in React preset

### DIFF
--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -498,6 +498,7 @@ export const CellView = View.extend({
         linkView.notifyPointerdown(evt, x, y);
         linkView.eventData(evt, linkView.startArrowheadMove('target', { whenNotAllowed: 'remove' }));
         this.eventData(evt, { linkView });
+        this.paper.setDragging(evt);
     },
 
     dragLink: function(evt, x, y) {

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -747,6 +747,7 @@ export const ElementView = CellView.extend({
         var view = this.getDelegatedView();
         if (!view || !view.can('elementMove')) return;
 
+        this.paper.setDragging(evt);
         this.eventData(evt, {
             action: DragActions.MOVE,
             delegatedView: view

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1597,6 +1597,8 @@ export const LinkView = CellView.extend({
 
             if (this.isDefaultInteractionPrevented(evt)) return;
 
+            this.paper.setDragging(evt);
+
             var labelNode = evt.currentTarget;
             var labelIdx = parseInt(labelNode.getAttribute('label-idx'), 10);
 
@@ -1637,6 +1639,8 @@ export const LinkView = CellView.extend({
 
         if (!this.can('arrowheadMove')) return;
 
+        this.paper.setDragging(evt);
+
         var arrowheadNode = evt.target;
         var arrowheadType = arrowheadNode.getAttribute('end');
         var data = this.startArrowheadMove(arrowheadType, { ignoreBackwardsCompatibility: true });
@@ -1649,6 +1653,8 @@ export const LinkView = CellView.extend({
         if (this.isDefaultInteractionPrevented(evt)) return;
 
         if (!this.can('linkMove')) return;
+
+        this.paper.setDragging(evt);
 
         this.eventData(evt, {
             action: 'move',

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3820,8 +3820,8 @@ export const Paper = View.extend({
     // Mark `evt` as belonging to an active drag. Called from each
     // action-confirmed drag-start branch (element, link, label, arrowhead,
     // magnet→link). External consumers read via `isDragging(evt)`.
-    setDragging: function(evt, value = true) {
-        this.eventData(evt, { isDragging: !!value });
+    setDragging: function(evt) {
+        this.eventData(evt, { isDragging: true });
     },
 
     // Returns true when a drag has been confirmed for `evt` (see `setDragging`).

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3817,6 +3817,18 @@ export const Paper = View.extend({
         this.delegateDocumentEvents(null, data);
     },
 
+    // Mark `evt` as belonging to an active drag. Called from each
+    // action-confirmed drag-start branch (element, link, label, arrowhead,
+    // magnet→link). External consumers read via `isDragging(evt)`.
+    setDragging: function(evt, value = true) {
+        this.eventData(evt, { isDragging: !!value });
+    },
+
+    // Returns true when a drag has been confirmed for `evt` (see `setDragging`).
+    isDragging: function(evt) {
+        return !!this.eventData(evt).isDragging;
+    },
+
     // Guard the specified event. If the event should be ignored, guard returns `true`.
     // Otherwise, it returns `false`.
     guard: function(evt, view) {

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -256,6 +256,67 @@ QUnit.module('paper', function(hooks) {
             'Paper area returns correct results for scaled and translated viewport.');
     });
 
+    QUnit.module('paper.setDragging() / paper.isDragging()', function() {
+
+        QUnit.test('round-trip via the public API', function(assert) {
+            const data = {};
+            const evt = { target: this.paper.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt), 'false on a fresh event');
+            this.paper.setDragging(evt);
+            assert.ok(this.paper.isDragging(evt), 'true after setDragging');
+        });
+
+        QUnit.test('isDragging is false until the drag-start gate passes', function(assert) {
+            const data = {};
+            const evt = { target: this.paper.el, type: 'mousedown', data: data };
+            // No drag-start has been called; data bag exists but lacks the flag.
+            assert.notOk(this.paper.isDragging(evt));
+            // A different event keeps a clean bag.
+            const data2 = {};
+            const evt2 = { target: this.paper.el, type: 'mousedown', data: data2 };
+            assert.notOk(this.paper.isDragging(evt2));
+        });
+
+        QUnit.test('ElementView.dragStart flips isDragging after can(\'elementMove\')', function(assert) {
+            const el = new joint.shapes.standard.Rectangle();
+            el.resize(100, 100);
+            el.addTo(this.graph);
+            const view = el.findView(this.paper);
+            const data = {};
+            const evt = { target: view.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt));
+            view.pointerdown(evt, 50, 50);
+            assert.ok(this.paper.isDragging(evt), 'set after element pointerdown');
+        });
+
+        QUnit.test('isDragging stays false when elementMove is denied', function(assert) {
+            this.paper.options.interactive = { elementMove: false };
+            const el = new joint.shapes.standard.Rectangle();
+            el.resize(100, 100);
+            el.addTo(this.graph);
+            const view = el.findView(this.paper);
+            const data = {};
+            const evt = { target: view.el, type: 'mousedown', data: data };
+            view.pointerdown(evt, 50, 50);
+            assert.notOk(this.paper.isDragging(evt), 'not set when can(elementMove) returns false');
+        });
+
+        QUnit.test('LinkView.dragStart flips isDragging after can(\'linkMove\')', function(assert) {
+            const source = new joint.shapes.standard.Rectangle().resize(40, 40).position(0, 0).addTo(this.graph);
+            const target = new joint.shapes.standard.Rectangle().resize(40, 40).position(200, 200).addTo(this.graph);
+            const link = new joint.shapes.standard.Link({
+                source: { id: source.id },
+                target: { id: target.id }
+            }).addTo(this.graph);
+            const linkView = link.findView(this.paper);
+            const data = {};
+            const evt = { target: linkView.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt));
+            linkView.pointerdown(evt, 100, 100);
+            assert.ok(this.paper.isDragging(evt), 'set after link pointerdown');
+        });
+    });
+
     QUnit.module('paper.getRestrictedArea()', function() {
 
         QUnit.test('function', function(assert) {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2046,6 +2046,10 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
+    setDragging(evt: dia.Event, value?: boolean): void;
+
+    isDragging(evt: dia.Event): boolean;
+
     getComputedSize(): Size;
 
     getArea(): g.Rect;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2046,7 +2046,7 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
-    setDragging(evt: dia.Event, value?: boolean): void;
+    setDragging(evt: dia.Event): void;
 
     isDragging(evt: dia.Event): boolean;
 

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2046,9 +2046,9 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
-    setDragging(evt: dia.Event): void;
+    setDragging(evt: Event): void;
 
-    isDragging(evt: dia.Event): boolean;
+    isDragging(evt: Event): boolean;
 
     getComputedSize(): Size;
 

--- a/packages/joint-react/src/css/styles.css
+++ b/packages/joint-react/src/css/styles.css
@@ -34,6 +34,14 @@
     --jj-shape-border-color: #8A98AD;
     --jj-shape-surface-color: #EFF3F6;
     --jj-paper-color: #eaf0f4;
+    /* Cursor for hover state on draggable elements */
+    --jj-drag-cursor: move;
+    /* Cursor for elements and link labels while dragging */
+    --jj-dragging-cursor: move;
+    /* Cursor for ports when they are active (ready to be dragged) */
+    --jj-port-drag-cursor: crosshair;
+    /* Cursor for ports while dragging */
+    --jj-port-dragging-cursor: crosshair;
 
     /* ── Paper ───────────────────────────────────────────────────────────── */
     --jj-paper-border-color: var(--jj-color-border-subtle);
@@ -146,7 +154,11 @@
   }
 
   .jj-port-body[magnet="active"] {
-    cursor: crosshair;
+    cursor: var(--jj-port-drag-cursor);
+   }
+
+  .jj-is-dragging .jj-port-body[magnet="active"] {
+    cursor: var(--jj-port-dragging-cursor);
    }
 
   .jj-port-body[magnet="active"]:hover {
@@ -187,6 +199,11 @@
     padding: var(--jj-box-padding);
     font-size: var(--jj-box-font-size);
     font-family: var(--jj-box-font-family);
+    cursor: var(--jj-drag-cursor);
+  }
+
+  .jj-is-dragging .jj-box {
+    cursor: var(--jj-dragging-cursor);
   }
 
   .jj-is-available .jj-box {

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -3,6 +3,41 @@ import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
 
+// ---------------------------------------------------------------------------
+// PointerEvents migration
+// ---------------------------------------------------------------------------
+// Joint-core's `events` hash stays unchanged — `mousedown` / `touchstart` still
+// drive `pointerdown`. Only the drag-survival layer (`documentEvents`) switches
+// to real pointer events, and the first `pointermove` of a drag acquires
+// `setPointerCapture` on `paper.el` so the drag stays locked to the host.
+const POINTER_DOCUMENT_EVENTS: Record<string, string> = {
+  pointermove: 'pointermove',
+  pointerup: 'pointerup',
+  pointercancel: 'pointerup',
+};
+
+type ProtectedPaperPrototype = {
+  readonly pointermove: (event: dia.Event) => void;
+  readonly pointerup: (event: dia.Event) => void;
+  readonly startListening: () => void;
+};
+
+const protectedProto = dia.Paper.prototype as unknown as ProtectedPaperPrototype;
+
+/**
+ * Resolve the underlying DOM PointerEvent's `pointerId` from a (possibly
+ * jQuery-wrapped) event. Returns `null` when the event isn't a PointerEvent
+ * (e.g. legacy fallbacks where capture isn't applicable).
+ * @param event - The event passed to a paper handler.
+ */
+function getPointerId(event: dia.Event): number | null {
+  const direct = (event as unknown as { pointerId?: unknown }).pointerId;
+  if (typeof direct === 'number') return direct;
+  const original = (event as unknown as { originalEvent?: { pointerId?: unknown } }).originalEvent;
+  const fromOriginal = original?.pointerId;
+  return typeof fromOriginal === 'number' ? fromOriginal : null;
+}
+
 // Inject CSS custom property into all built-in grid pattern colors
 // so they respond to --jj-paper-grid-color.
 // @ts-expect-error Accessing protected member to set default grid pattern colors
@@ -48,6 +83,13 @@ export const DEFAULT_HIGHLIGHTING = {
   },
 };
 
+/**
+ * Default link view factory. Uses the preset LinkView,
+ * unless a specific namespaced view constructor exists.
+ * @param _ - The link model for which a view is being constructed.
+ * @param NSViewCtor - The namespaced view constructor, if it exists. Passed by dia.Paper
+ * @returns A dia.LinkView constructor to use for link views on this paper.
+ */
 const linkView = (
   _: dia.Link,
   NSViewCtor: typeof dia.LinkView | null
@@ -61,6 +103,75 @@ const linkView = (
 export const Paper = dia.Paper.extend({
   className: 'jj-paper joint-paper',
   classNamePrefix: '',
+  documentEvents: POINTER_DOCUMENT_EVENTS,
+
+  /**
+   * Add listeners that record the original pointerdown target into the
+   * drag's `evt.data`, so `pointermove` can use it as a `setPointerCapture`
+   * target. Three sources cover every drag-start path: `cell:pointerdown`
+   * (element / link / label), `element:magnet:pointerdown` (magnet drag),
+   * `blank:pointerdown` (drag from empty paper area).
+   */
+  startListening(this: dia.Paper) {
+    protectedProto.startListening.call(this);
+    const storePointerTarget = (_: unknown, event: dia.Event) => {
+      // On passive magnets `element:magnet:pointerdown` fires before `cell:pointerdown`;
+      // keep the magnet's target (more specific) and let the cell event bail.
+      if (this.eventData(event).pointerTarget) return;
+      this.eventData(event, { pointerTarget: event.target });
+    };
+    this.on({
+      'cell:pointerdown': storePointerTarget,
+      'element:magnet:pointerdown': storePointerTarget,
+    });
+  },
+
+  /**
+   * Capture the pointer once a drag is confirmed by joint-core (the
+   * `isDragging` flag is set by every action-confirmed branch — element,
+   * link, label, arrowhead, magnet→link). Idempotent: once `captureTarget`
+   * is set in the drag's `evt.data`, subsequent pointermoves skip.
+   * @param event - The pointermove event from document delegation.
+   */
+  pointermove(this: dia.Paper, event: dia.Event) {
+    protectedProto.pointermove.call(this, event);
+    const data = this.eventData(event);
+    if (data.captureTarget) return;
+    if (!this.isDragging(event)) return;
+    const pointerId = getPointerId(event);
+    if (pointerId === null) return;
+    const target = data.pointerTarget instanceof Element ? data.pointerTarget : this.el;
+    this.el.classList.add('jj-is-dragging');
+    try {
+      target.setPointerCapture(pointerId);
+      this.eventData(event, { captureTarget: target });
+    } catch {
+      // Capture can fail if the element isn't connected — safe to ignore;
+      // the drag still works via `documentEvents`.
+    }
+  },
+
+  /**
+   * Run the upstream pointerup handler, then release capture. Also runs on
+   * `pointercancel` (mapped to the same method via the events hash) so
+   * OS-stolen pointers don't leave listeners attached.
+   * @param event - The pointerup or pointercancel event.
+   */
+  pointerup(this: dia.Paper, event: dia.Event) {
+    const pointerId = getPointerId(event);
+    const captureTarget = this.eventData(event).captureTarget as Element | undefined;
+    protectedProto.pointerup.call(this, event);
+    if (!captureTarget || pointerId === null) return;
+    this.el.classList.remove('jj-is-dragging');
+    if (captureTarget.hasPointerCapture?.(pointerId)) {
+      try {
+        captureTarget.releasePointerCapture(pointerId);
+      } catch {
+        // Ignored — release can fail if the element was already detached.
+      }
+    }
+  },
+
   options: {
     ...dia.Paper.prototype.options,
     // Required for React integration features:


### PR DESCRIPTION
## Summary

- **joint-core**: new public `Paper#setDragging(evt, value=true)` / `Paper#isDragging(evt)` API. Joint-core itself sets the flag from every action-confirmed drag-start branch (element / link / label / arrowhead / magnet→link). External consumers can ask "is a drag actually happening?" without poking view eventData internals.
- **joint-react**: paper drag-survival migrates to real `PointerEvent` (`pointermove` / `pointerup` / `pointercancel`) and acquires `setPointerCapture` on the original pointerdown target on the first `pointermove` of a confirmed drag. Drags now survive the pointer leaving the host.

Joint-core's `events` hash is unchanged — `mousedown` / `touchstart` still drive `pointerdown`. Only `documentEvents` (the drag-survival layer) is swapped to pointer events in the React preset.

## joint-core changes

- `dia/Paper.mjs` — add `setDragging` / `isDragging` near `delegateDragEvents`. No callers outside the new API methods.
- `dia/ElementView.mjs` — `dragStart` calls `paper.setDragging(evt)` after `can('elementMove')` passes.
- `dia/LinkView.mjs` — `dragStart`, `dragLabelStart`, `dragArrowheadStart` all call `paper.setDragging(evt)` inside their respective `can(\u2026)` gates.
- `dia/CellView.mjs` — `dragLinkStart` calls `paper.setDragging(evt)` once the magnet\u2192link transition actually creates the link (covers the magnet path that defers via `magnetThreshold='onleave'`).
- `types/dia.d.ts` — declare both methods.

## joint-react changes

`packages/joint-react/src/presets/paper.ts`:

- `documentEvents` overridden to `{ pointermove, pointerup, pointercancel }`.
- `startListening` extended to record `pointerTarget` on `cell:pointerdown` + `element:magnet:pointerdown` (magnet event fires first on passive magnets; guard prevents the later cell event from overwriting).
- `pointermove` override: when `paper.isDragging(event)` passes and `captureTarget` not yet set, calls `setPointerCapture(pointerId)` on `data.pointerTarget` (falls back to `paper.el`) and stashes `captureTarget`. Adds `jj-is-dragging` class to `paper.el`.
- `pointerup` override: releases capture on `captureTarget`, clears `jj-is-dragging` class.

`packages/joint-react/src/css/styles.css`:

- New CSS vars `--jj-drag-cursor`, `--jj-dragging-cursor`, `--jj-port-drag-cursor`, `--jj-port-dragging-cursor`.
- `.jj-is-dragging .jj-box`, `.jj-is-dragging .jj-port-body[magnet=\"active\"]` cursor rules gated on the dragging class.

## Test plan

- [ ] `yarn workspace @joint/react jest --testPathPatterns=\"paper\"` — 85/85 pass.
- [ ] `yarn workspace @joint/react typecheck` clean (modulo the pre-existing `code-controlled-mode-reset-bug.tsx` height regression already on dev).
- [ ] Live smoke (storybook):
  - Drag an element — captured, drag follows the pointer when it leaves paper bounds, drops at release point.
  - Drag a link / link label — same behavior.
  - Drag a magnet → creates a link — capture acquired after the magnet threshold; arrowhead follows the pointer beyond paper bounds.
  - Right-click on cells/blank — no drag, contextmenu fires normally.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)