### PR TITLE
fix(joint-react): discard stale feature ref after StrictMode cleanup in useCreateFeature

### DIFF
--- a/packages/joint-react/src/hooks/use-create-features.ts
+++ b/packages/joint-react/src/hooks/use-create-features.ts
@@ -331,12 +331,21 @@ export function useCreateFeature<T>(
   useLayoutEffect(() => {
     if (isPaperTarget && !paperStore) return;
 
-    // Re-register cached feature if it was removed by strict-mode cleanup
-    // OR if it was already created during render (inside-Paper case).
+    // Re-register cached feature if it was already created during render
+    // (inside-Paper case). In StrictMode, the cleanup runs feature.clean()
+    // which destroys JointJS views. If the cached feature is no longer in the
+    // store, discard it so a fresh instance is created below instead of
+    // re-registering dead views.
     if (featureRef.current) {
-      registerFeature(target, graphStore, paperStore, featureRef.current);
-      setForwardRef(forwardedRef, featureRef.current.instance);
-      return () => unregisterFeature(target, graphStore, paperStore, featureRef.current!.id);
+      const existingInStore = resolveExistingFeature(target, graphStore, paperStore, id);
+      if (existingInStore === featureRef.current) {
+        registerFeature(target, graphStore, paperStore, featureRef.current);
+        setForwardRef(forwardedRef, featureRef.current.instance);
+        return () => unregisterFeature(target, graphStore, paperStore, featureRef.current!.id);
+      }
+      // Feature was cleaned up (e.g. by StrictMode cleanup) — discard the dead
+      // reference so the creation path below creates a fresh instance.
+      featureRef.current = null;
     }
 
     // Adopt a feature that was already registered by the deferred-queue path


### PR DESCRIPTION
## Summary

- Fixes `useCreateFeature` re-registering a dead feature reference after React StrictMode double-invoke unmounts it
- In StrictMode the cleanup runs `feature.clean()`, which destroys the underlying JointJS views. The cached `featureRef.current` still pointed to that cleaned-up instance, causing re-registration of broken views on the second mount
- Now checks whether the cached ref is still present in the store via `resolveExistingFeature`; if it was evicted (StrictMode cleanup path), the ref is discarded so the normal creation path below builds a fresh instance instead

## Test plan
- [ ] Verify features (e.g. highlighters, tools) mount and render correctly in StrictMode (`<React.StrictMode>`)
- [ ] Confirm no "dead view" errors or visual glitches on second StrictMode mount
- [ ] Confirm features still work correctly outside StrictMode (single mount, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)