### PR TITLE
feat(joint-core): add Paper.getCellView() for strict view lookup

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2941,6 +2941,18 @@ export const Paper = View.extend({
         return cellView;
     },
 
+    // Returns the CellView for a `cell` (or its id) only if it has already been
+    // instantiated. Unlike `findViewByModel`, this does NOT resolve placeholders
+    // and does NOT schedule any updates. Returns `null` if no real view exists.
+    getCellView: function(cell) {
+
+        const cellViewLike = this._getCellViewLike(cell);
+        if (cellViewLike && cellViewLike[CELL_VIEW_MARKER]) {
+            return cellViewLike;
+        }
+        return null;
+    },
+
     // Find all views at given point
     findViewsFromPoint: function(p) {
 
@@ -3561,7 +3573,7 @@ export const Paper = View.extend({
             // The view could have been disposed during dragging
             // e.g. dragged outside of the viewport and hidden
             // The model can be removed in previous mousemove event handlers
-            view = this.findViewByModel(view.model) || view;
+            view = this.getCellView(view.model) || view;
             view.pointermove(evt, localPoint.x, localPoint.y);
         } else {
             this.trigger('blank:pointermove', evt, localPoint.x, localPoint.y);
@@ -3583,7 +3595,7 @@ export const Paper = View.extend({
             // The view could have been disposed during dragging
             // e.g. dragged outside of the viewport and hidden
             // The model can be removed in previous mouseup event handlers (e.g. when deleting an element after dragging)
-            view = this.findViewByModel(view.model) || view;
+            view = this.getCellView(view.model) || view;
             view.pointerup(normalizedEvt, localPoint.x, localPoint.y);
         } else {
             this.trigger('blank:pointerup', normalizedEvt, localPoint.x, localPoint.y);

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -286,6 +286,58 @@ QUnit.module('paper', function(hooks) {
         assert.ok(linkView.el.previousSibling === circleView.el, 'link view is after circle element in the DOM');
     });
 
+    QUnit.module('paper.getCellView()', function() {
+
+        QUnit.test('returns the view for an instantiated cell', function(assert) {
+
+            var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
+            this.graph.addCell(r1);
+
+            var view = this.paper.getCellView(r1);
+            assert.ok(view instanceof joint.dia.CellView, 'returns a CellView instance');
+            assert.equal(view.model, r1, 'view points to the original model');
+            assert.equal(this.paper.getCellView(r1.id), view, 'lookup by id returns the same view');
+        });
+
+        QUnit.test('returns null for an unknown cell or id', function(assert) {
+
+            assert.equal(this.paper.getCellView('does-not-exist'), null);
+            assert.equal(this.paper.getCellView(null), null);
+            assert.equal(this.paper.getCellView(undefined), null);
+        });
+
+        QUnit.test('returns null when only a placeholder exists and does not resolve it', function(assert) {
+
+            var paperEl = document.createElement('div');
+            fixtures.getElement().appendChild(paperEl);
+            var graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            var paper = new joint.dia.Paper({
+                el: paperEl,
+                model: graph,
+                async: true,
+                viewport: function() { return false; },
+                viewManagement: { lazyInitialize: true }
+            });
+
+            var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
+            graph.addCell(r1);
+
+            assert.equal(paper.getCellView(r1), null, 'no real view yet — placeholder only');
+            // Confirm a placeholder is registered (otherwise the assertion above is vacuous).
+            // Placeholders are plain objects without an `el`; real CellViews have one.
+            var viewLike = paper._getCellViewLike(r1);
+            assert.ok(viewLike, 'placeholder exists for the cell');
+            assert.notOk(viewLike.el, 'lookup returned the placeholder, not a real view');
+
+            // findViewByModel resolves the placeholder; getCellView must NOT have done so before this call.
+            var resolved = paper.findViewByModel(r1);
+            assert.ok(resolved instanceof joint.dia.CellView, 'findViewByModel resolves the placeholder');
+            assert.equal(paper.getCellView(r1), resolved, 'after resolution getCellView returns the real view');
+
+            paper.remove();
+        });
+    });
+
     QUnit.test('contextmenu', function(assert) {
 
         var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2065,6 +2065,8 @@ export class Paper extends mvc.View<Graph> {
 
     findViewByModel<T extends ElementView | LinkView>(model: Graph.CellRef): T;
 
+    getCellView<T extends ElementView | LinkView>(model: Graph.CellRef): T | null;
+
     /**
      * Finds all the element views at the specified point
      * @param point a point in local paper coordinates


### PR DESCRIPTION
## Summary

- New public method `paper.getCellView(cellOrId)` returning the real `CellView` if instantiated, `null` otherwise.
- Unlike `findViewByModel`, it does NOT resolve view placeholders and does NOT schedule view updates — pure lookup.
- Adopt internally in `pointermove` / `pointerup` handlers, where the cached `sourceView` is only being probed for liveness mid-drag (no reason to force-resolve a placeholder).

| State | `findViewByModel` | `getCellView` |
| --- | --- | --- |
| No entry | `undefined` | `null` |
| Real `CellView` exists | the view | the view |
| Placeholder only | resolves + view | `null` |
| Side effect | schedules update | none |

Motivation: consumers (joint-react cleanup paths, downstream apps) need to ask "do we already have a rendered view for this cell?" without inadvertently materializing a placeholder. Today the only options are `findViewByModel` (side-effectful) or reaching into private `paper._views[id]`.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn test-ts` clean
- [x] `karma:joint` — 1984/1984 pass (new `paper.getCellView()` QUnit module covering instantiated cell, unknown id, and placeholder-only paths via `viewport: () => false` + `viewManagement: { lazyInitialize: true }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)