### PR TITLE
feat(joint-react): dev warning for unstable selector references in useCells

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
@@ -544,4 +544,76 @@ describe('useCells (collection form)', () => {
     await act(async () => flush());
     expect(result.current).toEqual([]);
   });
+
+  it('array-returning selector without isEqual skips re-render when result is structurally equal', async () => {
+    storeRef = undefined;
+    let collection: mvc.Collection<dia.Cell> | undefined;
+    let renderCount = 0;
+    const { result } = renderHook(
+      () => {
+        const store = useGraphStore();
+        storeRef = store;
+        if (!collection) {
+          collection = new mvc.Collection<dia.Cell>([
+            store.graph.getCell('a')!,
+            store.graph.getCell('b')!,
+          ]);
+        }
+        renderCount++;
+        return useCells(
+          collection,
+          (cells) => cells.filter((c) => c.type === ELEMENT_MODEL_TYPE).map((c) => String(c.id))
+        );
+      },
+      { wrapper }
+    );
+    await act(async () => flush());
+    expect(result.current).toEqual(['a', 'b']);
+    const before = result.current;
+    const rendersBefore = renderCount;
+
+    // Change position on 'a' — ids list unchanged, should NOT re-render
+    await act(async () => {
+      storeRef!.graph.getCell('a')?.set('position', { x: 999, y: 999 });
+      await flush();
+    });
+    expect(result.current).toBe(before);
+    expect(renderCount).toBe(rendersBefore);
+  });
+
+  it('warns in dev when selector returns unstable object array without isEqual', async () => {
+    storeRef = undefined;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    let collection: mvc.Collection<dia.Cell> | undefined;
+    const { result } = renderHook(
+      () => {
+        const store = useGraphStore();
+        storeRef = store;
+        if (!collection) {
+          collection = new mvc.Collection<dia.Cell>([
+            store.graph.getCell('a')!,
+            store.graph.getCell('b')!,
+          ]);
+        }
+        return useCells(
+          collection,
+          (cells) => cells.map((c) => ({ id: String(c.id) }))
+        );
+      },
+      { wrapper }
+    );
+    await act(async () => flush());
+    expect(result.current).toEqual([{ id: 'a' }, { id: 'b' }]);
+
+    // Trigger a cell change — selector re-runs, produces new object refs
+    await act(async () => {
+      storeRef!.graph.getCell('a')?.set('position', { x: 50, y: 50 });
+      await flush();
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[useCells] Selector returns a new array of objects')
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -8,6 +8,7 @@ import { areArraysShallowEqual, arrayAwareEqual } from '../utils/selector-utils'
 import { isCollection } from '../utils/is';
 import { subscribeToCollection } from '../utils/collection-subscription';
 import { parseUseCellsArgs } from './use-cells.utils';
+import { warnUnstableSelector } from '../utils/dev-warnings';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -298,6 +299,9 @@ export function useCells<
       );
       if (cachedRef.current.hasValue && isEqualCallback(cachedRef.current.value, next)) {
         return cachedRef.current.value;
+      }
+      if (hasSelector && cachedRef.current.hasValue) {
+        warnUnstableSelector('useCells', cachedRef.current.value, next, !!isEqual);
       }
       // The all-cells form receives the container's mutable array. Shallow-copy
       // so the cached value is a distinct reference, enabling

--- a/packages/joint-react/src/utils/__tests__/dev-warnings.test.ts
+++ b/packages/joint-react/src/utils/__tests__/dev-warnings.test.ts
@@ -1,0 +1,73 @@
+import { warnUnstableSelector } from '../dev-warnings';
+
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('warnUnstableSelector', () => {
+  it('warns when arrays have same-length objects with identical shallow values', () => {
+    const previous = [{ id: 'a', x: 1 }, { id: 'b', x: 2 }];
+    const next = [{ id: 'a', x: 1 }, { id: 'b', x: 2 }];
+    warnUnstableSelector('useCells', previous, next, false);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[useCells] Selector returns a new array of objects')
+    );
+  });
+
+  it('does not warn when custom isEqual is provided', () => {
+    const previous = [{ id: 'a' }];
+    const next = [{ id: 'a' }];
+    warnUnstableSelector('useCells', previous, next, true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for primitive arrays', () => {
+    warnUnstableSelector('useCells', ['a', 'b'], ['a', 'b'], false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when arrays have different lengths', () => {
+    const previous = [{ id: 'a' }];
+    const next = [{ id: 'a' }, { id: 'b' }];
+    warnUnstableSelector('useCells', previous, next, false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when object values actually differ', () => {
+    const previous = [{ id: 'a', x: 1 }];
+    const next = [{ id: 'a', x: 999 }];
+    warnUnstableSelector('useCells', previous, next, false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for non-array values', () => {
+    warnUnstableSelector('useCells', 42, 42, false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for empty arrays', () => {
+    warnUnstableSelector('useCells', [], [], false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns only once per unique key shape', () => {
+    const previous1 = [{ id: 'a' }];
+    const next1 = [{ id: 'a' }];
+    warnUnstableSelector('useCell', previous1, next1, false);
+    warnUnstableSelector('useCell', previous1, next1, false);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when first element refs are identical', () => {
+    const record = { id: 'a' };
+    warnUnstableSelector('useCells', [record], [record], false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/joint-react/src/utils/dev-warnings.ts
+++ b/packages/joint-react/src/utils/dev-warnings.ts
@@ -1,0 +1,56 @@
+const WARNED = new Set<string>();
+
+/**
+ * Warns once per hook instance when a selector returns an unstable reference
+ * that could have been avoided. Dev-only — tree-shaken in production.
+ * Call after the equality check fails (new value will be emitted). Pass the
+ * previous and next values; the helper inspects whether the difference is
+ * only due to new object references with identical shallow content.
+ * @param hookName - Hook identifier for the warning message (e.g. "useCells").
+ * @param previous - Cached selector result.
+ * @param next - New selector result that failed the equality check.
+ * @param hasCustomIsEqual - True when the caller supplied a custom `isEqual`.
+ */
+export function warnUnstableSelector(
+  hookName: string,
+  previous: unknown,
+  next: unknown,
+  hasCustomIsEqual: boolean
+): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (hasCustomIsEqual) return;
+  if (!Array.isArray(previous) || !Array.isArray(next)) return;
+  if (previous.length !== next.length) return;
+  if (previous.length === 0) return;
+
+  const [firstNext] = next;
+  if (firstNext === null || typeof firstNext !== 'object') return;
+
+  const [firstPrevious] = previous;
+  if (firstPrevious === firstNext) return;
+  if (firstPrevious === null || typeof firstPrevious !== 'object') return;
+
+  const previousKeys = Object.keys(firstPrevious as Record<string, unknown>);
+  const nextKeys = Object.keys(firstNext as Record<string, unknown>);
+  if (previousKeys.length !== nextKeys.length) return;
+
+  const previousRecord = firstPrevious as Record<string, unknown>;
+  const nextRecord = firstNext as Record<string, unknown>;
+  for (const key of previousKeys) {
+    if (previousRecord[key] !== nextRecord[key]) return;
+  }
+
+  const deduplicationKey = `${hookName}:${previousKeys.toSorted((a, b) => a.localeCompare(b)).join(',')}`;
+  if (WARNED.has(deduplicationKey)) return;
+  WARNED.add(deduplicationKey);
+
+  console.warn(
+    `[${hookName}] Selector returns a new array of objects on every call, ` +
+      'causing unnecessary re-renders. Each element is a new object reference ' +
+      'with identical values.\n\n' +
+      'Options to fix:\n' +
+      '  1. Return primitives: (cells) => cells.map(c => c.id)\n' +
+      '  2. Return cell records directly: (cells) => cells.filter(predicate)\n' +
+      '  3. Provide a custom isEqual: useCells(input, selector, shallowEqual)\n'
+  );
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `dev` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Adds a dev-only warning when `useCells(input, selector)` detects the selector
returns a new array of objects with identical shallow values on every call —
a common source of unnecessary re-renders.

- New reusable utility `warnUnstableSelector` in `utils/dev-warnings.ts`
- Integrated into `useCells` select function (covers `useCell` via delegation)
- Zero production cost: guarded by `process.env.NODE_ENV === 'production'`,
  tree-shaken by consumer bundler
- Warns once per unique key shape, not on every call
- Does NOT warn for: primitives, stable cell refs, actual data changes,
  or when custom `isEqual` is provided

## Motivation and Context

Users calling `useCells(collection, cells => cells.map(c => ({ id: c.id })))`
get unnecessary re-renders because each `.map()` creates new object references.
The built-in `arrayAwareEqual` correctly handles primitives and stable refs,
but can't detect structurally-equal new objects. This warning guides users
toward the fix (return primitives, use filter, or provide isEqual).