### PR TITLE
refactor(joint-react): make PaperTarget public, unify paper naming

### DIFF
--- a/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
+++ b/packages/joint-react/src/hooks/use-nodes-measured-effect.ts
@@ -31,26 +31,26 @@ export function useNodesMeasuredEffect(
   dependencies?: DependencyList
 ): void;
 export function useNodesMeasuredEffect(
-  target: PaperTarget,
+  paperTarget: PaperTarget,
   callback: Callback,
   dependencies?: DependencyList
 ): void;
 export function useNodesMeasuredEffect(
-  targetOrCallback: PaperTarget | Callback,
+  paperTargetOrCallback: PaperTarget | Callback,
   callbackOrDependencies?: Callback | DependencyList,
   dependenciesArgument?: DependencyList
 ): void {
-  const isContextForm = typeof targetOrCallback === 'function';
+  const isContextForm = typeof paperTargetOrCallback === 'function';
 
-  const target = isContextForm ? undefined : (targetOrCallback as PaperTarget);
+  const paperTarget = isContextForm ? undefined : (paperTargetOrCallback as PaperTarget);
   const callback = isContextForm
-    ? (targetOrCallback as Callback)
+    ? (paperTargetOrCallback as Callback)
     : (callbackOrDependencies as Callback);
   const dependencies = isContextForm
     ? (callbackOrDependencies as DependencyList | undefined)
     : dependenciesArgument;
 
-  const paperId = useResolvePaperId(target);
+  const paperId = useResolvePaperId(paperTarget);
   const paperStore = usePaperStore(paperId);
 
   const callbackRef = useRef(callback);

--- a/packages/joint-react/src/hooks/use-paper-events.ts
+++ b/packages/joint-react/src/hooks/use-paper-events.ts
@@ -20,7 +20,7 @@ function isPaperEventMap(value: PaperEventMap | DependencyList): value is PaperE
 
 /** Resolved {@link usePaperEvents} arguments. */
 interface ResolvedPaperEventMapArgs {
-  readonly target: PaperTarget | undefined;
+  readonly paperTarget: PaperTarget | undefined;
   readonly handlers: PaperEventMap;
   readonly dependencies: DependencyList;
 }
@@ -28,26 +28,26 @@ interface ResolvedPaperEventMapArgs {
 /**
  * Resolves the overloaded `usePaperEvents` arguments into a paper target, a
  * handlers map, and a dependency list — using runtime type guards, no casts.
- * @param paperOrHandlers - First arg: a paper target, or the handlers map.
+ * @param paperTargetOrHandlers - First arg: a paper target, or the handlers map.
  * @param handlersOrDependencies - Second arg: handlers (target form) or dependencies (context form).
  * @param dependenciesArgument - Third arg: dependencies (target form only).
  * @returns The resolved target, handlers, and dependencies.
  */
 function resolvePaperEventMapArgs(
-  paperOrHandlers: PaperTarget | PaperEventMap,
+  paperTargetOrHandlers: PaperTarget | PaperEventMap,
   handlersOrDependencies: PaperEventMap | DependencyList,
   dependenciesArgument: DependencyList
 ): ResolvedPaperEventMapArgs {
-  if (!isPaperTarget(paperOrHandlers)) {
+  if (!isPaperTarget(paperTargetOrHandlers)) {
     // usePaperEvents(handlers, dependencies?)
     const dependencies = isPaperEventMap(handlersOrDependencies)
       ? EMPTY_DEPENDENCIES
       : handlersOrDependencies;
-    return { target: undefined, handlers: paperOrHandlers, dependencies };
+    return { paperTarget: undefined, handlers: paperTargetOrHandlers, dependencies };
   }
-  // usePaperEvents(target, handlers, dependencies?)
+  // usePaperEvents(paperTarget, handlers, dependencies?)
   const handlers = isPaperEventMap(handlersOrDependencies) ? handlersOrDependencies : EMPTY_HANDLERS;
-  return { target: paperOrHandlers, handlers, dependencies: dependenciesArgument };
+  return { paperTarget: paperTargetOrHandlers, handlers, dependencies: dependenciesArgument };
 }
 
 /**
@@ -99,28 +99,28 @@ export function subscribeToPaperEvents(
 export function usePaperEvents(handlers: PaperEventMap, dependencies?: DependencyList): void;
 /**
  * Subscribes to paper events on the given paper target.
- * @param paper - Paper reference (string ID, dia.Paper instance, or ref).
+ * @param paperTarget - Paper reference (string ID, dia.Paper instance, or ref).
  * @param handlers - Event handlers map.
  * @param dependencies - Optional dependency array controlling re-subscription.
  * @group Hooks
  */
 export function usePaperEvents(
-  paper: PaperTarget,
+  paperTarget: PaperTarget,
   handlers: PaperEventMap,
   dependencies?: DependencyList
 ): void;
 export function usePaperEvents(
-  paperOrHandlers: PaperTarget | PaperEventMap,
+  paperTargetOrHandlers: PaperTarget | PaperEventMap,
   handlersOrDependencies: PaperEventMap | DependencyList = EMPTY_DEPENDENCIES,
   dependenciesArgument: DependencyList = EMPTY_DEPENDENCIES
 ): void {
-  const { target, handlers, dependencies } = resolvePaperEventMapArgs(
-    paperOrHandlers,
+  const { paperTarget, handlers, dependencies } = resolvePaperEventMapArgs(
+    paperTargetOrHandlers,
     handlersOrDependencies,
     dependenciesArgument
   );
 
-  const paperId = useResolvePaperId(target);
+  const paperId = useResolvePaperId(paperTarget);
   const paperStore = usePaperStore(paperId);
 
   useLayoutEffect(() => {

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -14,22 +14,22 @@ import { isRef } from '../utils/is';
  * For string IDs and `dia.Paper` instances resolution is synchronous. For
  * `RefObject<dia.Paper>` targets, a layout effect re-resolves the ID once
  * `useImperativeHandle` has set the ref.
- * @param target - The paper target to resolve.
+ * @param paperTarget - The paper target to resolve.
  * @returns The paper ID string, or `undefined` when not yet available.
  * @internal
  */
-export function useResolvePaperId(target: PaperTarget | undefined): string | undefined {
-  const isRefTarget = isRef(target);
-  const paperId = resolvePaperId(target);
+export function useResolvePaperId(paperTarget: PaperTarget | undefined): string | undefined {
+  const isRefTarget = isRef(paperTarget);
+  const paperId = resolvePaperId(paperTarget);
   const [, forceRender] = useReducer((c: number) => c + 1, 0);
   const resolvedIdRef = useRef<string | null>(paperId);
   resolvedIdRef.current = paperId;
 
   useLayoutEffect(() => {
     if (!isRefTarget || resolvedIdRef.current) return;
-    const id = resolvePaperId(target);
-    if (id) {
-      resolvedIdRef.current = id;
+    const resolvedId = resolvePaperId(paperTarget);
+    if (resolvedId) {
+      resolvedIdRef.current = resolvedId;
       forceRender();
     }
   });
@@ -46,17 +46,17 @@ export function useResolvePaperId(target: PaperTarget | undefined): string | und
  * Resolution order (no explicit id):
  * 1. `PaperStoreContext` (when called inside a `<Paper>` subtree)
  * 2. `DEFAULT_PAPER_ID` lookup (when a single `<Paper>` exists without an explicit `id`)
- * @param id - An explicit paper id, or omitted for the context/default paper.
+ * @param paperId - An explicit paper id, or omitted for the context/default paper.
  * @returns The resolved paper store, or `undefined` when no paper is mounted yet.
  * @group Hooks
  */
-export function usePaperStore(id?: string): PaperStore | undefined {
+export function usePaperStore(paperId?: string): PaperStore | undefined {
   const contextStore = useContext(PaperStoreContext);
   const { getPaperStore } = useGraphStore();
 
   const paperStoreById = useInternalData((snapshot) => {
-    if (id) {
-      return snapshot.papers[id] ? (getPaperStore(id) ?? null) : null;
+    if (paperId) {
+      return snapshot.papers[paperId] ? (getPaperStore(paperId) ?? null) : null;
     }
     if (!contextStore && snapshot.papers[DEFAULT_PAPER_ID]) {
       return getPaperStore(DEFAULT_PAPER_ID) ?? null;
@@ -64,7 +64,7 @@ export function usePaperStore(id?: string): PaperStore | undefined {
     return null;
   });
 
-  if (id) return paperStoreById ?? undefined;
+  if (paperId) return paperStoreById ?? undefined;
   if (contextStore) return contextStore;
   return paperStoreById ?? undefined;
 }
@@ -87,13 +87,13 @@ export interface PaperHandle {
  *
  * The returned object is always stable; only `paper` is `undefined` until the
  * `<Paper>` view has mounted.
- * @param id - An explicit paper id, or omitted for the context/default paper.
+ * @param paperId - An explicit paper id, or omitted for the context/default paper.
  * @returns A stable object with the resolved `paper` (or `undefined`) and a `wakeUp` action.
  * @see https://docs.jointjs.com/learn/quickstart/paper
  * @group Hooks
  */
-export function usePaper(id?: string): PaperHandle {
-  const paperStore = usePaperStore(id);
+export function usePaper(paperId?: string): PaperHandle {
+  const paperStore = usePaperStore(paperId);
   const paper = paperStore?.paper ?? undefined;
   const wakeUp = useCallback(() => {
     paper?.wakeUp();

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -76,6 +76,7 @@ export type { GraphHandle, GraphJSON, ExportToJSONOptions } from './hooks/use-gr
  */
 export { usePaper } from './hooks/use-paper';
 export type { PaperHandle } from './hooks/use-paper';
+export type { PaperTarget } from './types/paper.types';
 
 /**
  * useCells()

--- a/packages/joint-react/src/types/index.ts
+++ b/packages/joint-react/src/types/index.ts
@@ -1,5 +1,3 @@
-import type { dia } from '@joint/core';
-
 /**
  * Union of known string literals plus arbitrary strings while preserving
  * intellisense for the known members.
@@ -22,11 +20,5 @@ export type Mutable<T> = { -readonly [K in keyof T]: T[K] };
  */
 export type Nullable<T> = { [K in keyof T]: T[K] | null };
 
-/**
- * Identifies a Paper instance — a registered id, a React ref, or the Paper
- * itself. Paper-targeting hooks never throw; an unresolved target simply means
- * "use the current Paper context or the default paper".
- */
-export type PaperTarget = string | React.RefObject<dia.Paper | null> | dia.Paper;
-
 export * from './event.types';
+export * from './paper.types';

--- a/packages/joint-react/src/types/paper.types.ts
+++ b/packages/joint-react/src/types/paper.types.ts
@@ -1,0 +1,9 @@
+import type { RefObject } from 'react';
+import type { dia } from '@joint/core';
+
+/**
+ * Identifies a Paper instance — a registered id, a React ref, or the Paper
+ * itself. Paper-targeting hooks never throw; an unresolved target simply means
+ * "use the current Paper context or the default paper".
+ */
+export type PaperTarget = string | RefObject<dia.Paper | null> | dia.Paper;

--- a/packages/joint-react/src/utils/resolve-paper-target.ts
+++ b/packages/joint-react/src/utils/resolve-paper-target.ts
@@ -16,33 +16,33 @@ export function isPaperTarget(value: unknown): value is PaperTarget {
 /**
  * Resolves a `dia.Paper` instance from a {@link PaperTarget}. String ids cannot
  * be resolved here (no access to the paper store) and return `null`.
- * @param target - The paper target to resolve.
+ * @param paperTarget - The paper target to resolve.
  * @returns The resolved paper, or `null`.
  */
-export function resolvePaper(target: PaperTarget): dia.Paper | null {
-  if (isString(target)) {
+export function resolvePaper(paperTarget: PaperTarget): dia.Paper | null {
+  if (isString(paperTarget)) {
     // ID form is not supported here since we don't have access to the paper store.
     return null;
   }
-  if (target instanceof dia.Paper) {
-    return target;
+  if (paperTarget instanceof dia.Paper) {
+    return paperTarget;
   }
   // Remaining union member: RefObject<dia.Paper | null>.
-  return target.current;
+  return paperTarget.current;
 }
 
 /**
  * Extracts the paper id from a {@link PaperTarget}.
- * @param target - The paper target to extract the id from.
+ * @param paperTarget - The paper target to extract the id from.
  * @returns The paper id string, or `null`.
  */
-export function resolvePaperId(target?: PaperTarget): string | null {
-  if (!target) {
+export function resolvePaperId(paperTarget?: PaperTarget): string | null {
+  if (!paperTarget) {
     return null;
   }
-  if (isString(target)) {
+  if (isString(paperTarget)) {
     // A string target is already the id.
-    return target;
+    return paperTarget;
   }
-  return resolvePaper(target)?.id ?? null;
+  return resolvePaper(paperTarget)?.id ?? null;
 }


### PR DESCRIPTION
## Why

`PaperTarget` (`string` id | `RefObject<dia.Paper>` | `dia.Paper`) was exported **only** from `@joint/react/internal`, yet it is the parameter type of **public** hooks — `usePaperEvents(paperTarget, …)` and `useNodesMeasuredEffect(paperTarget, …)`. Consumers could call those hooks but couldn't name the argument type without importing from `/internal`. The type is also part of `@joint/react-plus` component props (`<Navigator>`, `<Stencil>`) for the same reason.

Naming was inconsistent too: the same `PaperTarget` argument was called `paper` in some hooks and `target` in others.

## What

- **Make `PaperTarget` public** — exported from the package root.
- **Relocate the type** — moved from the generic-utilities `types/index.ts` (where it sat among `Mutable`, `Nullable`, `LiteralUnion`) into a dedicated **`types/paper.types.ts`**, matching the existing `cell.types` / `event.types` / `feature.types` convention. Leaf module, no import cycles. Re-exported from `types/index.ts`, so every existing `from '../types'` import keeps working.
- **Unify parameter naming** by what the value actually is:

  | Value | Name |
  |---|---|
  | `string` id | `paperId` |
  | `PaperTarget` (id \| ref \| instance) | `paperTarget` |
  | resolved `dia.Paper` | `paper` |

  Touches `usePaperEvents`, `useNodesMeasuredEffect`, `useResolvePaperId`, `resolvePaper`/`resolvePaperId`, and `usePaper`/`usePaperStore` (`id` → `paperId`).

## Compatibility

Parameter-name changes only — all call sites are **positional**, so existing callers are unaffected. No runtime behavior change.

## Verification

- `tsc --noEmit` on `joint-react`: **0 errors**.
- A companion `@joint/react-plus` change (component prop `paper` → `paperTarget`, plus picks up the now-public type) lands in a separate PR in the `plus` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)