### PR TITLE
test(joint-core): fix originX/originY fitToContent expected rect [dev]

### DIFF
--- a/packages/joint-core/test/jointjs/dia/Paper.js
+++ b/packages/joint-core/test/jointjs/dia/Paper.js
@@ -911,11 +911,10 @@ QUnit.module('joint.dia.Paper', function(hooks) {
                     originX: 50,
                     originY: 25
                 });
-                // Origin shifted by (50, 25): the returned rect's
-                // top-left moves by the same amount; dimensions are
-                // unchanged because content/grid relationship hasn't
-                // changed in origin-relative space.
-                assert.deepEqual(area.toJSON(), { x: -50, y: -75, width: 300, height: 400 });
+                // Grid lines now land at 50+n*100 (x) and 25+m*100 (y).
+                // Content x ∈ [-100, 200] snaps to [-150, 250] → width 400.
+                // Content y ∈ [-100, 300] snaps to [-175, 325] → height 500.
+                assert.deepEqual(area.toJSON(), { x: -150, y: -175, width: 400, height: 500 });
             });
 
             QUnit.test('origin without allowNewOrigin still offsets the rect', function(assert) {


### PR DESCRIPTION
## Summary
Follow-up to #3312. The `non-zero origin shifts the grid anchor` test had wrong expected values — its expected rect (`x: -50, y: -75, width: 300, height: 400`) did not contain the content (top edge `-75` cut off content extending to `y = -100`).

The expectation assumed the result was just the default-origin rect translated by `(originX, originY)`. But shifting the grid anchor changes which grid lines bracket the content, so dimensions can grow when content edges no longer align with the new grid.

## Trace (content `(-100,-100, 300×400)`, `originX=50, originY=25`, grid `100×100`, `allowNewOrigin: 'any'`)
- Grid lines: x at `50+n*100`, y at `25+m*100`.
- Content x ∈ `[-100, 200]` snaps to `[-150, 250]` → width 400.
- Content y ∈ `[-100, 300]` snaps to `[-175, 325]` → height 500.
- Correct rect: `{ x: -150, y: -175, width: 400, height: 500 }`.

## Test plan
- [ ] `yarn workspace @joint/core test-client` — `fitToContent() > options > originX / originY` passes.