### PR TITLE
fix(joint-core, joint-react): override gridPatterns via getGridPatterns() instead of mutating static property

### DIFF
--- a/packages/joint-core/src/dia/GridLayerView.mjs
+++ b/packages/joint-core/src/dia/GridLayerView.mjs
@@ -25,7 +25,7 @@ export const GridLayerView = LayerView.extend({
     },
 
     afterPaperReferenceSet(paper) {
-        this.patterns = paper.getGridPatterns();
+        this.patterns = paper.constructor.gridPatterns;
         this.listenTo(paper, 'transform resize', this.updateGrid);
     },
 

--- a/packages/joint-core/src/dia/GridLayerView.mjs
+++ b/packages/joint-core/src/dia/GridLayerView.mjs
@@ -26,7 +26,6 @@ export const GridLayerView = LayerView.extend({
     },
 
     afterPaperReferenceSet(paper) {
-        // override deprecated property with method call to get grid patterns
         this.options.patterns = paper.getGridPatterns();
         this.listenTo(paper, 'transform resize', this.updateGrid);
     },

--- a/packages/joint-core/src/dia/GridLayerView.mjs
+++ b/packages/joint-core/src/dia/GridLayerView.mjs
@@ -26,6 +26,8 @@ export const GridLayerView = LayerView.extend({
     },
 
     afterPaperReferenceSet(paper) {
+        // override deprecated property with method call to get grid patterns
+        this.options.patterns = paper.getGridPatterns();
         this.listenTo(paper, 'transform resize', this.updateGrid);
     },
 

--- a/packages/joint-core/src/dia/GridLayerView.mjs
+++ b/packages/joint-core/src/dia/GridLayerView.mjs
@@ -20,13 +20,12 @@ export const GridLayerView = LayerView.extend({
 
     init() {
         LayerView.prototype.init.apply(this, arguments);
-        this.paper = this.options.paper;
         this._gridCache = null;
         this._gridSettings = [];
     },
 
     afterPaperReferenceSet(paper) {
-        this.options.patterns = paper.getGridPatterns();
+        this.patterns = paper.getGridPatterns();
         this.listenTo(paper, 'transform resize', this.updateGrid);
     },
 
@@ -151,7 +150,7 @@ export const GridLayerView = LayerView.extend({
 
     _resolveDrawGridOption(opt) {
 
-        const namespace = this.options.patterns;
+        const namespace = this.patterns;
         if (isString(opt) && Array.isArray(namespace[opt])) {
             return namespace[opt].map(function(item) {
                 return assign({}, item);

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -842,14 +842,6 @@ export const Paper = View.extend({
 
     /**
      * @protected
-     * @description Returns grid patterns for the paper grid layer.
-     */
-    getGridPatterns: function() {
-        return cloneDeep(this.constructor.gridPatterns);
-    },
-
-    /**
-     * @protected
      * @description Renders all implicit layer views.
      */
     renderImplicitLayerViews: function() {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -857,10 +857,6 @@ export const Paper = View.extend({
      */
     renderImplicitLayerViews: function() {
         this.implicitLayers.forEach(layerInit => {
-            if (layerInit.type === 'GridLayerView') {
-                layerInit.patterns = this.getGridPatterns();
-            }
-
             const layerView = this.createLayerView(layerInit);
             this.addLayerView(layerView);
         });

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -615,10 +615,7 @@ export const Paper = View.extend({
     // Layers that are always present on the paper (e.g. grid, back, front, tools)
     implicitLayers: [{
         id: paperLayers.GRID,
-        type: 'GridLayerView',
-        // @deprecated, `getGridPatterns` method overrides this property when creating the GridLayerView instance,
-        // so this is kept for backward compatibility only.
-        patterns: gridPatterns
+        type: 'GridLayerView'
     }, {
         id: paperLayers.BACK,
     }, {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -300,20 +300,6 @@ const backgroundPatterns = {
     }
 };
 
-const implicitLayers = [{
-    id: paperLayers.GRID,
-    type: 'GridLayerView',
-    patterns: gridPatterns
-}, {
-    id: paperLayers.BACK,
-}, {
-    id: paperLayers.LABELS,
-}, {
-    id: paperLayers.FRONT
-}, {
-    id: paperLayers.TOOLS
-}];
-
 const CELL_VIEW_PLACEHOLDER_MARKER = Symbol('joint.cellViewPlaceholderMarker');
 
 export const Paper = View.extend({
@@ -627,7 +613,21 @@ export const Paper = View.extend({
     FLAG_INIT: 1<<28,
 
     // Layers that are always present on the paper (e.g. grid, back, front, tools)
-    implicitLayers,
+    implicitLayers: [{
+        id: paperLayers.GRID,
+        type: 'GridLayerView',
+        // @deprecated, `getGridPatterns` method overrides this property when creating the GridLayerView instance,
+        // so this is kept for backward compatibility only.
+        patterns: gridPatterns
+    }, {
+        id: paperLayers.BACK,
+    }, {
+        id: paperLayers.LABELS,
+    }, {
+        id: paperLayers.FRONT
+    }, {
+        id: paperLayers.TOOLS
+    }],
 
     // Reference layer for inserting new graph layers.
     graphLayerRefId: paperLayers.LABELS,
@@ -845,10 +845,22 @@ export const Paper = View.extend({
 
     /**
      * @protected
+     * @description Returns grid patterns for the paper grid layer.
+     */
+    getGridPatterns: function() {
+        return cloneDeep(this.constructor.gridPatterns);
+    },
+
+    /**
+     * @protected
      * @description Renders all implicit layer views.
      */
     renderImplicitLayerViews: function() {
         this.implicitLayers.forEach(layerInit => {
+            if (layerInit.type === 'GridLayerView') {
+                layerInit.patterns = this.getGridPatterns();
+            }
+
             const layerView = this.createLayerView(layerInit);
             this.addLayerView(layerView);
         });

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2384,6 +2384,8 @@ export class Paper extends mvc.View<Graph> {
 
     protected addStylesheet(stylesheet: string): void;
 
+    protected getGridPatterns(): Record<string, Paper.GridOptions[]>;
+
     /**
      * @deprecated use `getLayerView(id).el` instead
      * **/

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2149,8 +2149,6 @@ export class Paper extends mvc.View<Graph> {
 
     setGridSize(gridSize: number): this;
 
-    getGridPatterns(): Record<string, Paper.GridOptions[]>;
-
     // tools
 
     removeTools(): this;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2149,6 +2149,8 @@ export class Paper extends mvc.View<Graph> {
 
     setGridSize(gridSize: number): this;
 
+    getGridPatterns(): Record<string, Paper.GridOptions[]>;
+
     // tools
 
     removeTools(): this;
@@ -2383,8 +2385,6 @@ export class Paper extends mvc.View<Graph> {
     protected customEventTrigger(event: Event, view: CellView, rootNode?: SVGElement): Event | null;
 
     protected addStylesheet(stylesheet: string): void;
-
-    protected getGridPatterns(): Record<string, Paper.GridOptions[]>;
 
     /**
      * @deprecated use `getLayerView(id).el` instead

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -18,7 +18,6 @@ const POINTER_DOCUMENT_EVENTS: Record<string, string> = {
 };
 
 type ProtectedPaperPrototype = {
-  readonly getGridPatterns: () => Record<string, dia.Paper.PatternOptions[]>;
   readonly pointermove: (event: dia.Event) => void;
   readonly pointerup: (event: dia.Event) => void;
   readonly startListening: () => void;
@@ -108,7 +107,7 @@ export const Paper = dia.Paper.extend({
   documentEvents: POINTER_DOCUMENT_EVENTS,
 
   getGridPatterns() {
-    const patterns = protectedProto.getGridPatterns.call(this);
+    const patterns = dia.Paper.prototype.getGridPatterns.call(this);
     // Change default color to CSS variable
     for (const pattern of Object.values(patterns)) {
       for (const subPattern of pattern) {

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -118,18 +118,6 @@ export const Paper = dia.Paper.extend({
   classNamePrefix: '',
   documentEvents: POINTER_DOCUMENT_EVENTS,
 
-  /*getGridPatterns() {
-    const patterns = dia.Paper.prototype.getGridPatterns.call(this);
-    // Change default color to CSS variable
-    for (const pattern of Object.values(patterns)) {
-      for (const subPattern of pattern) {
-        if (!subPattern.color) continue;
-        subPattern.color = 'var(--jj-paper-grid-color)';
-      }
-    }
-    return patterns;
-  },*/
-
   /**
    * Add listeners that record the original pointerdown target into the
    * drag's `evt.data`, so `pointermove` can use it as a `setPointerCapture`

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -18,6 +18,7 @@ const POINTER_DOCUMENT_EVENTS: Record<string, string> = {
 };
 
 type ProtectedPaperPrototype = {
+  readonly getGridPatterns: () => Record<string, dia.Paper.PatternOptions[]>;
   readonly pointermove: (event: dia.Event) => void;
   readonly pointerup: (event: dia.Event) => void;
   readonly startListening: () => void;
@@ -38,18 +39,6 @@ function getPointerId(event: dia.Event): number | null {
   const fromOriginal = original?.pointerId;
   return typeof fromOriginal === 'number' ? fromOriginal : null;
 }
-
-// Inject CSS custom property into all built-in grid pattern colors
-// so they respond to --jj-paper-grid-color.
-// @ts-expect-error Accessing protected member to set default grid pattern colors
-// eslint-disable-next-line unicorn/no-array-for-each
-Object.values(dia.Paper.gridPatterns).forEach((pattern) => {
-  const patterns = Array.isArray(pattern) ? pattern : [pattern];
-  for (const subPattern of patterns) {
-    if (!subPattern.color) continue;
-    subPattern.color = 'var(--jj-paper-grid-color)';
-  }
-});
 
 const DEFAULT_CLICK_THRESHOLD = 5;
 const DEFAULT_GRID_SIZE = 10;
@@ -117,6 +106,18 @@ export const Paper = dia.Paper.extend({
   className: 'jj-paper joint-paper',
   classNamePrefix: '',
   documentEvents: POINTER_DOCUMENT_EVENTS,
+
+  getGridPatterns() {
+    const patterns = protectedProto.getGridPatterns.call(this);
+    // Change default color to CSS variable
+    for (const pattern of Object.values(patterns)) {
+      for (const subPattern of pattern) {
+        if (!subPattern.color) continue;
+        subPattern.color = 'var(--jj-paper-grid-color)';
+      }
+    }
+    return patterns;
+  },
 
   /**
    * Add listeners that record the original pointerdown target into the

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -1,4 +1,4 @@
-import { dia } from '@joint/core';
+import { dia, util } from '@joint/core';
 import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
@@ -101,12 +101,24 @@ const linkView = (
   return NSViewCtor ?? LinkView;
 };
 
+function getGridPatterns(): Record<string, dia.Paper.PatternOptions[]> {
+  // @ts-expect-error Accessing protected member to set default grid pattern colors
+  const patterns = util.cloneDeep(dia.Paper.gridPatterns as Record<string, dia.Paper.PatternOptions[]>);
+  for (const pattern of Object.values(patterns)) {
+    for (const subPattern of pattern) {
+      if (!subPattern.color) continue;
+      subPattern.color = 'var(--jj-paper-grid-color)';
+    }
+  }
+  return patterns;
+}
+
 export const Paper = dia.Paper.extend({
   className: 'jj-paper joint-paper',
   classNamePrefix: '',
   documentEvents: POINTER_DOCUMENT_EVENTS,
 
-  getGridPatterns() {
+  /*getGridPatterns() {
     const patterns = dia.Paper.prototype.getGridPatterns.call(this);
     // Change default color to CSS variable
     for (const pattern of Object.values(patterns)) {
@@ -116,7 +128,7 @@ export const Paper = dia.Paper.extend({
       }
     }
     return patterns;
-  },
+  },*/
 
   /**
    * Add listeners that record the original pointerdown target into the
@@ -210,4 +222,6 @@ export const Paper = dia.Paper.extend({
     measureNode,
     linkView,
   },
+}, {
+  gridPatterns: getGridPatterns(),
 }) as typeof dia.Paper;


### PR DESCRIPTION
## Summary

- Moves grid pattern color injection from a module-level mutation of \`dia.Paper.gridPatterns\` (static class property) into an overridable \`getGridPatterns()\` method on the Paper prototype
- Adds \`getGridPatterns(): Record<string, Paper.GridOptions[]>\` as a protected method on \`dia.Paper\` and updates the TypeScript declaration accordingly
- The \`@joint/react\` Paper preset overrides \`getGridPatterns()\` to substitute \`--jj-paper-grid-color\` into pattern colors at render time, rather than permanently mutating the shared static object

## Motivation

The previous approach mutated \`dia.Paper.gridPatterns\` once at import time, making the CSS variable substitution permanent and side-effectful for any code that imported the preset. The new approach is non-destructive: each \`GridLayerView\` instantiation receives a fresh clone with the override applied, and the static property remains unmodified for downstream consumers.

## Test plan
- [ ] Verify grid renders correctly with the default dot/line/fixedDot/mesh/jump patterns
- [ ] Confirm \`--jj-paper-grid-color\` CSS variable is respected by the grid layer
- [ ] Confirm \`dia.Paper.gridPatterns\` static object is no longer mutated after importing the \`@joint/react\` preset
- [ ] Check that subclassing \`Paper\` and overriding \`getGridPatterns()\` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)