### PR TITLE
fix(joint-react): fix cell-actions story RenderElement props and missing size

### DIFF
--- a/packages/joint-react/src/stories/examples/with-cell-actions/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-actions/code.tsx
@@ -64,8 +64,7 @@ const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
 
 // --- Node Component ---
 
-function RenderElement(element: Readonly<ElementRecord<NodeData>>) {
-  const { label = '', color = PRIMARY } = element.data ?? {};
+function RenderElement({ label = '', color = PRIMARY }: Readonly<NodeData>) {
   return (
     <HTMLHost
       useModelGeometry
@@ -397,6 +396,7 @@ function AddElementForm() {
       type: 'element',
       data: { label: label.trim(), color: PRIMARY },
       position: { x: randomX, y: randomY },
+      size: { width: 120, height: 60 },
     });
     setLabel('');
   };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `dev` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

- `RenderElement` received `data` spread as props but read `element.data` — always showed defaults (empty label, default color). Fixed to destructure `NodeData` directly.
- `AddElementForm` created elements without `size` — new nodes rendered at 0×0. Added default `size: { width: 120, height: 60 }`.

## Motivation and Context

The cell-actions story inspector controls worked but canvas never reflected changes. Root cause: `renderElement` callback receives `data` fields as props (not full `ElementRecord`), but the component typed it as `ElementRecord` and accessed `.data` — which was undefined due to `NodeData`'s index signature masking the type error.