### PR TITLE
feat(joint-core): originX/originY options for getFitToContentArea

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2373,6 +2373,10 @@ export const Paper = View.extend({
         const maxWidth = opt.maxWidth || Number.MAX_VALUE;
         const maxHeight = opt.maxHeight || Number.MAX_VALUE;
         const newOrigin = opt.allowNewOrigin;
+        // Shift the grid anchor so the first cell starts at (originX, originY)
+        // in paper-local coords. Default 0 reproduces the prior behavior.
+        const originX = opt.originX || 0;
+        const originY = opt.originY || 0;
 
         const area = ('contentArea' in opt) ? new Rect(opt.contentArea) : this.getContentArea(opt);
         const { sx, sy } = this.scale();
@@ -2380,6 +2384,10 @@ export const Paper = View.extend({
         area.y *= sy;
         area.width *= sx;
         area.height *= sy;
+        // Move the area into the origin-relative coordinate system.
+        // All grid math below then operates relative to (originX, originY).
+        area.x -= originX * sx;
+        area.y -= originY * sy;
 
         let calcWidth = Math.ceil((area.width + area.x) / gridWidth);
         let calcHeight = Math.ceil((area.height + area.y) / gridHeight);
@@ -2415,7 +2423,9 @@ export const Paper = View.extend({
         calcWidth = Math.min(calcWidth, maxWidth);
         calcHeight = Math.min(calcHeight, maxHeight);
 
-        return new Rect(-tx / sx, -ty / sy, calcWidth / sx, calcHeight / sy);
+        // Translate the returned rect back into the absolute coordinate
+        // system (undo the origin-relative shift applied to area.x/y).
+        return new Rect(-tx / sx + originX, -ty / sy + originY, calcWidth / sx, calcHeight / sy);
     },
 
     transformToFitContent: function(opt) {

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -893,7 +893,7 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     useModelGeometry: true,
                     gridWidth: 100,
                     gridHeight: 100,
-                    allowNewOrigin: 'any'
+                    allowNewOrigin: 'any',
                 });
                 // Content spans (-100, -100) → (200, 300). Grid at 0:
                 //   Right edge rounds to 200, Bottom to 300.
@@ -911,11 +911,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     originX: 50,
                     originY: 25
                 });
-                // Origin shifted by (50, 25): the returned rect's
-                // top-left moves by the same amount; dimensions are
-                // unchanged because content/grid relationship hasn't
-                // changed in origin-relative space.
-                assert.deepEqual(area.toJSON(), { x: -50, y: -75, width: 300, height: 400 });
+                // Grid lines now land at 50+n*100 (x) and 25+m*100 (y).
+                // Content x ∈ [-100, 200] snaps to [-150, 250] → width 400.
+                // Content y ∈ [-100, 300] snaps to [-175, 325] → height 500.
+                assert.deepEqual(area.toJSON(), { x: -150, y: -175, width: 400, height: 500 });
             });
 
             QUnit.test('origin without allowNewOrigin still offsets the rect', function(assert) {

--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -885,6 +885,55 @@ QUnit.module('joint.dia.Paper', function(hooks) {
             });
         });
 
+        QUnit.module('fitToContent() > options > originX / originY', function() {
+
+            QUnit.test('default origin (0, 0) — backward compatible', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    allowNewOrigin: 'any'
+                });
+                // Content spans (-100, -100) → (200, 300). Grid at 0:
+                //   Right edge rounds to 200, Bottom to 300.
+                //   New origin shifts negative content into view.
+                assert.deepEqual(area.toJSON(), { x: -100, y: -100, width: 300, height: 400 });
+            });
+
+            QUnit.test('non-zero origin shifts the grid anchor', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    allowNewOrigin: 'any',
+                    originX: 50,
+                    originY: 25
+                });
+                // Origin shifted by (50, 25): the returned rect's
+                // top-left moves by the same amount; dimensions are
+                // unchanged because content/grid relationship hasn't
+                // changed in origin-relative space.
+                assert.deepEqual(area.toJSON(), { x: -50, y: -75, width: 300, height: 400 });
+            });
+
+            QUnit.test('origin without allowNewOrigin still offsets the rect', function(assert) {
+                addCells(graph);
+                var area = paper.fitToContent({
+                    useModelGeometry: true,
+                    gridWidth: 100,
+                    gridHeight: 100,
+                    originX: 50,
+                    originY: 25
+                });
+                // Without allowNewOrigin the negative content is
+                // ignored; rect origin = (originX, originY).
+                assert.deepEqual(area.x, 50);
+                assert.deepEqual(area.y, 25);
+            });
+        });
+
         QUnit.module('fitToContent() > options > useModelGeometry', function() {
 
             [0.5, 1, 2].forEach(function(scale) {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1840,6 +1840,12 @@ export namespace Paper {
         maxHeight?: number;
         useModelGeometry?: boolean;
         contentArea?: BBox;
+        /**
+         * Shifts the grid anchor so the first cell starts at
+         * (`originX`, `originY`) in paper-local coordinates. Default `0`.
+         */
+        originX?: number;
+        originY?: number;
     }
 
     interface EventMap {


### PR DESCRIPTION
## Summary
- `getFitToContentArea` previously hard-anchored its grid at (0, 0): grid lines fell at `0, gridWidth, 2*gridWidth, …`.
- New `originX` / `originY` options (default `0`, paper-local coords) shift the anchor so grid lines land at `originX + n*gridWidth, originY + m*gridHeight`.
- Backward compatible — omitting the new opts reproduces today's behavior exactly. `paper.fitToContent` already forwards `opt` through, so it inherits the feature automatically.

## Test plan
- [x] Added unit tests covering `originX`/`originY` combinations in `test/jointjs/dia/Paper.js`
- [ ] Verify `paper.fitToContent()` with `allowNewOrigin` × non-zero origin