### PR TITLE
feat(joint-core, joint-react): add Paper.getCellView() + adopt in cleanup paths

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -2941,6 +2941,18 @@ export const Paper = View.extend({
         return cellView;
     },
 
+    // Returns the CellView for a `cell` (or its id) only if it has already been
+    // instantiated. Unlike `findViewByModel`, this does NOT resolve placeholders
+    // and does NOT schedule any updates. Returns `null` if no real view exists.
+    getCellView: function(cell) {
+
+        const cellViewLike = this._getCellViewLike(cell);
+        if (cellViewLike && cellViewLike[CELL_VIEW_MARKER]) {
+            return cellViewLike;
+        }
+        return null;
+    },
+
     // Find all views at given point
     findViewsFromPoint: function(p) {
 
@@ -3561,7 +3573,7 @@ export const Paper = View.extend({
             // The view could have been disposed during dragging
             // e.g. dragged outside of the viewport and hidden
             // The model can be removed in previous mousemove event handlers
-            view = this.findViewByModel(view.model) || view;
+            view = this.getCellView(view.model) || view;
             view.pointermove(evt, localPoint.x, localPoint.y);
         } else {
             this.trigger('blank:pointermove', evt, localPoint.x, localPoint.y);
@@ -3583,7 +3595,7 @@ export const Paper = View.extend({
             // The view could have been disposed during dragging
             // e.g. dragged outside of the viewport and hidden
             // The model can be removed in previous mouseup event handlers (e.g. when deleting an element after dragging)
-            view = this.findViewByModel(view.model) || view;
+            view = this.getCellView(view.model) || view;
             view.pointerup(normalizedEvt, localPoint.x, localPoint.y);
         } else {
             this.trigger('blank:pointerup', normalizedEvt, localPoint.x, localPoint.y);

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -286,6 +286,58 @@ QUnit.module('paper', function(hooks) {
         assert.ok(linkView.el.previousSibling === circleView.el, 'link view is after circle element in the DOM');
     });
 
+    QUnit.module('paper.getCellView()', function() {
+
+        QUnit.test('returns the view for an instantiated cell', function(assert) {
+
+            var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
+            this.graph.addCell(r1);
+
+            var view = this.paper.getCellView(r1);
+            assert.ok(view instanceof joint.dia.CellView, 'returns a CellView instance');
+            assert.equal(view.model, r1, 'view points to the original model');
+            assert.equal(this.paper.getCellView(r1.id), view, 'lookup by id returns the same view');
+        });
+
+        QUnit.test('returns null for an unknown cell or id', function(assert) {
+
+            assert.equal(this.paper.getCellView('does-not-exist'), null);
+            assert.equal(this.paper.getCellView(null), null);
+            assert.equal(this.paper.getCellView(undefined), null);
+        });
+
+        QUnit.test('returns null when only a placeholder exists and does not resolve it', function(assert) {
+
+            var paperEl = document.createElement('div');
+            fixtures.getElement().appendChild(paperEl);
+            var graph = new joint.dia.Graph({}, { cellNamespace: joint.shapes });
+            var paper = new joint.dia.Paper({
+                el: paperEl,
+                model: graph,
+                async: true,
+                viewport: function() { return false; },
+                viewManagement: { lazyInitialize: true }
+            });
+
+            var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
+            graph.addCell(r1);
+
+            assert.equal(paper.getCellView(r1), null, 'no real view yet — placeholder only');
+            // Confirm a placeholder is registered (otherwise the assertion above is vacuous).
+            // Placeholders are plain objects without an `el`; real CellViews have one.
+            var viewLike = paper._getCellViewLike(r1);
+            assert.ok(viewLike, 'placeholder exists for the cell');
+            assert.notOk(viewLike.el, 'lookup returned the placeholder, not a real view');
+
+            // findViewByModel resolves the placeholder; getCellView must NOT have done so before this call.
+            var resolved = paper.findViewByModel(r1);
+            assert.ok(resolved instanceof joint.dia.CellView, 'findViewByModel resolves the placeholder');
+            assert.equal(paper.getCellView(r1), resolved, 'after resolution getCellView returns the real view');
+
+            paper.remove();
+        });
+    });
+
     QUnit.test('contextmenu', function(assert) {
 
         var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -2065,6 +2065,8 @@ export class Paper extends mvc.View<Graph> {
 
     findViewByModel<T extends ElementView | LinkView>(model: Graph.CellRef): T;
 
+    getCellView<T extends ElementView | LinkView>(model: Graph.CellRef): T | null;
+
     /**
      * Finds all the element views at the specified point
      * @param point a point in local paper coordinates

--- a/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
@@ -194,8 +194,7 @@ describe('useMarkup', () => {
     // `if (!elementView) return;` early-out, we wrap a probe rendered via
     // CellIdContext directly (without an active Paper view). Throws on
     // useMarkup's `usePaper()` outside Paper, so render with Paper but no
-    // matching cell — provide a fake id so paper.findViewByModel returns
-    // undefined.
+    // matching cell — provide a fake id so paper.getCellView returns null.
     emptyCaptured = undefined;
     render(
       <GraphProvider initialCells={initialCells}>

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -69,7 +69,7 @@ export function useMarkup(): MarkupHandle {
   const id = useCellId();
   const applySelector = useCallback(
     (node: Element | null, selector: string) => {
-      const elementView = paper?.findViewByModel(id) as dia.ElementView | undefined;
+      const elementView = paper?.getCellView(id) as dia.ElementView | null;
       if (!elementView) return;
       if (node) {
         node.setAttribute('joint-selector', selector);

--- a/packages/joint-react/src/store/__tests__/clear-view.test.ts
+++ b/packages/joint-react/src/store/__tests__/clear-view.test.ts
@@ -253,11 +253,11 @@ describe('executeClearViewForCell', () => {
       size: { width: 10, height: 10 },
     });
 
-    const findViewByModel = jest.fn();
-    const paper = { findViewByModel } as unknown as dia.Paper;
+    const getCellView = jest.fn();
+    const paper = { getCellView } as unknown as dia.Paper;
 
     executeClearViewForCell([{ paper }], graph, 'a');
-    expect(findViewByModel).toHaveBeenCalledWith('a');
+    expect(getCellView).toHaveBeenCalledWith('a');
   });
 
   it('cleans the cell view nodes cache and clears connected link views', () => {
@@ -288,7 +288,7 @@ describe('executeClearViewForCell', () => {
     link.findView = jest.fn().mockReturnValue(mockLinkView) as unknown as typeof link.findView;
 
     const paper = {
-      findViewByModel: jest.fn().mockReturnValue(elementView),
+      getCellView: jest.fn().mockReturnValue(elementView),
     } as unknown as dia.Paper;
 
     executeClearViewForCell([{ paper }], graph, 'a');

--- a/packages/joint-react/src/store/__tests__/graph-store-clear-view.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-store-clear-view.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/no-useless-undefined */
 import { dia } from '@joint/core';
 import { GraphStore } from '../graph-store';
 
@@ -8,10 +7,10 @@ describe('GraphStore clearView scheduling', () => {
 
   beforeEach(() => {
     graphStore = new GraphStore({});
-    // Create a minimal mock paper — clearViewForElementAndLinks calls paper.findViewByModel
-    // which returns undefined when no real paper views exist, causing early return
+    // Create a minimal mock paper — clearViewForElementAndLinks calls paper.getCellView
+    // which returns null when no real paper views exist, causing early return
     mockPaper = {
-      findViewByModel: () => undefined,
+      getCellView: () => null,
     } as unknown as dia.Paper;
   });
 

--- a/packages/joint-react/src/store/__tests__/graph-store-features.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-store-features.test.ts
@@ -318,7 +318,7 @@ describe('GraphStore.clearViewForElementAndLinks', () => {
 
     const { paperStore } = store.addPaper('p1', { paperOptions: {} });
 
-    // Stub the paper internals so clearViewForElementAndLinks's findViewByModel
+    // Stub the paper internals so clearViewForElementAndLinks's getCellView
     // returns a real-shaped element view. We also replace findView on the link
     // so clearConnectedLinkViews finds a writable mock view.
     const cleanNodesCache = jest.fn();
@@ -332,7 +332,7 @@ describe('GraphStore.clearViewForElementAndLinks', () => {
     link.findView = jest.fn().mockReturnValue(fakeLinkView) as unknown as typeof link.findView;
 
     const fakePaper = {
-      findViewByModel: jest.fn().mockReturnValue(fakeElementView),
+      getCellView: jest.fn().mockReturnValue(fakeElementView),
       remove: jest.fn(),
     } as unknown as dia.Paper;
 
@@ -354,12 +354,12 @@ describe('GraphStore.clearViewForElementAndLinks', () => {
 
   it('returns early when the cell view is not found', () => {
     const store = new GraphStore<CellRecord, CellRecord>({});
-    const findViewByModel = jest.fn(() => {
+    const getCellView = jest.fn(() => {
       // explicit no-return to satisfy linter while emulating "not found"
     });
-    const fakePaper = { findViewByModel } as unknown as dia.Paper;
+    const fakePaper = { getCellView } as unknown as dia.Paper;
     store.clearViewForElementAndLinks({ cellId: 'missing', paper: fakePaper });
-    expect(findViewByModel).toHaveBeenCalled();
+    expect(getCellView).toHaveBeenCalled();
     store.destroy(false);
   });
 });

--- a/packages/joint-react/src/store/clear-view.ts
+++ b/packages/joint-react/src/store/clear-view.ts
@@ -125,7 +125,7 @@ export function executeClearViewForCell(
       continue;
     }
 
-    const elementView = paper.findViewByModel(cellId);
+    const elementView = paper.getCellView(cellId);
     if (!elementView) {
       continue;
     }

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -405,7 +405,7 @@ export class GraphStore<
     readonly paper: dia.Paper;
   }) => {
     const { cellId, onValidateLink, paper } = options;
-    const elementView = paper.findViewByModel(cellId);
+    const elementView = paper.getCellView(cellId);
     if (!elementView) {
       return;
     }


### PR DESCRIPTION
## Summary

- joint-core: new public method `paper.getCellView(cellOrId)` returning the real `CellView` if instantiated, `null` otherwise. Side-effect-free counterpart to `findViewByModel` (does not resolve placeholders, does not schedule updates). Adopt in Paper `pointermove` / `pointerup` handlers.
- joint-react: switch cleanup callsites (`clearViewForElementAndLinks`, `executeClearViewForCell`, `useMarkup` selector ref) to the strict lookup. Test mocks updated to match.

Companion PR against `master` with joint-core changes only: #3377.

| State | `findViewByModel` | `getCellView` |
| --- | --- | --- |
| No entry | `undefined` | `null` |
| Real `CellView` exists | the view | the view |
| Placeholder only | resolves + view | `null` |
| Side effect | schedules update | none |

## Test plan

- [x] joint-core: `yarn lint`, `yarn test-ts`, `karma:joint` — 1984/1984 pass (new `paper.getCellView()` QUnit module)
- [x] joint-react: `yarn typecheck`, `yarn lint`, `yarn jest` — 939/939 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)