### PR TITLE
feat(joint-core): Paper.resolveViewClass pass NSView to factory callback

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2645,7 +2645,7 @@ export const Paper = View.extend({
         const { options } = this;
         const { cellViewNamespace } = options;
         const type = cell.get('type') + 'View';
-        const namespaceViewClass = getByPath(cellViewNamespace, type, '.');
+        const namespaceViewClass = getByPath(cellViewNamespace, type, '.') ?? null;
         // A class taken from the paper options.
         let optionalViewClass;
         let defaultViewClass;
@@ -2665,7 +2665,7 @@ export const Paper = View.extend({
         //  3. if no view was found, use the default
         return (optionalViewClass.prototype instanceof ViewBase)
             ? namespaceViewClass || optionalViewClass
-            : optionalViewClass.call(this, cell) || namespaceViewClass || defaultViewClass;
+            : optionalViewClass.call(this, cell, namespaceViewClass) || namespaceViewClass || defaultViewClass;
     },
 
     // Returns a CellView instance or its placeholder for the given cell.


### PR DESCRIPTION
## Summary

Backport of the @joint/core portion of #3277 to `master`.

- **`Paper.resolveViewClass()`** — the `elementView` / `linkView` factory callbacks now receive a second argument `NSView` (the namespace view class, or `null`), and `namespaceViewClass` defaults to `null` instead of `undefined`.

The rest of the joint-core changes from #3277 (`CellView.computeNodeBoundingRect`, `HighlighterView` Element validation, types) already landed on `master` via subsequent commits — this PR closes the remaining gap.

## Test plan

- [ ] `yarn test-server` (joint-core)
- [ ] `yarn test-ts`
- [ ] Verify custom `elementView` / `linkView` factory functions can read the new `NSView` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)