### PR TITLE
fix(joint-core): guard against non-invertible screen CTM [dev]

### DIFF
--- a/packages/joint-core/src/V/transform.mjs
+++ b/packages/joint-core/src/V/transform.mjs
@@ -129,6 +129,16 @@ function getRootSVG(node) {
 }
 
 /**
+ * @param {SVGMatrix} matrix
+ * @returns {boolean}
+ * @description Checks if the given matrix is invertible.
+ */
+function isMatrixInvertible(matrix) {
+    const det = matrix.a * matrix.d - matrix.b * matrix.c;
+    return Number.isFinite(det) && det !== 0;
+}
+
+/**
  *
  * @param {SVGElement} a
  * @param {SVGElement} b
@@ -146,7 +156,7 @@ export function getRelativeTransformation(a, b) {
     if (rootA !== rootB) return null;
     // Get the transformation matrix from `a` to `b`.
     const am = b.getScreenCTM();
-    if (!am) return null;
+    if (!am || !isMatrixInvertible(am)) return null;
     const bm = a.getScreenCTM();
     if (!bm) return null;
     return am.inverse().multiply(bm);

--- a/packages/joint-core/test/vectorizer/vectorizer.js
+++ b/packages/joint-core/test/vectorizer/vectorizer.js
@@ -1682,18 +1682,12 @@ QUnit.module('vectorizer', function(hooks) {
             assert.equal(ctm.d, 0, 'Target CTM.d is 0');
             assert.equal(ctm.a * ctm.d - ctm.b * ctm.c, 0, 'Target CTM determinant is 0');
 
-            var matrix;
-            var threw = false;
-            try {
-                matrix = V(svgCircle).getTransformToElement(innerPath.node);
-            } catch (e) {
-                threw = true;
-            }
-            assert.notOk(threw, 'Does not throw on non-invertible target screen CTM');
+            // If the call throws, QUnit reports the test as failed.
+            var matrix = V(svgCircle).getTransformToElement(innerPath.node);
             assert.equal(
                 V.matrixToTransformString(matrix),
                 'matrix(1,0,0,1,0,0)',
-                'Falls back to identity matrix'
+                'Falls back to identity matrix (no throw)'
             );
 
             hostGroup.remove();

--- a/packages/joint-core/test/vectorizer/vectorizer.js
+++ b/packages/joint-core/test/vectorizer/vectorizer.js
@@ -1648,6 +1648,57 @@ QUnit.module('vectorizer', function(hooks) {
             assert.equal(V.matrixToTransformString(V(svgPath2).getTransformToElement(svgGroup1, { safe: true })), 'matrix(2,0,0,2,20,20)');
         });
 
+        QUnit.test('non-invertible target screen CTM returns identity (no throw)', function(assert) {
+
+            // A scale(0) ancestor produces a singular screen CTM (det = 0)
+            // for descendants. Without the invertibility guard, inverting it
+            // yields a zero/NaN matrix or throws. With the guard,
+            // getRelativeTransformation returns null and getTransformToElement
+            // falls back to identity.
+            var hostGroup = V('g', { transform: 'translate(100, 200)' });
+            var innerPath = V('path', { d: 'M 0 0 L 10 10', transform: 'translate(20, 30)' });
+            hostGroup.append(innerPath);
+            V(svgContainer).append(hostGroup);
+
+            // Baseline: with an invertible ancestor, the source/target
+            // transforms produce a real, non-identity matrix. This proves
+            // the identity result below is the guard's fallback, not a
+            // coincidence of trivial CTMs.
+            var baseline = V(svgCircle).getTransformToElement(innerPath.node);
+            assert.notEqual(
+                V.matrixToTransformString(baseline),
+                'matrix(1,0,0,1,0,0)',
+                'Baseline (invertible ancestor) is not identity'
+            );
+
+            // Collapse the ancestor → target's screen CTM becomes singular.
+            hostGroup.node.setAttribute('transform', 'scale(0)');
+
+            var ctm = innerPath.node.getScreenCTM();
+            assert.ok(ctm, 'Target getScreenCTM returns a matrix');
+            assert.equal(ctm.a, 0, 'Target CTM.a is 0');
+            assert.equal(ctm.b, 0, 'Target CTM.b is 0');
+            assert.equal(ctm.c, 0, 'Target CTM.c is 0');
+            assert.equal(ctm.d, 0, 'Target CTM.d is 0');
+            assert.equal(ctm.a * ctm.d - ctm.b * ctm.c, 0, 'Target CTM determinant is 0');
+
+            var matrix;
+            var threw = false;
+            try {
+                matrix = V(svgCircle).getTransformToElement(innerPath.node);
+            } catch (e) {
+                threw = true;
+            }
+            assert.notOk(threw, 'Does not throw on non-invertible target screen CTM');
+            assert.equal(
+                V.matrixToTransformString(matrix),
+                'matrix(1,0,0,1,0,0)',
+                'Falls back to identity matrix'
+            );
+
+            hostGroup.remove();
+        });
+
         QUnit.test('native getTransformToElement vs VElement getTransformToElement - translate', function(assert) {
 
             var container = V(svgContainer);


### PR DESCRIPTION
## Summary
If an SVG element sits inside a zero-sized container (e.g. an `<svg>` with `width=0` / `height=0`, a hidden `<foreignObject>`, or anything else the browser renders with no extent), its `getScreenCTM()` returns a zero matrix (`a=b=c=d=0`, `det=0`). We then call `.inverse()` on it inside `getRelativeTransformation()`, which either throws or yields a NaN/zero matrix — and `getTransformToElement()` breaks for everything in that subtree.

This PR adds a determinant check in `getRelativeTransformation()`. If the target's screen CTM isn't invertible, it returns `null` and `getTransformToElement()` falls back to the identity matrix, same as it does for any other failure case.

Regression test in `vectorizer.js`:
- baseline with an invertible ancestor proves the identity result isn't just trivial CTMs lining up,
- then forces the target CTM to be singular, asserts `a=b=c=d=0` and `det=0`,
- finally checks `getTransformToElement()` doesn't throw and returns identity.

## Test plan
- [x] `yarn grunt karma:vectorizer` — 453/453 pass
- [ ] Manual check in DevTools with a zero-sized ancestor

🤖 Generated with [Claude Code](https://claude.com/claude-code)