### PR TITLE
refactor(joint-react): default paper IDs + unified usePaper/usePaperStore signatures

### DIFF
--- a/packages/joint-react/src/components/paper/paper.tsx
+++ b/packages/joint-react/src/components/paper/paper.tsx
@@ -1,9 +1,10 @@
 import type { dia } from '@joint/core';
-import { forwardRef, useId, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { PaperStoreContext } from '../../context';
 import { useCreatePortalPaper } from '../../hooks/use-create-portal-paper';
 import type { PaperProps } from './paper.types';
+import { DEFAULT_PAPER_ID } from '../../models/react-paper';
 
 /**
  * Internal Paper implementation used by forwarded `Paper` component.
@@ -17,8 +18,7 @@ function PaperBase(
 ) {
   const { className, style, children, paper: externalPaper } = props;
   const paperHTMLElementRef = useRef<HTMLDivElement | null>(null);
-  const reactId = useId();
-  const id = props.id ?? `paper-${reactId}`;
+  const id = props.id ?? DEFAULT_PAPER_ID;
   const isExternalPaper = !!externalPaper;
   const { paperRef, paperStore, isReady, content } = useCreatePortalPaper({
     ...props,

--- a/packages/joint-react/src/components/paper/render-element/paper-element-item.tsx
+++ b/packages/joint-react/src/components/paper/render-element/paper-element-item.tsx
@@ -100,6 +100,7 @@ function SVGElementItemComponent(props: ElementItemProps) {
   const graphStore = useGraphStore();
   const { paper } = usePaper();
   useLayoutEffect(() => {
+    if (!paper) return;
     graphStore.clearViewForElementAndLinks({
       cellId: id,
       paper,

--- a/packages/joint-react/src/hooks/__tests__/use-cell-drag.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-drag.test.tsx
@@ -76,12 +76,12 @@ function makeDragState(
 }
 
 describe('useCellDrag', () => {
-  it('throws without PaperStoreContext', () => {
-    expect(() => {
-      renderHook(() => useCellDrag(), {
-        wrapper: createWrapper({ cellId: 'cell-1' }),
-      });
-    }).toThrow('usePaperStore must be used within a Paper or RenderElement');
+  it('returns idle state without PaperStoreContext', () => {
+    const { result } = renderHook(() => useCellDrag(), {
+      wrapper: createWrapper({ cellId: 'cell-1' }),
+    });
+
+    expect(result.current.isDragging).toBe(false);
   });
 
   it('returns idle state with paper but no drag', () => {

--- a/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
@@ -27,7 +27,7 @@ import { LINK_MODEL_TYPE } from '../../models/link-model';
 import type { CellRecord } from '../../types/cell.types';
 
 let capturedGraph: dia.Graph | null = null;
-let capturedPaper: dia.Paper | null = null;
+let capturedPaper: dia.Paper | undefined;
 
 const initialCells: readonly CellRecord[] = [
   {
@@ -104,7 +104,7 @@ const renderNoNodeProbe = () => <NoNodeProbe />;
 describe('useMeasureNode', () => {
   it('adds .jj-is-measuring on mount and removes it on the next paper render:done', async () => {
     capturedGraph = null;
-    capturedPaper = null;
+    capturedPaper = undefined;
     const { container } = renderProbe();
     // Class is applied by useMeasureNode in a layout effect; wait until it lands.
     await waitFor(() => {

--- a/packages/joint-react/src/hooks/__tests__/use-paper-context.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper-context.test.tsx
@@ -44,22 +44,12 @@ describe('use-paper-context', () => {
     expect(capturedContext).toHaveProperty('paperId');
   });
 
-  it('should throw error when used outside Paper and optional is false', () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => {
-      renderHook(() => usePaperStore(), {
-        wrapper: graphWrapper,
-      });
-    }).toThrow('usePaperStore must be used within a Paper or RenderElement');
-    consoleError.mockRestore();
-  });
-
-  it('should return null when used outside Paper and optional is true', () => {
-    const { result } = renderHook(() => usePaperStore({ optional: true }), {
+  it('should return undefined when used outside Paper (no default paper mounted)', () => {
+    const { result } = renderHook(() => usePaperStore(), {
       wrapper: graphWrapper,
     });
 
-    expect(result.current).toBeNull();
+    expect(result.current).toBeUndefined();
   });
 
   it('should return paper store by id from GraphProvider', async () => {

--- a/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
@@ -13,12 +13,11 @@ import type { CellRecord } from '../../types/cell.types';
 const EMPTY_CELLS: readonly CellRecord[] = [];
 
 describe('useResolvePaperId', () => {
-  it('returns null sentinel when target is undefined', () => {
+  it('returns undefined when target is undefined', () => {
     const wrapper = graphProviderWrapper({ initialCells: [] });
     const undefinedTarget: undefined = undefined;
     const { result } = renderHook(() => useResolvePaperId(undefinedTarget), { wrapper });
-    // OPTIONAL sentinel `{ optional: true }` is returned for unresolved targets.
-    expect(typeof result.current).toBe('object');
+    expect(result.current).toBeUndefined();
   });
 
   it('returns the id directly when target is a string', () => {
@@ -53,15 +52,15 @@ describe('useResolvePaperId', () => {
     await waitFor(() => expect(result.current).toBe('instance-paper'));
   });
 
-  it('resolves a ref-based target via the layout effect when ref attaches mid-mount (lines 33–35)', async () => {
+  it('resolves a ref-based target via the layout effect when ref attaches mid-mount', async () => {
     // Render <Paper ref={paperRef} /> together with a Probe that calls
     // `useResolvePaperId(paperRef)`. On the first render, `paperRef.current`
     // is still null (Paper's `useImperativeHandle` populates it AFTER child
     // effects run). The Probe's `useResolvePaperId` therefore returns the
     // null sentinel during render, but its layout effect runs *after* Paper
     // has attached to the ref — the layout effect re-resolves successfully
-    // and forces a re-render via `forceRender()`, hitting lines 33–35.
-    let resolvedId: string | { optional: true } | null = null;
+    // and forces a re-render via `forceRender()`.
+    let resolvedId: string | undefined;
     function Probe({ paperRef }: { readonly paperRef: React.RefObject<dia.Paper | null> }) {
       resolvedId = useResolvePaperId(paperRef);
       return null;
@@ -99,13 +98,13 @@ describe('usePaper', () => {
       paperProps: { id: 'context-paper' },
     });
     const { result } = renderHook(() => usePaper(), { wrapper });
-    await waitFor(() => expect(result.current.paper).not.toBeNull());
+    await waitFor(() => expect(result.current.paper).toBeDefined());
   });
 
-  it('returns { paper: null } with optional: true outside Paper context', () => {
+  it('returns { paper: undefined } outside Paper context', () => {
     const wrapper = graphProviderWrapper({ initialCells: [] });
-    const { result } = renderHook(() => usePaper({ optional: true }), { wrapper });
-    expect(result.current.paper).toBeNull();
+    const { result } = renderHook(() => usePaper(), { wrapper });
+    expect(result.current.paper).toBeUndefined();
   });
 
   it('looks up paper by id', async () => {
@@ -122,6 +121,6 @@ describe('usePaper', () => {
       paperProps: { id: 'by-id-paper' },
     });
     const { result } = renderHook(() => usePaper('by-id-paper'), { wrapper });
-    await waitFor(() => expect(result.current.paper).not.toBeNull());
+    await waitFor(() => expect(result.current.paper).toBeDefined());
   });
 });

--- a/packages/joint-react/src/hooks/use-cell-drag.ts
+++ b/packages/joint-react/src/hooks/use-cell-drag.ts
@@ -64,6 +64,8 @@ function equal(a: CellDragState, b: CellDragState): boolean {
 }
 
 const NOOP_SNAPSHOT = () => EMPTY_CELL_DRAG_STATE;
+const NOOP_CLEANUP = () => {};
+const NOOP_SUBSCRIBE = () => NOOP_CLEANUP;
 
 /**
  * Returns reactive drag state for the current cell. Self-contained — lazily
@@ -90,6 +92,7 @@ export function useCellDrag(): CellDragState {
   const cellId = useCellId();
   const { paper } = usePaper();
   const atomState = useMemo(() => {
+    if (!paper) return;
     return getCellDragState(paper);
   }, [paper]);
 
@@ -98,13 +101,11 @@ export function useCellDrag(): CellDragState {
     return ensureCellDragListeners(paper);
   }, [paper]);
 
-  const getSnapshot = useMemo(() => {
-    if (!paper) return NOOP_SNAPSHOT;
-    return atomState!.getSnapshot;
-  }, [atomState, paper]);
+  const subscribe = useMemo(() => atomState?.subscribe ?? NOOP_SUBSCRIBE, [atomState]);
+  const getSnapshot = useMemo(() => atomState?.getSnapshot ?? NOOP_SNAPSHOT, [atomState]);
 
   const data = useSyncExternalStoreWithSelector(
-    atomState.subscribe,
+    subscribe,
     getSnapshot,
     getSnapshot,
     (snap) => select(snap, cellId),

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -13,7 +13,7 @@ import { warnUnstableSelector } from '../utils/dev-warnings';
 // ── Types ───────────────────────────────────────────────────────────────────
 
 /** Union of all possible `useCells` return shapes (depends on argument form). */
-type UseCellsResult<Cell extends AnyCellRecord, Selected> =
+type CellsResult<Cell extends AnyCellRecord, Selected> =
   | readonly Cell[]
   | Cell
   | undefined
@@ -50,7 +50,7 @@ function computeNext<Cell extends AnyCellRecord, Selected>(
   subscribedIds: readonly CellId[] | undefined,
   arraySelector: ((cells: readonly Cell[]) => Selected) | undefined,
   cellSelector: ((cell: Cell | undefined) => Selected) | undefined
-): UseCellsResult<Cell, Selected> {
+): CellsResult<Cell, Selected> {
   if (targetId !== undefined) {
     const cell = container.get(targetId);
     return cellSelector ? cellSelector(cell) : cell;
@@ -191,14 +191,17 @@ export function useCells<
     | ((cell: Cell | undefined) => Selected)
     | ((a: Selected, b: Selected) => boolean),
   argument3?: (a: Selected, b: Selected) => boolean
-): UseCellsResult<Cell, Selected> {
+): CellsResult<Cell, Selected> {
   const store = useGraphStore();
   const container = store.graphProjection.cells as ReadonlyContainer<Cell>;
 
   const collectionArgument = isCollection(argument1) ? argument1 : undefined;
 
-  const { targetId, ids, arraySelector, cellSelector, isEqual } =
-    parseUseCellsArgs<Cell, Selected>(argument1, argument2, argument3);
+  const { targetId, ids, arraySelector, cellSelector, isEqual } = parseUseCellsArgs<Cell, Selected>(
+    argument1,
+    argument2,
+    argument3
+  );
   const hasSelector = arraySelector !== undefined || cellSelector !== undefined;
 
   const arraySelectorRef = useRef(arraySelector);
@@ -207,7 +210,7 @@ export function useCells<
   cellSelectorRef.current = cellSelector;
 
   /** Local alias for the hook's return shape so the cache type stays readable. */
-  type Result = UseCellsResult<Cell, Selected>;
+  type Result = CellsResult<Cell, Selected>;
   const cachedRef = useRef<{ hasValue: boolean; value: Result }>({
     hasValue: false,
     value: undefined,
@@ -283,11 +286,7 @@ export function useCells<
 
   // ── Selector ──
 
-  const isRawAllCells =
-    targetId === undefined &&
-    !ids &&
-    !collectionArgument &&
-    !hasSelector;
+  const isRawAllCells = targetId === undefined && !ids && !collectionArgument && !hasSelector;
 
   const select = useCallback(
     (): Result => {
@@ -308,7 +307,7 @@ export function useCells<
       // The all-cells form receives the container's mutable array. Shallow-copy
       // so the cached value is a distinct reference, enabling
       // areArraysShallowEqual to compare element-by-element on subsequent calls.
-      const value = isRawAllCells ? ([...next as readonly Cell[]] as unknown as Result) : next;
+      const value = isRawAllCells ? ([...(next as readonly Cell[])] as unknown as Result) : next;
       cachedRef.current = { hasValue: true, value };
       return value;
     },

--- a/packages/joint-react/src/hooks/use-create-features.ts
+++ b/packages/joint-react/src/hooks/use-create-features.ts
@@ -13,7 +13,6 @@ import {
 import type { FeaturesContext } from '../context';
 import type { Feature } from '../types/feature.types';
 import { selectGraphFeaturesVersion } from '../selectors';
-import { OPTIONAL } from '../types';
 
 const EMPTY_DEPENDENCIES: unknown[] = [];
 
@@ -257,7 +256,7 @@ export function useCreateFeature<T>(
   const isPaperTarget = target === 'paper';
   const graphStore = useGraphStore();
   // Always called — returns null when no PaperStoreContext is above
-  const contextPaperStore = usePaperStore(OPTIONAL);
+  const contextPaperStore = usePaperStore();
   const featuresRef = useRef<FeaturesContext>({ features: new Map() });
 
   // When the hook is called OUTSIDE a Paper subtree (e.g. PaperScroller wraps

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -53,7 +53,7 @@ type LinkModelConstructor = new (attributes?: dia.Link.Attributes) => dia.Link;
 const EMPTY_DATA: Readonly<Record<string, unknown>> = Object.freeze({});
 
 /** Options accepted by {@link useCreatePortalPaper}; extends all `PaperProps`. */
-export interface UseCreatePortalPaperOptions extends PaperProps {
+export interface CreatePortalPaperOptions extends PaperProps {
   /**
    * Host element ref where the paper should be mounted automatically.
    * When omitted, paper rendering is manual (e.g. via `onReady` callback).
@@ -66,7 +66,7 @@ export interface UseCreatePortalPaperOptions extends PaperProps {
 }
 
 /** Return value of {@link useCreatePortalPaper}: the paper id, ref, and helper APIs. */
-export interface UseCreatePortalPaperResult {
+export interface CreatePortalPaperHandle {
   /** Effective paper id used in GraphStore. */
   readonly id: string;
   /** Current paper instance, available synchronously after mount and kept in sync afterwards. */
@@ -179,8 +179,8 @@ const defaultRenderElement = (data: unknown) => {
  * @returns Hook state with paper instance and rendered portal content.
  */
 export function useCreatePortalPaper(
-  options: Readonly<UseCreatePortalPaperOptions>
-): UseCreatePortalPaperResult {
+  options: Readonly<CreatePortalPaperOptions>
+): CreatePortalPaperHandle {
   const {
     renderElement = defaultRenderElement,
     renderLink,

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -28,7 +28,7 @@ import type {
  * @template Link - link record shape (e.g. `LinkRecord<MyData>` /
  *                  `Computed<LinkRecord<MyData>>`)
  */
-export interface UseGraphResult<
+export interface GraphHandle<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
@@ -88,7 +88,7 @@ export interface UseGraphResult<
   readonly importFromJSON: (json: Parameters<dia.Graph['fromJSON']>[0]) => void;
 }
 
-/** Options accepted by {@link UseGraphResult.exportToJSON}. */
+/** Options accepted by {@link GraphHandle.exportToJSON}. */
 export interface ExportToJSONOptions {
   /**
    * When `true`, every attribute is preserved (defaults included) and no
@@ -109,12 +109,12 @@ export interface ExportToJSONOptions {
  *                    `Computed<ElementRecord<MyData>>` for read shapes)
  * @template Link - link record shape (use `LinkRecord<MyData>` /
  *                  `Computed<LinkRecord<MyData>>`)
- * @returns the imperative API described by {@link UseGraphResult}
+ * @returns the imperative API described by {@link GraphHandle}
  */
 export function useGraph<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
->(): UseGraphResult<Element, Link> {
+>(): GraphHandle<Element, Link> {
   const store = useGraphStore<Element, Link>();
   const { graph } = store;
 
@@ -124,7 +124,7 @@ export function useGraph<
   const resetCells = useResetCells<Element, Link>();
   const updateCells = useUpdateCells<Element, Link>();
 
-  const exportToJSON = useCallback<UseGraphResult<Element, Link>['exportToJSON']>(
+  const exportToJSON = useCallback<GraphHandle<Element, Link>['exportToJSON']>(
     (options) => {
       if (options?.includeDefaults) {
         // Raw graph state — defaults kept, no pruning.
@@ -145,7 +145,7 @@ export function useGraph<
     [graph]
   );
 
-  const importFromJSON = useCallback<UseGraphResult<Element, Link>['importFromJSON']>(
+  const importFromJSON = useCallback<GraphHandle<Element, Link>['importFromJSON']>(
     (json) => {
       graph.fromJSON(json);
     },

--- a/packages/joint-react/src/hooks/use-imperative-api.ts
+++ b/packages/joint-react/src/hooks/use-imperative-api.ts
@@ -22,7 +22,7 @@ interface OnLoadReturn<Instance> {
  * Options for the useImperativeApi hook.
  * @template Instance - The type of the instance being managed
  */
-export interface UseImperativeApiOptions<Instance, InstanceSelector = Instance> {
+export interface ImperativeApiOptions<Instance, InstanceSelector = Instance> {
   /**
    * Function called to create the instance.
    * Should return the instance and a cleanup function.
@@ -96,7 +96,7 @@ export type ImperativeStateResult<Instance> = ResultReady<Instance> | ResultNotR
  * @group Hooks
  */
 export function useImperativeApi<Instance, InstanceSelector = Instance>(
-  options: UseImperativeApiOptions<Instance, InstanceSelector>,
+  options: ImperativeApiOptions<Instance, InstanceSelector>,
   dependencies: DependencyList
 ): ImperativeStateResult<Instance> {
   const { onLoad, onUpdate, onReadyChange, instanceSelector, isDisabled, forwardedRef } = options;

--- a/packages/joint-react/src/hooks/use-link-layout.ts
+++ b/packages/joint-react/src/hooks/use-link-layout.ts
@@ -51,7 +51,7 @@ function isSameLayout(a: LinkLayout | undefined, b: LinkLayout | undefined): boo
 export function useLinkLayout(): LinkLayout | undefined {
   const id = useCellId();
   const paperStore = usePaperStore();
-  const { paper } = paperStore;
+  const paper = paperStore?.paper;
   const cachedRef = useRef<LinkLayout | undefined>(undefined);
 
   const subscribe = useCallback(
@@ -70,6 +70,7 @@ export function useLinkLayout(): LinkLayout | undefined {
   );
 
   const getSnapshot = useCallback((): LinkLayout | undefined => {
+    if (!paperStore) return undefined;
     const linkView = paperStore.getLinkView(id);
     const next = linkView ? getLinkLayout(linkView) : undefined;
     if (isSameLayout(cachedRef.current, next)) return cachedRef.current;

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -69,7 +69,7 @@ export function useMarkup(): MarkupUtils {
   const id = useCellId();
   const applySelector = useCallback(
     (node: Element | null, selector: string) => {
-      const elementView = paper.findViewByModel(id) as dia.ElementView | undefined;
+      const elementView = paper?.findViewByModel(id) as dia.ElementView | undefined;
       if (!elementView) return;
       if (node) {
         node.setAttribute('joint-selector', selector);

--- a/packages/joint-react/src/hooks/use-measure-node.tsx
+++ b/packages/joint-react/src/hooks/use-measure-node.tsx
@@ -176,8 +176,8 @@ export function useMeasureNode(
     // Hide the element view's until the element view is updated by the paper's
     // update cycle. This prevents flashes of incorrect position when the element
     // is measured, but waits for the paper to apply the new position.
-    const view = paper.findViewByModel(id);
-    if (view) {
+    const view = paper?.findViewByModel(id);
+    if (view && paper) {
       view.el.classList.add(MEASURING_CLASS_NAME);
       // Request a view update to remove the measuring class as part of its
       // next update cycle.

--- a/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
+++ b/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
@@ -5,7 +5,7 @@ import type { PaperTarget } from '../types';
 import { useGraphStore } from './use-graph-store';
 
 /** Options for {@link useNodesMeasuredEffect} controlling subscription behavior. */
-export interface UseOnElementsMeasuredOptions {
+export interface OnElementsMeasuredOptions {
   /** When true, the callback fires only once and then unsubscribes. */
   readonly once?: boolean;
 }
@@ -45,19 +45,19 @@ type Callback = (event: ElementsMeasuredEvent) => void;
 export function useNodesMeasuredEffect(
   callback: Callback,
   dependencies?: DependencyList,
-  options?: UseOnElementsMeasuredOptions
+  options?: OnElementsMeasuredOptions
 ): void;
 export function useNodesMeasuredEffect(
   target: PaperTarget,
   callback: Callback,
   dependencies?: DependencyList,
-  options?: UseOnElementsMeasuredOptions
+  options?: OnElementsMeasuredOptions
 ): void;
 export function useNodesMeasuredEffect(
   targetOrCallback: PaperTarget | Callback,
   callbackOrDependencies?: Callback | DependencyList,
-  dependenciesOrOptions?: DependencyList | UseOnElementsMeasuredOptions,
-  optionsArgument?: UseOnElementsMeasuredOptions
+  dependenciesOrOptions?: DependencyList | OnElementsMeasuredOptions,
+  optionsArgument?: OnElementsMeasuredOptions
 ): void {
   const isContextForm = typeof targetOrCallback === 'function';
 
@@ -69,7 +69,7 @@ export function useNodesMeasuredEffect(
     ? (callbackOrDependencies as DependencyList | undefined)
     : (dependenciesOrOptions as DependencyList | undefined);
   const options = isContextForm
-    ? (dependenciesOrOptions as UseOnElementsMeasuredOptions | undefined)
+    ? (dependenciesOrOptions as OnElementsMeasuredOptions | undefined)
     : optionsArgument;
 
   const paperId = useResolvePaperId(target);

--- a/packages/joint-react/src/hooks/use-paper-events.ts
+++ b/packages/joint-react/src/hooks/use-paper-events.ts
@@ -1,26 +1,53 @@
 import { useLayoutEffect, type DependencyList } from 'react';
-import { dia } from '@joint/core';
 import { usePaperStore, useResolvePaperId } from './use-paper';
 import type { PaperStore } from '../store';
-import { OPTIONAL, type PaperTarget } from '../types';
-import { isRecord, isRef, isString } from '../utils/is';
+import type { PaperTarget } from '../types';
+import { isPaperTarget } from '../utils/resolve-paper-target';
 import { addPaperEventListeners, type PaperEventMap } from '../presets/paper-events';
 
 const EMPTY_DEPENDENCIES: DependencyList = [];
+const EMPTY_HANDLERS: PaperEventMap = {};
 
 /**
- * Discriminates the first argument of `usePaperEvents` between a paper target
- * and a handlers map.
- * @param value - Candidate first argument.
- * @returns True when the value identifies a paper (id, instance, ref, or
- * `Optional` sentinel).
+ * Distinguishes a `PaperEventMap` (a plain object) from a `DependencyList`
+ * (an array) — used to resolve the overloaded second argument without casts.
+ * @param value - The handlers-or-dependencies argument.
+ * @returns True when `value` is a handlers map rather than a dependency list.
  */
-function isPaperTarget(value: unknown): value is PaperTarget {
-  if (isString(value)) return true;
-  if (value instanceof dia.Paper) return true;
-  if (isRef(value)) return true;
-  if (isRecord(value) && value.optional === true) return true;
-  return false;
+function isPaperEventMap(value: PaperEventMap | DependencyList): value is PaperEventMap {
+  return !Array.isArray(value);
+}
+
+/** Normalized {@link usePaperEvents} arguments. */
+interface ResolvedPaperEventsArgs {
+  readonly target: PaperTarget | undefined;
+  readonly handlers: PaperEventMap;
+  readonly dependencies: DependencyList;
+}
+
+/**
+ * Resolves the overloaded `usePaperEvents` arguments into a paper target, a
+ * handlers map, and a dependency list — using runtime type guards, no casts.
+ * @param paperOrHandlers - First arg: a paper target, or the handlers map.
+ * @param handlersOrDependencies - Second arg: handlers (target form) or dependencies (context form).
+ * @param dependenciesArgument - Third arg: dependencies (target form only).
+ * @returns The resolved target, handlers, and dependencies.
+ */
+function resolvePaperEventsArgs(
+  paperOrHandlers: PaperTarget | PaperEventMap,
+  handlersOrDependencies: PaperEventMap | DependencyList,
+  dependenciesArgument: DependencyList
+): ResolvedPaperEventsArgs {
+  if (!isPaperTarget(paperOrHandlers)) {
+    // usePaperEvents(handlers, dependencies?)
+    const dependencies = isPaperEventMap(handlersOrDependencies)
+      ? EMPTY_DEPENDENCIES
+      : handlersOrDependencies;
+    return { target: undefined, handlers: paperOrHandlers, dependencies };
+  }
+  // usePaperEvents(target, handlers, dependencies?)
+  const handlers = isPaperEventMap(handlersOrDependencies) ? handlersOrDependencies : EMPTY_HANDLERS;
+  return { target: paperOrHandlers, handlers, dependencies: dependenciesArgument };
 }
 
 /**
@@ -72,7 +99,7 @@ export function subscribeToPaperEvents(
 export function usePaperEvents(handlers: PaperEventMap, dependencies?: DependencyList): void;
 /**
  * Subscribes to paper events on the given paper target.
- * @param paper - Paper reference (string ID, dia.Paper instance, ref, or Optional).
+ * @param paper - Paper reference (string ID, dia.Paper instance, or ref).
  * @param handlers - Event handlers map.
  * @param dependencies - Optional dependency array controlling re-subscription.
  * @group Hooks
@@ -87,27 +114,17 @@ export function usePaperEvents(
   handlersOrDependencies: PaperEventMap | DependencyList = EMPTY_DEPENDENCIES,
   dependenciesArgument: DependencyList = EMPTY_DEPENDENCIES
 ): void {
-  const shouldUseContextPaper = !isPaperTarget(paperOrHandlers);
-  const target: PaperTarget = shouldUseContextPaper
-    ? OPTIONAL
-    : (paperOrHandlers as PaperTarget);
-  const handlers = shouldUseContextPaper
-    ? (paperOrHandlers as PaperEventMap)
-    : (handlersOrDependencies as PaperEventMap);
-  const dependencies = shouldUseContextPaper
-    ? (handlersOrDependencies as DependencyList)
-    : dependenciesArgument;
+  const { target, handlers, dependencies } = resolvePaperEventsArgs(
+    paperOrHandlers,
+    handlersOrDependencies,
+    dependenciesArgument
+  );
 
   const paperId = useResolvePaperId(target);
   const paperStore = usePaperStore(paperId);
 
-  if (shouldUseContextPaper && !paperStore) {
-    throw new Error('usePaperEvents without a paper target must be used within a Paper.');
-  }
-
   useLayoutEffect(() => {
     if (!paperStore) return;
-
     return subscribeToPaperEvents(paperStore, handlers);
     // Dependencies are explicit API contract for this hook.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -1,25 +1,24 @@
-/* eslint-disable @typescript-eslint/unified-signatures */
-import { useCallback, useContext, useReducer, useLayoutEffect, useRef } from 'react';
+import { useCallback, useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'react';
 import { PaperStoreContext } from '../context';
 import type { PaperStore } from '../store';
 import { useGraphStore } from './use-graph-store';
 import { useInternalData } from './use-stores';
 import type { ReactPaper } from '../models/react-paper';
+import { DEFAULT_PAPER_ID } from '../models/react-paper';
 import type { PaperTarget } from '../types';
-import { OPTIONAL, resolvePaperId } from '../types';
+import { resolvePaperId } from '../utils/resolve-paper-target';
+import { isRef } from '../utils/is';
 
 /**
  * Resolves a paper ID from any `PaperTarget`, handling the ref-timing problem.
- * For string IDs, `dia.Paper` instances, and `Nullable` targets, resolution is
- * synchronous — no effects are scheduled. For `RefObject<dia.Paper>` targets,
- * `resolvePaperId` returns `null` during render (ref not yet populated).
- * A layout effect re-resolves the ID once `useImperativeHandle` has set the ref
- * and triggers a single re-render.
+ * For string IDs and `dia.Paper` instances resolution is synchronous. For
+ * `RefObject<dia.Paper>` targets, a layout effect re-resolves the ID once
+ * `useImperativeHandle` has set the ref.
  * @param target - The paper target to resolve.
- * @returns The paper ID string, or `NULLABLE` sentinel when not yet available.
+ * @returns The paper ID string, or `undefined` when not yet available.
  * @internal
  */
-export function useResolvePaperId(target: PaperTarget | undefined): string | Optional {
+export function useResolvePaperId(target: PaperTarget | undefined): string | undefined {
   const isRefTarget = isRef(target);
   const paperId = resolvePaperId(target);
   const [, forceRender] = useReducer((c: number) => c + 1, 0);
@@ -28,7 +27,6 @@ export function useResolvePaperId(target: PaperTarget | undefined): string | Opt
 
   useLayoutEffect(() => {
     if (!isRefTarget || resolvedIdRef.current) return;
-    // Re-resolve inside the layout effect where the ref is already populated.
     const id = resolvePaperId(target);
     if (id) {
       resolvedIdRef.current = id;
@@ -36,152 +34,69 @@ export function useResolvePaperId(target: PaperTarget | undefined): string | Opt
     }
   });
 
-  return resolvedIdRef.current ?? OPTIONAL;
+  return resolvedIdRef.current ?? undefined;
 }
-import type { Optional } from '../types';
-import { isString, isRecord, isRef } from '../utils/is';
 
 /**
- * Returns the active paper store.
- * All overloads must be used inside a `GraphProvider`.
- * Use this hook in one of three modes:
- * - with no arguments, read the current `PaperStore` from `Paper` context
- * - with `{ optional: true }`, still read the current `PaperStore` from `Paper` context but return `null` instead of throwing when the context is missing
- * - with a paper id, read a specific paper store from the graph store
+ * Returns the active paper store from context, by ID, or via the default paper.
+ *
+ * A paper store is view-access: it exists only once a `<Paper>` has mounted, so
+ * the result is `PaperStore | undefined` and this hook never throws.
+ *
+ * Resolution order (no explicit id):
+ * 1. `PaperStoreContext` (when called inside a `<Paper>` subtree)
+ * 2. `DEFAULT_PAPER_ID` lookup (when a single `<Paper>` exists without an explicit `id`)
+ * @param id - An explicit paper id, or omitted for the context/default paper.
+ * @returns The resolved paper store, or `undefined` when no paper is mounted yet.
  * @group Hooks
- * @returns The resolved paper store for the current context or requested id.
- * @example
- * ```tsx
- * import { usePaperStore } from '@joint/react';
- *
- * function PaperToolbar() {
- *   const paperStore = usePaperStore();
- *
- *   return <span>{paperStore.paperId}</span>;
- * }
- * ```
- * @example
- * ```tsx
- * import { usePaperStore } from '@joint/react';
- *
- * function OptionalOverlay() {
- *   const paperStore = usePaperStore({ optional: true });
- *
- *   if (!paperStore) return null;
- *
- *   return <span>{paperStore.paper.svg.tagName}</span>;
- * }
- * ```
- * @example
- * ```tsx
- * import { usePaperStore } from '@joint/react';
- *
- * function Inspector() {
- *   const paperStore = usePaperStore('main-paper');
- *
- *   return paperStore ? <span>{paperStore.paperId}</span> : null;
- * }
- * ```
  */
-export function usePaperStore(): PaperStore;
-export function usePaperStore(options: Optional): PaperStore | null;
-export function usePaperStore(id: string): PaperStore | null;
-export function usePaperStore(idOrOptions?: string | Optional): PaperStore | null;
-export function usePaperStore(idOrOptions?: string | Optional): PaperStore | null {
+export function usePaperStore(id?: string): PaperStore | undefined {
   const contextStore = useContext(PaperStoreContext);
   const { getPaperStore } = useGraphStore();
-  const nullable = isRecord(idOrOptions) && idOrOptions.optional;
+
   const paperStoreById = useInternalData((snapshot) => {
-    if (!isString(idOrOptions)) {
-      return null;
+    if (id) {
+      return snapshot.papers[id] ? (getPaperStore(id) ?? null) : null;
     }
-    if (!snapshot.papers[idOrOptions]) {
-      return null;
+    if (!contextStore && snapshot.papers[DEFAULT_PAPER_ID]) {
+      return getPaperStore(DEFAULT_PAPER_ID) ?? null;
     }
-    return getPaperStore(idOrOptions) ?? null;
+    return null;
   });
 
-  if (isString(idOrOptions)) {
-    return paperStoreById;
-  }
-
-  if (!contextStore && !nullable) {
-    throw new Error('usePaperStore must be used within a Paper or RenderElement');
-  }
-
-  return contextStore ?? null;
+  if (id) return paperStoreById ?? undefined;
+  if (contextStore) return contextStore;
+  return paperStoreById ?? undefined;
 }
 
-/**
- * Returns the active `ReactPaper` instance (a `dia.Paper` subclass) wrapped in an object, from context or by paper id.
- *
- * All overloads must be used inside a `GraphProvider`.
- * Use this hook in one of three modes:
- * - with no arguments, read the current `ReactPaper` from `Paper` context
- * - with `{ optional: true }`, still read the current `ReactPaper` from `Paper` context, but return `null` paper instead of throwing when the context is missing
- * - with a paper id, read a specific paper from the graph store
- * @see https://docs.jointjs.com/learn/quickstart/paper
- * @group Hooks
- * @returns An object containing the resolved JointJS paper instance.
- * @example
- * ```tsx
- * import { usePaper } from '@joint/react';
- *
- * function PaperCanvasInfo() {
- *   const { paper } = usePaper();
- *
- *   return <span>{paper.svg.tagName}</span>;
- * }
- * ```
- * @example
- * ```tsx
- * import { usePaper } from '@joint/react';
- *
- * function OptionalPaperInfo() {
- *   const { paper } = usePaper({ optional: true });
- *
- *   if (!paper) return null;
- *
- *   return <span>{paper.svg.tagName}</span>;
- * }
- * ```
- * @example
- * ```tsx
- * import { usePaper } from '@joint/react';
- *
- * function SecondaryPaperInfo() {
- *   const { paper } = usePaper('secondary-paper');
- *
- *   return paper ? <span>{paper.svg.tagName}</span> : null;
- * }
- * ```
- */
-/** Imperative actions returned alongside the paper instance from {@link usePaper}. */
-interface UsePaperActions {
+/** Result of {@link usePaper} — the paper instance and imperative actions. */
+export interface PaperHandle {
+  /** Resolved JointJS paper instance, or `undefined` until a `<Paper>` has mounted. */
+  readonly paper?: ReactPaper;
   /**
-   * Trigger a render pass on the paper. Forwards to `paper.wakeUp()` —
-   * useful after mutations that don't go through React state (e.g. toggling
-   * a `cellVisibility` predicate that closes over external state). No-op
-   * when the paper isn't resolved yet.
+   * Trigger a render pass on the paper. Forwards to `paper.wakeUp()`.
+   * No-op when the paper isn't resolved yet.
    * @see https://docs.jointjs.com/api/dia/Paper#wakeUp
    */
   readonly wakeUp: () => void;
 }
 
-export function usePaper(): { paper: ReactPaper } & UsePaperActions;
-export function usePaper(options: Optional): { paper: ReactPaper | null } & UsePaperActions;
-export function usePaper(id: string): { paper: ReactPaper | null } & UsePaperActions;
-export function usePaper(
-  idOrOptions?: string | Optional
-): { paper: ReactPaper | null } & UsePaperActions;
-/** Hook that returns the paper instance and actions for the given paper id or options. */
-export function usePaper(
-  idOrOptions?: string | Optional
-): { paper: ReactPaper | null } & UsePaperActions {
-  const paperStore = usePaperStore(idOrOptions);
-  const paper = paperStore?.paper ?? null;
+/**
+ * Returns the active `ReactPaper` instance from context, by ID, or via the
+ * default paper. Wraps {@link usePaperStore} and exposes `wakeUp()`.
+ *
+ * The returned object is always stable; only `paper` is `undefined` until the
+ * `<Paper>` view has mounted.
+ * @param id - An explicit paper id, or omitted for the context/default paper.
+ * @returns A stable object with the resolved `paper` (or `undefined`) and a `wakeUp` action.
+ * @see https://docs.jointjs.com/learn/quickstart/paper
+ * @group Hooks
+ */
+export function usePaper(id?: string): PaperHandle {
+  const paperStore = usePaperStore(id);
+  const paper = paperStore?.paper ?? undefined;
   const wakeUp = useCallback(() => {
     paper?.wakeUp();
   }, [paper]);
-  return { paper, wakeUp };
+  return useMemo(() => ({ paper, wakeUp }), [paper, wakeUp]);
 }

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -30,7 +30,7 @@ export { useCell } from './hooks/use-cell';
 export { useCellId } from './hooks/use-cell-id';
 export { useLinkLayout } from './hooks/use-link-layout';
 export { useGraph } from './hooks/use-graph';
-export type { UseGraphResult, ExportToJSONOptions } from './hooks/use-graph';
+export type { GraphHandle, ExportToJSONOptions } from './hooks/use-graph';
 export type { CellInput, CellRef } from './utils/normalize-cell-input';
 export { useGraphStore } from './hooks/use-graph-store';
 export { usePaper, usePaperStore } from './hooks/use-paper';

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -63,13 +63,13 @@ export {
 export type { ElementJSONInit, LinkJSONInit } from './types/cell.types';
 
 // Utility Functions
-export { assignOptions, pickValues } from './utils/object-utilities';
-export { resolvePaper, resolvePaperId } from './types';
+export { assignOptions, pickValues, makeOptions } from './utils/object-utilities';
+export { resolvePaper, resolvePaperId, isPaperTarget } from './utils/resolve-paper-target';
+export { isRecord } from './utils/is';
 
 // Constants
 export { ELEMENT_MODEL_TYPE, PORTAL_SELECTOR } from './models/element-model';
 export { LINK_MODEL_TYPE } from './models/link-model';
-export { OPTIONAL } from './types';
 
 // Internal Selectors
 export {
@@ -79,13 +79,7 @@ export {
 } from './selectors';
 
 // Internal Types (used by react-plus)
-export type {
-  Optional,
-  Mutable,
-  RemoveIndexSignature,
-  OmitWithoutIndexSignature,
-  PaperTarget,
-} from './types';
+export type { OmitWithoutIndexSignature, PaperTarget } from './types';
 export type { PortalSelector } from './models/react-paper.types';
 export type { MeasureNodeOptions } from './hooks/use-measure-node';
 

--- a/packages/joint-react/src/models/react-paper.ts
+++ b/packages/joint-react/src/models/react-paper.ts
@@ -10,6 +10,9 @@ const noopViewMountChange = (): void => {
   // No-op default for onViewMountChange callback
 };
 
+/** Well-known paper ID used when no explicit `id` is provided to `<Paper>`. */
+export const DEFAULT_PAPER_ID = 'default-paper';
+
 /**
  * Extended Paper class that manages React view lifecycle.
  *

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -23,6 +23,7 @@ import {
 } from './graph-projection';
 import { simpleScheduler } from '../utils/scheduler';
 import { cellInputToModel, type CellInput } from '../utils/normalize-cell-input';
+import { warnDuplicatePapers } from '../utils/dev-warnings';
 
 export const DEFAULT_CELL_NAMESPACE: Record<string, unknown> = {
   ...shapes,
@@ -375,6 +376,9 @@ export class GraphStore<
   };
 
   public addPaper = (id: string, paperOptions: AddPaperOptions) => {
+    if (process.env.NODE_ENV !== 'production') {
+      warnDuplicatePapers(id, this.paperStores.keys());
+    }
     const paperStore = new PaperStore({ ...paperOptions, graphStore: this, id });
     this.paperStores.set(id, paperStore);
     this.updatePaperSnapshot(id, () => getDefaultPaperState());

--- a/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
+++ b/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
@@ -127,8 +127,6 @@ async function loadSnapshotFromFile(file: File): Promise<Snapshot> {
 const COLUMN_WIDTH = 230;
 const ROW_GAP = 50;
 const PADDING = 40;
-const PAPER_ID = 'automatic-layout-storage-paper';
-
 function LayoutRunner() {
   const { graph } = useGraph<ElementRecord<NodeData>>();
 
@@ -191,7 +189,7 @@ function LayoutRunner() {
     }
   }, [graph]);
 
-  useNodesMeasuredEffect(PAPER_ID, runLayout, [runLayout]);
+  useNodesMeasuredEffect(runLayout, [runLayout]);
   return null;
 }
 
@@ -488,7 +486,6 @@ function InnerShell({ onLoadFile }: Readonly<InnerShellProps>) {
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 relative bg-[radial-gradient(rgba(28,36,52,0.12)_1px,transparent_1px)] bg-[length:20px_20px] [background-position:12px_12px]">
           <Paper style={{ backgroundColor: 'transparent', width: "100%", height: "100%" }}
-            id={PAPER_ID}
             linkRouting={linkRoutingOrthogonal({
               sourceOffset: 6,
               targetOffset: 6,

--- a/packages/joint-react/src/stories/demos/collaboration/code.tsx
+++ b/packages/joint-react/src/stories/demos/collaboration/code.tsx
@@ -789,7 +789,7 @@ function Toolbar() {
 
 function DragTracker({ manager }: Readonly<{ manager: ReturnType<typeof createPeerManager> }>) {
   const draggingRef = useRef<Set<string>>(new Set());
-  usePaperEvents(PAPER_ID, {
+  usePaperEvents({
     onElementPointerDown: ({ id }) => {
       draggingRef.current.add(String(id));
       manager.sendDrag([...draggingRef.current]);
@@ -803,8 +803,6 @@ function DragTracker({ manager }: Readonly<{ manager: ReturnType<typeof createPe
 }
 
 // ── Main ────────────────────────────────────────────────────────────────────
-
-const PAPER_ID = 'collab-paper';
 
 function GraphWithRedux() {
   const isDark = useContext(ThemeContext);
@@ -913,7 +911,6 @@ function GraphWithRedux() {
           onIncrementalCellsChange={handleIncrementalChange}
         >
           <Paper style={{ backgroundColor: theme.canvas, width: "100%", height: "100%" }}
-            id={PAPER_ID}
             gridSize={1}
             overflow
             linkPinning={false}

--- a/packages/joint-react/src/stories/demos/flowchart/code.tsx
+++ b/packages/joint-react/src/stories/demos/flowchart/code.tsx
@@ -7,7 +7,7 @@ import { GraphProvider, Paper, useMarkup, useMeasureNode, useNodesMeasuredEffect
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 import { dia, highlighters, linkTools } from '@joint/core';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
-import { forwardRef, useId, useRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 
 const unit = 4;
 const bevel = 2 * unit;
@@ -408,11 +408,9 @@ function RenderFlowchartElement(data: Readonly<ElementData>) {
 // Create link tools
 
 function Main() {
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
 
   usePaperEvents(
-    paperId,
     {
       onLinkPointerClick: ({ view: linkView, paper }) => {
         paper.removeTools();
@@ -496,7 +494,7 @@ function Main() {
     []
   );
 
-  useNodesMeasuredEffect(paperId, ({ isInitial, paper }) => {
+  useNodesMeasuredEffect(({ isInitial, paper }) => {
     if (!isInitial) return;
     paper.transformToFitContent({
       padding: 40,
@@ -509,7 +507,6 @@ function Main() {
   return (
     <Paper style={{ height: 600 }}
       ref={paperRef}
-      id={paperId}
       gridSize={5}
       overflow
       snapLabels

--- a/packages/joint-react/src/stories/demos/link-arrows/code.tsx
+++ b/packages/joint-react/src/stories/demos/link-arrows/code.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { dia, util } from '@joint/core';
 import type { CellRecord, LinkRecord, LinkMarker } from '@joint/react';
 import { GraphProvider, Paper, usePaperEvents, usePaper, jsx } from '@joint/react';
@@ -445,8 +445,7 @@ function zoomToFit(paper: dia.Paper, contentArea: dia.BBox | null = paper.model.
 }
 
 function Main() {
-  const paperId = useId();
-  const { paper } = usePaper(paperId);
+  const { paper } = usePaper();
   const [zoom, setZoom] = useState<ZoomState>({ type: 'overview' });
 
   // Enable smooth zoom transitions once paper is ready
@@ -483,7 +482,7 @@ function Main() {
     }
   }, [zoom, paper]);
 
-  usePaperEvents(paperId, {
+  usePaperEvents({
     onLinkPointerDown: ({ model: link }) => {
       setZoom((previous) => {
         if (previous.type === 'link' && previous.link === link) {
@@ -497,7 +496,6 @@ function Main() {
 
   return (
     <Paper style={{ background: BG_COLOR, width: "100%" }}
-      id={paperId}
       className={`${PAPER_CLASSNAME} h-150`}
       interactive={false}
       drawGrid={false}

--- a/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
+++ b/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
-import { useId } from 'react';
 import { dia, highlighters, linkTools, V } from '@joint/core';
 import type { CellRecord, ElementPort } from '@joint/react';
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
@@ -118,15 +117,13 @@ const toolsView = new dia.ToolsView({
 });
 
 function Main() {
-  const paperId = useId();
-  usePaperEvents(paperId, {
+  usePaperEvents({
     onLinkMouseEnter: ({ view }) => view.addTools(toolsView),
     onLinkMouseLeave: ({ view }) => view.removeTools(),
   });
 
   return (
     <Paper style={{ width: "100%" }}
-      id={paperId}
       defaultLink={{
         style: { color: PRIMARY, targetMarker: 'arrow' },
       }}

--- a/packages/joint-react/src/stories/demos/saasflow/code.tsx
+++ b/packages/joint-react/src/stories/demos/saasflow/code.tsx
@@ -449,8 +449,6 @@ function Toolbar({ paperRef }: Readonly<{ paperRef: React.RefObject<dia.Paper | 
 
 // ── Main ────────────────────────────────────────────────────────────────────
 
-const PAPER_ID = 'saasflow-paper';
-
 function ThemeUpdater() {
   const isDark = useContext(ThemeContext);
   const theme = isDark ? DARK : LIGHT;
@@ -492,7 +490,6 @@ function Main() {
     <GraphProvider initialCells={initialCells}>
       <Paper style={{ backgroundColor: 'transparent', width: "100%", height: "100%" }}
         ref={paperRef}
-        id={PAPER_ID}
         gridSize={5}
         drawGrid={false}
         overflow

--- a/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
@@ -14,7 +14,7 @@ import {
   type ElementRecord,
   type Computed,
 } from '@joint/react';
-import { useCallback, useId, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { dia } from '@joint/core';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 
@@ -36,7 +36,6 @@ const initialCells: ReadonlyArray<CellRecord<ElementData>> = [
 
 function Main() {
   const { graph, setCell } = useGraph<ElementRecord<ElementData>>();
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
 
   // Number of elements per row
@@ -62,7 +61,7 @@ function Main() {
     []
   );
 
-  useNodesMeasuredEffect(paperId, () => {
+  useNodesMeasuredEffect(() => {
     makeLayoutWithGrid({ graph, gridXSize });
   }, []);
 
@@ -111,7 +110,6 @@ function Main() {
       </div>
       <Paper style={{ height: 450 }}
         ref={paperRef}
-        id={paperId}
         className={PAPER_CLASSNAME}
         renderElement={renderElement}
       />

--- a/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
-import { useCallback, useEffect, useId } from 'react';
+import { useCallback, useEffect } from 'react';
 import { dia, elementTools } from '@joint/core';
 import {
   type CellRecord,
@@ -362,7 +362,6 @@ function useContainerAutoResize() {
 
 function Main() {
   useContainerAutoResize();
-  const paperId = useId();
 
   const { graph } = useGraph();
 
@@ -409,7 +408,6 @@ function Main() {
   }, [graph]);
 
   usePaperEvents(
-    paperId,
     {
       onElementMouseEnter: ({ view }) => {
         view.removeTools();
@@ -432,7 +430,6 @@ function Main() {
 
   return (
     <Paper style={{ backgroundColor: '#F3F7F6', height: 500 }}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       cellVisibility={cellVisibility}

--- a/packages/joint-react/src/stories/examples/with-collapsible-subtrees/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-collapsible-subtrees/code.tsx
@@ -3,7 +3,7 @@
 import type { CellRecord, LinkRecord, LinkStyle } from '@joint/react';
 import { type ElementRecord, GraphProvider, jsx, Paper, SVGText, useCell, useCellId, useGraph, useMarkup, useNodesMeasuredEffect, usePaper, usePaperEvents, selectElementSize } from '@joint/react';
 import { BG, LIGHT, PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, TEXT } from 'storybook-config/theme';
-import { useCallback, useId, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { dia, elementTools } from '@joint/core';
 import { DirectedGraph } from '@joint/layout-directed-graph';
 
@@ -248,7 +248,7 @@ function useElementPattern() {
   const { paper } = usePaper();
 
   return useMemo(() => {
-    const patternId = paper.definePattern({
+    const patternId = paper?.definePattern({
       id: 'body-pattern',
       attrs: {
         width: 12,
@@ -274,7 +274,7 @@ function useGatePattern() {
   const { paper } = usePaper();
 
   return useMemo(() => {
-    const patternId = paper.definePattern({
+    const patternId = paper?.definePattern({
       id: 'gate-pattern',
       attrs: {
         width: 6,
@@ -688,7 +688,6 @@ function addExpandTools(paper: dia.Paper) {
 // Application Components
 // ----------------------------------------------------------------------------
 function Main() {
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
   const cellVisibilityCallback = useCallback(({ model }: { model: dia.Cell }) => {
     return !model.prop('hidden');
@@ -740,7 +739,6 @@ function Main() {
   }, []);
 
   usePaperEvents(
-    paperId,
     {
       'element:expand': (elementView) => {
         const view = elementView as dia.ElementView;
@@ -751,14 +749,13 @@ function Main() {
     [handleExpand]
   );
 
-  useNodesMeasuredEffect(paperId, handleElementsMeasured);
+  useNodesMeasuredEffect(handleElementsMeasured);
 
   const renderElement = useCallback((data: FTAData) => RenderFTAElement(data), []);
 
   return (
     <Paper style={{ ...PAPER_STYLE, height: 600 }}
       ref={paperRef}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       cellVisibility={cellVisibilityCallback}

--- a/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   type CellRecord,
   GraphProvider,
@@ -35,13 +35,11 @@ const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
 // ============================================================================
 
 interface EditControllerProps {
-  readonly paperId: string;
   readonly onSelect: (id: string | null) => void;
 }
 
-function EditController({ paperId, onSelect }: Readonly<EditControllerProps>) {
+function EditController({ onSelect }: Readonly<EditControllerProps>) {
   usePaperEvents(
-    paperId,
     {
       onElementPointerClick: ({ id }) => onSelect(String(id)),
       onBlankPointerClick: () => onSelect(null),
@@ -51,14 +49,9 @@ function EditController({ paperId, onSelect }: Readonly<EditControllerProps>) {
   return null;
 }
 
-interface ViewControllerProps {
-  readonly paperId: string;
-}
-
-function ViewController({ paperId }: Readonly<ViewControllerProps>) {
+function ViewController() {
   const [hovered, setHovered] = useState<string | null>(null);
   usePaperEvents(
-    paperId,
     {
       onElementMouseEnter: ({ id, model }) => {
         const data = model.attributes.data as NodeData | undefined;
@@ -132,7 +125,6 @@ function PropertyEditor({ selectedId }: Readonly<PropertyEditorProps>) {
 // ============================================================================
 
 function Main() {
-  const paperId = useId();
   const [editMode, setEditMode] = useState(true);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -157,11 +149,11 @@ function Main() {
 
       <div className="flex">
         <div className="flex-1 relative">
-          <Paper id={paperId} className={PAPER_CLASSNAME + ' h-[300px]'} interactive={editMode} />
+          <Paper className={PAPER_CLASSNAME + ' h-[300px]'} interactive={editMode} />
           {editMode ? (
-            <EditController paperId={paperId} onSelect={setSelectedId} />
+            <EditController onSelect={setSelectedId} />
           ) : (
-            <ViewController paperId={paperId} />
+            <ViewController />
           )}
         </div>
         {editMode && (

--- a/packages/joint-react/src/stories/examples/with-dynamic-status-icons/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-status-icons/code.tsx
@@ -2,7 +2,7 @@
 
 import { type dia, g, highlighters, V } from '@joint/core';
 import { type CellRecord, GraphProvider, useCell, Paper, SVGText, useGraph, useNodesMeasuredEffect, selectElementSize } from '@joint/react';
-import { useCallback, useEffect, useId, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { BG, PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, TEXT } from 'storybook-config/theme';
 
 const ShapeTypes = {
@@ -214,7 +214,6 @@ function useInterval(action: () => void, interval: number = 1000) {
 // ----------------------------------------------------------------------------
 function Main() {
   const { graph } = useGraph();
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
 
   const setRandomStatuses = useCallback(() => {
@@ -226,7 +225,7 @@ function Main() {
 
   useInterval(setRandomStatuses);
 
-  useNodesMeasuredEffect(paperId, ({ isInitial, paper }) => {
+  useNodesMeasuredEffect(({ isInitial, paper }) => {
     if (!isInitial) return;
     for (const element of graph.getElements()) {
       StatusList.add(element.findView(paper), 'root', 'status', {
@@ -243,7 +242,6 @@ function Main() {
   return (
     <Paper style={{ ...PAPER_STYLE, height: 500 }}
       ref={paperRef}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={RenderElement}
       gridSize={20}

--- a/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
@@ -2,7 +2,7 @@ import { type CellRecord, GraphProvider, useCell, Paper, useNodesMeasuredEffect,
 import '../index.css';
 import { PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, LIGHT, TEXT } from 'storybook-config/theme';
 import { dia, elementTools, g } from '@joint/core';
-import { useCallback, useId } from 'react';
+import { useCallback } from 'react';
 
 // ----------------------------------------------------------------------------
 // Type Definitions
@@ -732,8 +732,6 @@ function addElementControls(paper: dia.Paper) {
 // Application Components
 // ----------------------------------------------------------------------------
 function Main() {
-  const paperId = useId();
-
   const handleElementsMeasured = useCallback(
     ({ isInitial, paper }: { isInitial: boolean; paper: dia.Paper }) => {
       if (!isInitial) return;
@@ -742,11 +740,10 @@ function Main() {
     []
   );
 
-  useNodesMeasuredEffect(paperId, handleElementsMeasured);
+  useNodesMeasuredEffect(handleElementsMeasured);
 
   return (
     <Paper style={{ ...PAPER_STYLE, width: "100%", height: 600 }}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       drawGrid={false}

--- a/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
-import { useEffect, useId, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { CellRecord, LinkStyle } from '@joint/react';
 import { GraphProvider, useCell, jsx, Paper, resolveLinkMarker, usePaperEvents, selectElementSize } from '@joint/react';
 import { PAPER_CLASSNAME, PAPER_STYLE, BG, PRIMARY, TEXT, LIGHT } from 'storybook-config/theme';
@@ -352,7 +352,6 @@ function getLinkTools(_linkView: dia.LinkView) {
 // Main Component
 // ----------------------------------------------------------------------------
 function Main() {
-  const paperId = useId();
   const currentToolsViewRef = useRef<dia.ToolsView | null>(null);
   const timeoutIdRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -365,7 +364,7 @@ function Main() {
     };
   }, []);
 
-  usePaperEvents(paperId, {
+  usePaperEvents({
     onCellMouseEnter: ({ model, view, paper }) => {
       paper.removeTools();
 
@@ -401,7 +400,6 @@ function Main() {
 
   return (
     <Paper style={{ ...PAPER_STYLE, width: "100%", height: 650 }}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={RenderElement}
       gridSize={20}

--- a/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
@@ -1,6 +1,6 @@
 
 
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type CellRecord, GraphProvider, useCell, Paper, SVGText, useGraph, useMarkup, usePaperEvents, selectElementSize } from '@joint/react';
 import { highlighters, type dia } from '@joint/core';
 import { LIGHT, PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, SECONDARY } from 'storybook-config/theme';
@@ -163,7 +163,6 @@ function clearHighlighters(paper: dia.Paper) {
 
 function Main() {
   const { graph } = useGraph();
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
 
   const [highlightState, setHighlightState] = useState<HighlightState>(INITIAL_STATE);
@@ -181,7 +180,6 @@ function Main() {
   }, [highlightState]);
 
   usePaperEvents(
-    paperId,
     {
       onElementPointerClick: ({ id }) => {
         const clickedId = String(id);
@@ -218,7 +216,6 @@ function Main() {
   return (
     <Paper style={{ ...PAPER_STYLE, width: "100%", height: 500 }}
       ref={paperRef}
-      id={paperId}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       drawGrid={false}

--- a/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
@@ -2,7 +2,7 @@
 import { type CellRecord, GraphProvider, useCell, Paper, useMarkup, usePaperEvents, selectElementSize } from '@joint/react';
 import { type dia, highlighters } from '@joint/core';
 import '../index.css';
-import { useId, useRef } from 'react';
+import { useRef } from 'react';
 import { PAPER_CLASSNAME, PRIMARY, SECONDARY } from 'storybook-config/theme';
 
 interface NodeData {
@@ -97,11 +97,9 @@ function removeHighlighter(variant: HighlighterVariant, elementView: dia.Element
 }
 
 function Main({ variant }: Readonly<MainProps>) {
-  const paperId = useId();
   const paperRef = useRef<dia.Paper | null>(null);
 
   usePaperEvents(
-    paperId,
     {
       onElementMouseEnter: ({ view }) => addHighlighter(variant, view),
       onElementMouseLeave: ({ view }) => removeHighlighter(variant, view),
@@ -112,7 +110,6 @@ function Main({ variant }: Readonly<MainProps>) {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <Paper style={{ height: 280 }}
-        id={paperId}
         ref={paperRef}
         className={PAPER_CLASSNAME}
         renderElement={RenderElement}

--- a/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
@@ -2,7 +2,6 @@
 import { dia, linkTools } from '@joint/core';
 import '../index.css';
 import { type CellRecord, GraphProvider, jsx, Paper, usePaperEvents } from '@joint/react';
-import { useId } from 'react';
 import { PRIMARY, SECONDARY, PAPER_CLASSNAME } from 'storybook-config/theme';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
 
@@ -93,9 +92,7 @@ const toolsView = new dia.ToolsView({
 });
 
 function Main() {
-  const paperId = useId();
-
-  usePaperEvents(paperId, {
+  usePaperEvents({
     onLinkMouseEnter: ({ view }) => view.addTools(toolsView),
     onLinkMouseLeave: ({ view }) => view.removeTools(),
   });
@@ -103,7 +100,6 @@ function Main() {
   return (
     <div style={{ display: 'flex', flexDirection: 'row', position: 'relative' }}>
       <Paper style={{ height: 280 }}
-        id={paperId}
         className={PAPER_CLASSNAME}
         linkRouting={ORTHOGONAL_LINKS}
       />

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -20,7 +20,7 @@ import {
   selectElementSize,
 } from '@joint/react';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { LIGHT, PAPER_STYLE } from 'storybook-config/theme';
 
 // ============================================================================
@@ -211,6 +211,7 @@ function Selection({ selectedId }: { selectedId: CellId | null }) {
   const { graph } = useGraph();
 
   useEffect(() => {
+    if (!paper) return;
     highlighters.mask.removeAll(paper);
 
     if (!selectedId) return;
@@ -274,7 +275,6 @@ function RenderElementWithBadge({
 }
 
 function Main() {
-  const paperId = useId();
   const [paper, setPaper] = useState<dia.Paper | null>(null);
   const [showMinimap, setShowMinimap] = useState(false);
   const [selectedElement, setSelectedElement] = useState<CellId | null>(null);
@@ -289,7 +289,6 @@ function Main() {
   useCells();
 
   usePaperEvents(
-    paperId,
     {
       onElementPointerClick: ({ id }) => setSelectedElement(id),
       onElementPointerDblClick: ({ model, graph }) => {
@@ -303,7 +302,6 @@ function Main() {
   return (
     <div className="flex flex-col relative w-full h-full">
       <Paper style={{ ...PAPER_STYLE, height: "calc(100vh - 100px)" }}
-        id={paperId}
         {...PAPER_PROPS}
         ref={setPaper}
         className={PAPER_CLASSNAME}

--- a/packages/joint-react/src/stories/examples/with-theme-editor/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-theme-editor/code.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
-import { useState, useCallback, useEffect, useMemo, useRef, memo, useId } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, memo } from 'react';
 import type { CSSProperties } from 'react';
 import {
   type CellRecord,
@@ -462,10 +462,9 @@ interface DiagramProps {
 }
 
 function Diagram({ zoom }: Readonly<DiagramProps>) {
-  const paperId = useId();
   const { setCell } = useGraph<CellRecord<Data>>();
 
-  usePaperEvents(paperId, {
+  usePaperEvents({
     'blank:pointerdblclick': (_event, x, y) => {
       setCell({
         id: `node-${Date.now()}`,
@@ -511,7 +510,6 @@ function Diagram({ zoom }: Readonly<DiagramProps>) {
 
   return (
     <Paper
-      id={paperId}
       className={PAPER_CLASSNAME}
       style={{ height: PAPER_HEIGHT }}
       renderElement={renderElement}

--- a/packages/joint-react/src/types/index.ts
+++ b/packages/joint-react/src/types/index.ts
@@ -1,5 +1,4 @@
-import { dia } from '@joint/core';
-import { isString } from '../utils/is';
+import type { dia } from '@joint/core';
 
 /**
  * Union of known string literals plus arbitrary strings while preserving
@@ -24,59 +23,10 @@ export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 export type Nullable<T> = { [K in keyof T]: T[K] | null };
 
 /**
- * Shared sentinel for nullable hooks so a new object isn't created each render.
+ * Identifies a Paper instance — a registered id, a React ref, or the Paper
+ * itself. Paper-targeting hooks never throw; an unresolved target simply means
+ * "use the current Paper context or the default paper".
  */
-export const OPTIONAL: Optional = { optional: true } as const;
-
-/**
- * A string type that preserves intellisense for known literal unions.
- * Use instead of `| string` or `[key: string]` to keep autocomplete working.
- * Pass `{ optional: true }` to hooks like `usePaper` or `usePaperStore`
- * so they return `null` instead of throwing when context is missing.
- */
-export interface Optional {
-  readonly optional: true;
-}
-
-/**
- * Identifies a Paper instance — a registered id, a React ref, the Paper
- * itself, or an `Optional` sentinel that opts out of throwing.
- */
-export type PaperTarget = string | React.RefObject<dia.Paper | null> | dia.Paper | Optional;
-
-/**
- * Resolves a Paper instance from a PaperTarget.
- * @param target - The paper target to resolve.
- * @returns The resolved Paper instance, or null.
- */
-export function resolvePaper(target: PaperTarget): dia.Paper | null {
-  if (isString(target)) {
-    // ID form is not supported here since we don't have access to the paper store.
-    return null;
-  }
-  if (target instanceof dia.Paper) {
-    return target;
-  }
-  if ('current' in target) {
-    return target.current;
-  }
-  return null;
-}
-
-/**
- * Extracts the paper ID from a PaperTarget.
- * @param target - The paper target to extract the ID from.
- * @returns The paper ID string, or null.
- */
-export function resolvePaperId(target?: PaperTarget): string | null {
-  if (!target) {
-    return null;
-  }
-  if (isString(target)) {
-    // Is already an ID.
-    return target;
-  }
-  return resolvePaper(target)?.id ?? null;
-}
+export type PaperTarget = string | React.RefObject<dia.Paper | null> | dia.Paper;
 
 export * from './event.types';

--- a/packages/joint-react/src/utils/__tests__/resolve-paper-target.test.ts
+++ b/packages/joint-react/src/utils/__tests__/resolve-paper-target.test.ts
@@ -1,11 +1,24 @@
 import { dia } from '@joint/core';
-import { OPTIONAL, resolvePaper, resolvePaperId } from '../index';
-import type { PaperTarget } from '../index';
+import { isPaperTarget, resolvePaper, resolvePaperId } from '../resolve-paper-target';
 
-describe('types/index runtime exports', () => {
-  describe('OPTIONAL sentinel', () => {
-    it('is a frozen-style readonly object with optional: true', () => {
-      expect(OPTIONAL).toEqual({ optional: true });
+describe('resolve-paper-target', () => {
+  describe('isPaperTarget', () => {
+    it('is true for a string id', () => {
+      expect(isPaperTarget('paper-id')).toBe(true);
+    });
+
+    it('is true for a dia.Paper instance', () => {
+      expect(isPaperTarget(new dia.Paper({ width: 1, height: 1 }))).toBe(true);
+    });
+
+    it('is true for a RefObject', () => {
+      expect(isPaperTarget({ current: null })).toBe(true);
+    });
+
+    it('is false for a handlers/options object or nullish value', () => {
+      const nothing: unknown = undefined;
+      expect(isPaperTarget({ onElementPointerClick: () => {} })).toBe(false);
+      expect(isPaperTarget(nothing)).toBe(false);
     });
   });
 
@@ -29,15 +42,10 @@ describe('types/index runtime exports', () => {
       const ref: React.RefObject<dia.Paper | null> = { current: null };
       expect(resolvePaper(ref)).toBeNull();
     });
-
-    it('returns null for the OPTIONAL sentinel', () => {
-      expect(resolvePaper(OPTIONAL as PaperTarget)).toBeNull();
-    });
   });
 
   describe('resolvePaperId', () => {
     it('returns null for nullish target', () => {
-      expect(resolvePaperId()).toBeNull();
       expect(resolvePaperId()).toBeNull();
     });
 
@@ -49,10 +57,6 @@ describe('types/index runtime exports', () => {
       const paper = new dia.Paper({ width: 1, height: 1 });
       (paper as unknown as { id: string }).id = 'paper-1';
       expect(resolvePaperId(paper)).toBe('paper-1');
-    });
-
-    it('returns null when target cannot be resolved (e.g. OPTIONAL)', () => {
-      expect(resolvePaperId(OPTIONAL as PaperTarget)).toBeNull();
     });
 
     it('returns the paper id when target is a RefObject with paper', () => {

--- a/packages/joint-react/src/utils/dev-warnings.ts
+++ b/packages/joint-react/src/utils/dev-warnings.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_PAPER_ID } from '../models/react-paper';
+
 const WARNED = new Set<string>();
 
 /**
@@ -53,4 +55,32 @@ export function warnUnstableSelector(
       '  2. Return cell records directly: (cells) => cells.filter(predicate)\n' +
       '  3. Provide a custom isEqual: useCells(input, selector, shallowEqual)\n'
   );
+}
+
+/**
+ * Warns when multiple `<Paper>` components register with the same default ID.
+ * This typically means two Papers were rendered without explicit `id` props.
+ * @param paperId - The paper ID being registered.
+ * @param existingPaperIds - Set of already-registered paper IDs.
+ */
+export function warnDuplicatePapers(paperId: string, existingPaperIds: Iterable<string>): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (paperId !== DEFAULT_PAPER_ID) return;
+
+  for (const existingId of existingPaperIds) {
+    if (existingId === DEFAULT_PAPER_ID) {
+      const key = 'duplicate-default-paper';
+      if (WARNED.has(key)) return;
+      WARNED.add(key);
+
+      console.warn(
+        '[Paper] Multiple <Paper> components rendered without an explicit `id` prop. ' +
+          `They share the default ID "${DEFAULT_PAPER_ID}", which causes conflicts.\n\n` +
+          'Fix: give each Paper a unique `id` prop:\n' +
+          '  <Paper id="primary" ... />\n' +
+          '  <Paper id="secondary" ... />\n'
+      );
+      return;
+    }
+  }
 }

--- a/packages/joint-react/src/utils/object-utilities.ts
+++ b/packages/joint-react/src/utils/object-utilities.ts
@@ -3,6 +3,31 @@
 import { util } from '@joint/core';
 
 /**
+ * Creates a shallow copy of options without `undefined` values.
+ *
+ * JointJS treats an explicitly-set `undefined` as a concrete value, so these
+ * keys must be omitted entirely when building an options object.
+ * @param options - The source options (may contain `undefined` values).
+ * @returns A new object with the `undefined`-valued keys removed.
+ * @example
+ * ```ts
+ * makeOptions<{ width?: number; color?: string }>({ width: 100, color: undefined });
+ * // Result: { width: 100 }
+ * ```
+ */
+export function makeOptions<T extends object>(options: Readonly<Partial<T>>): T {
+  const result: Partial<T> = {};
+  for (const key in options) {
+    const value = options[key];
+    if (value === undefined) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result as T;
+}
+
+/**
  * Assign new properties to an instance, ignoring undefined values.
  * @param props - The instance to which new properties will be assigned.
  * @param newProps - An object containing new properties to assign to the instance.

--- a/packages/joint-react/src/utils/resolve-paper-target.ts
+++ b/packages/joint-react/src/utils/resolve-paper-target.ts
@@ -1,0 +1,48 @@
+import { dia } from '@joint/core';
+import type { PaperTarget } from '../types';
+import { isRef, isString } from './is';
+
+/**
+ * Narrows an unknown value to a {@link PaperTarget} — a paper id string, a
+ * `dia.Paper` instance, or a `RefObject<dia.Paper>`. Used to discriminate
+ * overloaded hook arguments (target vs handlers/options).
+ * @param value - Candidate value.
+ * @returns True when `value` is a paper target.
+ */
+export function isPaperTarget(value: unknown): value is PaperTarget {
+  return isString(value) || value instanceof dia.Paper || isRef(value);
+}
+
+/**
+ * Resolves a `dia.Paper` instance from a {@link PaperTarget}. String ids cannot
+ * be resolved here (no access to the paper store) and return `null`.
+ * @param target - The paper target to resolve.
+ * @returns The resolved paper, or `null`.
+ */
+export function resolvePaper(target: PaperTarget): dia.Paper | null {
+  if (isString(target)) {
+    // ID form is not supported here since we don't have access to the paper store.
+    return null;
+  }
+  if (target instanceof dia.Paper) {
+    return target;
+  }
+  // Remaining union member: RefObject<dia.Paper | null>.
+  return target.current;
+}
+
+/**
+ * Extracts the paper id from a {@link PaperTarget}.
+ * @param target - The paper target to extract the id from.
+ * @returns The paper id string, or `null`.
+ */
+export function resolvePaperId(target?: PaperTarget): string | null {
+  if (!target) {
+    return null;
+  }
+  if (isString(target)) {
+    // A string target is already the id.
+    return target;
+  }
+  return resolvePaper(target)?.id ?? null;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Streamlines `<Paper>` identity and the paper-access hooks:

- **Default paper id** — `<Paper>` without an `id` registers under `DEFAULT_PAPER_ID`; every paper-id hook argument is now optional and resolves **context → default paper**. Duplicate default-paper registrations emit a dev warning (`dev-warnings.ts`).
- **Unified signatures** — `usePaperStore(id?)` and `usePaper(id?)` collapse their overloads into one signature; view access is typed `T | undefined` (never throws), and the returned object is always stable. Removed the `OPTIONAL` / `Optional` sentinel.
- **Result types → `[Concept]Handle`** — `UseGraphResult → GraphHandle`, `UsePaperResult → PaperHandle`, `UseCreatePortalPaperResult → CreatePortalPaperHandle`.
- **Dedup / utils** — extracted `resolvePaper` / `resolvePaperId` / `isPaperTarget` into `utils/resolve-paper-target.ts` (+ tests) and shared `makeOptions` / `assignOptions` / `pickValues` in `utils/object-utilities.ts`; trimmed `internal.ts` to what `@joint/react-plus` actually consumes.
- Cleaned hardcoded paper IDs and unused hooks across demo / example stories.

## Motivation and Context

The paper hooks had overloads that flipped return types between guaranteed and optional, and some threw while others returned `null`. This unifies the contract — views are `undefined` until mounted, models throw on misconfiguration — and lets a single `<Paper>` work without an explicit `id`, improving DX.

### Screenshots (if appropriate):