### PR TITLE
fix(joint-react): interactive={true} disables linkMove/labelMove by default

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper-interactive.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-interactive.test.tsx
@@ -35,12 +35,25 @@ async function mountPaper(interactive: CellInteractivity): Promise<dia.Paper> {
 const linkView = (paper: dia.Paper): dia.LinkView =>
   paper.findViewByModel(paper.model.getCell('l1')) as dia.LinkView;
 
+const elementView = (paper: dia.Paper): dia.ElementView =>
+  paper.findViewByModel(paper.model.getCell('a')) as dia.ElementView;
+
 describe('Paper interactive — link move', () => {
-  it('interactive={true} enables linkMove on the link view', async () => {
+  it('interactive={true} disables linkMove/labelMove but keeps the rest interactive', async () => {
     const paper = await mountPaper(true);
-    expect(paper.options.interactive).toBe(true);
+    expect(paper.options.interactive).toEqual({ linkMove: false, labelMove: false });
     // `dragStart` (LinkView) gates link-body move on `can('linkMove')`.
-    expect(linkView(paper).can('linkMove')).toBe(true);
+    expect(linkView(paper).can('linkMove')).toBe(false);
+    expect(linkView(paper).can('labelMove')).toBe(false);
+    // The rest stays true implicitly — connected elements are still movable.
+    expect(elementView(paper).can('elementMove')).toBe(true);
+  });
+
+  it('interactive={false} disables every interaction', async () => {
+    const paper = await mountPaper(false);
+    expect(paper.options.interactive).toBe(false);
+    expect(elementView(paper).can('elementMove')).toBe(false);
+    expect(linkView(paper).can('linkMove')).toBe(false);
   });
 
   it('default (no interactive) keeps linkMove disabled', async () => {

--- a/packages/joint-react/src/mvc/element-model.tsx
+++ b/packages/joint-react/src/mvc/element-model.tsx
@@ -1,5 +1,5 @@
 import { dia } from '@joint/core';
-import { PortalHostCell } from './paper.types';
+import type { PortalHostCell } from './paper.types';
 export const ELEMENT_MODEL_TYPE = 'element';
 
 /**

--- a/packages/joint-react/src/mvc/link-model.ts
+++ b/packages/joint-react/src/mvc/link-model.ts
@@ -1,6 +1,6 @@
 import { dia } from '@joint/core';
 import { linkStyle } from '../presets/link-style';
-import { PortalHostCell } from './paper.types';
+import type { PortalHostCell } from './paper.types';
 
 export const LINK_MODEL_TYPE = 'link';
 

--- a/packages/joint-react/src/presets/__tests__/preset-coverage.test.ts
+++ b/packages/joint-react/src/presets/__tests__/preset-coverage.test.ts
@@ -176,8 +176,11 @@ describe('presets / interactive', () => {
     expect((native as any).call(fakePaper, cellView, 'elementMove')).toBe(true);
     expect(cb).toHaveBeenCalled();
   });
-  it('boolean passes through', () => {
-    expect(toNativeCellInteractivity(true)).toBe(true);
+  it('true returns defaults (linkMove/labelMove disabled, rest implicit true)', () => {
+    expect(toNativeCellInteractivity(true)).toEqual({ linkMove: false, labelMove: false });
+  });
+  it('false passes through (all interactions disabled)', () => {
+    expect(toNativeCellInteractivity(false)).toBe(false);
   });
   it('object form merges defaults', () => {
     const out = toNativeCellInteractivity({ elementMove: false } as any);

--- a/packages/joint-react/src/presets/cell-interactivity.ts
+++ b/packages/joint-react/src/presets/cell-interactivity.ts
@@ -32,9 +32,9 @@ export type CellInteractivity =
 
 /**
  * joint-react defaults applied when the user supplies no `interactive` prop,
- * or merged under user-supplied object values. Preserves the JointJS native
- * `labelMove: false` and adds `linkMove: false` so link endpoints don't drag
- * by default.
+ * passes `interactive={true}`, or as the base merged under user-supplied object
+ * values. Preserves the JointJS native `labelMove: false` and adds
+ * `linkMove: false` so link endpoints don't drag by default.
  */
 const DEFAULT_INTERACTIVE: dia.CellView.InteractivityOptions = {
   labelMove: false,
@@ -44,8 +44,9 @@ const DEFAULT_INTERACTIVE: dia.CellView.InteractivityOptions = {
 /**
  * Adapt the `interactive` prop to the native form.
  *
- * - `undefined` → defaults (`labelMove`/`linkMove` disabled).
- * - boolean → pass through.
+ * - `undefined` → defaults (`labelMove`/`linkMove` disabled, rest implicit true).
+ * - `true` → same defaults (`labelMove`/`linkMove` disabled, rest implicit true).
+ * - `false` → pass through (every interaction disabled).
  * - object → defaults applied first, user keys win.
  * - function → wrapped so the user callback receives an `CellInteractivityParams`
  *   instead of the native positional `(cellView, interaction)` args.
@@ -57,8 +58,8 @@ const DEFAULT_INTERACTIVE: dia.CellView.InteractivityOptions = {
 export function toNativeCellInteractivity(
   value: CellInteractivity | undefined
 ): dia.Paper.Options['interactive'] {
-  if (value === undefined) return { ...DEFAULT_INTERACTIVE };
-  if (typeof value === 'boolean') return value;
+  if (value === undefined || value === true) return DEFAULT_INTERACTIVE;
+  if (value === false) return false;
   if (typeof value === 'object') return { ...DEFAULT_INTERACTIVE, ...value };
   return function (this: dia.Paper, cellView: dia.CellView, interaction: string) {
     return value({

--- a/packages/joint-react/src/presets/magnet-highlighter.ts
+++ b/packages/joint-react/src/presets/magnet-highlighter.ts
@@ -1,4 +1,5 @@
-import { dia, highlighters, V } from '@joint/core';
+import type { dia} from '@joint/core';
+import { highlighters, V } from '@joint/core';
 import { CONNECTING_CLASS_NAME } from './link-view';
 
 /** Name used to register this highlighter in the paper's highlighterNamespace. */
@@ -10,7 +11,7 @@ export const MAGNET_HIGHLIGHTER_NAME = 'magnetHighlighter';
  * allows CSS @starting-style transitions to animate the highlighter's appearance.
  */
 export const MagnetHighlighter = highlighters.stroke.extend({
-    className: `jj-magnet-highlighter`,
+    className: 'jj-magnet-highlighter',
     classNamePrefix: '',
 
     highlight(this: highlighters.stroke, cellView: dia.CellView, node: SVGElement): void {

--- a/packages/joint-react/src/store/__tests__/update-layout-state.test.ts
+++ b/packages/joint-react/src/store/__tests__/update-layout-state.test.ts
@@ -14,7 +14,7 @@ describe('getElementLayoutFields', () => {
   it('returns null when the element has no size attribute', () => {
     const element = new dia.Element() as LooseElement;
     // dia.Element has a default size; force it to undefined to exercise the early return
-    // eslint-disable-next-line sonarjs/no-undefined-argument -- undefined is the value under test
+     
     element.set('size', undefined);
     expect(getElementLayoutFields(element)).toBeNull();
   });
@@ -36,7 +36,7 @@ describe('getElementLayoutFields', () => {
     const element = new dia.Element({
       size: { width: 100, height: 50 },
     }) as LooseElement;
-    // eslint-disable-next-line sonarjs/no-undefined-argument -- undefined is the value under test
+     
     element.set('position', undefined);
     const result = getElementLayoutFields(element);
     expect(result?.position).toEqual({ x: 0, y: 0 });

--- a/packages/joint-react/src/utils/__tests__/is.test.ts
+++ b/packages/joint-react/src/utils/__tests__/is.test.ts
@@ -68,7 +68,7 @@ describe('is.ts utility functions', () => {
     });
 
     test('returns false when property is undefined', () => {
-      // eslint-disable-next-line sonarjs/no-undefined-argument -- undefined is the value under test
+       
       expect(is.hasProperty({ foo: 1 }, undefined)).toBe(false);
     });
 


### PR DESCRIPTION
## Description

Changes how the `interactive` Paper prop maps to native JointJS:

- `interactive={false}` → `false` (every interaction disabled)
- `interactive={true}` → `{ linkMove: false, labelMove: false }` (rest implicit `true`)
- object form → defaults merged, user keys win
- function form → explicit takeover (unchanged)

Connected elements stay movable under `interactive={true}` (link endpoints follow); only link-body drag (`linkMove`) and label drag (`labelMove`) are off by default.

## Motivation and Context

`interactive={true}` previously passed raw `true` to JointJS, enabling `linkMove`/`labelMove` — links and labels dragged unintentionally. Aligns boolean handling with the documented default (`labelMove: false`) plus `linkMove: false`.

### Screenshots (if appropriate):