### PR TITLE
fix(joint-react): useCells falls back to collection for non-graph cells

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cells.test.tsx
@@ -712,6 +712,79 @@ describe('useCells (collection form)', () => {
     });
     expect(result.current).toEqual(['b', 'c']);
   });
+
+  // ── Non-graph cells (clipboard-style: cell instances not in the graph) ──
+
+  it('returns records for cells that are not in the graph', async () => {
+    storeRef = undefined;
+    let collection: mvc.Collection<dia.Cell> | undefined;
+    const { result } = renderHook(
+      () => {
+        const store = useGraphStore();
+        storeRef = store;
+        if (!collection) {
+          const clone = store.graph.getCell('a')!.clone() as dia.Cell;
+          collection = new mvc.Collection<dia.Cell>([clone]);
+        }
+        return useCells(collection);
+      },
+      { wrapper }
+    );
+    await act(async () => flush());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]!.type).toBe(ELEMENT_MODEL_TYPE);
+  });
+
+  it('selector sees correct length when cells are not in the graph', async () => {
+    storeRef = undefined;
+    let collection: mvc.Collection<dia.Cell> | undefined;
+    const { result } = renderHook(
+      () => {
+        const store = useGraphStore();
+        storeRef = store;
+        if (!collection) collection = new mvc.Collection<dia.Cell>([]);
+        return useCells(collection, (cells) => cells.length === 0);
+      },
+      { wrapper }
+    );
+    await act(async () => flush());
+    expect(result.current).toBe(true);
+
+    await act(async () => {
+      const clone = storeRef!.graph.getCell('a')!.clone() as dia.Cell;
+      collection!.add(clone);
+      await flush();
+    });
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      collection!.reset([]);
+      await flush();
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns stable record reference across renders for non-graph cells', async () => {
+    storeRef = undefined;
+    let collection: mvc.Collection<dia.Cell> | undefined;
+    const { result, rerender } = renderHook(
+      () => {
+        const store = useGraphStore();
+        storeRef = store;
+        if (!collection) {
+          const clone = store.graph.getCell('a')!.clone() as dia.Cell;
+          collection = new mvc.Collection<dia.Cell>([clone]);
+        }
+        return useCells(collection);
+      },
+      { wrapper }
+    );
+    await act(async () => flush());
+    const first = result.current;
+    rerender();
+    await act(async () => flush());
+    expect(result.current).toBe(first);
+  });
 });
 
 // ── Collection + selector reactivity (empty-start, the real-world pattern) ──

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -9,6 +9,7 @@ import { isCollection } from '../utils/is';
 import { subscribeToCollection } from '../utils/collection-subscription';
 import { parseUseCellsArgs } from './use-cells.utils';
 import { warnUnstableSelector } from '../utils/dev-warnings';
+import { toCellRecord } from '../state/data-mapping/cell-record-merge';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -25,16 +26,43 @@ type UnknownEqual = (a: unknown, b: unknown) => boolean;
 // ── Module-scoped helpers ───────────────────────────────────────────────────
 
 /**
- * Picks cells named by `subscribedIds` from the container in order.
- * Missing ids are skipped.
+ * Resolves a single cell record for the collection form. Tries the graph
+ * container first; falls back to the collection itself for cells that exist
+ * outside the graph (e.g. `ui.Clipboard` clones). Fallback records are cached
+ * by `dia.Cell` identity so repeat renders share the same reference and the
+ * outer shallow-equality short-circuit can fire.
+ */
+function resolveCell<Cell extends AnyCellRecord>(
+  id: CellId,
+  container: ReadonlyContainer<Cell>,
+  collection: mvc.Collection<dia.Cell> | undefined,
+  fallbackCache: WeakMap<dia.Cell, AnyCellRecord> | undefined
+): Cell | undefined {
+  const fromContainer = container.get(id);
+  if (fromContainer !== undefined) return fromContainer;
+  if (!collection || !fallbackCache) return undefined;
+  const rawCell = collection.get(id);
+  if (!rawCell) return undefined;
+  const cached = fallbackCache.get(rawCell);
+  if (cached !== undefined) return cached as Cell;
+  const record = toCellRecord(rawCell) as Cell;
+  fallbackCache.set(rawCell, record);
+  return record;
+}
+
+/**
+ * Picks cells named by `subscribedIds` in order. Missing ids (not in the
+ * graph container and not in the optional fallback `collection`) are skipped.
  */
 function pickCells<Cell extends AnyCellRecord>(
   container: ReadonlyContainer<Cell>,
-  subscribedIds: readonly CellId[]
+  subscribedIds: readonly CellId[],
+  collection: mvc.Collection<dia.Cell> | undefined,
+  fallbackCache: WeakMap<dia.Cell, AnyCellRecord> | undefined
 ): readonly Cell[] {
   const picked: Cell[] = [];
   for (const id of subscribedIds) {
-    const cell = container.get(id);
+    const cell = resolveCell(id, container, collection, fallbackCache);
     if (cell !== undefined) picked.push(cell);
   }
   return picked;
@@ -48,15 +76,19 @@ function computeNext<Cell extends AnyCellRecord, Selected>(
   container: ReadonlyContainer<Cell>,
   targetId: CellId | undefined,
   subscribedIds: readonly CellId[] | undefined,
+  collection: mvc.Collection<dia.Cell> | undefined,
+  fallbackCache: WeakMap<dia.Cell, AnyCellRecord> | undefined,
   arraySelector: ((cells: readonly Cell[]) => Selected) | undefined,
   cellSelector: ((cell: Cell | undefined) => Selected) | undefined
 ): CellsResult<Cell, Selected> {
   if (targetId !== undefined) {
-    const cell = container.get(targetId);
+    const cell = resolveCell(targetId, container, collection, fallbackCache);
     return cellSelector ? cellSelector(cell) : cell;
   }
   const source: readonly Cell[] =
-    subscribedIds === undefined ? container.getAll() : pickCells(container, subscribedIds);
+    subscribedIds === undefined
+      ? container.getAll()
+      : pickCells(container, subscribedIds, collection, fallbackCache);
   return arraySelector ? arraySelector(source) : source;
 }
 
@@ -65,7 +97,8 @@ function computeNext<Cell extends AnyCellRecord, Selected>(
 /**
  * Subscribe to a collection's cells. Tracks collection membership
  * (`add`/`remove`/`reset`) and reads cell records from the GraphProvider's
- * container. Collection cells not present in the graph are skipped.
+ * container. Cells not in the graph (e.g. `ui.Clipboard` clones) fall back to
+ * the collection's own `dia.Cell` instances, converted to records on demand.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param collection - JointJS collection whose member IDs drive the subscription
  * @returns readonly resolved cells array filtered by collection membership
@@ -224,6 +257,7 @@ export function useCells<
 
   const collectionIdsRef = useRef<readonly CellId[]>([]);
   const collectionVersionRef = useRef(0);
+  const fallbackCacheRef = useRef<WeakMap<dia.Cell, AnyCellRecord>>(new WeakMap());
 
   // Use `null` sentinel so the init-block runs on first render too, picking up
   // any models that already exist in the collection at subscribe time.
@@ -295,6 +329,8 @@ export function useCells<
         container,
         targetId,
         subscribedIds,
+        collectionArgument,
+        fallbackCacheRef.current,
         arraySelectorRef.current,
         cellSelectorRef.current
       );


### PR DESCRIPTION
## Summary

`useCells(collection, …)` previously resolved every member id through the GraphProvider's cell container. Cells living outside the graph (e.g. `ui.Clipboard` clones, freshly constructed `dia.Cell` instances) were silently skipped, so a selector like `(cells) => cells.length === 0` always returned `true` regardless of how many cells the collection actually held.

Resolve cells from the collection itself when the graph container lacks them. The raw `dia.Cell` is converted on the fly via the existing `toCellRecord` mapper. A per-hook `WeakMap<dia.Cell, AnyCellRecord>` keeps the converted records reference-stable across renders so the outer shallow-equality short-circuit can still fire.

Per-cell `change` events are not subscribed for the fallback path — the only caller today (clipboard membership) needs add/remove/reset reactivity, which the collection-level subscription already covers. Adding per-cell listening is straightforward later if a use case appears.

## Changes

- `packages/joint-react/src/hooks/use-cells.ts` — new `resolveCell` helper, `pickCells` / `computeNext` thread `collection` + `WeakMap` cache through; collection overload JSDoc updated.
- `packages/joint-react/src/hooks/__tests__/use-cells.test.tsx` — 3 new tests covering non-graph cells (records returned, length-selector reactive, ref stable across renders).

## Test plan
- [x] `yarn jest --testPathPatterns=\"use-cells\"` — 60 tests pass (incl. 3 new)
- [x] Full `yarn jest` in `@joint/react` — clean
- [x] `yarn typecheck` in `@joint/react-plus` (downstream consumer of new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)