### PR TITLE
Release v4.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+11-06-2026 (v4.2.5)
+
+  @joint/core
+  * util - fix to guard `merge()`, `omit()`, `pick()`, `assign()` against potential prototype pollution attacks
+
 13-02-2026 (v4.2.4)
 
   @joint/core

--- a/examples/anchors-ts/package.json
+++ b/examples/anchors-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-anchors-ts",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/bezier-js/package.json
+++ b/examples/bezier-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-bezier-js",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/connection-points-ts/package.json
+++ b/examples/connection-points-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-connection-points-ts",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/container/package.json
+++ b/examples/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-container",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "dist/bundle.js",
   "author": {
     "name": "client IO",

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-decorators",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-dwdm",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/fta-js/package.json
+++ b/examples/fta-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-fta-js",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-isometric",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-directed-graph/package.json
+++ b/examples/layout-directed-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-directed-graph",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - Directed Graph Layout Demo",
   "main": "./index.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-elk-ts/package.json
+++ b/examples/layout-elk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-elk-ts",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - ELK Layout Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-msagl/package.json
+++ b/examples/layout-msagl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-msagl",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - MSAGL Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-libavoid",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/link-labels-ts/package.json
+++ b/examples/link-labels-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-link-labels-ts",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-list",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/offscreen-rendering/package.json
+++ b/examples/offscreen-rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-offscreen-rendering",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-shapes-general",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-of-life",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "src/index.ts",
   "author": {
     "name": "client IO",

--- a/examples/tree-shake/package.json
+++ b/examples/tree-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-shake",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - Tree Shake Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "sideEffects": false,
   "homepage": "https://jointjs.com",
   "author": {

--- a/packages/joint-core/demo/custom-shapes/package.json
+++ b/packages/joint-core/demo/custom-shapes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-custom-shapes",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - Custom Shapes Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/elk/package.json
+++ b/packages/joint-core/demo/elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-elk-graph",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - Eclipse Layout Kernel Graph Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/rough/package.json
+++ b/packages/joint-core/demo/rough/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-rough",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - RoughJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/ts-demo/package.json
+++ b/packages/joint-core/demo/ts-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-ts",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - TypeScript Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/vuejs/package.json
+++ b/packages/joint-core/demo/vuejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-vuejs",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JointJS - VueJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/core",
   "title": "JointJS",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "JavaScript diagramming library",
   "sideEffects": false,
   "main": "./dist/joint.min.js",

--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/decorators",
   "title": "JointJS Decorators",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Decorators module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-eslint-config/package.json
+++ b/packages/joint-eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/eslint-config",
   "title": "JointJS ESLintConfig",
-  "version": "4.2.3",
+  "version": "4.2.5",
   "description": "ESLintConfig module for JointJS",
   "sideEffects": false,
   "type": "module",

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-directed-graph",
   "title": "JointJS LayoutDirectedGraph",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "LayoutDirectedGraph module for JointJS",
   "main": "dist/DirectedGraph.js",
   "module": "./DirectedGraph.mjs",

--- a/packages/joint-layout-msagl/package.json
+++ b/packages/joint-layout-msagl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-msagl",
   "title": "JointJS LayoutMSAGL",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "LayoutMSAGL module for JointJS",
   "sideEffects": false,
   "main": "./dist/esm/index.mjs",

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general-tools",
   "title": "JointJS General Shapes Tools",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "General Shapes Tools module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general",
   "title": "JointJS General Shapes",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "General Shapes module for JointJS",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",


### PR DESCRIPTION
# CHANGELOG

## @joint/core
- **util** - fix to guard `merge()`, `omit()`, `pick()`, `assign()` against potential prototype pollution attacks (a000876758b4c946c9f7b4698c4f915d5d7c631f)