### PR TITLE
refactor(joint-react): align Paper options naming with react-plus

### DIFF
--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -44,13 +44,16 @@ export type DefaultLink =
   | ((context: DefaultLinkParams) => dia.Link | Partial<LinkRecord>)
   | Partial<LinkRecord>;
 
+/** Raw `dia.Paper.Options` passthrough — the type of the `options` escape-hatch prop. */
+export type PaperOptions = dia.Paper.Options;
+
 /**
  * Officially supported Paper options. Pass-through props inherit their exact
  * native types via indexed access (`dia.Paper.Options['name']`), so any
  * type-level change in JointJS propagates automatically. Anything not listed
  * here is reachable via the `options` escape hatch, never implicitly exposed.
  */
-export interface PortalPaperOptions {
+export interface PaperSupportedOptions {
   // ── Wrapped (structured) ─────────────────────────────────────────────────
 
   /**
@@ -186,7 +189,7 @@ export interface PortalPaperOptions {
    * (`async`, `sorting`, `viewManagement`, `frozen`, `autoFreeze`) — the
    * portal rendering depends on their set values.
    */
-  readonly options?: dia.Paper.Options;
+  readonly options?: PaperOptions;
 }
 
 /**
@@ -237,7 +240,7 @@ export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
  * use the `usePaperEvents` hook.
  * @see https://docs.jointjs.com/api/dia/Paper
  */
-export interface PaperProps extends PortalPaperOptions, PropsWithChildren, PaperEventHandlers {
+export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, PaperEventHandlers {
   /**
    * A function that renders the element.
    *

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -21,7 +21,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 import type { LinkRecord } from '../types/cell.types';
 import type { PaperStore } from '../store';
 import { ReactPaper } from '../mvc/react-paper';
-import type { PaperProps, PaperSupportedOptions, RenderLink } from '../components/paper/paper.types';
+import type { DefaultLink, PaperProps, RenderLink } from '../components/paper/paper.types';
 import { HTMLBox } from '../components/html-box';
 
 import { mapLinkToAttributes } from '../state/data-mapping';
@@ -101,7 +101,7 @@ function getLinkModelConstructor(graph: dia.Graph): LinkModelConstructor {
  * into JointJS link model instances.
  * @param defaultLink
  */
-function createDefaultLinkCallback(defaultLink: PaperSupportedOptions['defaultLink']) {
+function createDefaultLinkCallback(defaultLink: DefaultLink | undefined) {
   // Guard for JS callers (TS already forbids it): a raw `dia.Link` instance
   // would force defensive `.clone()` on every connection and silently couple
   // every created link to one mutable model. Require a factory instead.

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -21,7 +21,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 import type { LinkRecord } from '../types/cell.types';
 import type { PaperStore } from '../store';
 import { ReactPaper } from '../mvc/react-paper';
-import type { PaperProps, PortalPaperOptions, RenderLink } from '../components/paper/paper.types';
+import type { PaperProps, PaperSupportedOptions, RenderLink } from '../components/paper/paper.types';
 import { HTMLBox } from '../components/html-box';
 
 import { mapLinkToAttributes } from '../state/data-mapping';
@@ -101,7 +101,7 @@ function getLinkModelConstructor(graph: dia.Graph): LinkModelConstructor {
  * into JointJS link model instances.
  * @param defaultLink
  */
-function createDefaultLinkCallback(defaultLink: PortalPaperOptions['defaultLink']) {
+function createDefaultLinkCallback(defaultLink: PaperSupportedOptions['defaultLink']) {
   // Guard for JS callers (TS already forbids it): a raw `dia.Link` instance
   // would force defensive `.clone()` on every connection and silently couple
   // every created link to one mutable model. Require a factory instead.

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -18,6 +18,7 @@ export type { IncrementalCellsChange } from './store/graph-projection';
 export { Paper } from './components/paper/paper';
 export type {
   PaperProps,
+  PaperOptions,
   PaperTransform,
   RenderElement,
   RenderLink,


### PR DESCRIPTION
## Why

Follow-up to #3351. `@joint/react-plus` names component config consistently — `<Component>Options` for the raw `options` escape-hatch type, `<Component>SupportedOptions` for the curated supported-props base. Core's `<Paper>` diverged: no named type for the escape hatch (inline `options?: dia.Paper.Options`), and its base was `PortalPaperOptions`. This aligns the two packages.

## What

- **Add & export `PaperOptions = dia.Paper.Options`** — a named type for the `options` escape-hatch prop; the `options?:` field now references it. Mirrors react-plus `<Component>Options`. Exported from the root barrel under the `<Paper/>` block.
- **Rename `PortalPaperOptions` → `PaperSupportedOptions`** (internal — not exported, no external consumer). Matches react-plus `<Component>SupportedOptions`. Updated the two internal references (`PaperProps extends …`, and `use-create-portal-paper.tsx`).
- **Type the `defaultLink` helper with the public `DefaultLink` type** — `use-create-portal-paper.tsx`'s `createDefaultLinkCallback` now takes `DefaultLink | undefined` (the canonical exported type + explicit optionality, since the prop is optional and the helper handles the absent case) instead of an internal-base reference.

## Compatibility

No behavior change. `PaperProps` unchanged. The renamed base was never public.

## Verification

`tsc --noEmit` on `joint-react`: **0 errors**.

## Related
- #3351 (PaperTarget public + paper-param naming) — merged.
- Companion react-plus PRs: clientIO/joint-plus#674 (merged), clientIO/joint-plus#677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)