### PR TITLE
chore(joint-react): graph provider better DX for controlled mode

### DIFF
--- a/packages/joint-react/README.md
+++ b/packages/joint-react/README.md
@@ -289,7 +289,7 @@ export function Controlled() {
 
 ### 5) Incremental change mode (Redux, Zustand, etc.)
 
-`onIncrementalChange` is orthogonal to controlled/uncontrolled — it fires in any mode with granular `added` / `changed` / `removed` sets.
+`onIncrementalCellsChange` is orthogonal to controlled/uncontrolled — it fires in any mode with granular `added` / `changed` / `removed` sets.
 
 ```tsx
 import React from 'react'
@@ -314,7 +314,7 @@ export function IncrementalExample() {
   return (
     <GraphProvider
       initialElements={initialElements}
-      onIncrementalChange={handleChange}
+      onIncrementalCellsChange={handleChange}
     >
       <Paper height={320} />
     </GraphProvider>
@@ -397,7 +397,7 @@ export function FitOnMount() {
 - **Give each view a stable `id`** when rendering multiple `Paper` instances.
 - **Prefer declarative first**: reach for hooks/props; use imperative APIs (refs/graph methods) for targeted operations only.
 - **Accessing component instances via refs**: `Paper` forwards a ref to the underlying JointJS `dia.Paper` instance. `GraphProvider` forwards a ref to the underlying `dia.Graph`.
-- **Choose the right mode**: default to uncontrolled (`initialElements` / `initialLinks`). Switch to controlled (`elements` + `onElementsChange`) only when React must own the source of truth — e.g. for undo/redo, persistence, or multi-store integration. Mix per stream as needed. Use `onIncrementalChange` for granular external-store sync (Redux, Zustand).
+- **Choose the right mode**: default to uncontrolled (`initialElements` / `initialLinks`). Switch to controlled (`elements` + `onElementsChange`) only when React must own the source of truth — e.g. for undo/redo, persistence, or multi-store integration. Mix per stream as needed. Use `onIncrementalCellsChange` for granular external-store sync (Redux, Zustand).
 - **Use selectors efficiently**: when using `useElements` or `useLinks`, provide custom selectors and equality functions to minimize re-renders.
 - **Batch updates**: the library automatically batches updates, but be mindful of rapid state changes in controlled mode.
 - **Test in Safari early** when using `<foreignObject>`; fall back to `useHTMLOverlay` if needed.

--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -1,10 +1,10 @@
 import type { dia } from '@joint/core';
-import React, { useLayoutEffect, type Dispatch, type SetStateAction } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useImperativeApi } from '../../hooks/use-imperative-api';
 import { GraphStoreContext } from '../../context';
 import { GraphStore } from '../../store';
 import type { AutoSizeOrigin } from '../../store/graph-store';
-import type { IncrementalCellsChange } from '../../store/graph-projection';
+import type { OnIncrementalCellsChange } from '../../store/graph-projection';
 import type { ElementJSONInit, LinkJSONInit } from '../../types/cell.types';
 import type { CellInput } from '../../utils/normalize-cell-input';
 
@@ -18,7 +18,7 @@ type ProviderCells<Element extends ElementJSONInit, Link extends LinkJSONInit> =
  * @template ElementData - User data attached to each element record.
  * @template LinkData - User data attached to each link record.
  */
-interface GraphProviderBaseProps<
+export interface GraphProviderProps<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
@@ -50,59 +50,20 @@ interface GraphProviderBaseProps<
   readonly autoSizeOrigin?: AutoSizeOrigin;
   /** Pre-built `GraphStore` instance. When provided, GraphProvider does not own its lifecycle. */
   readonly store?: GraphStore<Element, Link>;
+
+  /**
+   * Initial cells for uncontrolled mode. Ignored if `cells` is provided. Should not
+   */
+  readonly initialCells?: ReadonlyArray<CellInput<Element, Link>>;
+  readonly cells?: ProviderCells<Element, Link>;
+  /** Notification-only callback — React state is NOT pushed back into the graph. */
+  readonly onCellsChange?: (newCells: ProviderCells<Element, Link>) => void;
   /**
    * Notification fired with granular `added` / `changed` / `removed` sets
    * after each commit. Independent of controlled/uncontrolled mode.
    */
-  readonly onIncrementalCellsChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
+  readonly onIncrementalCellsChange?: OnIncrementalCellsChange<Element, Link>;
 }
-
-/**
- * Uncontrolled — parent provides seed cells only, JointJS drives the graph.
- * `initialCells` accepts both plain records and dia.Cell instances.
- * @template ElementData - user data on each element
- * @template LinkData - user data on each link
- */
-interface GraphProviderUncontrolledProps<Element extends ElementJSONInit, Link extends LinkJSONInit>
-  extends GraphProviderBaseProps<Element, Link> {
-  readonly initialCells?: ReadonlyArray<CellInput<Element, Link>>;
-  readonly cells?: never;
-  /** Notification-only callback — React state is NOT pushed back into the graph. */
-  readonly onCellsChange?: (cells: ProviderCells<Element, Link>) => void;
-}
-
-/**
- * Controlled — parent is the source of truth; GraphProvider keeps the graph
- * synced to the `cells` prop.
- * @template ElementData - user data on each element
- * @template LinkData - user data on each link
- */
-interface GraphProviderControlledProps<Element extends ElementJSONInit, Link extends LinkJSONInit>
-  extends GraphProviderBaseProps<Element, Link> {
-  readonly cells: ProviderCells<Element, Link>;
-  readonly initialCells?: never;
-  /**
-   * Fires whenever cells change. Consumers MUST update their React state
-   * from this callback for the graph to reflect new data.
-   */
-  readonly onCellsChange?: Dispatch<SetStateAction<ProviderCells<Element, Link>>>;
-}
-
-/**
- * Props for `GraphProvider`. Cells are a single unified stream — either
- * `initialCells` (uncontrolled) or `cells` (controlled).
- *
- * **Modes:**
- * - **Uncontrolled:** Pass `initialCells`. JointJS owns the graph after mount.
- *   `onCellsChange` may still be passed as a notification-only callback.
- * - **Controlled:** Pass `cells` and `onCellsChange`. React owns the data.
- * @template ElementData - User data attached to each element record.
- * @template LinkData - User data attached to each link record.
- */
-export type GraphProviderProps<
-  Element extends ElementJSONInit = ElementJSONInit,
-  Link extends LinkJSONInit = LinkJSONInit,
-> = GraphProviderUncontrolledProps<Element, Link> | GraphProviderControlledProps<Element, Link>;
 
 /**
  * Provider props normalised to the unparameterised base shape.
@@ -136,11 +97,11 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
     cellNamespace,
     cellModel,
     autoSizeOrigin,
+    initialCells,
+    cells,
   } = props;
 
-  const cellsProperty = 'cells' in props ? props.cells : undefined;
-  const initialCells = 'initialCells' in props ? props.initialCells : undefined;
-  const isControlled = cellsProperty !== undefined;
+  const isControlled = !!cells;
 
   const { isReady, ref } = useImperativeApi<GraphStore<ElementJSONInit, LinkJSONInit>, dia.Graph>(
     {
@@ -149,26 +110,13 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
       onLoad() {
         const graphStore =
           store ??
-          (isControlled
-            ? new GraphStore<ElementJSONInit, LinkJSONInit>({
-                graph,
-                cellNamespace,
-                cellModel,
-                cells: cellsProperty,
-                onCellsChange,
-                onIncrementalCellsChange,
-                autoSizeOrigin,
-              })
-            : new GraphStore<ElementJSONInit, LinkJSONInit>({
-                graph,
-                cellNamespace,
-                cellModel,
-                initialCells,
-                onCellsChange,
-                onIncrementalCellsChange,
-                autoSizeOrigin,
-              }));
-
+          new GraphStore<ElementJSONInit, LinkJSONInit>({
+            graph,
+            cellNamespace,
+            cellModel,
+            initialCells: cells ?? initialCells ?? [],
+            autoSizeOrigin,
+          });
         return {
           cleanup() {
             if (store) return;
@@ -182,9 +130,21 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
   );
 
   useLayoutEffect(() => {
-    if (!isControlled || !isReady || !ref.current) return;
-    ref.current.applyControlled(cellsProperty ?? []);
-  }, [cellsProperty, isControlled, isReady, ref]);
+    if (!isReady) return;
+    ref.current.setOnIncrementalCellsChange((changeSet) => {
+      onIncrementalCellsChange?.(changeSet);
+      if (onCellsChange) {
+        onCellsChange([...ref.current.graphProjection.cells.getAll()]);
+        return;
+      }
+      if (isControlled) {
+        ref.current.applyControlled(cells);
+      }
+    });
+    if (isControlled) {
+      ref.current.applyControlled(cells ?? []);
+    }
+  }, [isReady, onIncrementalCellsChange, onCellsChange, ref, isControlled, cells]);
 
   if (!isReady) {
     return null;

--- a/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
@@ -17,7 +17,7 @@ describe('graphProjection — incremental remove of element with connected links
     const incrementalCallback = jest.fn();
     const view = graphProjection<ElementRecord, LinkRecord>({
       graph,
-      onIncrementalChange: incrementalCallback,
+      onIncrementalCellsChange: incrementalCallback,
     });
 
     graph.addCells([
@@ -60,7 +60,7 @@ describe('graphProjection — incremental remove of element with connected links
     const graph = createGraph();
     const view = graphProjection<ElementRecord, LinkRecord>({
       graph,
-      onIncrementalChange: () => {
+      onIncrementalCellsChange: () => {
         // tracking enabled to exercise the trackChanges branch
       },
     });
@@ -129,12 +129,10 @@ describe('graphProjection — updateGraph branch coverage', () => {
 
     // Inject a stub `getCell` that returns undefined for 'phantom-id'.
     const realGetCell = graph.getCell.bind(graph);
-    jest
-      .spyOn(graph, 'getCell')
-      .mockImplementation(((id: unknown) => {
-        if (id === 'phantom-id') return undefined as unknown as dia.Cell;
-        return realGetCell(id as Parameters<typeof realGetCell>[0]);
-      }) as typeof graph.getCell);
+    jest.spyOn(graph, 'getCell').mockImplementation(((id: unknown) => {
+      if (id === 'phantom-id') return undefined as unknown as dia.Cell;
+      return realGetCell(id as Parameters<typeof realGetCell>[0]);
+    }) as typeof graph.getCell);
 
     // Pass a cell whose id will resolve to undefined post-sync. The internal
     // updateGraph result will include the id from cellIds and writeCell will

--- a/packages/joint-react/src/store/__tests__/graph-projection-incremental.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-projection-incremental.test.ts
@@ -9,14 +9,7 @@ function createGraph(): dia.Graph {
   return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
 }
 
-function addElement(
-  graph: dia.Graph,
-  id: string,
-  x = 10,
-  y = 20,
-  width = 100,
-  height = 50
-): void {
+function addElement(graph: dia.Graph, id: string, x = 10, y = 20, width = 100, height = 50): void {
   graph.addCell({ id, type: ELEMENT_MODEL_TYPE, position: { x, y }, size: { width, height } });
 }
 
@@ -41,14 +34,14 @@ function cloneChanges(c: IncrementalCellsChange): IncrementalCellsChange {
   };
 }
 
-describe('graphProjection onIncrementalChange', () => {
+describe('graphProjection onIncrementalCellsChange', () => {
   it('fires with added cell when an element is added to the graph', async () => {
     const graph = createGraph();
     const allChanges: IncrementalCellsChange[] = [];
 
     const view = graphProjection({
       graph,
-      onIncrementalChange: (c) => allChanges.push(cloneChanges(c)),
+      onIncrementalCellsChange: (c) => allChanges.push(cloneChanges(c)),
     });
 
     addElement(graph, 'el-1');
@@ -67,7 +60,7 @@ describe('graphProjection onIncrementalChange', () => {
 
     const view = graphProjection({
       graph,
-      onIncrementalChange: (c) => allChanges.push(cloneChanges(c)),
+      onIncrementalCellsChange: (c) => allChanges.push(cloneChanges(c)),
     });
 
     addElement(graph, 'el-1');
@@ -90,7 +83,7 @@ describe('graphProjection onIncrementalChange', () => {
 
     const view = graphProjection({
       graph,
-      onIncrementalChange: (c) => allChanges.push(cloneChanges(c)),
+      onIncrementalCellsChange: (c) => allChanges.push(cloneChanges(c)),
     });
 
     addElement(graph, 'el-1');
@@ -110,7 +103,7 @@ describe('graphProjection onIncrementalChange', () => {
     view.destroy();
   });
 
-  it('does not throw when no onIncrementalChange is provided', async () => {
+  it('does not throw when no onIncrementalCellsChange is provided', async () => {
     const graph = createGraph();
     const view = graphProjection({ graph });
 
@@ -121,13 +114,13 @@ describe('graphProjection onIncrementalChange', () => {
     view.destroy();
   });
 
-  it('commits container state before firing onIncrementalChange', async () => {
+  it('commits container state before firing onIncrementalCellsChange', async () => {
     const graph = createGraph();
     let containerValueDuringCallback: unknown;
 
     const view = graphProjection({
       graph,
-      onIncrementalChange: () => {
+      onIncrementalCellsChange: () => {
         containerValueDuringCallback = view.cells.get('el-1');
       },
     });
@@ -194,7 +187,7 @@ describe('graphProjection onIncrementalChange', () => {
     const allChanges: IncrementalCellsChange[] = [];
     const view = graphProjection({
       graph,
-      onIncrementalChange: (c) => allChanges.push(cloneChanges(c)),
+      onIncrementalCellsChange: (c) => allChanges.push(cloneChanges(c)),
     });
 
     addElement(graph, 'a');
@@ -214,7 +207,7 @@ describe('graphProjection onIncrementalChange', () => {
     const allChanges: IncrementalCellsChange[] = [];
     const view = graphProjection({
       graph,
-      onIncrementalChange: (c) => allChanges.push(cloneChanges(c)),
+      onIncrementalCellsChange: (c) => allChanges.push(cloneChanges(c)),
     });
 
     addElement(graph, 'a');

--- a/packages/joint-react/src/store/__tests__/graph-store-features.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-store-features.test.ts
@@ -194,15 +194,6 @@ describe('GraphStore feature lifecycle', () => {
   });
 });
 
-describe('GraphStore.getGraphProjection typed accessor', () => {
-  it('returns the same graphProjection reference', () => {
-    const store = new GraphStore({});
-    const view = store.getGraphProjection();
-    expect(view).toBe(store.graphProjection);
-    store.destroy(false);
-  });
-});
-
 describe('GraphStore.applyControlled', () => {
   it('routes through graphProjection.updateGraph with the react-origin flag', () => {
     const store = new GraphStore({});
@@ -487,11 +478,8 @@ describe('GraphStore size observer integration', () => {
     store.destroy(false);
   });
 
-  it('throws via getCellTransform when the targeted cell is not an element', () => {
+  it('silently ignores resize when the targeted cell has been removed from the graph', () => {
     const store = new GraphStore<CellRecord, CellRecord>({});
-    // Prepare an element on the graph then add the measured node, but
-    // remove the element afterwards before triggering resize so that
-    // `getCell()` either returns a non-element or undefined.
     store.graph.addCell({
       id: 'ghost',
       type: 'element',
@@ -501,11 +489,12 @@ describe('GraphStore size observer integration', () => {
     const node = document.createElement('div');
     store.setMeasuredNode({ id: 'ghost', node });
 
-    // Replace the cell with a non-element under the same id by removing it.
+    // Remove the cell — the projection no longer contains it, so
+    // processSizeChange bails out before reaching getCellTransform.
     store.graph.removeCells([store.graph.getCell('ghost')]);
 
     const observer = MockResizeObserver.instances.at(-1)!;
-    expect(() => observer.triggerResize(node, 100, 50)).toThrow(/Cell not valid/);
+    expect(() => observer.triggerResize(node, 100, 50)).not.toThrow();
     store.destroy(false);
   });
 });

--- a/packages/joint-react/src/store/__tests__/graph-store.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-store.test.ts
@@ -151,7 +151,7 @@ describe('GraphStore', () => {
           size: { width: 10, height: 10 },
         } as CellRecord,
       ];
-      const store = new GraphStore({ cells });
+      const store = new GraphStore({ initialCells: cells });
       expect(store.graphProjection.cells.has('x')).toBe(true);
       expect(store.graph.getCell('x')).toBeDefined();
       store.destroy(false);
@@ -161,7 +161,10 @@ describe('GraphStore', () => {
   describe('onCellsChange', () => {
     it('fires with the full cells array after a graph mutation', async () => {
       const onCellsChange = jest.fn();
-      const store = new GraphStore({ onCellsChange });
+      const store = new GraphStore({});
+      store.setOnIncrementalCellsChange(() => {
+        onCellsChange(store.graphProjection.cells.getAll());
+      });
       store.graph.addCell({
         id: 'a',
         type: ELEMENT_MODEL_TYPE,
@@ -191,9 +194,8 @@ describe('GraphStore', () => {
 
     it('fires with added/changed/removed summary', async () => {
       const snaps: Array<ReturnType<typeof snapshot>> = [];
-      const store = new GraphStore({
-        onIncrementalCellsChange: (c) => snaps.push(snapshot(c as Parameters<typeof snapshot>[0])),
-      });
+      const store = new GraphStore({});
+      store.setOnIncrementalCellsChange((c) => snaps.push(snapshot(c as Parameters<typeof snapshot>[0])));
       store.graph.addCell({
         id: 'a',
         type: ELEMENT_MODEL_TYPE,
@@ -210,9 +212,8 @@ describe('GraphStore', () => {
 
     it('reports links alongside elements in the unified pipeline', async () => {
       const snaps: Array<ReturnType<typeof snapshot>> = [];
-      const store = new GraphStore({
-        onIncrementalCellsChange: (c) => snaps.push(snapshot(c as Parameters<typeof snapshot>[0])),
-      });
+      const store = new GraphStore({});
+      store.setOnIncrementalCellsChange((c) => snaps.push(snapshot(c as Parameters<typeof snapshot>[0])));
       store.graph.addCells([
         {
           id: 'a',
@@ -250,7 +251,7 @@ describe('GraphStore', () => {
           size: { width: 10, height: 10 },
         } as CellRecord,
       ];
-      const store = new GraphStore({ cells: initial });
+      const store = new GraphStore({ initialCells: initial });
       expect(store.graphProjection.cells.has('a')).toBe(true);
 
       store.applyControlled([

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -15,13 +15,19 @@ export interface IncrementalCellsChange<
   readonly changed: Map<CellId, Element | Link>;
   readonly removed: Set<CellId>;
 }
+/**
+ * Callback type for incremental cell changes. Emitted after each graph change batch
+ */
+export type OnIncrementalCellsChange<Element extends ElementJSONInit, Link extends LinkJSONInit> = (
+  changes: IncrementalCellsChange<Element, Link>
+) => void;
 
 interface GraphProjectionState<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
   readonly graph: dia.Graph;
-  readonly onIncrementalChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
+  readonly onIncrementalCellsChange?: OnIncrementalCellsChange<Element, Link>;
   readonly onElementsSizeChange?: (id: CellId, size: dia.Size) => void;
 }
 
@@ -29,11 +35,11 @@ export function graphProjection<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 >(options: GraphProjectionState<Element, Link>) {
-  const { graph, onIncrementalChange, onElementsSizeChange } = options;
+  const { graph, onIncrementalCellsChange, onElementsSizeChange } = options;
 
   const cells = createContainer<Element | Link>();
 
-  const trackChanges = onIncrementalChange !== undefined;
+  const trackChanges = onIncrementalCellsChange !== undefined;
   const added = trackChanges ? new Map<CellId, Element | Link>() : undefined;
   const changed = trackChanges ? new Map<CellId, Element | Link>() : undefined;
   const removed = trackChanges ? new Set<CellId>() : undefined;
@@ -93,7 +99,7 @@ export function graphProjection<
         (added!.size > 0 || changed!.size > 0 || removed!.size > 0);
 
       if (hasTrackedChanges) {
-        onIncrementalChange!({ added: added!, changed: changed!, removed: removed! });
+        onIncrementalCellsChange!({ added: added!, changed: changed!, removed: removed! });
         added!.clear();
         changed!.clear();
         removed!.clear();

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -16,7 +16,11 @@ import { LAYOUT_UPDATE_EVENT } from './graph-changes';
 import { createAtom, type Atom } from './state-container';
 import type { IncrementalChange } from '../state/incremental.types';
 import type { Feature } from '../types/feature.types';
-import { graphProjection, type GraphProjection, type IncrementalCellsChange } from './graph-projection';
+import {
+  graphProjection,
+  type GraphProjection,
+  type OnIncrementalCellsChange,
+} from './graph-projection';
 import { simpleScheduler } from '../utils/scheduler';
 import { cellInputToModel, type CellInput } from '../utils/normalize-cell-input';
 
@@ -63,46 +67,24 @@ export interface GraphStoreInternalSnapshot {
  */
 export type AutoSizeOrigin = 'top-left' | 'center';
 
-interface GraphStoreOptionsBase<
+/**
+ * Options for creating a `GraphStore` in controlled mode. Requires the full cells
+ */
+export interface GraphStoreOptions<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
   readonly graph?: dia.Graph;
   readonly cellNamespace?: unknown;
   readonly cellModel?: typeof dia.Cell;
-  readonly onIncrementalCellsChange?: (changes: IncrementalCellsChange<Element, Link>) => void;
   /**
    * Reference point that stays fixed when an auto-sized element's measured size
    * changes. See {@link AutoSizeOrigin}.
    * @default 'top-left'
    */
   readonly autoSizeOrigin?: AutoSizeOrigin;
-}
-
-/** Uncontrolled mode: parent provides only seed data. */
-interface GraphStoreOptionsUncontrolled<Element extends ElementJSONInit, Link extends LinkJSONInit>
-  extends GraphStoreOptionsBase<Element, Link> {
   readonly initialCells?: ReadonlyArray<CellInput<Element, Link>>;
-  readonly cells?: never;
-  readonly onCellsChange?: (cells: ReadonlyArray<Element | Link>) => void;
 }
-
-/** Controlled mode: parent is the source of truth; store applies snapshots. */
-interface GraphStoreOptionsControlled<Element extends ElementJSONInit, Link extends LinkJSONInit>
-  extends GraphStoreOptionsBase<Element, Link> {
-  readonly cells: ReadonlyArray<Element | Link>;
-  readonly initialCells?: never;
-  readonly onCellsChange?: (cells: ReadonlyArray<Element | Link>) => void;
-}
-
-/**
- * Constructor options for {@link GraphStore} — either uncontrolled (`initialCells`)
- * or controlled (`cells` + `onCellsChange`).
- */
-export type GraphStoreOptions<
-  Element extends ElementJSONInit = ElementJSONInit,
-  Link extends LinkJSONInit = LinkJSONInit,
-> = GraphStoreOptionsUncontrolled<Element, Link> | GraphStoreOptionsControlled<Element, Link>;
 
 /**
  * Central store for managing graph state, synchronization, and paper instances.
@@ -111,36 +93,26 @@ export class GraphStore<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
+  public readonly graphProjection: GraphProjection<Element, Link>;
   public readonly internalState: Atom<GraphStoreInternalSnapshot>;
   public readonly measureState: Atom<number> = createAtom(0);
   public readonly graph: dia.Graph;
-
+  public readonly autoSizeOrigin: AutoSizeOrigin;
   public paperStores = new Map<string, PaperStore>();
   public features: Record<string, Feature> = {};
+
   private observer: GraphStoreObserver;
-  public readonly graphProjection: GraphProjection<Element, Link>;
-
-  public getGraphProjection<
-    E extends ElementJSONInit = ElementJSONInit,
-    L extends LinkJSONInit = LinkJSONInit,
-  >(): GraphProjection<E, L> {
-    return this.graphProjection as unknown as GraphProjection<E, L>;
-  }
-
-  public readonly autoSizeOrigin: AutoSizeOrigin;
+  private onIncrementalCellsChange?: OnIncrementalCellsChange<Element, Link>;
 
   constructor(public readonly config: GraphStoreOptions<Element, Link>) {
     const {
       cellModel,
       cellNamespace = DEFAULT_CELL_NAMESPACE,
       graph,
-      onCellsChange,
-      onIncrementalCellsChange,
       autoSizeOrigin = 'top-left',
+      initialCells,
     } = config;
     this.autoSizeOrigin = autoSizeOrigin;
-    const controlledCells = 'cells' in config ? config.cells : undefined;
-    const initialCells = 'initialCells' in config ? config.initialCells : undefined;
 
     this.graph =
       graph ??
@@ -167,12 +139,12 @@ export class GraphStore<
         this.measureState.set((previous) => previous + 1);
       }
     };
+
     this.graphProjection = graphProjection<Element, Link>({
       graph: this.graph,
-      onIncrementalChange: this.buildIncrementalChangeHandler(
-        onIncrementalCellsChange,
-        onCellsChange
-      ),
+      onIncrementalCellsChange: (changes) => {
+        this.onIncrementalCellsChange?.(changes);
+      },
       onElementsSizeChange: (id, size) => {
         if (size.width > 0 && size.height > 0) {
           elementsMeasured.add(id);
@@ -239,13 +211,11 @@ export class GraphStore<
       },
     });
 
-    // Initial sync
-    const seedCells = controlledCells ?? initialCells;
-    if (seedCells && seedCells.length > 0) {
+    if (initialCells && initialCells.length > 0) {
       // Replace existing graph state with the seed cells. The graph-changes
       // listener handles `reset` synchronously and populates the cells
       // container — no manual `syncFromGraph` needed.
-      const models = seedCells.map((cell) => cellInputToModel(cell, this.graph));
+      const models = initialCells.map((cell) => cellInputToModel(cell, this.graph));
       this.graph.resetCells(models);
     } else if (this.graph.getCells().length > 0) {
       // External graph already has cells — populate the cells container
@@ -256,30 +226,9 @@ export class GraphStore<
     }
   }
 
-  /**
-   * Build the incremental-change relay that fans out store-level callbacks.
-   * Calling `onIncrementalCellsChange` with the raw `{added, changed, removed}`
-   * summary, and `onCellsChange` with the full cells-array snapshot.
-   * @param onIncrementalCellsChange - user callback for the summary
-   * @param onCellsChange - user callback for the full-array snapshot
-   * @returns combined handler, or undefined when both are absent (avoids allocation)
-   */
-  private buildIncrementalChangeHandler(
-    onIncrementalCellsChange:
-      | ((changes: IncrementalCellsChange<Element, Link>) => void)
-      | undefined,
-    onCellsChange: ((cells: ReadonlyArray<Element | Link>) => void) | undefined
-  ): ((changes: IncrementalCellsChange<Element, Link>) => void) | undefined {
-    if (!onIncrementalCellsChange && !onCellsChange) {
-      return undefined;
-    }
-    return (changes) => {
-      onIncrementalCellsChange?.(changes);
-      if (onCellsChange) {
-        onCellsChange(this.graphProjection.cells.getAll() as ReadonlyArray<Element | Link>);
-      }
-    };
-  }
+  public setOnIncrementalCellsChange = (callback: OnIncrementalCellsChange<Element, Link>) => {
+    this.onIncrementalCellsChange = callback;
+  };
 
   /**
    * Apply a controlled cells snapshot (called by GraphProvider when the


### PR DESCRIPTION
Refactor the graph provider to enhance the developer experience by renaming the `onIncrementalChange` callback to `onIncrementalCellsChange` for clarity and consistency. This change improves the API's usability in controlled mode, ensuring that developers can better manage incremental updates to graph elements and links. Additionally, update related documentation to reflect this change.

