### PR TITLE
feat(joint-react): usePaperEvents context form + onBatchUpdate refactor + hide-while-measuring via CSS class

### DIFF
--- a/packages/joint-react/src/css/styles.css
+++ b/packages/joint-react/src/css/styles.css
@@ -191,6 +191,14 @@
 
   /* ── Elements ────────────────────────────────────────────────────────── */
 
+  /* Applied to a cell view's root while its DOM is being measured by
+     useMeasureNode. Removed on the view's first updateView so the element
+     only becomes visible after its transform is applied — avoids a jump
+     when measurement is paired with a position change. */
+  .jj-is-measuring {
+    visibility: hidden;
+  }
+
   .jj-box {
     background: var(--jj-box-color);
     color: var(--jj-box-text-color);

--- a/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
@@ -15,13 +15,19 @@ class CatchErrorBoundary extends Component<
     return this.state.hasError ? null : this.props.children;
   }
 }
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
+import type { dia } from '@joint/core';
 import { GraphProvider, Paper } from '../../components';
 import { CellIdContext } from '../../context';
 import { useMeasureNode } from '../use-measure-node';
+import { useGraphStore } from '../use-graph-store';
+import { usePaper } from '../use-paper';
 import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type { CellRecord } from '../../types/cell.types';
+
+let capturedGraph: dia.Graph | null = null;
+let capturedPaper: dia.Paper | null = null;
 
 const initialCells: readonly CellRecord[] = [
   {
@@ -44,11 +50,13 @@ const initialCells: readonly CellRecord[] = [
   } as CellRecord,
 ];
 
-type Visibility = 'show-all' | 'hide-node' | 'hide-all';
-
-function ProbeWithVisibility({ visibility }: Readonly<{ visibility?: Visibility }>) {
+function Probe() {
   const nodeRef = useRef<SVGRectElement | null>(null);
-  const size = useMeasureNode(nodeRef, { visibility });
+  const { graph } = useGraphStore();
+  const { paper } = usePaper();
+  capturedGraph = graph;
+  capturedPaper = paper;
+  const size = useMeasureNode(nodeRef);
   return (
     <>
       <rect ref={nodeRef} width={80} height={120} />
@@ -59,27 +67,18 @@ function ProbeWithVisibility({ visibility }: Readonly<{ visibility?: Visibility 
   );
 }
 
-function renderHideAll() {
-  return <ProbeWithVisibility />;
-}
-function renderHideNode() {
-  return <ProbeWithVisibility visibility="hide-node" />;
-}
-function renderShowAll() {
-  return <ProbeWithVisibility visibility="show-all" />;
+function renderProbeElement() {
+  return <Probe />;
 }
 
-function pickRenderProbe(visibility?: Visibility) {
-  if (visibility === 'hide-node') return renderHideNode;
-  if (visibility === 'show-all') return renderShowAll;
-  return renderHideAll;
-}
-
-function renderProbe(visibility?: Visibility) {
-  const function_ = pickRenderProbe(visibility);
+function renderProbe() {
   return render(
     <GraphProvider initialCells={initialCells}>
-      <Paper style={{ width: 200, height: 200 }} id="measure-paper" renderElement={function_} />
+      <Paper
+        style={{ width: 200, height: 200 }}
+        id="measure-paper"
+        renderElement={renderProbeElement}
+      />
     </GraphProvider>
   );
 }
@@ -103,32 +102,31 @@ function NoNodeProbe() {
 const renderNoNodeProbe = () => <NoNodeProbe />;
 
 describe('useMeasureNode', () => {
-  it('returns the live width/height (default visibility = hide-all)', async () => {
+  it('adds .jj-is-measuring on mount and removes it on the next paper render:done', async () => {
+    capturedGraph = null;
+    capturedPaper = null;
     const { container } = renderProbe();
+    // Class is applied by useMeasureNode in a layout effect; wait until it lands.
     await waitFor(() => {
-      const rect = container.querySelector('rect');
-      expect(rect).not.toBeNull();
+      const elementView = container.querySelector('.joint-cell.joint-element');
+      expect(elementView).not.toBeNull();
+      expect(elementView?.classList.contains('jj-is-measuring')).toBe(true);
     });
-    // Settle layout effects.
-    await new Promise((resolve) => setTimeout(resolve, 30));
-  });
-
-  it('honors visibility="hide-node"', async () => {
-    const { container } = renderProbe('hide-node');
-    await waitFor(() => {
-      const rect = container.querySelector('rect');
-      expect(rect).not.toBeNull();
+    // Listen for the next render:done before triggering it. In production
+    // this fires after the ResizeObserver-driven size write; here we
+    // simulate that with a direct model mutation since the jsdom
+    // ResizeObserver mock doesn't deliver entries.
+    const rendered = new Promise<void>((resolve) => {
+      capturedPaper?.once('render:done', () => resolve());
     });
-    await new Promise((resolve) => setTimeout(resolve, 30));
-  });
-
-  it('honors visibility="show-all"', async () => {
-    const { container } = renderProbe('show-all');
-    await waitFor(() => {
-      const rect = container.querySelector('rect');
-      expect(rect).not.toBeNull();
+    act(() => {
+      capturedGraph?.getCell('el').set('position', { x: 1, y: 1 });
     });
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await act(async () => {
+      await rendered;
+    });
+    const elementView = container.querySelector('.joint-cell.joint-element');
+    expect(elementView?.classList.contains('jj-is-measuring')).toBe(false);
   });
 
   it('throws when used outside CellIdContext', () => {

--- a/packages/joint-react/src/hooks/use-measure-node.tsx
+++ b/packages/joint-react/src/hooks/use-measure-node.tsx
@@ -6,14 +6,7 @@ import { usePaper } from './use-paper';
 import type { ElementSize } from '../types/cell.types';
 import { useCell } from './use-cell';
 import { selectElementSize } from '../selectors';
-
-/**
- * Controls element visibility until the first measurement completes.
- * - `'show-all'` — hides nothing; the element is visible immediately
- * - `'hide-node'` — hides the observed DOM element (default)
- * - `'hide-all'` — hides the entire element view (`cellView.el`)
- */
-export type VisibilityStrategy = 'show-all' | 'hide-node' | 'hide-all';
+import { MEASURING_CLASS_NAME } from '../utils/class-names';
 
 /**
  * Options for configuring how the node size is measured and applied.
@@ -37,15 +30,6 @@ export interface MeasureNodeOptions {
    * ```
    */
   readonly transform?: OnTransformElement;
-
-  /**
-   * Controls element visibility until the first measurement completes.
-   * - `'show-all'` — hides nothing; the element is visible immediately
-   * - `'hide-node'` — hides the observed DOM element
-   * - `'hide-all'` — hides the entire element view (`cellView.el`)
-   * @default 'hide-all'
-   */
-  readonly visibility?: VisibilityStrategy;
 }
 
 const EMPTY_OBJECT: MeasureNodeOptions = {};
@@ -163,9 +147,9 @@ const EMPTY_OBJECT: MeasureNodeOptions = {};
  */
 export function useMeasureNode(
   nodeRef: RefObject<HTMLElement | SVGElement | null>,
-  options?: MeasureNodeOptions
+  options: MeasureNodeOptions = EMPTY_OBJECT
 ): Required<ElementSize> {
-  const { transform, visibility } = options ?? EMPTY_OBJECT;
+  const { transform } = options;
   const { graph, setMeasuredNode } = useGraphStore();
   const { paper } = usePaper();
   const id = useContext(CellIdContext);
@@ -189,20 +173,21 @@ export function useMeasureNode(
       return;
     }
 
-    // DOM node to hide (visibility: hidden) until the first measurement completes.
-    let visibilityNode: HTMLElement | SVGElement | undefined;
-    if (visibility === 'hide-node') {
-      visibilityNode = nodeRef.current;
-    } else if (visibility !== 'show-all') {
-      // 'hide-all' (default)
-      visibilityNode = paper.findViewByModel(id)?.el;
-    }
+    // Hide the element view's root until PortalPaper.updateView has applied
+    // its first transform — see PortalPaper.updateView for the why. The
+    // matching `visibility: hidden` rule lives in styles.css and is opt-in,
+    // so users who don't import the stylesheet won't get the hide-flash
+    // protection.
+    const view = paper.findViewByModel(id);
+    view?.el.classList.add(MEASURING_CLASS_NAME);
 
-    const clean = setMeasuredNode({ id, node: nodeRef.current, transform, visibilityNode });
+    const clean = setMeasuredNode({ id, node: nodeRef.current, transform });
     return () => {
+      // No class cleanup here: views aren't recycled today, so the view
+      // is gone with the cell.
       clean();
     };
-    // transform and visibility are not dependencies because they don't change
+    // transform is not a dependency because it doesn't change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodeRef, graph, id, paper, setMeasuredNode]);
 

--- a/packages/joint-react/src/hooks/use-paper-events.ts
+++ b/packages/joint-react/src/hooks/use-paper-events.ts
@@ -1,10 +1,27 @@
 import { useLayoutEffect, type DependencyList } from 'react';
+import { dia } from '@joint/core';
 import { usePaperStore, useResolvePaperId } from './use-paper';
 import type { PaperStore } from '../store';
-import { type PaperTarget } from '../types';
+import { OPTIONAL, type PaperTarget } from '../types';
+import { isRecord, isRef, isString } from '../utils/is';
 import { addPaperEventListeners, type PaperEventMap } from '../presets/paper-events';
 
 const EMPTY_DEPENDENCIES: DependencyList = [];
+
+/**
+ * Discriminates the first argument of `usePaperEvents` between a paper target
+ * and a handlers map.
+ * @param value - Candidate first argument.
+ * @returns True when the value identifies a paper (id, instance, ref, or
+ * `Optional` sentinel).
+ */
+function isPaperTarget(value: unknown): value is PaperTarget {
+  if (isString(value)) return true;
+  if (value instanceof dia.Paper) return true;
+  if (isRef(value)) return true;
+  if (isRecord(value) && value.optional === true) return true;
+  return false;
+}
 
 /**
  * Subscribes all handlers to a paper, delegating runtime wiring to
@@ -21,13 +38,15 @@ export function subscribeToPaperEvents(
 }
 
 /**
- * Subscribes to paper events. Two key forms can be mixed in the same handlers
- * map:
+ * Subscribes to paper events. The paper argument is optional — when omitted
+ * the hook reads the active paper from the surrounding `Paper` context (it
+ * throws if no `Paper` context is available). Two key forms can be mixed in
+ * the same handlers map:
  *
  * **Normalized form**: `on<Category><Event>` keys deliver a single context
  * object with named properties.
  * ```tsx
- * usePaperEvents(paperId, {
+ * usePaperEvents({
  *   onElementPointerClick: ({ id, model, paper, graph, event, x, y }) => {},
  *   onBlankPointerClick: ({ paper, graph, event, x, y }) => {},
  * });
@@ -46,6 +65,13 @@ export function subscribeToPaperEvents(
  * The normalized context omits the React-store `record` — to read the
  * normalised record shape, call `useCell(id, selector)` from your own
  * component (the handler closure has access to the `id` it emits).
+ * @param handlers - Event handlers map.
+ * @param dependencies - Optional dependency array controlling re-subscription.
+ * @group Hooks
+ */
+export function usePaperEvents(handlers: PaperEventMap, dependencies?: DependencyList): void;
+/**
+ * Subscribes to paper events on the given paper target.
  * @param paper - Paper reference (string ID, dia.Paper instance, ref, or Optional).
  * @param handlers - Event handlers map.
  * @param dependencies - Optional dependency array controlling re-subscription.
@@ -54,10 +80,30 @@ export function subscribeToPaperEvents(
 export function usePaperEvents(
   paper: PaperTarget,
   handlers: PaperEventMap,
-  dependencies: DependencyList = EMPTY_DEPENDENCIES
+  dependencies?: DependencyList
+): void;
+export function usePaperEvents(
+  paperOrHandlers: PaperTarget | PaperEventMap,
+  handlersOrDependencies: PaperEventMap | DependencyList = EMPTY_DEPENDENCIES,
+  dependenciesArgument: DependencyList = EMPTY_DEPENDENCIES
 ): void {
-  const paperId = useResolvePaperId(paper);
+  const shouldUseContextPaper = !isPaperTarget(paperOrHandlers);
+  const target: PaperTarget = shouldUseContextPaper
+    ? OPTIONAL
+    : (paperOrHandlers as PaperTarget);
+  const handlers = shouldUseContextPaper
+    ? (paperOrHandlers as PaperEventMap)
+    : (handlersOrDependencies as PaperEventMap);
+  const dependencies = shouldUseContextPaper
+    ? (handlersOrDependencies as DependencyList)
+    : dependenciesArgument;
+
+  const paperId = useResolvePaperId(target);
   const paperStore = usePaperStore(paperId);
+
+  if (shouldUseContextPaper && !paperStore) {
+    throw new Error('usePaperEvents without a paper target must be used within a Paper.');
+  }
 
   useLayoutEffect(() => {
     if (!paperStore) return;

--- a/packages/joint-react/src/models/portal-paper.ts
+++ b/packages/joint-react/src/models/portal-paper.ts
@@ -1,9 +1,10 @@
-import type { dia } from '@joint/core';
+import type { dia, mvc } from '@joint/core';
 import type { CellId } from '../types/cell.types';
 import type { PortalHostCell, PortalSelector, PortalPaperOptions } from './portal-paper.types';
 import type { IncrementalChange } from '../state/incremental.types';
 import { simpleScheduler } from '../utils/scheduler';
 import { Paper } from '../presets/paper';
+import { MEASURING_CLASS_NAME } from '../utils/class-names';
 
 const noopViewMountChange = (): void => {
   // No-op default for onViewMountChange callback
@@ -232,6 +233,26 @@ export class PortalPaper extends Paper {
   removeView(cell: dia.Cell): dia.CellView {
     this.notifyViewUnmount(cell);
     return super.removeView(cell);
+  }
+
+  /**
+   * Removes the `MEASURING_CLASS_NAME` class from element views once
+   * `updateView` has applied the latest size and position written to the
+   * model. Removing the class here (rather than when the ResizeObserver
+   * fires) avoids the flash at the pre-update position that happens when
+   * size lands on the model before position.
+   * @param view - The view being updated.
+   * @param flag - Bitmask of pending update flags.
+   * @param opt - Update options forwarded to `view.confirmUpdate`.
+   * @returns Leftover flag count, as returned by the base `updateView`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  updateView(view: mvc.View<any, any>, flag: number, opt?: dia.Paper.UpdateViewOptions): number {
+    const result = super.updateView(view, flag, opt);
+    if (view.model?.isElement?.()) {
+      view.el.classList.remove(MEASURING_CLASS_NAME);
+    }
+    return result;
   }
 
   /**

--- a/packages/joint-react/src/presets/link-view.ts
+++ b/packages/joint-react/src/presets/link-view.ts
@@ -1,7 +1,5 @@
 import { dia } from '@joint/core';
-
-const LINK_CONNECTING_CLASS = 'jj-is-connecting';
-const LINK_SNAPPED_CN = 'jj-is-snapped';
+import { CONNECTING_CLASS_NAME, SNAPPED_CLASS_NAME } from '../utils/class-names';
 
 /**
  * Custom LinkView that adds CSS class hooks for link interaction states.
@@ -14,20 +12,20 @@ export class LinkView extends dia.LinkView {
   _beforeArrowheadMove(data: unknown) {
     // @ts-expect-error Protected method override
     super._beforeArrowheadMove(data);
-    this.el.classList.add(LINK_CONNECTING_CLASS);
+    this.el.classList.add(CONNECTING_CLASS_NAME);
   }
 
   _afterArrowheadMove(data: unknown) {
     // @ts-expect-error Protected method override
     super._afterArrowheadMove(data);
-    this.el.classList.remove(LINK_CONNECTING_CLASS, LINK_SNAPPED_CN);
+    this.el.classList.remove(CONNECTING_CLASS_NAME, SNAPPED_CLASS_NAME);
   }
 
   _snapArrowhead(event_: dia.Event, x: number, y: number) {
     // @ts-expect-error Protected method override
     const isSnapped = super._snapArrowhead(event_, x, y);
-    this.el.classList.toggle(LINK_CONNECTING_CLASS, !isSnapped);
-    this.el.classList.toggle(LINK_SNAPPED_CN, !!isSnapped);
+    this.el.classList.toggle(CONNECTING_CLASS_NAME, !isSnapped);
+    this.el.classList.toggle(SNAPPED_CLASS_NAME, !!isSnapped);
     return isSnapped;
   }
 }

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -2,6 +2,7 @@ import { dia } from '@joint/core';
 import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
+import { AVAILABLE_CLASS_NAME, DRAGGING_CLASS_NAME } from '../utils/class-names';
 
 // ---------------------------------------------------------------------------
 // PointerEvents migration
@@ -72,13 +73,13 @@ export const DEFAULT_HIGHLIGHTING = {
   [dia.CellView.Highlighting.MAGNET_AVAILABILITY]: {
     name: 'addClass',
     options: {
-      className: 'jj-is-available',
+      className: AVAILABLE_CLASS_NAME,
     },
   },
   [dia.CellView.Highlighting.ELEMENT_AVAILABILITY]: {
     name: 'addClass',
     options: {
-      className: 'jj-is-available',
+      className: AVAILABLE_CLASS_NAME,
     },
   },
 };
@@ -141,7 +142,7 @@ export const Paper = dia.Paper.extend({
     const pointerId = getPointerId(event);
     if (pointerId === null) return;
     const target = data.pointerTarget instanceof Element ? data.pointerTarget : this.el;
-    this.el.classList.add('jj-is-dragging');
+    this.el.classList.add(DRAGGING_CLASS_NAME);
     try {
       target.setPointerCapture(pointerId);
       this.eventData(event, { captureTarget: target });
@@ -162,7 +163,7 @@ export const Paper = dia.Paper.extend({
     const captureTarget = this.eventData(event).captureTarget as Element | undefined;
     protectedProto.pointerup.call(this, event);
     if (!captureTarget || pointerId === null) return;
-    this.el.classList.remove('jj-is-dragging');
+    this.el.classList.remove(DRAGGING_CLASS_NAME);
     if (captureTarget.hasPointerCapture?.(pointerId)) {
       try {
         captureTarget.releasePointerCapture(pointerId);

--- a/packages/joint-react/src/store/__tests__/create-elements-size-observer.test.ts
+++ b/packages/joint-react/src/store/__tests__/create-elements-size-observer.test.ts
@@ -438,25 +438,6 @@ describe('createElementsSizeObserver', () => {
       expect(updateCall['element-1'].height).toBe(60); // 50 + 10
     });
 
-    it('should handle visibility node on the active element', () => {
-      const nodeA = document.createElement('div');
-      const nodeB = document.createElement('div');
-      const visibilityNodeA = document.createElement('div');
-      const visibilityNodeB = document.createElement('div');
-
-      observer.add({ id: 'element-1', node: nodeA, visibilityNode: visibilityNodeA });
-      expect(visibilityNodeA.style.getPropertyValue('visibility')).toBe('hidden');
-
-      observer.add({ id: 'element-1', node: nodeB, visibilityNode: visibilityNodeB });
-      expect(visibilityNodeB.style.getPropertyValue('visibility')).toBe('hidden');
-
-      // Trigger resize on nodeB — its visibility node should be unhidden
-      const resizeObserver = MockResizeObserver.getLastInstance()!;
-      resizeObserver.triggerResize(nodeB, 100, 50);
-
-      expect(visibilityNodeB.style.getPropertyValue('visibility')).toBe('');
-    });
-
     it('cleanup should be idempotent', () => {
       const nodeA = document.createElement('div');
 

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -49,17 +49,11 @@ export interface SetMeasuredNodeOptions {
   readonly transform?: OnTransformElement;
   /** The ID of the cell in the graph that corresponds to this DOM node */
   readonly id: CellId;
-  /**
-   * DOM node to hide until measurement is complete.
-   * When `undefined`, nothing is hidden.
-   */
-  readonly visibilityNode?: HTMLElement | SVGElement;
 }
 
 interface ObservedElement {
   readonly id: CellId;
   readonly node: HTMLElement | SVGElement;
-  readonly visibilityNode?: HTMLElement | SVGElement;
   readonly transform?: OnTransformElement;
   lastWidth?: number;
   lastHeight?: number;
@@ -248,8 +242,6 @@ export function createElementsSizeObserver(options: Options): GraphStoreObserver
       );
       if (!observedElement) continue;
 
-      observedElement.visibilityNode?.style.removeProperty('visibility');
-
       if (!borderBoxSize || borderBoxSize.length === 0) {
         continue;
       }
@@ -288,13 +280,10 @@ export function createElementsSizeObserver(options: Options): GraphStoreObserver
   });
 
   return {
-    add({ id, node, transform, visibilityNode }: SetMeasuredNodeOptions) {
-      visibilityNode?.style.setProperty('visibility', 'hidden');
-
+    add({ id, node, transform }: SetMeasuredNodeOptions) {
       const observedElement: ObservedElement = {
         id,
         node,
-        visibilityNode,
         transform,
         isMeasured: false,
       };

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -200,27 +200,28 @@ export class GraphStore<
       onBatchUpdate: (updatedElements) => {
         this.graph.startBatch('auto-size');
         for (const [id, data] of Object.entries(updatedElements)) {
-          const cell = this.graph.getCell(id);
-          if (!cell?.isElement()) continue;
-          // Capture center BEFORE size write so the center-anchor path can
-          // re-derive position from the pre-resize center.
-          const center = this.autoSizeOrigin === 'center' ? cell.getCenter() : null;
-          const setOptions = { autoSize: true };
+          const model = this.graph.getCell(id);
+          if (!model?.isElement()) continue;
           // `autoSize: true` marks writes that originate from the
           // ResizeObserver pipeline so `change:size` listeners can tell our
           // own writes apart from external ones (controlled-mode sync,
           // direct `cell.resize`, etc.) and avoid feedback loops.
-          cell.set('size', { width: data.width, height: data.height }, setOptions);
+          const attributes: dia.Cell.Attributes = {
+            size: { width: data.width, height: data.height },
+          };
 
           if (data.x !== undefined && data.y !== undefined) {
-            cell.set('position', { x: data.x, y: data.y }, setOptions);
-          } else if (center) {
+            attributes.position = { x: data.x, y: data.y };
+          } else if (this.autoSizeOrigin === 'center') {
             // Center-anchored auto-size: keep the geometric center fixed.
-            cell.set('position', {
+            const center = model.getCenter();
+            attributes.position = {
               x: center.x - data.width / 2,
               y: center.y - data.height / 2,
-            }, setOptions);
+            };
           }
+
+          model.set(attributes, { autoSize: true });
           // Top-left auto-size (default): don't write position — the cell's
           // top-left stays put implicitly and it grows right/down.
         }

--- a/packages/joint-react/src/utils/class-names.ts
+++ b/packages/joint-react/src/utils/class-names.ts
@@ -1,0 +1,20 @@
+/**
+ * CSS state-class names shared between TypeScript and `src/css/styles.css`.
+ * Each constant must match a rule defined in `styles.css` — when adding a
+ * new state class, add the rule there first.
+ */
+
+/** Applied to a cell view's root while `useMeasureNode` is hiding it. */
+export const MEASURING_CLASS_NAME = 'jj-is-measuring';
+
+/** Applied to the paper's host while a pointer drag is in progress. */
+export const DRAGGING_CLASS_NAME = 'jj-is-dragging';
+
+/** Applied to a link view while its arrowhead is being dragged. */
+export const CONNECTING_CLASS_NAME = 'jj-is-connecting';
+
+/** Applied to a link view while its arrowhead is snapped to a valid target. */
+export const SNAPPED_CLASS_NAME = 'jj-is-snapped';
+
+/** Applied to magnet/link elements highlighted as available drop targets. */
+export const AVAILABLE_CLASS_NAME = 'jj-is-available';


### PR DESCRIPTION
## Summary

Three independent changes bundled in this PR.

### 1. `usePaperEvents` — paper argument is now optional
- New overload `usePaperEvents(handlers, deps?)` reads the active paper from the surrounding `Paper` context, mirroring the `useGraphEvents` API.
- Existing `usePaperEvents(paper, handlers, deps?)` form preserved (string id, `dia.Paper`, ref, or `Optional` sentinel).
- Throws when the context form is used outside a `<Paper>`.

### 2. `GraphStore.onBatchUpdate` — coalesce writes
- Combine size + position writes into a single `model.set(attributes, { autoSize: true })` call.
- Avoids redundant `change:*` cycles and centralises the `autoSize` flag.
- Pre-resize center captured on demand only inside the center-anchor branch.

### 3. Hide-while-measuring via `.jj-is-measuring` CSS class
Replaces inline `visibility: hidden` writes with a class-based mechanism:

- New `.jj-is-measuring { visibility: hidden; }` rule in `src/css/styles.css`.
- `useMeasureNode` adds the class to the cell view's root (`view.el`) on mount.
- `PortalPaper.updateView` removes it once the view's transform has been applied — fixes the brief flash at the pre-measure position when measurement is paired with a position change (e.g. center-anchored auto-size).
- Drops the `visibility` option and `VisibilityStrategy` type from `useMeasureNode`. Drops the `visibilityNode` field from `SetMeasuredNodeOptions` and `ObservedElement` in `create-elements-size-observer`. Always targets `view.el`.
- Centralises state-class literals in a new `src/utils/class-names.ts`: `MEASURING_CLASS_NAME`, `DRAGGING_CLASS_NAME`, `CONNECTING_CLASS_NAME`, `SNAPPED_CLASS_NAME`, `AVAILABLE_CLASS_NAME`. Existing inline literals in `src/presets/paper.ts` and `src/presets/link-view.ts` adopted.

### Breaking changes (under `@joint/react` consumer surface)

- `useMeasureNode` no longer accepts a `visibility` option, and the `VisibilityStrategy` type is removed. The hide-flash protection is now always on `view.el` and only works when `src/css/styles.css` is imported.
- `SetMeasuredNodeOptions.visibilityNode` is gone.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn jest` — 863 pass; only pre-existing `graph-store-features` `/Cell not valid/` failure remains (lives on `dev`, unrelated)
- [x] Targeted: `yarn jest --testPathPatterns="use-paper-events|use-measure-node|portal-paper|graph-store|paper-store|extra-coverage"` all green
- [ ] Manual: `usePaperEvents({ ... })` inside `<Paper>` — events fire
- [ ] Manual: `usePaperEvents({ ... })` outside `<Paper>` — throws
- [ ] Manual: auto-size with `autoSizeOrigin: 'center'` still keeps geometric center fixed
- [ ] Manual: element with `useMeasureNode` does not flash at the pre-measure position (storybook example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)