### PR TITLE
fix(dia.GridLayerView): allow GridLayerView to directly read patterns from paper static field

### DIFF
--- a/packages/joint-core/src/dia/GridLayerView.mjs
+++ b/packages/joint-core/src/dia/GridLayerView.mjs
@@ -20,12 +20,12 @@ export const GridLayerView = LayerView.extend({
 
     init() {
         LayerView.prototype.init.apply(this, arguments);
-        this.paper = this.options.paper;
         this._gridCache = null;
         this._gridSettings = [];
     },
 
     afterPaperReferenceSet(paper) {
+        this.patterns = paper.constructor.gridPatterns;
         this.listenTo(paper, 'transform resize', this.updateGrid);
     },
 
@@ -150,7 +150,7 @@ export const GridLayerView = LayerView.extend({
 
     _resolveDrawGridOption(opt) {
 
-        const namespace = this.options.patterns;
+        const namespace = this.patterns;
         if (isString(opt) && Array.isArray(namespace[opt])) {
             return namespace[opt].map(function(item) {
                 return assign({}, item);

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -300,20 +300,6 @@ const backgroundPatterns = {
     }
 };
 
-const implicitLayers = [{
-    id: paperLayers.GRID,
-    type: 'GridLayerView',
-    patterns: gridPatterns
-}, {
-    id: paperLayers.BACK,
-}, {
-    id: paperLayers.LABELS,
-}, {
-    id: paperLayers.FRONT
-}, {
-    id: paperLayers.TOOLS
-}];
-
 const CELL_VIEW_PLACEHOLDER_MARKER = Symbol('joint.cellViewPlaceholderMarker');
 
 export const Paper = View.extend({
@@ -627,7 +613,18 @@ export const Paper = View.extend({
     FLAG_INIT: 1<<28,
 
     // Layers that are always present on the paper (e.g. grid, back, front, tools)
-    implicitLayers,
+    implicitLayers: [{
+        id: paperLayers.GRID,
+        type: 'GridLayerView'
+    }, {
+        id: paperLayers.BACK,
+    }, {
+        id: paperLayers.LABELS,
+    }, {
+        id: paperLayers.FRONT
+    }, {
+        id: paperLayers.TOOLS
+    }],
 
     // Reference layer for inserting new graph layers.
     graphLayerRefId: paperLayers.LABELS,


### PR DESCRIPTION
Copy of #3330 for the master branch.

Now GridLayerView reads patterns directly from `dia.Paper.gridPatterns` static field which allows for overriding.