### PR TITLE
fix(joint-react): add link hover color and stroke transition

### DIFF
--- a/packages/joint-react/src/css/joint-react.css
+++ b/packages/joint-react/src/css/joint-react.css
@@ -31,7 +31,7 @@
     padding: var(--jj-box-padding);
     font-size: var(--jj-box-font-size);
     font-family: var(--jj-box-font-family);
-    transition: border-color 0.2s;
+    transition: border-color var(--jj-transition-duration);
 }
 
 .jj-box:hover {

--- a/packages/joint-react/src/css/theme.css
+++ b/packages/joint-react/src/css/theme.css
@@ -58,6 +58,8 @@
     --jj-port-drag-cursor: crosshair;
     /* Cursor for ports while dragging */
     --jj-port-dragging-cursor: crosshair;
+    /* Transition duration, set to 0 to disable */
+    --jj-transition-duration: 0.2s;
 }
 
 @media (min-resolution: 1.5dppx) {

--- a/packages/joint-react/src/presets/element-ports.css
+++ b/packages/joint-react/src/presets/element-ports.css
@@ -15,7 +15,10 @@
     fill: var(--jj-port-color);
     stroke: var(--jj-port-border-color);
     stroke-width: var(--jj-port-border-width);
-    transition: fill 0.2s, stroke 0.2s, stroke-width 0.2s;
+    transition:
+        fill var(--jj-transition-duration),
+        stroke var(--jj-transition-duration),
+        stroke-width var(--jj-transition-duration);
 }
 
 .jj-port[magnet="active"] {

--- a/packages/joint-react/src/presets/link-labels.css
+++ b/packages/joint-react/src/presets/link-labels.css
@@ -21,7 +21,7 @@
     fill: var(--jj-link-label-bg-color);
     stroke: var(--jj-link-label-border-color);
     stroke-width: var(--jj-link-label-border-width);
-    transition: stroke 0.2s;
+    transition: stroke var(--jj-transition-duration);
 }
 
 .jj-link-label-bg:hover {

--- a/packages/joint-react/src/presets/link-view.css
+++ b/packages/joint-react/src/presets/link-view.css
@@ -1,6 +1,7 @@
 :root {
-        /* ── Links ───────────────────────────────────────────────────────────── */
+    /* ── Links ───────────────────────────────────────────────────────────── */
     --jj-link-color: var(--jj-color-link);
+    --jj-link-hover-color: var(--jj-color-primary);
     --jj-link-width: var(--jj-stroke-width);
     --jj-link-dash: none;
     --jj-link-line-cap: butt;
@@ -16,11 +17,11 @@
     stroke-width: var(--jj-link-width);
     stroke-dasharray: var(--jj-link-dash);
     stroke-linecap: var(--jj-link-line-cap);
+    transition: stroke 0.2s;
 }
 
-.jj-link-wrapper {
-    stroke: var(--jj-link-wrapper-color, transparent);
-    stroke-width: var(--jj-link-wrapper-width, 10);
+.jj-link-wrapper:hover+.jj-link-line {
+    stroke: var(--jj-link-hover-color);
 }
 
 .jj-is-connecting {
@@ -32,4 +33,3 @@
 .jj-is-snapped {
     --jj-link-color: var(--jj-color-primary);
 }
-

--- a/packages/joint-react/src/presets/link-view.css
+++ b/packages/joint-react/src/presets/link-view.css
@@ -17,7 +17,7 @@
     stroke-width: var(--jj-link-width);
     stroke-dasharray: var(--jj-link-dash);
     stroke-linecap: var(--jj-link-line-cap);
-    transition: stroke 0.2s;
+    transition: stroke var(--jj-transition-duration);
 }
 
 .jj-link-wrapper:hover+.jj-link-line {

--- a/packages/joint-react/src/presets/paper.css
+++ b/packages/joint-react/src/presets/paper.css
@@ -2,8 +2,8 @@
     /* ── Paper ───────────────────────────────────────────────────────────── */
     --jj-paper-color: var(--jj-color-light-300);
     --jj-paper-grid-color: var(--jj-color-light-700);
-    --jj-connecting-highlight-color: var(--jj-color-primary);
-    --jj-embedding-highlight-color: var(--jj-color-primary);
+    --jj-highlighter-connecting-color: var(--jj-color-primary);
+    --jj-highlighter-embedding-color: var(--jj-color-primary);
 
     /* ── Paper Interactions ────────────────────────────────────────────────── */
     --jj-port-hover-color: var(--jj-color-shape-surface);

--- a/packages/joint-react/src/presets/paper.css
+++ b/packages/joint-react/src/presets/paper.css
@@ -2,8 +2,8 @@
     /* ── Paper ───────────────────────────────────────────────────────────── */
     --jj-paper-color: var(--jj-color-light-300);
     --jj-paper-grid-color: var(--jj-color-light-700);
-    --jj-paper-connecting-highlight-color: var(--jj-color-primary);
-    --jj-paper-embedding-highlight-color: var(--jj-color-primary);
+    --jj-connecting-highlight-color: var(--jj-color-primary);
+    --jj-embedding-highlight-color: var(--jj-color-primary);
 
     /* ── Paper Interactions ────────────────────────────────────────────────── */
     --jj-port-hover-color: var(--jj-color-shape-surface);

--- a/packages/joint-react/src/presets/paper.css
+++ b/packages/joint-react/src/presets/paper.css
@@ -63,7 +63,7 @@
 /* ── Magnet highlighter stroke ────────────────────────────────────────── */
 
 .jj-magnet-highlighter {
-    transition: opacity 0.2s ease;
+    transition: opacity var(--jj-transition-duration) ease;
     opacity: 1;
 }
 

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -63,7 +63,7 @@ export const DEFAULT_HIGHLIGHTING = {
     options: {
       attrs: {
         strokeWidth: 1,
-        stroke: 'var(--jj-connecting-highlight-color)'
+        stroke: 'var(--jj-highlighter-connecting-color)'
       },
       rx: 4,
       ry: 4,
@@ -75,7 +75,7 @@ export const DEFAULT_HIGHLIGHTING = {
     options: {
       attrs: {
         strokeWidth: 'var(--jj-stroke-width)',
-        stroke: 'var(--jj-embedding-highlight-color)',
+        stroke: 'var(--jj-highlighter-embedding-color)',
       },
       rx: 4,
       ry: 4,

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -63,7 +63,7 @@ export const DEFAULT_HIGHLIGHTING = {
     options: {
       attrs: {
         strokeWidth: 1,
-        stroke: 'var(--jj-paper-connecting-highlight-color)'
+        stroke: 'var(--jj-connecting-highlight-color)'
       },
       rx: 4,
       ry: 4,
@@ -75,7 +75,7 @@ export const DEFAULT_HIGHLIGHTING = {
     options: {
       attrs: {
         strokeWidth: 'var(--jj-stroke-width)',
-        stroke: 'var(--jj-paper-embedding-highlight-color)',
+        stroke: 'var(--jj-embedding-highlight-color)',
       },
       rx: 4,
       ry: 4,

--- a/packages/joint-react/stories/examples/theme-editor/code.tsx
+++ b/packages/joint-react/stories/examples/theme-editor/code.tsx
@@ -825,15 +825,29 @@ export default function App() {
   const [isDark, setIsDark] = useState(false);
   const [overrides, setOverrides] = useState<CSSVars>({});
   const [zoom, setZoom] = useState(1);
+  const [isThemeChanging, setIsThemeChanging] = useState(false);
 
   const themeVars = isDark ? DARK_THEME : LIGHT_THEME;
 
   const effectiveVars = useMemo(
-    () => ({ ...themeVars, ...overrides }),
-    [themeVars, overrides]
+    () => ({
+      ...themeVars,
+      ...overrides,
+      ...(isThemeChanging ? { '--jj-transition-duration': '0' } : {}),
+    }),
+    [themeVars, overrides, isThemeChanging]
   );
 
-  const toggleTheme = useCallback(() => setIsDark((previous) => !previous), []);
+  const toggleTheme = useCallback(() => {
+    setIsThemeChanging(true);
+    setIsDark((previous) => !previous);
+  }, []);
+
+  useEffect(() => {
+    if (!isThemeChanging) return;
+    const frameId = requestAnimationFrame(() => setIsThemeChanging(false));
+    return () => cancelAnimationFrame(frameId);
+  }, [isThemeChanging]);
   const zoomIn    = useCallback(() => setZoom((z) => Math.min(MAX_ZOOM, Math.round((z + ZOOM_STEP) * 10) / 10)), []);
   const zoomOut   = useCallback(() => setZoom((z) => Math.max(MIN_ZOOM, Math.round((z - ZOOM_STEP) * 10) / 10)), []);
   const resetZoom = useCallback(() => setZoom(1), []);


### PR DESCRIPTION
## Summary

- Adds `--jj-link-hover-color` CSS variable (defaults to `--jj-color-primary`) to `link-view.css`
- Applies a `stroke 0.2s` transition on `.jj-link-line` for smooth hover animation
- Rewires hover effect: `.jj-link-wrapper:hover + .jj-link-line` now drives the hover stroke color (removes the old separate `.jj-link-wrapper` rule)
- Fixes indentation in `:root` variables block

## Test plan

- [ ] Hover over a link in the React paper — stroke color should transition to the primary color
- [ ] Verify no visual regression on non-hovered links
- [ ] Verify connecting/snapped state CSS variables still apply correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)