### PR TITLE
feat(joint-core): add `Paper#setDragging` / `Paper#isDragging` API

### DIFF
--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -498,6 +498,7 @@ export const CellView = View.extend({
         linkView.notifyPointerdown(evt, x, y);
         linkView.eventData(evt, linkView.startArrowheadMove('target', { whenNotAllowed: 'remove' }));
         this.eventData(evt, { linkView });
+        this.paper.setDragging(evt);
     },
 
     dragLink: function(evt, x, y) {

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -747,6 +747,7 @@ export const ElementView = CellView.extend({
         var view = this.getDelegatedView();
         if (!view || !view.can('elementMove')) return;
 
+        this.paper.setDragging(evt);
         this.eventData(evt, {
             action: DragActions.MOVE,
             delegatedView: view

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1597,6 +1597,8 @@ export const LinkView = CellView.extend({
 
             if (this.isDefaultInteractionPrevented(evt)) return;
 
+            this.paper.setDragging(evt);
+
             var labelNode = evt.currentTarget;
             var labelIdx = parseInt(labelNode.getAttribute('label-idx'), 10);
 
@@ -1637,6 +1639,8 @@ export const LinkView = CellView.extend({
 
         if (!this.can('arrowheadMove')) return;
 
+        this.paper.setDragging(evt);
+
         var arrowheadNode = evt.target;
         var arrowheadType = arrowheadNode.getAttribute('end');
         var data = this.startArrowheadMove(arrowheadType, { ignoreBackwardsCompatibility: true });
@@ -1649,6 +1653,8 @@ export const LinkView = CellView.extend({
         if (this.isDefaultInteractionPrevented(evt)) return;
 
         if (!this.can('linkMove')) return;
+
+        this.paper.setDragging(evt);
 
         this.eventData(evt, {
             action: 'move',

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3807,6 +3807,18 @@ export const Paper = View.extend({
         this.delegateDocumentEvents(null, data);
     },
 
+    // Mark `evt` as belonging to an active drag. Called from each
+    // action-confirmed drag-start branch (element, link, label, arrowhead,
+    // magnet→link). External consumers read via `isDragging(evt)`.
+    setDragging: function(evt, value = true) {
+        this.eventData(evt, { isDragging: !!value });
+    },
+
+    // Returns true when a drag has been confirmed for `evt` (see `setDragging`).
+    isDragging: function(evt) {
+        return !!this.eventData(evt).isDragging;
+    },
+
     // Guard the specified event. If the event should be ignored, guard returns `true`.
     // Otherwise, it returns `false`.
     guard: function(evt, view) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3810,8 +3810,8 @@ export const Paper = View.extend({
     // Mark `evt` as belonging to an active drag. Called from each
     // action-confirmed drag-start branch (element, link, label, arrowhead,
     // magnet→link). External consumers read via `isDragging(evt)`.
-    setDragging: function(evt, value = true) {
-        this.eventData(evt, { isDragging: !!value });
+    setDragging: function(evt) {
+        this.eventData(evt, { isDragging: true });
     },
 
     // Returns true when a drag has been confirmed for `evt` (see `setDragging`).

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -256,6 +256,67 @@ QUnit.module('paper', function(hooks) {
             'Paper area returns correct results for scaled and translated viewport.');
     });
 
+    QUnit.module('paper.setDragging() / paper.isDragging()', function() {
+
+        QUnit.test('round-trip via the public API', function(assert) {
+            const data = {};
+            const evt = { target: this.paper.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt), 'false on a fresh event');
+            this.paper.setDragging(evt);
+            assert.ok(this.paper.isDragging(evt), 'true after setDragging');
+        });
+
+        QUnit.test('isDragging is false until the drag-start gate passes', function(assert) {
+            const data = {};
+            const evt = { target: this.paper.el, type: 'mousedown', data: data };
+            // No drag-start has been called; data bag exists but lacks the flag.
+            assert.notOk(this.paper.isDragging(evt));
+            // A different event keeps a clean bag.
+            const data2 = {};
+            const evt2 = { target: this.paper.el, type: 'mousedown', data: data2 };
+            assert.notOk(this.paper.isDragging(evt2));
+        });
+
+        QUnit.test('ElementView.dragStart flips isDragging after can(\'elementMove\')', function(assert) {
+            const el = new joint.shapes.standard.Rectangle();
+            el.resize(100, 100);
+            el.addTo(this.graph);
+            const view = el.findView(this.paper);
+            const data = {};
+            const evt = { target: view.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt));
+            view.pointerdown(evt, 50, 50);
+            assert.ok(this.paper.isDragging(evt), 'set after element pointerdown');
+        });
+
+        QUnit.test('isDragging stays false when elementMove is denied', function(assert) {
+            this.paper.options.interactive = { elementMove: false };
+            const el = new joint.shapes.standard.Rectangle();
+            el.resize(100, 100);
+            el.addTo(this.graph);
+            const view = el.findView(this.paper);
+            const data = {};
+            const evt = { target: view.el, type: 'mousedown', data: data };
+            view.pointerdown(evt, 50, 50);
+            assert.notOk(this.paper.isDragging(evt), 'not set when can(elementMove) returns false');
+        });
+
+        QUnit.test('LinkView.dragStart flips isDragging after can(\'linkMove\')', function(assert) {
+            const source = new joint.shapes.standard.Rectangle().resize(40, 40).position(0, 0).addTo(this.graph);
+            const target = new joint.shapes.standard.Rectangle().resize(40, 40).position(200, 200).addTo(this.graph);
+            const link = new joint.shapes.standard.Link({
+                source: { id: source.id },
+                target: { id: target.id }
+            }).addTo(this.graph);
+            const linkView = link.findView(this.paper);
+            const data = {};
+            const evt = { target: linkView.el, type: 'mousedown', data: data };
+            assert.notOk(this.paper.isDragging(evt));
+            linkView.pointerdown(evt, 100, 100);
+            assert.ok(this.paper.isDragging(evt), 'set after link pointerdown');
+        });
+    });
+
     QUnit.module('paper.getRestrictedArea()', function() {
 
         QUnit.test('function', function(assert) {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2040,6 +2040,10 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
+    setDragging(evt: dia.Event, value?: boolean): void;
+
+    isDragging(evt: dia.Event): boolean;
+
     getComputedSize(): Size;
 
     getArea(): g.Rect;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2040,7 +2040,7 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
-    setDragging(evt: dia.Event, value?: boolean): void;
+    setDragging(evt: dia.Event): void;
 
     isDragging(evt: dia.Event): boolean;
 

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2040,9 +2040,9 @@ export class Paper extends mvc.View<Graph> {
 
     isDefined(defId: string): boolean;
 
-    setDragging(evt: dia.Event): void;
+    setDragging(evt: Event): void;
 
-    isDragging(evt: dia.Event): boolean;
+    isDragging(evt: Event): boolean;
 
     getComputedSize(): Size;
 


### PR DESCRIPTION
## Summary

Adds two public methods on `dia.Paper` for marking and reading the active-drag state on an event:

- `paper.setDragging(evt, value = true)` — stash the drag flag on the event's per-paper `eventData` bag (defaults to `true`).
- `paper.isDragging(evt)` — boolean read of the same flag.

Joint-core itself sets the flag from every action-confirmed drag-start branch:

| File | Method | Gate |
|---|---|---|
| `dia/ElementView.mjs` | `dragStart` | after `can('elementMove')` |
| `dia/LinkView.mjs` | `dragStart` | after `can('linkMove')` |
| `dia/LinkView.mjs` | `dragLabelStart` | inside `can('labelMove')` block |
| `dia/LinkView.mjs` | `dragArrowheadStart` | after `can('arrowheadMove')` |
| `dia/CellView.mjs` | `dragLinkStart` | when the magnet→link transition actually creates the link |

The magnet path notably waits until `CellView.dragLinkStart` runs (which may be deferred under `magnetThreshold: 'onleave'`), so a magnet pointerdown alone doesn't trip the flag — only when the link actually starts.

## Motivation

External consumers (plugins, embedding hosts) currently have to inspect view-level `eventData` (`action`, `linkView`, etc) to determine whether a drag is actually in progress, which means leaking joint-core internals across the API boundary. With these two methods, the question "is a drag actually happening?" becomes a one-call public API.

Use cases:

- Capture-on-drag (`setPointerCapture` only after a drag is confirmed — i.e. not on every pointerdown).
- Drag-aware UI overlays / cursors that need to react only to confirmed drags.
- Plugins that listen on `pointermove` and want to gate their work on real drag state.

A follow-up PR in `@joint/react` uses this API to drive `setPointerCapture` + a `jj-is-dragging` CSS class.

## Changes

- `packages/joint-core/src/dia/Paper.mjs` — define `setDragging` and `isDragging`.
- `packages/joint-core/src/dia/ElementView.mjs` — call `paper.setDragging(evt)` after `can('elementMove')`.
- `packages/joint-core/src/dia/LinkView.mjs` — call `paper.setDragging(evt)` in `dragStart`, `dragLabelStart`, `dragArrowheadStart`.
- `packages/joint-core/src/dia/CellView.mjs` — call `paper.setDragging(evt)` at the end of `dragLinkStart`.
- `packages/joint-core/types/dia.d.ts` — declarations for both methods.

## Test plan

- [ ] `yarn workspace @joint/core test` — full QUnit suite (server + client).
- [ ] `grunt test:server --file=test/jointjs/paper.js` — Paper-specific.
- [ ] Manual: in any demo, attach `paper.on('pointermove', evt => console.log(paper.isDragging(evt)))` — expect `true` only after a drag-start gate has passed (drag the element / link / label / arrowhead, or magnet-to-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)