### PR TITLE
feat(joint-react): normalized paper events as <Paper> props

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper-events.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-events.test.tsx
@@ -1,0 +1,376 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+import { useCallback, useState } from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { mvc, type dia } from '@joint/core';
+import { Paper } from '../paper';
+import { GraphProvider } from '../../graph/graph-provider';
+import { ELEMENT_MODEL_TYPE } from '../../../models/element-model';
+import type { CellRecord } from '../../../types/cell.types';
+
+const CELLS: readonly CellRecord[] = [
+  {
+    id: '1',
+    type: ELEMENT_MODEL_TYPE,
+    position: { x: 0, y: 0 },
+    size: { width: 50, height: 50 },
+  } as CellRecord,
+];
+
+const renderRectElement = () => <rect />;
+const fakeEvent = {} as dia.Event;
+
+interface HarnessProps {
+  readonly setRef: (paper: dia.Paper | null) => void;
+}
+
+/**
+ * Mounts a paper and resolves once the `dia.Paper` instance is available.
+ * @param ui - Factory receiving a ref callback; returns the tree under test.
+ * @returns The created paper.
+ */
+async function mountPaper(
+  ui: (ref: (paper: dia.Paper | null) => void) => React.ReactElement
+): Promise<{ paper: dia.Paper }> {
+  let current: dia.Paper | null = null;
+  const setRef = (paper: dia.Paper | null) => {
+    if (paper) current = paper;
+  };
+  render(<GraphProvider initialCells={CELLS}>{ui(setRef)}</GraphProvider>);
+  await waitFor(() => {
+    expect(current).not.toBeNull();
+  });
+  return { paper: current as unknown as dia.Paper };
+}
+
+const clickTestId = (testId: string) =>
+  act(() => {
+    (document.querySelector(`[data-testid="${testId}"]`) as HTMLButtonElement).click();
+  });
+
+describe('Paper normalized event props', () => {
+  it('fires a normalized handler with a context object', async () => {
+    const onBlankContextMenu = jest.fn();
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onBlankContextMenu={onBlankContextMenu}
+      />
+    ));
+
+    act(() => {
+      paper.trigger('blank:contextmenu', fakeEvent, 10, 20);
+    });
+
+    expect(onBlankContextMenu).toHaveBeenCalledTimes(1);
+    expect(onBlankContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({ paper, graph: paper.model, event: fakeEvent, x: 10, y: 20 })
+    );
+  });
+
+  it('does NOT re-subscribe across unrelated re-renders when handlers are stable refs', async () => {
+    const listenToSpy = jest.spyOn(mvc.Listener.prototype, 'listenTo');
+    const bindCount = (eventName: string) =>
+      listenToSpy.mock.calls.filter((call) => String(call[1]) === eventName).length;
+
+    const handler = jest.fn();
+    function Harness({ setRef }: Readonly<HarnessProps>) {
+      const [, force] = useState(0);
+      // eslint-disable-next-line sonarjs/no-nested-functions
+      const rerender = () => force((n) => n + 1);
+      // Stable reference across renders — this is the documented contract.
+      const onBlankContextMenu = useCallback(handler, []);
+      return (
+        <>
+          <button type="button" data-testid="rerender" onClick={rerender} />
+          <Paper
+            ref={setRef}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+            onBlankContextMenu={onBlankContextMenu}
+          />
+        </>
+      );
+    }
+
+    const { paper } = await mountPaper((ref) => <Harness setRef={ref} />);
+    expect(bindCount('blank:contextmenu')).toBe(1);
+
+    for (let index = 0; index < 3; index++) clickTestId('rerender');
+
+    // Stable ref → no re-subscribe across unrelated re-renders.
+    expect(bindCount('blank:contextmenu')).toBe(1);
+
+    act(() => {
+      paper.trigger('blank:contextmenu', fakeEvent, 0, 0);
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    listenToSpy.mockRestore();
+  });
+
+  it('re-subscribes and invokes the new handler when its reference changes', async () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    function Harness({ setRef }: Readonly<HarnessProps>) {
+      const [useSecond, setUseSecond] = useState(false);
+      const swap = () => setUseSecond(true);
+      // Two distinct stable references; swapping changes the dependency.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const handler = useCallback(useSecond ? second : first, [useSecond]);
+      return (
+        <>
+          <button type="button" data-testid="swap" onClick={swap} />
+          <Paper
+            ref={setRef}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+            onBlankContextMenu={handler}
+          />
+        </>
+      );
+    }
+
+    const { paper } = await mountPaper((ref) => <Harness setRef={ref} />);
+
+    clickTestId('swap');
+    act(() => {
+      paper.trigger('blank:contextmenu', fakeEvent, 0, 0);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-subscribes when a new handler key is added', async () => {
+    const listenToSpy = jest.spyOn(mvc.Listener.prototype, 'listenTo');
+    const bindCount = (eventName: string) =>
+      listenToSpy.mock.calls.filter((call) => String(call[1]) === eventName).length;
+
+    const ctxHandler = jest.fn();
+    const clickHandler = jest.fn();
+    function Harness({ setRef }: Readonly<HarnessProps>) {
+      const [withExtra, setWithExtra] = useState(false);
+      const addKey = () => setWithExtra(true);
+      const onBlankContextMenu = useCallback(ctxHandler, []);
+      const onBlankPointerClick = useCallback(clickHandler, []);
+      return (
+        <>
+          <button type="button" data-testid="add-key" onClick={addKey} />
+          <Paper
+            ref={setRef}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+            onBlankContextMenu={onBlankContextMenu}
+            onBlankPointerClick={withExtra ? onBlankPointerClick : undefined}
+          />
+        </>
+      );
+    }
+
+    await mountPaper((ref) => <Harness setRef={ref} />);
+    expect(bindCount('blank:pointerclick')).toBe(0);
+
+    clickTestId('add-key');
+
+    // The added key activates → the subscription re-runs and binds it.
+    expect(bindCount('blank:pointerclick')).toBe(1);
+    listenToSpy.mockRestore();
+  });
+
+  it('documents the contract: a new inline handler re-subscribes every render', async () => {
+    const listenToSpy = jest.spyOn(mvc.Listener.prototype, 'listenTo');
+    const bindCount = (eventName: string) =>
+      listenToSpy.mock.calls.filter((call) => String(call[1]) === eventName).length;
+
+    function Harness({ setRef }: Readonly<HarnessProps>) {
+      const [, force] = useState(0);
+      // eslint-disable-next-line sonarjs/no-nested-functions
+      const rerender = () => force((n) => n + 1);
+      return (
+        <>
+          <button type="button" data-testid="rerender" onClick={rerender} />
+          <Paper
+            ref={setRef}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+            // New reference every render → re-subscribes every render (by design).
+            onBlankContextMenu={() => {}}
+          />
+        </>
+      );
+    }
+
+    await mountPaper((ref) => <Harness setRef={ref} />);
+    const afterMount = bindCount('blank:contextmenu');
+
+    clickTestId('rerender');
+
+    // Inline handler changed identity → one more bind. Stable refs avoid this.
+    expect(bindCount('blank:contextmenu')).toBe(afterMount + 1);
+    listenToSpy.mockRestore();
+  });
+
+  it('does NOT re-subscribe when only a non-event prop changes', async () => {
+    const listenToSpy = jest.spyOn(mvc.Listener.prototype, 'listenTo');
+    const bindCount = (eventName: string) =>
+      listenToSpy.mock.calls.filter((call) => String(call[1]) === eventName).length;
+
+    const handler = jest.fn();
+    function Harness({ setRef }: Readonly<HarnessProps>) {
+      const [grid, setGrid] = useState(5);
+      // eslint-disable-next-line sonarjs/no-nested-functions
+      const bumpGrid = () => setGrid((g) => g + 1);
+      const onBlankContextMenu = useCallback(handler, []);
+      return (
+        <>
+          <button type="button" data-testid="bump" onClick={bumpGrid} />
+          <Paper
+            ref={setRef}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+            gridSize={grid}
+            onBlankContextMenu={onBlankContextMenu}
+          />
+        </>
+      );
+    }
+
+    await mountPaper((ref) => <Harness setRef={ref} />);
+    expect(bindCount('blank:contextmenu')).toBe(1);
+
+    clickTestId('bump');
+
+    // A non-event prop (gridSize) changed → events must not re-subscribe.
+    expect(bindCount('blank:contextmenu')).toBe(1);
+    listenToSpy.mockRestore();
+  });
+});
+
+/**
+ * Resolves the `dia.ElementView` for the seeded cell once it is rendered.
+ * @param paper - The paper instance.
+ * @returns The element view for cell `'1'`.
+ */
+const elementView = (paper: dia.Paper): dia.ElementView => {
+  const model = paper.model.getCell('1');
+  return paper.findViewByModel(model) as dia.ElementView;
+};
+
+describe('Paper event context shapes', () => {
+  it('delivers element pointer context (id, model, view, coords)', async () => {
+    const onElementPointerClick = jest.fn();
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onElementPointerClick={onElementPointerClick}
+      />
+    ));
+    const view = elementView(paper);
+
+    act(() => {
+      paper.trigger('element:pointerclick', view, fakeEvent, 5, 6);
+    });
+
+    expect(onElementPointerClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: '1',
+        model: view.model,
+        view,
+        paper,
+        graph: paper.model,
+        event: fakeEvent,
+        x: 5,
+        y: 6,
+      })
+    );
+  });
+
+  it('delivers cell-level pointer context for an element', async () => {
+    const onCellPointerClick = jest.fn();
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onCellPointerClick={onCellPointerClick}
+      />
+    ));
+    const view = elementView(paper);
+
+    act(() => {
+      paper.trigger('cell:pointerclick', view, fakeEvent, 1, 2);
+    });
+
+    expect(onCellPointerClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '1', model: view.model, view, x: 1, y: 2 })
+    );
+  });
+
+  it('delivers hover context with event but no coords', async () => {
+    const onElementMouseEnter = jest.fn();
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onElementMouseEnter={onElementMouseEnter}
+      />
+    ));
+    const view = elementView(paper);
+
+    act(() => {
+      paper.trigger('element:mouseenter', view, fakeEvent);
+    });
+
+    const [[ctx]] = onElementMouseEnter.mock.calls;
+    expect(ctx).toMatchObject({ id: '1', view, event: fakeEvent });
+    expect(ctx).not.toHaveProperty('x');
+  });
+
+  it('delivers blank wheel context with delta', async () => {
+    const onBlankMouseWheel = jest.fn();
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onBlankMouseWheel={onBlankMouseWheel}
+      />
+    ));
+
+    act(() => {
+      paper.trigger('blank:mousewheel', fakeEvent, 1, 2, 3);
+    });
+
+    expect(onBlankMouseWheel).toHaveBeenCalledWith(
+      expect.objectContaining({ event: fakeEvent, x: 1, y: 2, delta: 3, paper, graph: paper.model })
+    );
+  });
+
+  it('delivers paper-level resize context from raw native args', async () => {
+    const onResize = jest.fn();
+    const options = { source: 'test' };
+    const { paper } = await mountPaper((ref) => (
+      <Paper
+        ref={ref}
+        style={{ width: 100, height: 100 }}
+        renderElement={renderRectElement}
+        onResize={onResize}
+      />
+    ));
+
+    act(() => {
+      paper.trigger('resize', 800, 600, options);
+    });
+
+    expect(onResize).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 800, height: 600, options, paper, graph: paper.model })
+    );
+  });
+});

--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -3,12 +3,20 @@ import type { LinkRecord } from '../../types/cell.types';
 import type { PortalSelector } from '../../models/react-paper.types';
 import type { ReactPaper } from '../../models/react-paper';
 import type { CSSProperties, PropsWithChildren, ReactNode } from 'react';
-import type { ConnectionEnd, CanConnectOptions, ValidateConnectionContext } from '../../presets/can-connect';
+import type {
+  ConnectionEnd,
+  CanConnectOptions,
+  ValidateConnectionContext,
+} from '../../presets/can-connect';
 import type { ValidateEmbeddingContext, ValidateUnembeddingContext } from '../../presets/can-embed';
-import type { ConnectionStrategyOptions, ConnectionStrategyContext } from '../../presets/connection-strategy';
+import type {
+  ConnectionStrategyOptions,
+  ConnectionStrategyContext,
+} from '../../presets/connection-strategy';
 import type { CellVisibility } from '../../presets/cell-visibility';
 import type { Interactive } from '../../presets/interactive';
 import type { LinkRouting } from '../../presets/link-routing';
+import type { NormalizedPaperHandlers } from '../../presets/paper-events';
 
 /**
  * Value accepted by the Paper `transform` prop. Strings are parsed via the
@@ -212,9 +220,23 @@ export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
 /**
  * The props for the Paper component. Extend the `dia.Paper.Options` interface.
  * For more information, see the JointJS documentation.
+ *
+ * Normalized paper events are exposed directly as props
+ * (`onBlankContextMenu`, `onElementPointerClick`, `onLinkMouseEnter`, …) via
+ * {@link NormalizedPaperHandlers}. Each handler receives a single context
+ * object — e.g. `onBlankContextMenu={({ paper, event, x, y }) => …}`.
+ *
+ * Handlers participate in the event subscription's dependency list, exactly
+ * like a `useEffect` dependency: the subscription re-binds whenever a handler's
+ * **reference** changes. Pass **stable references** — `useCallback` or a
+ * module-level function — so the paper subscribes once. A new inline arrow on
+ * every render (`onBlankContextMenu={() => …}`) re-subscribes that paper's
+ * events on every render; correct, but wasteful. For raw native event names or
+ * events without a normalized form (`resize`, `transform`, `render:done`, …),
+ * use the `usePaperEvents` hook.
  * @see https://docs.jointjs.com/api/dia/Paper
  */
-export interface PaperProps extends PortalPaperOptions, PropsWithChildren {
+export interface PaperProps extends PortalPaperOptions, PropsWithChildren, NormalizedPaperHandlers {
   /**
    * A function that renders the element.
    *

--- a/packages/joint-react/src/components/paper/render-element/__tests__/paper-element-item.test.tsx
+++ b/packages/joint-react/src/components/paper/render-element/__tests__/paper-element-item.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
- 
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+
 import { render, waitFor } from '@testing-library/react';
 import { useContext, type ComponentType } from 'react';
 import { GraphProvider } from '../../../graph/graph-provider';

--- a/packages/joint-react/src/components/paper/render-element/__tests__/paper-html-overlay.test.tsx
+++ b/packages/joint-react/src/components/paper/render-element/__tests__/paper-html-overlay.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
- 
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+
 import { render, waitFor } from '@testing-library/react';
 import { GraphProvider } from '../../../graph/graph-provider';
 import { Paper } from '../../paper';

--- a/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
@@ -166,11 +166,11 @@ describe('useCells', () => {
 
   it('no-arg form handles large cell counts without stack overflow', async () => {
     const largeCells: CellRecord[] = [];
-    for (let i = 0; i < 5000; i++) {
+    for (let index = 0; index < 5000; index++) {
       largeCells.push({
-        id: `el-${i}`,
+        id: `el-${index}`,
         type: ELEMENT_MODEL_TYPE,
-        position: { x: i, y: 0 },
+        position: { x: index, y: 0 },
         size: { width: 10, height: 10 },
       } as CellRecord);
     }

--- a/packages/joint-react/src/hooks/__tests__/use-create-features.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-create-features.test.tsx
@@ -1,5 +1,4 @@
- 
- 
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { render, waitFor } from '@testing-library/react';
 import { GraphProvider, Paper } from '../../components';
 import { FeaturesProvider } from '../../components/features-provider/features-provider';

--- a/packages/joint-react/src/hooks/__tests__/use-create-portal-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-create-portal-paper.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import { dia } from '@joint/core';
 import { useEffect, useRef } from 'react';

--- a/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useCallback, useEffect, useRef } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { GraphProvider, Paper } from '../../components';

--- a/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-measure-node.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { Component, useRef, type ReactNode } from 'react';
 
 class CatchErrorBoundary extends Component<

--- a/packages/joint-react/src/hooks/__tests__/use-nodes-measured-effect.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-nodes-measured-effect.test.tsx
@@ -6,7 +6,7 @@ import { ELEMENT_MODEL_TYPE } from '../../models/element-model';
 import { useGraphStore } from '../use-graph-store';
 import type { CellRecord } from '../../types/cell.types';
 import type { ElementsMeasuredEvent } from '../../types/event.types';
-import { dia } from '@joint/core';
+import type { dia } from '@joint/core';
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 

--- a/packages/joint-react/src/hooks/__tests__/use-paper-events.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper-events.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { mvc } from '@joint/core';
 import { renderHook, render, waitFor } from '@testing-library/react';
 import { GraphProvider, Paper } from '../../components';

--- a/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { useRef } from 'react';
 import type { dia } from '@joint/core';

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -45,8 +45,9 @@ import {
 } from '../components/paper/render-element/paper-element-item';
 import { createSelectPaperVersion } from '../selectors';
 import { useAreElementsMeasured } from './use-are-elements-measured';
-import { LINK_MODEL_TYPE } from '../internal';
+import { LINK_MODEL_TYPE, subscribeToPaperEvents } from '../internal';
 import type { CellId } from '../types/cell.types';
+import { extractEventsFromPaperProps } from '../presets/paper-events';
 
 type LinkModelConstructor = new (attributes?: dia.Link.Attributes) => dia.Link;
 
@@ -289,6 +290,16 @@ export function useCreatePortalPaper(
   const interactiveValue = useMemo(() => toNativeInteractive(interactive), [interactive]);
 
   const isReady = !!paper && (isExternalPaper || !elementRef || !!elementRef.current);
+
+  const { eventDependencies, eventHandlers } = useMemo(
+    () => extractEventsFromPaperProps(paperOptions),
+    [paperOptions]
+  );
+  useLayoutEffect(() => {
+    if (!paperStore) return;
+    return subscribeToPaperEvents(paperStore, eventHandlers);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paperStore, ...eventDependencies]);
 
   useLayoutEffect(() => {
     const hostElementForCreation = elementRef?.current;

--- a/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
+++ b/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
@@ -26,8 +26,8 @@ describe('presets / element-ports / elementPort — group-positioned', () => {
 
   it('marks port magnet as passive when configured', () => {
     const port = elementPort({ passive: true });
-    const attributes = port.attrs as { portBody: { magnet: string } };
-    expect(attributes.portBody.magnet).toBe('passive');
+    const attributes = port.attrs as { port: { magnet: string } };
+    expect(attributes.port.magnet).toBe('passive');
   });
 });
 

--- a/packages/joint-react/src/presets/__tests__/link-labels.test.ts
+++ b/packages/joint-react/src/presets/__tests__/link-labels.test.ts
@@ -13,31 +13,35 @@ describe('presets / link-labels / linkLabel', () => {
     const label = linkLabel({ text: 'x', backgroundShape: 'ellipse' });
     const [body] = label.markup as Array<{ tagName: string }>;
     expect(body.tagName).toBe('ellipse');
-    const labelBodyAttributes = (label.attrs as { labelBody: Record<string, unknown> }).labelBody;
-    expect(labelBodyAttributes.cx).toBe('0');
-    expect(labelBodyAttributes.rx).toBeDefined();
+    const labelBackgroundAttributes = (label.attrs as { labelBackground: Record<string, unknown> })
+      .labelBackground;
+    expect(labelBackgroundAttributes.cx).toBe('0');
+    expect(labelBackgroundAttributes.rx).toBeDefined();
   });
 
   it('builds a path-shaped label using SVG path d', () => {
     const label = linkLabel({ text: 'x', backgroundShape: 'M 0 0 L 10 10' });
     const [body] = label.markup as Array<{ tagName: string }>;
     expect(body.tagName).toBe('path');
-    const labelBodyAttributes = (label.attrs as { labelBody: Record<string, unknown> }).labelBody;
-    expect(labelBodyAttributes.d).toBe('M 0 0 L 10 10');
+    const labelBackgroundAttributes = (label.attrs as { labelBackground: Record<string, unknown> })
+      .labelBackground;
+    expect(labelBackgroundAttributes.d).toBe('M 0 0 L 10 10');
   });
 
   it('uses calc-expression path with ref', () => {
     const label = linkLabel({ text: 'x', backgroundShape: 'M calc(w) 0 L 10 10' });
     const [body] = label.markup as Array<{ tagName: string }>;
     expect(body.tagName).toBe('path');
-    const labelBodyAttributes = (label.attrs as { labelBody: Record<string, unknown> }).labelBody;
-    expect(labelBodyAttributes.ref).toBe('labelText');
+    const labelBackgroundAttributes = (label.attrs as { labelBackground: Record<string, unknown> })
+      .labelBackground;
+    expect(labelBackgroundAttributes.ref).toBe('label');
   });
 
   it('applies opacity when provided', () => {
     const label = linkLabel({ text: 'x', backgroundOpacity: 0.5 });
-    const labelBodyAttributes = (label.attrs as { labelBody: Record<string, unknown> }).labelBody;
-    expect(labelBodyAttributes.opacity).toBe(0.5);
+    const labelBackgroundAttributes = (label.attrs as { labelBackground: Record<string, unknown> })
+      .labelBackground;
+    expect(labelBackgroundAttributes.opacity).toBe(0.5);
   });
 
   it('applies offset when provided', () => {
@@ -48,8 +52,9 @@ describe('presets / link-labels / linkLabel', () => {
 
   it('handles numeric backgroundPadding', () => {
     const label = linkLabel({ text: 'x', backgroundPadding: 5 });
-    const labelBodyAttributes = (label.attrs as { labelBody: Record<string, unknown> }).labelBody;
-    expect(labelBodyAttributes.x).toContain('5');
+    const labelBackgroundAttributes = (label.attrs as { labelBackground: Record<string, unknown> })
+      .labelBackground;
+    expect(labelBackgroundAttributes.x).toContain('5');
   });
 
   it('handles partial backgroundPadding object', () => {
@@ -85,8 +90,8 @@ describe('presets / link-labels / linkLabels', () => {
       { a: { text: 'A' } },
       { color: '#fff' }
     );
-    const attributes = out[0].attrs as { labelText: { style: { fill: string } } };
-    expect(attributes.labelText.style.fill).toBe('#fff');
+    const attributes = out[0].attrs as { label: { style: { fill: string } } };
+    expect(attributes.label.style.fill).toBe('#fff');
   });
 
   it('per-label fields override label style', () => {
@@ -94,7 +99,7 @@ describe('presets / link-labels / linkLabels', () => {
       { a: { text: 'A', color: '#000' } },
       { color: '#fff' }
     );
-    const attributes = out[0].attrs as { labelText: { style: { fill: string } } };
-    expect(attributes.labelText.style.fill).toBe('#000');
+    const attributes = out[0].attrs as { label: { style: { fill: string } } };
+    expect(attributes.label.style.fill).toBe('#000');
   });
 });

--- a/packages/joint-react/src/presets/paper-events.ts
+++ b/packages/joint-react/src/presets/paper-events.ts
@@ -228,7 +228,6 @@ const LINK_CONNECT_MAP = {
 //   onRenderIdle: 'render:idle',
 // } as const;
 
-
 const POINTER_BLANK_MAP = {
   onBlankPointerDown: 'blank:pointerdown',
   onBlankPointerMove: 'blank:pointermove',
@@ -278,7 +277,7 @@ const TRANSFORM_MAP = {
   onTransform: 'transform',
 } as const;
 
-const NORMALIZED_KEYS = new Set<string>([
+export const NORMALIZED_KEYS = new Set<string>([
   ...Object.keys(POINTER_CELL_MAP),
   ...Object.keys(HOVER_CELL_MAP),
   ...Object.keys(WHEEL_CELL_MAP),
@@ -308,7 +307,7 @@ const NORMALIZED_KEYS = new Set<string>([
  * `'cell:unhighlight'`, `'cell:highlight:invalid'`, `'link:snap:connect'`,
  * `'link:snap:disconnect'`.
  */
-interface NormalizedPaperHandlers {
+export interface NormalizedPaperHandlers {
   // pointer (cell — fires for any cell, element OR link)
   readonly onCellPointerDown?: (ctx: PointerCellEventContext) => void;
   readonly onCellPointerMove?: (ctx: PointerCellEventContext) => void;
@@ -461,34 +460,75 @@ function subscribeRaw(
  * @param handlers - Normalized + raw event handlers.
  * @returns Cleanup callback that calls `listener.stopListening()`.
  */
-export function addPaperEventListeners(
-  paper: dia.Paper,
-  handlers: PaperEventMap
-): () => void {
+export function addPaperEventListeners(paper: dia.Paper, handlers: PaperEventMap): () => void {
   const graph = paper.model;
   const controller = new mvc.Listener();
   const eventMap = handlers as EventHandlerMap;
   const baseContext: BaseContext = { paper, graph };
 
-  subscribeGroup(controller, paper, eventMap, POINTER_CELL_MAP,
-    (view: dia.CellView, event: dia.Event, x: number, y: number) =>
-      ({ ...baseContext, ...makeCellContext(view), event, x, y }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    POINTER_CELL_MAP,
+    (view: dia.CellView, event: dia.Event, x: number, y: number) => ({
+      ...baseContext,
+      ...makeCellContext(view),
+      event,
+      x,
+      y,
+    })
+  );
 
-  subscribeGroup(controller, paper, eventMap, HOVER_CELL_MAP,
-    (view: dia.CellView, event: dia.Event) => ({ ...baseContext, ...makeCellContext(view), event }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    HOVER_CELL_MAP,
+    (view: dia.CellView, event: dia.Event) => ({ ...baseContext, ...makeCellContext(view), event })
+  );
 
-  subscribeGroup(controller, paper, eventMap, WHEEL_CELL_MAP,
-    (view: dia.CellView, event: dia.Event, x: number, y: number, delta: number) =>
-      ({ ...baseContext, ...makeCellContext(view), event, x, y, delta }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    WHEEL_CELL_MAP,
+    (view: dia.CellView, event: dia.Event, x: number, y: number, delta: number) => ({
+      ...baseContext,
+      ...makeCellContext(view),
+      event,
+      x,
+      y,
+      delta,
+    })
+  );
 
   // Native magnet arg order is (view, evt, magnet, x, y) — not (view, evt, x, y, magnet).
-  subscribeGroup(controller, paper, eventMap, MAGNET_MAP,
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    MAGNET_MAP,
     (view: dia.ElementView, event: dia.Event, magnet: DOMElement, x: number, y: number) => {
       const end = toConnectionEnd(view, magnet);
-      return { ...baseContext, ...makeCellContext(view), event, x, y, magnet, port: end.port, selector: end.selector };
-    });
+      return {
+        ...baseContext,
+        ...makeCellContext(view),
+        event,
+        x,
+        y,
+        magnet,
+        port: end.port,
+        selector: end.selector,
+      };
+    }
+  );
 
-  subscribeGroup(controller, paper, eventMap, LINK_CONNECT_MAP,
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    LINK_CONNECT_MAP,
     (
       linkView: dia.LinkView,
       event: dia.Event,
@@ -501,52 +541,150 @@ export function addPaperEventListeners(
       event,
       end,
       endCell: toConnectionEnd(endView, endMagnet),
-    }));
+    })
+  );
 
-  subscribeGroup(controller, paper, eventMap, POINTER_BLANK_MAP,
-    (event: dia.Event, x: number, y: number) => ({ ...baseContext, event, x, y }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    POINTER_BLANK_MAP,
+    (event: dia.Event, x: number, y: number) => ({ ...baseContext, event, x, y })
+  );
 
-  subscribeGroup(controller, paper, eventMap, HOVER_BLANK_MAP,
-    (event: dia.Event) => ({ ...baseContext, event }));
+  subscribeGroup(controller, paper, eventMap, HOVER_BLANK_MAP, (event: dia.Event) => ({
+    ...baseContext,
+    event,
+  }));
 
-  subscribeGroup(controller, paper, eventMap, WHEEL_BLANK_MAP,
-    (event: dia.Event, x: number, y: number, delta: number) =>
-      ({ ...baseContext, event, x, y, delta }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    WHEEL_BLANK_MAP,
+    (event: dia.Event, x: number, y: number, delta: number) => ({
+      ...baseContext,
+      event,
+      x,
+      y,
+      delta,
+    })
+  );
 
   // Paper-level hover (`paper:mouseenter` / `paper:mouseleave`) — native (evt).
-  subscribeGroup(controller, paper, eventMap, PAPER_HOVER_MAP,
-    (event: dia.Event) => ({ ...baseContext, event }));
+  subscribeGroup(controller, paper, eventMap, PAPER_HOVER_MAP, (event: dia.Event) => ({
+    ...baseContext,
+    event,
+  }));
 
   // Paper-level pan (`paper:pan`) — native (evt, deltaX, deltaY).
-  subscribeGroup(controller, paper, eventMap, PAPER_PAN_MAP,
-    (event: dia.Event, deltaX: number, deltaY: number) =>
-      ({ ...baseContext, event, deltaX, deltaY }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    PAPER_PAN_MAP,
+    (event: dia.Event, deltaX: number, deltaY: number) => ({
+      ...baseContext,
+      event,
+      deltaX,
+      deltaY,
+    })
+  );
 
   // Paper-level pinch (`paper:pinch`) — native (evt, x, y, scale).
-  subscribeGroup(controller, paper, eventMap, PAPER_PINCH_MAP,
-    (event: dia.Event, x: number, y: number, scale: number) =>
-      ({ ...baseContext, event, x, y, scale }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    PAPER_PINCH_MAP,
+    (event: dia.Event, x: number, y: number, scale: number) => ({
+      ...baseContext,
+      event,
+      x,
+      y,
+      scale,
+    })
+  );
 
   // `translate` — native (tx, ty, data).
-  subscribeGroup(controller, paper, eventMap, TRANSLATE_MAP,
-    (translateX: number, translateY: number, options: unknown) =>
-      ({ ...baseContext, translateX, translateY, options }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    TRANSLATE_MAP,
+    (translateX: number, translateY: number, options: unknown) => ({
+      ...baseContext,
+      translateX,
+      translateY,
+      options,
+    })
+  );
 
   // `scale` — native (sx, sy, data).
-  subscribeGroup(controller, paper, eventMap, SCALE_MAP,
-    (scaleX: number, scaleY: number, options: unknown) =>
-      ({ ...baseContext, scaleX, scaleY, options }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    SCALE_MAP,
+    (scaleX: number, scaleY: number, options: unknown) => ({
+      ...baseContext,
+      scaleX,
+      scaleY,
+      options,
+    })
+  );
 
   // `resize` — native (width, height, data).
-  subscribeGroup(controller, paper, eventMap, RESIZE_MAP,
-    (width: number, height: number, options: unknown) =>
-      ({ ...baseContext, width, height, options }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    RESIZE_MAP,
+    (width: number, height: number, options: unknown) => ({
+      ...baseContext,
+      width,
+      height,
+      options,
+    })
+  );
 
   // `transform` — native (matrix, data).
-  subscribeGroup(controller, paper, eventMap, TRANSFORM_MAP,
-    (matrix: SVGMatrix, options: unknown) => ({ ...baseContext, matrix, options }));
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    TRANSFORM_MAP,
+    (matrix: SVGMatrix, options: unknown) => ({ ...baseContext, matrix, options })
+  );
 
   subscribeRaw(controller, paper, eventMap);
 
   return () => controller.stopListening();
+}
+
+/**
+ * Picks the normalized paper-event handlers (`onBlankContextMenu`, …) out of a
+ * props object. Returns the handlers map (to subscribe) plus a parallel
+ * `eventDependencies` array of the handler values, in key order — spread it
+ * into a `useLayoutEffect` dependency list so the subscription re-runs only
+ * when a handler reference changes. Non-event props are ignored, so changing
+ * them never re-subscribes.
+ * @param props - Any object that may contain normalized handler keys.
+ * @returns `eventHandlers` (the matched `on*` entries) and `eventDependencies` (their values, in key order).
+ */
+export function extractEventsFromPaperProps(props: Partial<NormalizedPaperHandlers>) {
+  const eventHandlers: Partial<NormalizedPaperHandlers> = {};
+  const eventDependencies: unknown[] = [];
+  for (const property in props) {
+    const key = property as keyof NormalizedPaperHandlers;
+    if (NORMALIZED_KEYS.has(key)) {
+      // Variable-key write: cast past the readonly/union index to assign.
+      (eventHandlers as Record<string, unknown>)[key] = props[key];
+      eventDependencies.push(props[key]);
+    }
+  }
+  return {
+    eventHandlers,
+    eventDependencies,
+  };
 }

--- a/packages/joint-react/src/state/__tests__/data-mapper.test.ts
+++ b/packages/joint-react/src/state/__tests__/data-mapper.test.ts
@@ -151,7 +151,7 @@ describe('dataMapper', () => {
       const [port] = cellJson.ports!.items!;
       expect(port.label).toBeDefined();
       expect(port.label!.position!.name).toBe('outside');
-      expect(port.attrs?.text?.text).toBe('Port A');
+      expect(port.attrs?.label?.text).toBe('Port A');
     });
 
     it('should handle rect shape ports', () => {

--- a/packages/joint-react/src/store/__tests__/paper-store.test.ts
+++ b/packages/joint-react/src/store/__tests__/paper-store.test.ts
@@ -81,7 +81,7 @@ describe('PaperStore', () => {
       expect((highlighting as Record<string, unknown>)?.magnetAvailability).toMatchObject({
         name: 'addClass',
         options: {
-          className: 'jj-is-available',
+          className: 'jj-is-magnet-available',
         },
       });
     });

--- a/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
+++ b/packages/joint-react/src/stories/demos/automatic-layout-storage/code.tsx
@@ -485,7 +485,7 @@ function InnerShell({ onLoadFile }: Readonly<InnerShellProps>) {
 
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 relative bg-[radial-gradient(rgba(28,36,52,0.12)_1px,transparent_1px)] bg-[length:20px_20px] [background-position:12px_12px]">
-          <Paper style={{ backgroundColor: 'transparent', width: "100%", height: "100%" }}
+          <Paper style={{ backgroundColor: 'transparent', width: '100%', height: '100%' }}
             linkRouting={linkRoutingOrthogonal({
               sourceOffset: 6,
               targetOffset: 6,

--- a/packages/joint-react/src/stories/demos/collaboration/code.tsx
+++ b/packages/joint-react/src/stories/demos/collaboration/code.tsx
@@ -15,7 +15,6 @@ import {
   type IncrementalCellsChange,
 } from '@joint/react';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
-import { usePaperEvents } from '../../../hooks';
 import Peer, { type DataConnection } from 'peerjs';
 import {
   createContext,
@@ -785,23 +784,6 @@ function Toolbar() {
   );
 }
 
-// ── Drag Tracker (broadcasts local drags to peers) ─────────────────────────
-
-function DragTracker({ manager }: Readonly<{ manager: ReturnType<typeof createPeerManager> }>) {
-  const draggingRef = useRef<Set<string>>(new Set());
-  usePaperEvents({
-    onElementPointerDown: ({ id }) => {
-      draggingRef.current.add(String(id));
-      manager.sendDrag([...draggingRef.current]);
-    },
-    onElementPointerUp: ({ id }) => {
-      draggingRef.current.delete(String(id));
-      manager.sendDrag([...draggingRef.current]);
-    },
-  }, [manager]);
-  return null;
-}
-
 // ── Main ────────────────────────────────────────────────────────────────────
 
 function GraphWithRedux() {
@@ -821,6 +803,7 @@ function GraphWithRedux() {
     () => USER_COLORS[Math.floor(Math.random() * USER_COLORS.length)]
   );
   const [remoteDragging, setRemoteDragging] = useState<Set<string>>(() => new Set());
+  const draggingRef = useRef<Set<string>>(new Set());
 
   const [manager] = useState(() =>
     createPeerManager({
@@ -910,7 +893,7 @@ function GraphWithRedux() {
           initialCells={themedCells}
           onIncrementalCellsChange={handleIncrementalChange}
         >
-          <Paper style={{ backgroundColor: theme.canvas, width: "100%", height: "100%" }}
+          <Paper style={{ backgroundColor: theme.canvas, width: '100%', height: '100%' }}
             gridSize={1}
             overflow
             linkPinning={false}
@@ -921,6 +904,14 @@ function GraphWithRedux() {
             defaultLink={{ style: { color: theme.link, width: 1.5, targetMarker: 'none' } }}
             validateConnection={({ target }) => target.port === 'in'}
             renderElement={RenderAgentNode}
+            onElementPointerDown={({ id }) => {
+              draggingRef.current.add(String(id));
+              manager.sendDrag([...draggingRef.current]);
+            }}
+            onElementPointerUp={({ id }) => {
+              draggingRef.current.delete(String(id));
+              manager.sendDrag([...draggingRef.current]);
+            }}
           />
           <ConnectionPanel
             peerId={peerId}
@@ -929,7 +920,6 @@ function GraphWithRedux() {
             peerName={peerName}
             onConnect={handleConnect}
           />
-          <DragTracker manager={manager} />
           <Toolbar />
         </GraphProvider>
       </RemoteDragContext.Provider>

--- a/packages/joint-react/src/stories/demos/collaboration/code.tsx
+++ b/packages/joint-react/src/stories/demos/collaboration/code.tsx
@@ -7,6 +7,7 @@ import {
   GraphProvider,
   Paper,
   useCellId,
+  useCellDrag,
   useGraph,
   HTMLHost,
   type CellRecord,
@@ -350,8 +351,10 @@ function createPeerManager(callbacks: {
 function RenderAgentNode({ title, role, icon, status }: Readonly<AgentNodeData>) {
   const theme = useTheme();
   const isDark = theme === DARK;
+  const localUser = useContext(UserContext);
   const remoteDrag = useContext(RemoteDragContext);
   const elementId = String(useCellId());
+  const { isDragging: isLocalDragging } = useCellDrag();
   const isRemoteDragging = remoteDrag.dragging.has(elementId);
 
   const statusColors: Record<string, string> = {
@@ -361,12 +364,12 @@ function RenderAgentNode({ title, role, icon, status }: Readonly<AgentNodeData>)
   };
   const statusColor = statusColors[status] ?? theme.muted;
 
-  const isActive = isRemoteDragging;
-  const activeName = remoteDrag.name;
-  const activeColor = remoteDrag.color;
+  // Local drag shows your own color/name; remote drag shows the peer's.
+  const isActive = isLocalDragging || isRemoteDragging;
+  const activeName = isLocalDragging ? localUser.name : remoteDrag.name;
+  const activeColor = isLocalDragging ? localUser.color : remoteDrag.color;
 
-  let borderColor: string = theme.cardBorder;
-  if (isActive) borderColor = activeColor;
+  const borderColor = isActive ? activeColor : theme.cardBorder;
 
   const defaultShadow = `0 2px 12px rgba(0,0,0,${isDark ? 0.3 : 0.06})`;
   const activeShadow = isDark

--- a/packages/joint-react/src/stories/demos/flowchart/code.tsx
+++ b/packages/joint-react/src/stories/demos/flowchart/code.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import './index.css';
 import type { CellRecord, ElementRecord, LinkRecord, LinkLabel, TransformOptions } from '@joint/react';
-import { GraphProvider, Paper, useMarkup, useMeasureNode, useNodesMeasuredEffect, usePaperEvents } from '@joint/react';
+import { GraphProvider, Paper, useMarkup, useMeasureNode, useNodesMeasuredEffect } from '@joint/react';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 import { dia, highlighters, linkTools } from '@joint/core';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
@@ -410,9 +411,27 @@ function RenderFlowchartElement(data: Readonly<ElementData>) {
 function Main() {
   const paperRef = useRef<dia.Paper | null>(null);
 
-  usePaperEvents(
-    {
-      onLinkPointerClick: ({ view: linkView, paper }) => {
+  useNodesMeasuredEffect(({ isInitial, paper }) => {
+    if (!isInitial) return;
+    paper.transformToFitContent({
+      padding: 40,
+      useModelGeometry: true,
+      verticalAlign: 'middle',
+      horizontalAlign: 'middle',
+    });
+  });
+
+  return (
+    <Paper style={{ height: 600 }}
+      ref={paperRef}
+      gridSize={5}
+      overflow
+      snapLabels
+      className={`${PAPER_CLASSNAME} flowchart-paper w-[200px]`}
+      renderElement={RenderFlowchartElement}
+      drawGrid={false}
+      linkRouting={ORTHOGONAL_LINKS}
+      onLinkPointerClick={({ view: linkView, paper }) => {
         paper.removeTools();
         dia.HighlighterView.removeAll(paper);
         const snapAnchor: linkTools.AnchorCallback<dia.Point> = (
@@ -452,8 +471,8 @@ function Main() {
           nonScalingStroke: true,
         });
         strokeHighlighter.el.classList.add('jj-flow-selection');
-      },
-      onElementMouseEnter: ({ view }) => {
+      }}
+      onElementMouseEnter={({ view }) => {
         const hl = highlighters.mask.add(view, 'body', 'frame', {
           padding: unit * 1.5,
           attrs: {
@@ -462,11 +481,11 @@ function Main() {
           },
         });
         hl.el.classList.add('jj-frame');
-      },
-      onElementMouseLeave: ({ view }) => {
+      }}
+      onElementMouseLeave={({ view }) => {
         highlighters.mask.remove(view, 'frame');
-      },
-      onLinkMouseEnter: ({ view: linkView }) => {
+      }}
+      onLinkMouseEnter={({ view: linkView }) => {
         if (highlighters.stroke.get(linkView, 'selection')) return;
         const frame = highlighters.mask.add(
           linkView,
@@ -482,38 +501,14 @@ function Main() {
           }
         );
         frame.el.classList.add('jj-frame');
-      },
-      onLinkMouseLeave: ({ paper }) => {
+      }}
+      onLinkMouseLeave={({ paper }) => {
         highlighters.mask.removeAll(paper, 'frame');
-      },
-      onBlankPointerDown: ({ paper }) => {
+      }}
+      onBlankPointerDown={({ paper }) => {
         paper.removeTools();
         dia.HighlighterView.removeAll(paper);
-      },
-    },
-    []
-  );
-
-  useNodesMeasuredEffect(({ isInitial, paper }) => {
-    if (!isInitial) return;
-    paper.transformToFitContent({
-      padding: 40,
-      useModelGeometry: true,
-      verticalAlign: 'middle',
-      horizontalAlign: 'middle',
-    });
-  });
-
-  return (
-    <Paper style={{ height: 600 }}
-      ref={paperRef}
-      gridSize={5}
-      overflow
-      snapLabels
-      className={`${PAPER_CLASSNAME} flowchart-paper w-[200px]`}
-      renderElement={RenderFlowchartElement}
-      drawGrid={false}
-      linkRouting={ORTHOGONAL_LINKS}
+      }}
     />
   );
 }

--- a/packages/joint-react/src/stories/demos/introduction-demo/code.tsx
+++ b/packages/joint-react/src/stories/demos/introduction-demo/code.tsx
@@ -22,7 +22,6 @@ import {
   type LinkRecord,
   type ElementPort,
   type PaperProps,
-  usePaperEvents,
   selectElementSize,
 } from '@joint/react';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
@@ -481,18 +480,6 @@ function Main() {
 
   const paperId = useId();
 
-  usePaperEvents(
-    paperId,
-    {
-      onLinkMouseEnter: ({ view }) => view.addTools(toolsView),
-      onLinkMouseLeave: ({ view }) => view.removeTools(),
-      onElementPointerClick: ({ id }) => setSelectedElementId(id as CellId),
-      onLinkPointerClick: () => setSelectedElementId(null),
-      onBlankPointerClick: () => setSelectedElementId(null),
-    },
-    [setSelectedElementId]
-  );
-
   return (
     <div className="flex flex-col relative">
       <div className="flex flex-col relative">
@@ -531,6 +518,11 @@ function Main() {
           }}
           renderElement={renderElement}
           className={`${PAPER_CLASSNAME} h-[600px] bg-gray-900 shadow-md`}
+          onLinkMouseEnter={({ view }) => view.addTools(toolsView)}
+          onLinkMouseLeave={({ view }) => view.removeTools()}
+          onElementPointerClick={({ id }) => setSelectedElementId(id as CellId)}
+          onLinkPointerClick={() => setSelectedElementId(null)}
+          onBlankPointerClick={() => setSelectedElementId(null)}
         />
 
         {isMinimapVisible && <MiniMap />}

--- a/packages/joint-react/src/stories/demos/investment-calculator/code.tsx
+++ b/packages/joint-react/src/stories/demos/investment-calculator/code.tsx
@@ -686,7 +686,7 @@ function Main() {
   }, [graph]);
 
   return (
-    <Paper style={{ backgroundColor: '#0f172a', width: "100%", height: 800 }}
+    <Paper style={{ backgroundColor: '#0f172a', width: '100%', height: 800 }}
       ref={paperRef}
       className={PAPER_CLASSNAME}
       renderElement={RenderElement}

--- a/packages/joint-react/src/stories/demos/link-arrows/code.tsx
+++ b/packages/joint-react/src/stories/demos/link-arrows/code.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 
 import { useEffect, useState } from 'react';
 import { dia, util } from '@joint/core';
 import type { CellRecord, LinkRecord, LinkMarker } from '@joint/react';
-import { GraphProvider, Paper, usePaperEvents, usePaper, jsx } from '@joint/react';
+import { GraphProvider, Paper, usePaper, jsx } from '@joint/react';
 import { PAPER_CLASSNAME, BG } from 'storybook-config/theme';
 
 const BG_COLOR = BG;
@@ -482,23 +483,20 @@ function Main() {
     }
   }, [zoom, paper]);
 
-  usePaperEvents({
-    onLinkPointerDown: ({ model: link }) => {
-      setZoom((previous) => {
-        if (previous.type === 'link' && previous.link === link) {
-          return { type: 'arrow', link };
-        }
-        return { type: 'link', link };
-      });
-    },
-    onBlankPointerDown: () => setZoom({ type: 'overview' }),
-  });
-
   return (
-    <Paper style={{ background: BG_COLOR, width: "100%" }}
+    <Paper style={{ background: BG_COLOR, width: '100%' }}
       className={`${PAPER_CLASSNAME} h-150`}
       interactive={false}
       drawGrid={false}
+      onLinkPointerDown={({ model: link }) => {
+        setZoom((previous) => {
+          if (previous.type === 'link' && previous.link === link) {
+            return { type: 'arrow', link };
+          }
+          return { type: 'link', link };
+        });
+      }}
+      onBlankPointerDown={() => setZoom({ type: 'overview' })}
     />
   );
 }

--- a/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
+++ b/packages/joint-react/src/stories/demos/pulsing-port/code.tsx
@@ -7,7 +7,6 @@ import {
   GraphProvider,
   jsx,
   Paper,
-  usePaperEvents,
   useCells,
   useCellId,
   HTMLBox,
@@ -117,13 +116,10 @@ const toolsView = new dia.ToolsView({
 });
 
 function Main() {
-  usePaperEvents({
-    onLinkMouseEnter: ({ view }) => view.addTools(toolsView),
-    onLinkMouseLeave: ({ view }) => view.removeTools(),
-  });
-
   return (
-    <Paper style={{ width: "100%" }}
+    <Paper style={{ width: '100%' }}
+      onLinkMouseEnter={({ view }) => view.addTools(toolsView)}
+      onLinkMouseLeave={({ view }) => view.removeTools()}
       defaultLink={{
         style: { color: PRIMARY, targetMarker: 'arrow' },
       }}

--- a/packages/joint-react/src/stories/demos/saasflow/code.tsx
+++ b/packages/joint-react/src/stories/demos/saasflow/code.tsx
@@ -488,7 +488,7 @@ function Main() {
 
   return (
     <GraphProvider initialCells={initialCells}>
-      <Paper style={{ backgroundColor: 'transparent', width: "100%", height: "100%" }}
+      <Paper style={{ backgroundColor: 'transparent', width: '100%', height: '100%' }}
         ref={paperRef}
         gridSize={5}
         drawGrid={false}

--- a/packages/joint-react/src/stories/examples/markup-selectors-html/code.tsx
+++ b/packages/joint-react/src/stories/examples/markup-selectors-html/code.tsx
@@ -141,7 +141,7 @@ function Main() {
   }, []);
 
   return (
-    <Paper style={{ width: "100%", height: 280 }}
+    <Paper style={{ width: '100%', height: 280 }}
       renderElement={renderElement}
       magnetThreshold="onleave"
       linkPinning={false}

--- a/packages/joint-react/src/stories/examples/markup-selectors/code.tsx
+++ b/packages/joint-react/src/stories/examples/markup-selectors/code.tsx
@@ -159,7 +159,7 @@ function Main() {
   }, []);
 
   return (
-    <Paper style={{ ...PAPER_STYLE, width: "100%", height: 250 }}
+    <Paper style={{ ...PAPER_STYLE, width: '100%', height: 250 }}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       magnetThreshold={'onleave'}

--- a/packages/joint-react/src/stories/examples/stress/code.tsx
+++ b/packages/joint-react/src/stories/examples/stress/code.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable sonarjs/pseudo-random */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { HTMLBox, GraphProvider, Paper, type CellRecord, type ElementRecord, type LinkRecord } from '@joint/react';
 import '../index.css';
 import React, { useCallback, useState, startTransition } from 'react';

--- a/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-layout/code.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-shadow */
 /* eslint-disable sonarjs/pseudo-random */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import '../index.css';
 import {
   GraphProvider,

--- a/packages/joint-react/src/stories/examples/with-auto-size-origin/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-auto-size-origin/code.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import {
   type AutoSizeOrigin,
   type CellRecord,
@@ -108,7 +109,7 @@ export default function App() {
         <select
           id="autoSizeOriginToggle"
           value={origin}
-          onChange={(e) => setOrigin(e.target.value as AutoSizeOrigin)}
+          onChange={(event) => setOrigin(event.target.value as AutoSizeOrigin)}
         >
           <option value="top-left">top-left</option>
           <option value="center">center</option>

--- a/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-cell-json/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { PAPER_CLASSNAME, PRIMARY } from 'storybook-config/theme';
 import { shapes, dia } from '@joint/core';
 import '../index.css';

--- a/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-collapsible-container/code.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { useCallback, useEffect } from 'react';
 import { dia, elementTools } from '@joint/core';
 import {
@@ -9,7 +10,6 @@ import {
   useCell,
   useCellId,
   useGraph,
-  usePaperEvents,
   SVGText,
   selectElementSize,
 } from '@joint/react';
@@ -407,9 +407,12 @@ function Main() {
     }
   }, [graph]);
 
-  usePaperEvents(
-    {
-      onElementMouseEnter: ({ view }) => {
+  return (
+    <Paper style={{ backgroundColor: '#F3F7F6', height: 500 }}
+      className={PAPER_CLASSNAME}
+      renderElement={renderElement}
+      cellVisibility={cellVisibility}
+      onElementMouseEnter={({ view }) => {
         view.removeTools();
         view.addTools(
           new dia.ToolsView({
@@ -422,17 +425,8 @@ function Main() {
             ],
           })
         );
-      },
-      onElementMouseLeave: ({ view }) => view.removeTools(),
-    },
-    []
-  );
-
-  return (
-    <Paper style={{ backgroundColor: '#F3F7F6', height: 500 }}
-      className={PAPER_CLASSNAME}
-      renderElement={renderElement}
-      cellVisibility={cellVisibility}
+      }}
+      onElementMouseLeave={({ view }) => view.removeTools()}
     />
   );
 }

--- a/packages/joint-react/src/stories/examples/with-default-element/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-default-element/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useState, useCallback, useMemo, useRef, memo } from 'react';
 import { type CellRecord, GraphProvider, Paper, HTMLBox, type LinkMarkerName } from '@joint/react';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';

--- a/packages/joint-react/src/stories/examples/with-default-link/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-default-link/code.tsx
@@ -1,4 +1,4 @@
-
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
 import '../index.css';

--- a/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react-perf/jsx-no-new-function-as-prop */
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   type CellRecord,
   GraphProvider,
@@ -20,6 +19,11 @@ interface NodeData {
 }
 
 const SIZE = { width: 140, height: 50 };
+
+type PaperInteraction = Pick<
+  React.ComponentProps<typeof Paper>,
+  'onElementPointerClick' | 'onBlankPointerClick' | 'onElementMouseEnter' | 'onElementMouseLeave'
+>;
 
 const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
   { id: 'a', type: 'element', data: { label: 'Source' }, position: { x: 60, y: 60 }, size: SIZE },
@@ -97,6 +101,23 @@ function Main() {
     });
   }, []);
 
+  // Edit mode: select & edit elements. View mode: read-only, hover for info.
+  const interactivity = useMemo<PaperInteraction>(() => {
+    if (editMode) {
+      return {
+        onElementPointerClick: ({ id }) => setSelectedId(String(id)),
+        onBlankPointerClick: () => setSelectedId(null),
+      };
+    }
+    return {
+      onElementMouseEnter: ({ id, model }) => {
+        const data = model.attributes.data as NodeData | undefined;
+        setHovered(data?.label ?? String(id));
+      },
+      onElementMouseLeave: () => setHovered(null),
+    };
+  }, [editMode]);
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
@@ -113,17 +134,7 @@ function Main() {
           <Paper
             className={PAPER_CLASSNAME + ' h-[300px]'}
             interactive={editMode}
-            onElementPointerClick={editMode ? ({ id }) => setSelectedId(String(id)) : undefined}
-            onBlankPointerClick={editMode ? () => setSelectedId(null) : undefined}
-            onElementMouseEnter={
-              editMode
-                ? undefined
-                : ({ id, model }) => {
-                    const data = model.attributes.data as NodeData | undefined;
-                    setHovered(data?.label ?? String(id));
-                  }
-            }
-            onElementMouseLeave={editMode ? undefined : () => setHovered(null)}
+            {...interactivity}
           />
           {!editMode && hovered && (
             <div className="absolute top-2 right-2 px-3 py-1 rounded-md bg-white border border-gray-200 shadow-md text-xs font-medium text-gray-700 pointer-events-none">

--- a/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-dynamic-interactivity/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { useCallback, useState } from 'react';
 import {
   type CellRecord,
@@ -5,9 +6,7 @@ import {
   Paper,
   useCells,
   useGraph,
-  usePaperEvents,
 } from '@joint/react';
-import { type dia } from '@joint/core';
 import { BUTTON_CLASSNAME, PAPER_CLASSNAME } from 'storybook-config/theme';
 
 import '../index.css';
@@ -29,45 +28,6 @@ const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
   { id: 'a→b', type: 'link', source: { id: 'a' }, target: { id: 'b' }, style: { targetMarker: 'arrow' } },
   { id: 'b→c', type: 'link', source: { id: 'b' }, target: { id: 'c' }, style: { targetMarker: 'arrow' } },
 ];
-
-// ============================================================================
-// Controllers — different event wiring per mode
-// ============================================================================
-
-interface EditControllerProps {
-  readonly onSelect: (id: string | null) => void;
-}
-
-function EditController({ onSelect }: Readonly<EditControllerProps>) {
-  usePaperEvents(
-    {
-      onElementPointerClick: ({ id }) => onSelect(String(id)),
-      onBlankPointerClick: () => onSelect(null),
-    },
-    [onSelect]
-  );
-  return null;
-}
-
-function ViewController() {
-  const [hovered, setHovered] = useState<string | null>(null);
-  usePaperEvents(
-    {
-      onElementMouseEnter: ({ id, model }) => {
-        const data = model.attributes.data as NodeData | undefined;
-        setHovered(data?.label ?? String(id));
-      },
-      onElementMouseLeave: () => setHovered(null),
-    },
-    []
-  );
-  if (!hovered) return null;
-  return (
-    <div className="absolute top-2 right-2 px-3 py-1 rounded-md bg-white border border-gray-200 shadow-md text-xs font-medium text-gray-700 pointer-events-none">
-      Hovering: {hovered}
-    </div>
-  );
-}
 
 // ============================================================================
 // Property Editor — visible only in edit mode
@@ -127,6 +87,7 @@ function PropertyEditor({ selectedId }: Readonly<PropertyEditorProps>) {
 function Main() {
   const [editMode, setEditMode] = useState(true);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null);
 
   const toggleMode = useCallback(() => {
     setEditMode((previous) => {
@@ -149,11 +110,25 @@ function Main() {
 
       <div className="flex">
         <div className="flex-1 relative">
-          <Paper className={PAPER_CLASSNAME + ' h-[300px]'} interactive={editMode} />
-          {editMode ? (
-            <EditController onSelect={setSelectedId} />
-          ) : (
-            <ViewController />
+          <Paper
+            className={PAPER_CLASSNAME + ' h-[300px]'}
+            interactive={editMode}
+            onElementPointerClick={editMode ? ({ id }) => setSelectedId(String(id)) : undefined}
+            onBlankPointerClick={editMode ? () => setSelectedId(null) : undefined}
+            onElementMouseEnter={
+              editMode
+                ? undefined
+                : ({ id, model }) => {
+                    const data = model.attributes.data as NodeData | undefined;
+                    setHovered(data?.label ?? String(id));
+                  }
+            }
+            onElementMouseLeave={editMode ? undefined : () => setHovered(null)}
+          />
+          {!editMode && hovered && (
+            <div className="absolute top-2 right-2 px-3 py-1 rounded-md bg-white border border-gray-200 shadow-md text-xs font-medium text-gray-700 pointer-events-none">
+              Hovering: {hovered}
+            </div>
           )}
         </div>
         {editMode && (

--- a/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-controls/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { type CellRecord, GraphProvider, useCell, Paper, useNodesMeasuredEffect, type ElementRecord, selectElementSize } from '@joint/react';
 import '../index.css';
 import { PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, LIGHT, TEXT } from 'storybook-config/theme';
@@ -743,7 +744,7 @@ function Main() {
   useNodesMeasuredEffect(handleElementsMeasured);
 
   return (
-    <Paper style={{ ...PAPER_STYLE, width: "100%", height: 600 }}
+    <Paper style={{ ...PAPER_STYLE, width: '100%', height: 600 }}
       className={PAPER_CLASSNAME}
       renderElement={renderElement}
       drawGrid={false}

--- a/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-defaults/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import type {
   ElementRecord,
   LinkRecord} from '@joint/react';

--- a/packages/joint-react/src/stories/examples/with-element-ports-groups/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-element-ports-groups/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { type CellRecord, GraphProvider, Paper, HTMLBox } from '@joint/react';
 import { elementPort } from '@joint/react/presets';
 import { PAPER_CLASSNAME, PRIMARY, SECONDARY } from 'storybook-config/theme';

--- a/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-fixed-connection-points/code.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { useEffect, useRef } from 'react';
 import type { CellRecord, LinkStyle } from '@joint/react';
-import { GraphProvider, useCell, jsx, Paper, resolveLinkMarker, usePaperEvents, selectElementSize } from '@joint/react';
+import { GraphProvider, useCell, jsx, Paper, resolveLinkMarker, selectElementSize } from '@joint/react';
 import { PAPER_CLASSNAME, PAPER_STYLE, BG, PRIMARY, TEXT, LIGHT } from 'storybook-config/theme';
 import { dia, elementTools, linkTools, highlighters, g } from '@joint/core';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
@@ -364,42 +364,39 @@ function Main() {
     };
   }, []);
 
-  usePaperEvents({
-    onCellMouseEnter: ({ model, view, paper }) => {
-      paper.removeTools();
-
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current);
-        timeoutIdRef.current = null;
-      }
-
-      const tools = model.isLink()
-        ? getLinkTools(view as dia.LinkView)
-        : getElementTools(view as dia.ElementView);
-
-      const toolsView = new dia.ToolsView({ tools });
-      view.addTools(toolsView);
-      currentToolsViewRef.current = toolsView;
-    },
-    onCellMouseLeave: () => {
-      timeoutIdRef.current = setTimeout(() => {
-        currentToolsViewRef.current?.remove();
-        currentToolsViewRef.current = null;
-        timeoutIdRef.current = null;
-      }, 1000);
-
-      currentToolsViewRef.current?.el.classList.add(
-        'opacity-0',
-        'transition-opacity',
-        'duration-300',
-        'delay-300'
-      );
-    },
-    onElementPointerMove: ({ view }) => view.removeTools(),
-  });
-
   return (
-    <Paper style={{ ...PAPER_STYLE, width: "100%", height: 650 }}
+    <Paper style={{ ...PAPER_STYLE, width: '100%', height: 650 }}
+      onCellMouseEnter={({ model, view, paper }) => {
+        paper.removeTools();
+
+        if (timeoutIdRef.current) {
+          clearTimeout(timeoutIdRef.current);
+          timeoutIdRef.current = null;
+        }
+
+        const tools = model.isLink()
+          ? getLinkTools(view as dia.LinkView)
+          : getElementTools(view as dia.ElementView);
+
+        const toolsView = new dia.ToolsView({ tools });
+        view.addTools(toolsView);
+        currentToolsViewRef.current = toolsView;
+      }}
+      onCellMouseLeave={() => {
+        timeoutIdRef.current = setTimeout(() => {
+          currentToolsViewRef.current?.remove();
+          currentToolsViewRef.current = null;
+          timeoutIdRef.current = null;
+        }, 1000);
+
+        currentToolsViewRef.current?.el.classList.add(
+          'opacity-0',
+          'transition-opacity',
+          'duration-300',
+          'delay-300'
+        );
+      }}
+      onElementPointerMove={({ view }) => view.removeTools()}
       className={PAPER_CLASSNAME}
       renderElement={RenderElement}
       gridSize={20}

--- a/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-graph-neighbors/code.tsx
@@ -1,7 +1,8 @@
-
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type CellRecord, GraphProvider, useCell, Paper, SVGText, useGraph, useMarkup, usePaperEvents, selectElementSize } from '@joint/react';
+import { type CellRecord, GraphProvider, useCell, Paper, SVGText, useGraph, useMarkup, selectElementSize } from '@joint/react';
 import { highlighters, type dia } from '@joint/core';
 import { LIGHT, PAPER_CLASSNAME, PAPER_STYLE, PRIMARY, SECONDARY } from 'storybook-config/theme';
 
@@ -179,9 +180,18 @@ function Main() {
     }
   }, [highlightState]);
 
-  usePaperEvents(
-    {
-      onElementPointerClick: ({ id }) => {
+  const renderElement = useCallback(
+    (data: NodeData) => <RenderNode {...data} />,
+    []
+  );
+
+  return (
+    <Paper style={{ ...PAPER_STYLE, width: '100%', height: 500 }}
+      ref={paperRef}
+      className={PAPER_CLASSNAME}
+      renderElement={renderElement}
+      drawGrid={false}
+      onElementPointerClick={({ id }) => {
         const clickedId = String(id);
         setHighlightState((previous) => {
           if (previous.selectedId === clickedId) {
@@ -202,23 +212,8 @@ function Main() {
             connectedLinkIds: nextConnectedLinkIds,
           };
         });
-      },
-      onBlankPointerClick: () => setHighlightState(INITIAL_STATE),
-    },
-    [graph]
-  );
-
-  const renderElement = useCallback(
-    (data: NodeData) => <RenderNode {...data} />,
-    []
-  );
-
-  return (
-    <Paper style={{ ...PAPER_STYLE, width: "100%", height: 500 }}
-      ref={paperRef}
-      className={PAPER_CLASSNAME}
-      renderElement={renderElement}
-      drawGrid={false}
+      }}
+      onBlankPointerClick={() => setHighlightState(INITIAL_STATE)}
     />
   );
 }

--- a/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-highlighter/code.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
-import { type CellRecord, GraphProvider, useCell, Paper, useMarkup, usePaperEvents, selectElementSize } from '@joint/react';
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+import { type CellRecord, GraphProvider, useCell, Paper, useMarkup, selectElementSize } from '@joint/react';
 import { type dia, highlighters } from '@joint/core';
 import '../index.css';
 import { useRef } from 'react';
@@ -99,20 +100,14 @@ function removeHighlighter(variant: HighlighterVariant, elementView: dia.Element
 function Main({ variant }: Readonly<MainProps>) {
   const paperRef = useRef<dia.Paper | null>(null);
 
-  usePaperEvents(
-    {
-      onElementMouseEnter: ({ view }) => addHighlighter(variant, view),
-      onElementMouseLeave: ({ view }) => removeHighlighter(variant, view),
-    },
-    [variant]
-  );
-
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <Paper style={{ height: 280 }}
         ref={paperRef}
         className={PAPER_CLASSNAME}
         renderElement={RenderElement}
+        onElementMouseEnter={({ view }) => addHighlighter(variant, view)}
+        onElementMouseLeave={({ view }) => removeHighlighter(variant, view)}
       />
     </div>
   );

--- a/packages/joint-react/src/stories/examples/with-link-labels/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-labels/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { type CellRecord, GraphProvider, Paper } from '@joint/react';
 import { LIGHT, PAPER_CLASSNAME, PRIMARY, SECONDARY } from 'storybook-config/theme';
 import '../index.css';
@@ -79,7 +80,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
 
 function Main() {
   return (
-    <Paper style={{ width: "100%", height: 350 }}
+    <Paper style={{ width: '100%', height: 350 }}
       className={PAPER_CLASSNAME}
       interactive={INTERACTIVE_OPTIONS}
     />

--- a/packages/joint-react/src/stories/examples/with-link-markers-named/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-markers-named/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import type { CellRecord, LinkRecord } from '@joint/react';
 import { GraphProvider, Paper } from '@joint/react';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
@@ -51,7 +52,7 @@ const initialCells = buildCells();
 export default function App() {
   return (
     <GraphProvider initialCells={initialCells}>
-      <Paper style={{ width: "100%" }}
+      <Paper style={{ width: '100%' }}
         transform={'scale(2)'}
         className={`${PAPER_CLASSNAME} h-[800px]`}
         interactive={false}

--- a/packages/joint-react/src/stories/examples/with-link-markers/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-markers/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useCallback, useMemo, useState, type ChangeEvent } from 'react';
 import type { CellRecord, ElementPort, ElementRecord, LinkRecord } from '@joint/react';
 import { GraphProvider, Paper, HTMLBox } from '@joint/react';

--- a/packages/joint-react/src/stories/examples/with-link-routing/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-routing/code.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useEffect, useMemo, useState } from 'react';
 import { type CellRecord, GraphProvider, useCell, Paper, HTMLBox, useMarkup, type ElementPort, type LinkRecord, usePaper, selectElementSize } from '@joint/react';
 import { linkRoutingStraight, linkRoutingOrthogonal, linkRoutingSmooth, type LinkRoutingStraightOptions, type LinkRoutingOrthogonalOptions, type LinkRoutingSmoothOptions, type LinkMode } from '@joint/react/presets';

--- a/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-link-tools/code.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { dia, linkTools } from '@joint/core';
 import '../index.css';
-import { type CellRecord, GraphProvider, jsx, Paper, usePaperEvents } from '@joint/react';
+import { type CellRecord, GraphProvider, jsx, Paper } from '@joint/react';
 import { PRIMARY, SECONDARY, PAPER_CLASSNAME } from 'storybook-config/theme';
 import { linkRoutingOrthogonal } from '@joint/react/presets';
 
@@ -92,16 +93,13 @@ const toolsView = new dia.ToolsView({
 });
 
 function Main() {
-  usePaperEvents({
-    onLinkMouseEnter: ({ view }) => view.addTools(toolsView),
-    onLinkMouseLeave: ({ view }) => view.removeTools(),
-  });
-
   return (
     <div style={{ display: 'flex', flexDirection: 'row', position: 'relative' }}>
       <Paper style={{ height: 280 }}
         className={PAPER_CLASSNAME}
         linkRouting={ORTHOGONAL_LINKS}
+        onLinkMouseEnter={({ view }) => view.addTools(toolsView)}
+        onLinkMouseLeave={({ view }) => view.removeTools()}
       />
       <div
         style={{

--- a/packages/joint-react/src/stories/examples/with-list-node/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-list-node/code.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @eslint-react/no-array-index-key */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import '../index.css';
 import { useCallback, useRef, type PropsWithChildren } from 'react';

--- a/packages/joint-react/src/stories/examples/with-minimap/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-minimap/code.tsx
@@ -47,7 +47,7 @@ function MiniMap() {
 
   return (
     <div className="absolute bottom-4 right-6 w-[200px] h-[150px] border border-[#dde6ed] rounded-lg overflow-hidden">
-      <Paper style={{ height: "100%" }}
+      <Paper style={{ height: '100%' }}
         id="minimap"
         interactive={false}
         transform={'scale(0.4)'}

--- a/packages/joint-react/src/stories/examples/with-native-ports/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-native-ports/code.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { PAPER_CLASSNAME, PAPER_STYLE } from 'storybook-config/theme';
 import type { dia } from '@joint/core';
 import '../index.css';

--- a/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-portal-selector/code.tsx
@@ -11,7 +11,6 @@ import {
   useGraph,
   useMeasureNode,
   usePaper,
-  usePaperEvents,
   ELEMENT_MODEL_TYPE,
   type CellId,
   type PaperProps,
@@ -191,7 +190,7 @@ function MiniMap({ paper }: Readonly<{ paper: dia.Paper }>) {
       className="absolute bg-black bottom-6 right-6 border border-[#dde6ed] rounded-lg overflow-hidden"
       style={{ width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT }}
     >
-      <Paper style={{ backgroundColor: LIGHT, height: "100%" }}
+      <Paper style={{ backgroundColor: LIGHT, height: '100%' }}
         {...PAPER_PROPS}
         interactive={false}
         transform={`scale(${scale})`}
@@ -288,20 +287,9 @@ function Main() {
   // Subscribe to cells so the story reflects graph size in devtools if needed.
   useCells();
 
-  usePaperEvents(
-    {
-      onElementPointerClick: ({ id }) => setSelectedElement(id),
-      onElementPointerDblClick: ({ model, graph }) => {
-        model.clone().translate(10, 10).addTo(graph);
-      },
-      onBlankPointerClick: () => setSelectedElement(null),
-    },
-    [setSelectedElement]
-  );
-
   return (
     <div className="flex flex-col relative w-full h-full">
-      <Paper style={{ ...PAPER_STYLE, height: "calc(100vh - 100px)" }}
+      <Paper style={{ ...PAPER_STYLE, height: 'calc(100vh - 100px)' }}
         {...PAPER_PROPS}
         ref={setPaper}
         className={PAPER_CLASSNAME}
@@ -313,6 +301,11 @@ function Main() {
           // implicit: use the default selector for ElementModel cells
         }}
         drawGrid={false}
+        onElementPointerClick={({ id }) => setSelectedElement(id)}
+        onElementPointerDblClick={({ model, graph }) => {
+          model.clone().translate(10, 10).addTo(graph);
+        }}
+        onBlankPointerClick={() => setSelectedElement(null)}
       >
         <Selection selectedId={selectedElement} />
       </Paper>

--- a/packages/joint-react/src/stories/examples/with-shape-animations/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-shape-animations/code.tsx
@@ -420,7 +420,7 @@ function PowerControl() {
 function Main() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <Paper style={{ width: "100%", height: 500 }}
+      <Paper style={{ width: '100%', height: 500 }}
         className={PAPER_CLASSNAME}
         renderElement={RenderShapeElement}
         transform={'scale(3)'}

--- a/packages/joint-react/src/stories/examples/with-tailwind-theme/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-tailwind-theme/code.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import { useState, useCallback, useRef } from 'react';
 import { type CellRecord, GraphProvider, Paper, selectElementSize, useCell } from '@joint/react';

--- a/packages/joint-react/src/stories/examples/with-theme-editor/code.tsx
+++ b/packages/joint-react/src/stories/examples/with-theme-editor/code.tsx
@@ -9,7 +9,6 @@ import {
   Paper,
   HTMLBox,
   type LinkMarkerName,
-  usePaperEvents,
   useGraph,
 } from '@joint/react';
 import { PAPER_CLASSNAME } from 'storybook-config/theme';
@@ -464,50 +463,6 @@ interface DiagramProps {
 function Diagram({ zoom }: Readonly<DiagramProps>) {
   const { setCell } = useGraph<CellRecord<Data>>();
 
-  usePaperEvents({
-    'blank:pointerdblclick': (_event, x, y) => {
-      setCell({
-        id: `node-${Date.now()}`,
-        type: 'element',
-        data: { label: 'New Node' },
-        position: { x, y },
-        portMap: { in: PORT_IN, out: PORT_OUT },
-        z: 2,
-      });
-    },
-    'link:contextmenu': (linkView, event_, _x, _y) => {
-      const labelNode = (event_.target as Element | null)?.closest('[label-idx]');
-      if (!labelNode) return;
-      const labelIndex = Number.parseInt(labelNode.getAttribute('label-idx') ?? '', 10);
-      if (Number.isNaN(labelIndex)) return;
-      event_.preventDefault();
-      setCell(String(linkView.model.id), (previous) => {
-        const rawLabelMap = (previous as { labelMap?: Record<string, unknown> }).labelMap;
-        if (!rawLabelMap) return previous;
-        const keys = Object.keys(rawLabelMap);
-        if (labelIndex >= keys.length) return previous;
-        const labelKey = keys[labelIndex];
-        const labelMap = Object.fromEntries(
-          Object.entries(rawLabelMap).filter(([key]) => key !== labelKey)
-        );
-        return { ...previous, labelMap } as CellRecord<Data>;
-      });
-    },
-    'link:pointerdblclick': (linkView, _event, x, y) => {
-      const totalLength = linkView.getConnectionLength();
-      const closestLength = linkView.getClosestPointLength({ x, y });
-      const position = totalLength > 0 ? closestLength / totalLength : 0.5;
-      const labelKey = `label-${Date.now()}`;
-      setCell(String(linkView.model.id), (previous) => {
-        const linkRecord = previous as CellRecord<Data> & { labelMap?: Record<string, unknown> };
-        return {
-          ...linkRecord,
-          labelMap: { ...linkRecord.labelMap, [labelKey]: { position, text: 'New Label' } },
-        };
-      });
-    },
-  });
-
   return (
     <Paper
       className={PAPER_CLASSNAME}
@@ -518,6 +473,47 @@ function Diagram({ zoom }: Readonly<DiagramProps>) {
       embeddingMode
       validateEmbedding={validateEmbedding}
       transform={`scale(${zoom})`}
+      onBlankPointerDblClick={({ x, y }) => {
+        setCell({
+          id: `node-${Date.now()}`,
+          type: 'element',
+          data: { label: 'New Node' },
+          position: { x, y },
+          portMap: { in: PORT_IN, out: PORT_OUT },
+          z: 2,
+        });
+      }}
+      onLinkContextMenu={({ view, event }) => {
+        const labelNode = (event.target as Element | null)?.closest('[label-idx]');
+        if (!labelNode) return;
+        const labelIndex = Number.parseInt(labelNode.getAttribute('label-idx') ?? '', 10);
+        if (Number.isNaN(labelIndex)) return;
+        event.preventDefault();
+        setCell(String(view.model.id), (previous) => {
+          const rawLabelMap = (previous as { labelMap?: Record<string, unknown> }).labelMap;
+          if (!rawLabelMap) return previous;
+          const keys = Object.keys(rawLabelMap);
+          if (labelIndex >= keys.length) return previous;
+          const labelKey = keys[labelIndex];
+          const labelMap = Object.fromEntries(
+            Object.entries(rawLabelMap).filter(([key]) => key !== labelKey)
+          );
+          return { ...previous, labelMap } as CellRecord<Data>;
+        });
+      }}
+      onLinkPointerDblClick={({ view, x, y }) => {
+        const totalLength = view.getConnectionLength();
+        const closestLength = view.getClosestPointLength({ x, y });
+        const position = totalLength > 0 ? closestLength / totalLength : 0.5;
+        const labelKey = `label-${Date.now()}`;
+        setCell(String(view.model.id), (previous) => {
+          const linkRecord = previous as CellRecord<Data> & { labelMap?: Record<string, unknown> };
+          return {
+            ...linkRecord,
+            labelMap: { ...linkRecord.labelMap, [labelKey]: { position, text: 'New Label' } },
+          };
+        });
+      }}
     />
   );
 }

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-jotai.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-jotai.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/pseudo-random */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 /**
  * ============================================================================

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-peerjs.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-peerjs.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/pseudo-random */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 /**
  * ============================================================================

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-redux.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-redux.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
 /* eslint-disable sonarjs/pseudo-random */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 import {
   GraphProvider,

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-zustand.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-controlled-mode-zustand.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/pseudo-random */
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 
 /**
  * ============================================================================

--- a/packages/joint-react/src/stories/tutorials/step-by-step/code-html-renderer.tsx
+++ b/packages/joint-react/src/stories/tutorials/step-by-step/code-html-renderer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useCallback, useRef, useState } from 'react';
 import {
   type CellRecord,

--- a/packages/joint-react/src/utils/joint-jsx/jsx-to-markup.stories.tsx
+++ b/packages/joint-react/src/utils/joint-jsx/jsx-to-markup.stories.tsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useMemo } from 'react';
 import { dia } from '@joint/core';
 import '../../stories/examples/index.css';

--- a/packages/joint-react/src/utils/test-wrappers.tsx
+++ b/packages/joint-react/src/utils/test-wrappers.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useCallback } from 'react';
 import { GraphProvider, Paper, type GraphProviderProps, type PaperProps } from '../components';
 import { dia } from '@joint/core';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Adds normalized paper events as first-class `<Paper>` props, so events can be wired declaratively instead of via the `usePaperEvents` hook:

```tsx
<Paper
  onBlankContextMenu={({ paper, event, x, y }) => /* ... */}
  onElementPointerClick={({ id, model, view }) => /* ... */}
  onLinkMouseEnter={({ view }) => /* ... */}
/>
```

- New `NormalizedPaperHandlers` exposes every normalized event as an `on<Category><Event>` prop on `PaperProps`; each handler receives a single context object.
- `extractEventsFromPaperProps` peels the handler props off the rest of the props and returns them plus a parallel dependency array; the subscription is a `useLayoutEffect(..., [paperStore, ...eventDependencies])`.
- **Only the event-handler props participate in the subscription deps** — pass stable references (`useCallback` / module-level) to subscribe once; inline arrows work too but re-subscribe per render. Non-event props (`gridSize`, `style`, ...) never re-subscribe. Documented on `PaperProps`.
- All stories migrated from `usePaperEvents` to `<Paper onX>`. `usePaperEvents` stays available and is still used for raw events with no normalized form (`element:expand`, `render:done render:idle`).
- Tests cover handler firing, context shapes (element / cell / hover / wheel / paper-level), and the re-subscribe semantics.
- Repo-wide ESLint cleanup and re-alignment of stale unit tests to current behavior.

## Motivation and Context

`usePaperEvents` required a separate hook call (often in a different component than `<Paper>`), with manual paper-target plumbing and dependency arrays. Exposing events as props makes the common case declarative and colocated with the `<Paper>`, while keeping the hook for advanced / raw events.

### Screenshots (if appropriate):
