### PR TITLE
chore(joint-react): add dist script, prepack script doesn't need test [dev]

### DIFF
--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -58,7 +58,8 @@
   ],
   "scripts": {
     "prepublishOnly": "echo \"Publishing via NPM is not allowed!\" && exit 1",
-    "prepack": "yarn test && yarn build",
+    "prepack": "yarn run dist",
+    "dist": "yarn run build",
     "build": "rollup -c rollup.config.ts --configPlugin esbuild && tsc --project tsconfig.types.json",
     "build-storybook": "storybook build",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Description

Replaced by #3360 

Fixes `joint-react` scripts to be consistent with other packages (adds `dist` script and doesnt run `test` as part of `prepack`)