### PR TITLE
fix(joint-react): useCells picks up pre-existing collection items on first render

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, render, act } from '@testing-library/react';
 import { mvc, type dia } from '@joint/core';
 import { GraphProvider } from '../../components/graph/graph-provider';
 import { useCells } from '../use-cells';
@@ -615,5 +615,52 @@ describe('useCells (collection form)', () => {
       expect.stringContaining('[useCells] Selector returns a new array of objects')
     );
     warnSpy.mockRestore();
+  });
+
+  it('returns pre-existing collection items on first render after graph is fully synced', async () => {
+    // Reproduces the case where a consumer mounts *after* the graph store has
+    // already settled (its commit microtask fired) and the collection was
+    // populated before the consumer subscribed. Without picking up the items
+    // synchronously in the render phase, no container listener would fire to
+    // notify React, and `useCells` would stay stuck at `[]`.
+    let collection: mvc.Collection<dia.Cell> | null = null;
+    let renderedIds: readonly string[] = [];
+
+    function Setup() {
+      const store = useGraphStore();
+      if (!collection) {
+        collection = new mvc.Collection<dia.Cell>([
+          store.graph.getCell('a')!,
+          store.graph.getCell('b')!,
+        ]);
+      }
+      return null;
+    }
+
+    function Consumer() {
+      const cells = useCells(collection!);
+      renderedIds = cells.map((c) => String(c.id));
+      return null;
+    }
+
+    const { rerender } = render(
+      <GraphProvider initialCells={initialCells}>
+        <Setup />
+      </GraphProvider>
+    );
+
+    // Allow the graph store's initial sync + commit to settle. The Consumer is
+    // NOT mounted yet, so no useCells listener is registered for these cells.
+    await act(async () => flush());
+
+    rerender(
+      <GraphProvider initialCells={initialCells}>
+        <Setup />
+        <Consumer />
+      </GraphProvider>
+    );
+    await act(async () => flush());
+
+    expect(renderedIds).toEqual(['a', 'b']);
   });
 });

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -222,7 +222,9 @@ export function useCells<
   const collectionIdsRef = useRef<readonly CellId[]>([]);
   const collectionVersionRef = useRef(0);
 
-  const previousCollectionRef = useRef(collectionArgument);
+  // Use `null` sentinel so the init-block runs on first render too, picking up
+  // any models that already exist in the collection at subscribe time.
+  const previousCollectionRef = useRef<mvc.Collection<dia.Cell> | undefined | null>(null);
   if (previousCollectionRef.current !== collectionArgument) {
     previousCollectionRef.current = collectionArgument;
     collectionIdsRef.current = collectionArgument


### PR DESCRIPTION
## Summary

`useCells(collection, ...)` was using `useRef(collectionArgument)` as the "previous collection" sentinel. On the first render the ref is already `===` to `collectionArgument`, so the render-phase init block never ran, and `collectionIdsRef.current` stayed at its `[]` default. The commit-phase `subscribeToCollection` updates the ref but does not bump the version — so React was never notified, and any items already in the collection at mount time were invisible to `useCells` until the next membership change.

Switched the sentinel to `null` so the init block always runs on the first render: ids + version are populated synchronously from the current collection state. Subsequent renders behave as before (no-op when the collection ref hasn't changed).

## Reproduction (before this fix)

```tsx
<GraphProvider initialCells={cells}>
  <Consumer />
</GraphProvider>
```

```tsx
function Consumer() {
  const collection = useSomeCollectionWithItems(); // already populated at mount
  const cells = useCells(collection);
  // cells === [] forever (until the collection fires add/remove/reset)
}
```

After the fix, `cells` reflects the collection's current contents on first render.

## Test plan
- [ ] `yarn workspace @joint/react test` (or whichever runs the jest suite)
- [ ] Run a consumer that mounts on top of an already-populated collection and confirm `useCells` returns its items immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)