### PR TITLE
feat(joint-react): autoSizeOrigin on GraphProvider + identityTransform fix

### DIFF
--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -3,6 +3,7 @@ import React, { useLayoutEffect, type Dispatch, type SetStateAction } from 'reac
 import { useImperativeApi } from '../../hooks/use-imperative-api';
 import { GraphStoreContext } from '../../context';
 import { GraphStore } from '../../store';
+import type { AutoSizeOrigin } from '../../store/graph-store';
 import type { IncrementalCellsChange } from '../../store/graph-view';
 import type { ElementJSONInit, LinkJSONInit } from '../../types/cell.types';
 
@@ -36,6 +37,17 @@ interface GraphProviderBaseProps<
   readonly cellNamespace?: unknown;
   /** Custom cell model used as the base class for all cells in the graph. */
   readonly cellModel?: typeof dia.Cell;
+  /**
+   * Reference point that stays fixed when an auto-sized element's measured
+   * size changes (via `useMeasureNode`). Mirrors CSS `transform-origin` semantics.
+   * - `'top-left'` (default): element grows right/down.
+   * - `'center'`: element grows symmetrically — its geometric center stays put.
+   *
+   * Only affects measurement-driven writes. Manual `cell.resize()`, interactive
+   * resize tools, and direct `cell.set('size', ...)` calls are unaffected.
+   * @default 'top-left'
+   */
+  readonly autoSizeOrigin?: AutoSizeOrigin;
   /** Pre-built `GraphStore` instance. When provided, GraphProvider does not own its lifecycle. */
   readonly store?: GraphStore<Element, Link>;
   /**
@@ -129,6 +141,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
     graph,
     cellNamespace,
     cellModel,
+    autoSizeOrigin,
   } = props;
 
   const cellsProperty = 'cells' in props ? props.cells : undefined;
@@ -153,6 +166,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
                 cells: cellsProperty,
                 onCellsChange,
                 onIncrementalCellsChange,
+                autoSizeOrigin,
               })
             : new GraphStore<ElementJSONInit, LinkJSONInit>({
                 graph,
@@ -161,6 +175,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
                 initialCells,
                 onCellsChange,
                 onIncrementalCellsChange,
+                autoSizeOrigin,
               }));
 
         return {

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -4,6 +4,7 @@
 // Components
 export { GraphProvider } from './components/graph/graph-provider';
 export type { GraphProviderProps as GraphProps } from './components/graph/graph-provider';
+export type { AutoSizeOrigin } from './store/graph-store';
 export { Paper } from './components/paper/paper';
 export type {
   PaperProps,

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -29,7 +29,7 @@ export type ElementLayoutOptionalXY = Pick<ElementLayout, 'width' | 'height'> &
  */
 export interface TransformOptions extends Required<ElementLayout> {
   /** The JointJS element instance */
-  readonly element: dia.Element;
+  readonly model: dia.Element;
   readonly id: CellId;
 }
 
@@ -66,10 +66,6 @@ interface ObservedElement {
   isMeasured: boolean;
 }
 
-function identityTransform(options: TransformOptions): ElementLayoutOptionalXY {
-  const { width, height } = options;
-  return { width, height };
-}
 /**
  * Options for creating an elements size observer.
  */
@@ -79,7 +75,7 @@ interface Options {
   /** Function to get the current size of a cell from the graph */
   readonly getCellTransform: (
     id: CellId
-  ) => ElementLayoutOptionalXY & { element: dia.Element; angle: number };
+  ) => ElementLayoutOptionalXY & { model: dia.Element; angle: number };
   /** Function to get the elements from the container */
   readonly getElements: () => Map<CellId, ElementJSONInit>;
   /** Callback function called when a batch of elements needs to be updated */
@@ -146,12 +142,12 @@ function processSizeChange(options: ProcessSizeChangeOptions): boolean {
     elements,
     mutableLayouts,
   } = options;
-  const currentCellTransform = getCellTransform(observedElement.id);
 
   if (!elements.has(observedElement.id)) {
     return false;
   }
 
+  const currentCellTransform = getCellTransform(observedElement.id);
   if (
     Math.abs(currentCellTransform.width - measuredWidth) <= EPSILON &&
     Math.abs(currentCellTransform.height - measuredHeight) <= EPSILON
@@ -169,18 +165,26 @@ function processSizeChange(options: ProcessSizeChangeOptions): boolean {
   observedElement.lastWidth = measuredWidth;
   observedElement.lastHeight = measuredHeight;
 
-  const { x, y, angle, element: cell } = currentCellTransform;
-  const transform = observedElement.transform ?? identityTransform;
-
-  mutableLayouts[observedElement.id] = transform({
-    x: x ?? 0,
-    y: y ?? 0,
-    angle: angle ?? 0,
-    element: cell,
-    width: measuredWidth,
-    height: measuredHeight,
-    id: observedElement.id,
-  });
+  const { transform } = observedElement;
+  if (transform) {
+    // Provide the full current transform to the callback
+    const { x = 0, y = 0, angle = 0, model } = currentCellTransform;
+    mutableLayouts[observedElement.id] = transform({
+      x,
+      y,
+      angle,
+      model,
+      width: measuredWidth,
+      height: measuredHeight,
+      id: observedElement.id,
+    });
+  } else {
+    // No transform provided, use measured size directly. Position is left unchanged.
+    mutableLayouts[observedElement.id] = {
+      width: measuredWidth,
+      height: measuredHeight,
+    };
+  }
 
   return true;
 }

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -66,9 +66,9 @@ interface ObservedElement {
   isMeasured: boolean;
 }
 
-function identityTransform(options: TransformOptions) {
-  const { width, height, x, y } = options;
-  return { width, height, x, y };
+function identityTransform(options: TransformOptions): ElementLayoutOptionalXY {
+  const { width, height } = options;
+  return { width, height };
 }
 /**
  * Options for creating an elements size observer.

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -164,12 +164,12 @@ export function graphChanges(options: Options) {
     (
       cell: dia.Cell,
       newSize: { width: number; height: number },
-      opt: { fromMeasure?: boolean } = {}
+      opt: { autoSize?: boolean } = {}
     ) => {
       if (!onElementsSizeChange) return;
-      // Writes from the ResizeObserver pipeline are marked `fromMeasure` —
+      // Writes from the ResizeObserver pipeline are marked `autoSize` —
       // skip them so the observer never reacts to its own output.
-      if (opt.fromMeasure) return;
+      if (opt.autoSize) return;
       onElementsSizeChange(cell.id, newSize);
     }
   );

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -227,16 +227,13 @@ export class GraphStore<
         this.graph.stopBatch('auto-size');
       },
       getCellTransform: (id) => {
-        const cell = this.graph.getCell(id);
-        if (!cell?.isElement()) throw new Error('Cell not valid');
-        const size = cell.size();
-        const position = cell.get('position');
+        const model = this.graph.getCell(id);
+        if (!model?.isElement()) throw new Error('Cell not found or not an element: ' + id);
         return {
-          width: size.width,
-          height: size.height,
-          element: cell,
-          angle: cell.get('angle') ?? 0,
-          ...position,
+          model,
+          ...model.size(),
+          ...model.position().toJSON(),
+          angle: model.angle(),
         };
       },
     });

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -51,6 +51,18 @@ export interface GraphStoreInternalSnapshot {
  * to rule out the nonsensical combination of `cells` and `initialCells`
  * being passed together.
  */
+/**
+ * Reference point that stays fixed when an auto-sized element's measured size
+ * changes. Mirrors CSS `transform-origin` semantics.
+ *
+ * - `'top-left'` (default): element grows right/down — top-left stays put.
+ * - `'center'`: element grows symmetrically — geometric center stays put.
+ *
+ * Only affects writes from the `useMeasureNode` pipeline. Manual `cell.resize()`,
+ * interactive resize tools, and direct `cell.set('size', ...)` calls are unaffected.
+ */
+export type AutoSizeOrigin = 'top-left' | 'center';
+
 interface GraphStoreOptionsBase<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
@@ -59,6 +71,12 @@ interface GraphStoreOptionsBase<
   readonly cellNamespace?: unknown;
   readonly cellModel?: typeof dia.Cell;
   readonly onIncrementalCellsChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
+  /**
+   * Reference point that stays fixed when an auto-sized element's measured size
+   * changes. See {@link AutoSizeOrigin}.
+   * @default 'top-left'
+   */
+  readonly autoSizeOrigin?: AutoSizeOrigin;
 }
 
 /** Uncontrolled mode: parent provides only seed data. */
@@ -109,6 +127,8 @@ export class GraphStore<
     return this.graphView as unknown as GraphView<E, L>;
   }
 
+  public readonly autoSizeOrigin: AutoSizeOrigin;
+
   constructor(public readonly config: GraphStoreOptions<Element, Link>) {
     const {
       cellModel,
@@ -116,7 +136,9 @@ export class GraphStore<
       graph,
       onCellsChange,
       onIncrementalCellsChange,
+      autoSizeOrigin = 'top-left',
     } = config;
+    this.autoSizeOrigin = autoSizeOrigin;
     const controlledCells = 'cells' in config ? config.cells : undefined;
     const initialCells = 'initialCells' in config ? config.initialCells : undefined;
 
@@ -180,18 +202,32 @@ export class GraphStore<
         for (const [id, data] of Object.entries(updatedElements)) {
           const cell = this.graph.getCell(id);
           if (cell?.isElement()) {
+            // Capture center BEFORE size write so the center-anchor path can
+            // re-derive position from the pre-resize center.
+            const center = this.autoSizeOrigin === 'center' ? cell.getCenter() : null;
             // `fromMeasure: true` marks writes that originate from the
             // ResizeObserver pipeline so `change:size` listeners can tell our
             // own writes apart from external ones (controlled-mode sync,
             // direct `cell.resize`, etc.) and avoid feedback loops.
             cell.set('size', { width: data.width, height: data.height }, {
               fromMeasure: true,
-            } as object);
+            });
+
             if (data.x !== undefined && data.y !== undefined) {
               cell.set('position', { x: data.x, y: data.y }, {
                 fromMeasure: true,
-              } as object);
+              });
+            } else if (center) {
+              // Center-anchored auto-size: keep the geometric center fixed.
+              cell.set('position', {
+                x: center.x - data.width / 2,
+                y: center.y - data.height / 2,
+              }, {
+                fromMeasure: true,
+              });
             }
+            // Top-left auto-size (default): don't write position — the cell's
+            // top-left stays put implicitly and it grows right/down.
           }
         }
         this.graph.stopBatch('resize');

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -198,15 +198,15 @@ export class GraphStore<
         return map;
       },
       onBatchUpdate: (updatedElements) => {
-        this.graph.startBatch('resize');
+        this.graph.startBatch('auto-size');
         for (const [id, data] of Object.entries(updatedElements)) {
           const cell = this.graph.getCell(id);
           if (!cell?.isElement()) continue;
           // Capture center BEFORE size write so the center-anchor path can
           // re-derive position from the pre-resize center.
           const center = this.autoSizeOrigin === 'center' ? cell.getCenter() : null;
-          const setOptions = { fromMeasure: true };
-          // `fromMeasure: true` marks writes that originate from the
+          const setOptions = { autoSize: true };
+          // `autoSize: true` marks writes that originate from the
           // ResizeObserver pipeline so `change:size` listeners can tell our
           // own writes apart from external ones (controlled-mode sync,
           // direct `cell.resize`, etc.) and avoid feedback loops.
@@ -224,7 +224,7 @@ export class GraphStore<
           // Top-left auto-size (default): don't write position — the cell's
           // top-left stays put implicitly and it grows right/down.
         }
-        this.graph.stopBatch('resize');
+        this.graph.stopBatch('auto-size');
       },
       getCellTransform: (id) => {
         const cell = this.graph.getCell(id);

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -201,34 +201,28 @@ export class GraphStore<
         this.graph.startBatch('resize');
         for (const [id, data] of Object.entries(updatedElements)) {
           const cell = this.graph.getCell(id);
-          if (cell?.isElement()) {
-            // Capture center BEFORE size write so the center-anchor path can
-            // re-derive position from the pre-resize center.
-            const center = this.autoSizeOrigin === 'center' ? cell.getCenter() : null;
-            // `fromMeasure: true` marks writes that originate from the
-            // ResizeObserver pipeline so `change:size` listeners can tell our
-            // own writes apart from external ones (controlled-mode sync,
-            // direct `cell.resize`, etc.) and avoid feedback loops.
-            cell.set('size', { width: data.width, height: data.height }, {
-              fromMeasure: true,
-            });
+          if (!cell?.isElement()) continue;
+          // Capture center BEFORE size write so the center-anchor path can
+          // re-derive position from the pre-resize center.
+          const center = this.autoSizeOrigin === 'center' ? cell.getCenter() : null;
+          const setOptions = { fromMeasure: true };
+          // `fromMeasure: true` marks writes that originate from the
+          // ResizeObserver pipeline so `change:size` listeners can tell our
+          // own writes apart from external ones (controlled-mode sync,
+          // direct `cell.resize`, etc.) and avoid feedback loops.
+          cell.set('size', { width: data.width, height: data.height }, setOptions);
 
-            if (data.x !== undefined && data.y !== undefined) {
-              cell.set('position', { x: data.x, y: data.y }, {
-                fromMeasure: true,
-              });
-            } else if (center) {
-              // Center-anchored auto-size: keep the geometric center fixed.
-              cell.set('position', {
-                x: center.x - data.width / 2,
-                y: center.y - data.height / 2,
-              }, {
-                fromMeasure: true,
-              });
-            }
-            // Top-left auto-size (default): don't write position — the cell's
-            // top-left stays put implicitly and it grows right/down.
+          if (data.x !== undefined && data.y !== undefined) {
+            cell.set('position', { x: data.x, y: data.y }, setOptions);
+          } else if (center) {
+            // Center-anchored auto-size: keep the geometric center fixed.
+            cell.set('position', {
+              x: center.x - data.width / 2,
+              y: center.y - data.height / 2,
+            }, setOptions);
           }
+          // Top-left auto-size (default): don't write position — the cell's
+          // top-left stays put implicitly and it grows right/down.
         }
         this.graph.stopBatch('resize');
       },

--- a/packages/joint-react/src/stories/demos/flowchart/code.tsx
+++ b/packages/joint-react/src/stories/demos/flowchart/code.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
- 
+
 import './index.css';
 import type { CellRecord, ElementRecord, LinkRecord, LinkLabel, TransformOptions } from '@joint/react';
 import { GraphProvider, Paper, useMarkup, useMeasureNode, useNodesMeasuredEffect, usePaperEvents } from '@joint/react';
@@ -11,7 +11,7 @@ import { forwardRef, useId, useRef, useState } from 'react';
 
 const unit = 4;
 const bevel = 2 * unit;
-const nodeFontSize = 13;
+const elementFontSize = 13;
 const labelFontSize = 15;
 const linkOffset = unit * 1.5;
 
@@ -21,64 +21,75 @@ const ORTHOGONAL_LINKS = linkRoutingOrthogonal({
   margin: unit * 7,
 });
 
-type NodeElementData = {
+type ElementData = {
   readonly label: string;
   readonly type: 'start' | 'step' | 'decision';
-  readonly cx: number;
-  readonly cy: number;
 };
 
-const flowchartNodes: Array<ElementRecord<NodeElementData>> = [
-  { id: 'start', type: 'element', data: { label: 'Start', type: 'start', cx: 60, cy: 40 } },
+// `position` doubles as the desired final center: default size is 0×0, so
+// top-left coincides with center, and `autoSizeOrigin="center"` preserves
+// that center through the first DOM measurement.
+const flowchartElements: Array<ElementRecord<ElementData>> = [
+  { id: 'start', type: 'element', data: { label: 'Start', type: 'start' }, position: { x: 60, y: 40 } },
   {
     id: 'addToCart',
     type: 'element',
-    data: { label: 'Add to Cart', type: 'step', cx: 195, cy: 40 },
+    data: { label: 'Add to Cart', type: 'step' },
+    position: { x: 195, y: 40 },
   },
   {
     id: 'checkoutItems',
     type: 'element',
-    data: { label: 'Checkout Items', type: 'step', cx: 365, cy: 40 },
+    data: { label: 'Checkout Items', type: 'step' },
+    position: { x: 365, y: 40 },
   },
   {
     id: 'addShippingInfo',
     type: 'element',
-    data: { label: 'Add Shipping Info', type: 'step', cx: 550, cy: 40 },
+    data: { label: 'Add Shipping Info', type: 'step' },
+    position: { x: 550, y: 40 },
   },
   {
     id: 'addPaymentInfo',
     type: 'element',
-    data: { label: 'Add Payment Info', type: 'step', cx: 550, cy: 150 },
+    data: { label: 'Add Payment Info', type: 'step' },
+    position: { x: 550, y: 150 },
   },
   {
     id: 'validPayment',
     type: 'element',
-    data: { label: 'Valid Payment?', type: 'decision', cx: 550, cy: 270 },
+    data: { label: 'Valid Payment?', type: 'decision' },
+    position: { x: 550, y: 270 },
   },
   {
     id: 'presentErrorMessage',
     type: 'element',
-    data: { label: 'Present Error Message', type: 'step', cx: 810, cy: 380 },
+    data: { label: 'Present Error Message', type: 'step' },
+    position: { x: 810, y: 380 },
   },
   {
     id: 'sendOrder',
     type: 'element',
-    data: { label: 'Send Order to Warehouse', type: 'step', cx: 230, cy: 270 },
+    data: { label: 'Send Order to Warehouse', type: 'step' },
+    position: { x: 230, y: 270 },
   },
   {
     id: 'packOrder',
     type: 'element',
-    data: { label: 'Pack Order', type: 'step', cx: 40, cy: 380 },
+    data: { label: 'Pack Order', type: 'step' },
+    position: { x: 40, y: 380 },
   },
   {
     id: 'qualityCheck',
     type: 'element',
-    data: { label: 'Quality Check?', type: 'decision', cx: 230, cy: 500 },
+    data: { label: 'Quality Check?', type: 'decision' },
+    position: { x: 230, y: 500 },
   },
   {
     id: 'shipItems',
     type: 'element',
-    data: { label: 'Ship Items to Customer', type: 'step', cx: 550, cy: 500 },
+    data: { label: 'Ship Items to Customer', type: 'step' },
+    position: { x: 550, y: 500 },
   },
 ];
 const TOP = { name: 'top', args: { useModelGeometry: true, dy: -linkOffset } } as const;
@@ -242,36 +253,30 @@ const flowchartLinks: LinkRecord[] = [
   },
 ];
 
-const initialCells: ReadonlyArray<CellRecord<NodeElementData>> = [...flowchartNodes, ...flowchartLinks];
+const initialCells: ReadonlyArray<CellRecord<ElementData>> = [...flowchartElements, ...flowchartLinks];
 
 interface PropsWithClick {
   readonly onMouseEnter?: () => void;
   readonly onMouseLeave?: () => void;
   readonly isToolActive?: boolean;
 }
-type FlowchartNodeProps = NodeElementData & PropsWithClick;
+type FlowchartElementProps = ElementData & PropsWithClick;
 
-function computeNodeBBox(options: TransformOptions & { padding: number; cx: number; cy: number }) {
-  const { width: nodeWidth, height: nodeHeight, padding, cx, cy } = options;
-  const modelWidth = nodeWidth + 2 * padding;
-  const modelHeight = nodeHeight + 2 * padding;
+// Inflate measured text by symmetric padding. No x/y here — autoSizeOrigin="center"
+// (set on GraphProvider) keeps the cell's geometric center fixed as it resizes.
+function applyElementPadding(options: TransformOptions, padding: number = 30) {
   return {
-    width: modelWidth,
-    height: modelHeight,
-    x: cx - modelWidth / 2,
-    y: cy - modelHeight / 2,
+    width: options.width + 2 * padding,
+    height: options.height + 2 * padding,
   };
 }
-function DecisionNodeRaw(
-  { label, cx, cy, onMouseEnter, onMouseLeave }: FlowchartNodeProps,
+function DecisionElementRaw(
+  { label, onMouseEnter, onMouseLeave }: FlowchartElementProps,
   ref: React.ForwardedRef<SVGPolygonElement>
 ) {
-  // If we define custom size, not defined in initial nodes, we have to use measure node
-  const padding = 30;
-
   const textRef = useRef<SVGTextElement>(null);
   const { width, height } = useMeasureNode(textRef, {
-    transform: (options) => computeNodeBBox({ ...options, padding, cx, cy }),
+    transform: (options) => applyElementPadding(options),
   });
 
   return (
@@ -295,7 +300,7 @@ function DecisionNodeRaw(
         y={height / 2}
         textAnchor="middle"
         dominantBaseline="middle"
-        fontSize={nodeFontSize}
+        fontSize={elementFontSize}
       >
         {label}
       </text>
@@ -303,15 +308,15 @@ function DecisionNodeRaw(
   );
 }
 
-function StartNodeRaw(
-  { label, cx, cy, onMouseEnter, onMouseLeave }: FlowchartNodeProps,
+function StartElementRaw(
+  { label, onMouseEnter, onMouseLeave }: FlowchartElementProps,
   ref: React.ForwardedRef<SVGRectElement>
 ) {
   const padding = 20;
 
   const textRef = useRef<SVGTextElement>(null);
   const { width, height } = useMeasureNode(textRef, {
-    transform: (options) => computeNodeBBox({ ...options, padding, cx, cy }),
+    transform: (options) => applyElementPadding(options, padding),
   });
 
   return (
@@ -336,7 +341,7 @@ function StartNodeRaw(
         y={height / 2}
         textAnchor="middle"
         dominantBaseline="middle"
-        fontSize={nodeFontSize}
+        fontSize={elementFontSize}
       >
         {label}
       </text>
@@ -344,15 +349,15 @@ function StartNodeRaw(
   );
 }
 
-function StepNodeRaw(
-  { label, cx, cy, onMouseEnter, onMouseLeave }: FlowchartNodeProps,
+function StepElementRaw(
+  { label, onMouseEnter, onMouseLeave }: FlowchartElementProps,
   ref: React.ForwardedRef<SVGPolygonElement>
 ) {
   const padding = 20;
 
   const textRef = useRef<SVGTextElement>(null);
   const { width, height } = useMeasureNode(textRef, {
-    transform: (options) => computeNodeBBox({ ...options, padding, cx, cy }),
+    transform: (options) => applyElementPadding(options, padding),
   });
 
   return (
@@ -375,29 +380,29 @@ function StepNodeRaw(
         y={height / 2}
         textAnchor="middle"
         dominantBaseline="middle"
-        fontSize={nodeFontSize}
+        fontSize={elementFontSize}
       >
         {label}
       </text>
     </>
   );
 }
-const DecisionNode = forwardRef<SVGPolygonElement, FlowchartNodeProps>(DecisionNodeRaw);
-const StartNode = forwardRef<SVGRectElement, FlowchartNodeProps>(StartNodeRaw);
-const StepNode = forwardRef<SVGPolygonElement, FlowchartNodeProps>(StepNodeRaw);
+const DecisionElement = forwardRef<SVGPolygonElement, FlowchartElementProps>(DecisionElementRaw);
+const StartElement = forwardRef<SVGRectElement, FlowchartElementProps>(StartElementRaw);
+const StepElement = forwardRef<SVGPolygonElement, FlowchartElementProps>(StepElementRaw);
 
-function RenderFlowchartNode(data: Readonly<NodeElementData>) {
+function RenderFlowchartElement(data: Readonly<ElementData>) {
   const { selectorRef } = useMarkup();
 
   const bodyRef = selectorRef('body');
 
   if (data.type === 'decision') {
-    return <DecisionNode ref={bodyRef as React.ForwardedRef<SVGPolygonElement>} {...data} />;
+    return <DecisionElement ref={bodyRef as React.ForwardedRef<SVGPolygonElement>} {...data} />;
   }
   if (data.type === 'start') {
-    return <StartNode ref={bodyRef as React.ForwardedRef<SVGRectElement>} {...data} />;
+    return <StartElement ref={bodyRef as React.ForwardedRef<SVGRectElement>} {...data} />;
   }
-  return <StepNode ref={bodyRef as React.ForwardedRef<SVGPolygonElement>} {...data} />;
+  return <StepElement ref={bodyRef as React.ForwardedRef<SVGPolygonElement>} {...data} />;
 }
 
 // Create link tools
@@ -513,7 +518,7 @@ function Main() {
       overflow
       snapLabels
       className={`${PAPER_CLASSNAME} flowchart-paper w-[200px]`}
-      renderElement={RenderFlowchartNode}
+      renderElement={RenderFlowchartElement}
       drawGrid={false}
       linkRouting={ORTHOGONAL_LINKS}
     />
@@ -562,7 +567,7 @@ export default function App() {
   const [isLight, setIsLight] = useState(false);
   return (
     <div className={`flowchart-wrapper${isLight ? ' light-theme' : ''}`}>
-      <GraphProvider initialCells={initialCells}>
+      <GraphProvider initialCells={initialCells} autoSizeOrigin="center">
         <Main />
       </GraphProvider>
       <ThemeSwitch onClick={() => setIsLight((v) => !v)} />

--- a/packages/joint-react/src/stories/examples/with-auto-size-origin/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-size-origin/code.tsx
@@ -1,0 +1,130 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+import {
+  type AutoSizeOrigin,
+  type CellRecord,
+  type ElementRecord,
+  type Computed,
+  GraphProvider,
+  Paper,
+  useCell,
+  useCellId,
+  useGraph,
+  useMeasureNode,
+} from '@joint/react';
+import { useCallback, useRef, useState } from 'react';
+import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
+import '../index.css';
+
+interface NodeData {
+  readonly [key: string]: unknown;
+  readonly label: string;
+}
+
+const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
+  { id: '1', type: 'element', data: { label: 'edit me' }, position: { x: 100, y: 60 } },
+  { id: '2', type: 'element', data: { label: 'edit me too' }, position: { x: 100, y: 240 } },
+  {
+    id: 'l',
+    type: 'link',
+    source: { id: '1' },
+    target: { id: '2' },
+    style: { color: PRIMARY },
+  },
+];
+
+const STOP_DRAG = (event: React.MouseEvent | React.PointerEvent) => event.stopPropagation();
+
+function EditableNode() {
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const id = useCellId();
+  const { graph } = useGraph();
+  const label = useCell((element: Computed<ElementRecord<NodeData>>) => element.data.label);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      graph.getCell(id)?.prop('data/label', event.target.value);
+    },
+    [graph, id]
+  );
+
+  const { width, height } = useMeasureNode(nodeRef);
+
+  return (
+    <foreignObject width={width} height={height} overflow="visible">
+      <div
+        ref={nodeRef}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          padding: '8px 12px',
+          backgroundColor: '#fff',
+          border: `1px solid ${PRIMARY}`,
+          borderRadius: 8,
+          fontFamily: 'Ppfraktionsans, sans-serif',
+          color: '#131e29',
+          cursor: 'move',
+        }}
+      >
+        <input
+          value={label}
+          onChange={handleChange}
+          onMouseDown={STOP_DRAG}
+          onPointerDown={STOP_DRAG}
+          size={Math.max(label.length, 6)}
+          style={{
+            border: 'none',
+            outline: 'none',
+            background: 'transparent',
+            font: 'inherit',
+            color: 'inherit',
+            cursor: 'text',
+            minWidth: 40,
+          }}
+        />
+      </div>
+    </foreignObject>
+  );
+}
+
+function Diagram() {
+  return (
+    <Paper
+      style={{ height: 380 }}
+      className={PAPER_CLASSNAME}
+      renderElement={EditableNode}
+    />
+  );
+}
+
+export default function App() {
+  const [origin, setOrigin] = useState<AutoSizeOrigin>('top-left');
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: 8 }}>
+        <label htmlFor="autoSizeOriginToggle" style={{ fontFamily: 'Ppfraktionsans, sans-serif' }}>
+          autoSizeOrigin:
+        </label>
+        <select
+          id="autoSizeOriginToggle"
+          value={origin}
+          onChange={(e) => setOrigin(e.target.value as AutoSizeOrigin)}
+        >
+          <option value="top-left">top-left</option>
+          <option value="center">center</option>
+        </select>
+        <span style={{ opacity: 0.7, fontFamily: 'Ppfraktionsans, sans-serif' }}>
+          (switching remounts the provider — current edits reset to initial)
+        </span>
+      </div>
+      {/*
+        Workaround: `autoSizeOrigin` is read at GraphStore construction time.
+        Remount via `key` so the new value takes effect — keeps example logic
+        trivial without plumbing live-prop updates into the store.
+      */}
+      <GraphProvider key={origin} initialCells={initialCells} autoSizeOrigin={origin}>
+        <Diagram />
+      </GraphProvider>
+    </div>
+  );
+}

--- a/packages/joint-react/src/stories/examples/with-auto-size-origin/story.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-size-origin/story.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../index.css';
+import Code from './code';
+import { makeRootDocumentation } from '../../utils/make-story';
+
+import CodeRaw from './code?raw';
+export type Story = StoryObj<typeof Code>;
+
+export default {
+  title: 'Examples/Auto-size origin',
+  component: Code,
+  tags: ['example'],
+  parameters: makeRootDocumentation({
+    code: CodeRaw,
+  }),
+} satisfies Meta<typeof Code>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary

- Adds `autoSizeOrigin: 'top-left' | 'center'` to `GraphProvider` (threaded to `GraphStore`). Controls which point stays fixed when a `useMeasureNode`-driven resize updates the cell.
- Removes the implicit `identityTransform` fallback in `createElementsSizeObserver`: previously echoed the cell's current x/y, which always populated `data.x/y` in the commit pipeline and short-circuited the center-anchor branch even when no user transform was supplied. Now, when `useMeasureNode` is called without a `transform`, the observer writes only `{ width, height }` and lets `autoSizeOrigin` drive any position update.
- Renames `TransformOptions.element` → `model` (and the `getCellTransform` return field) for consistency with the rest of the React API.
- Renames the internal `fromMeasure` set-option flag → `autoSize` and the resize batch name → `'auto-size'`.
- Migrates the Flowchart demo to the new option — drops the `data.cx/cy` + transform x/y math.
- New `Examples/Auto-size origin` story: two linked nodes with editable text inputs that auto-resize as you type, plus an origin toggle.

## API

```tsx
<GraphProvider autoSizeOrigin="center" initialCells={[...]}>
  <Paper />
</GraphProvider>
```

- `'top-left'` (default): element grows right/down — top-left stays put.
- `'center'`: element grows symmetrically — geometric center stays put.

Only affects measurement-driven writes. Manual `cell.resize()`, interactive resize tools, and direct `cell.set('size', ...)` calls are unaffected.

Naming mirrors CSS `transform-origin`. `'top-left' | 'center'` enum can extend to the full 9-position grid later without a breaking change.

## Flowchart demo migration

Before:
```ts
data: { label: 'Start', type: 'start', cx: 60, cy: 40 }
// + per-component transform that returned x = cx - W/2, y = cy - H/2
```

After:
```ts
data: { label: 'Start', type: 'start' }, position: { x: 60, y: 40 }
// transform only adds padding; autoSizeOrigin="center" anchors the resize
```

JointJS default element size is 0×0, so `position` doubles as the desired center on first render — `autoSizeOrigin="center"` then preserves that center through the first DOM measurement.

## No-transform path

`createElementsSizeObserver` previously fell back to an `identityTransform` when `useMeasureNode` had no user `transform`. The fallback re-emitted the cell's current x/y, which then hit the explicit-position branch in `GraphStore.onBatchUpdate` and never reached the new center-anchor branch. The fallback is now gone: with no user transform, the observer writes `{ width, height }` only, and `autoSizeOrigin` decides what (if anything) happens to position.

## Renames

- `TransformOptions.element` → `TransformOptions.model` (also in `getCellTransform`'s return shape).
- Internal `fromMeasure` set-option → `autoSize`; batch name `'resize'` → `'auto-size'`. These are private to the React store and not part of the public API.

## Test plan

- [ ] `yarn workspace @joint/react typecheck`
- [ ] `yarn workspace @joint/react lint`
- [ ] `yarn workspace @joint/react jest --testPathPatterns="graph-store|graph-provider|size-observer|measure-node"` — all pass
- [ ] Storybook: open `Examples/Auto-size origin` — type into the inputs, toggle origin, verify both modes anchor as documented
- [ ] Storybook: open `Demos/Flowchart` — verify layout matches the previous version (no shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
