### PR TITLE
fix(joint-react): normalize interactive function-form return value

### DIFF
--- a/packages/joint-react/src/presets/__tests__/preset-coverage.test.ts
+++ b/packages/joint-react/src/presets/__tests__/preset-coverage.test.ts
@@ -168,13 +168,42 @@ describe('presets / element-ports', () => {
 });
 
 describe('presets / interactive', () => {
-  it('function form wraps via native callback', () => {
+  it('function form wraps via native callback and normalizes the return value', () => {
     const cb = jest.fn(() => true);
     const native = toNativeCellInteractivity(cb);
     const fakePaper = { model: {} } as any;
     const cellView = { model: { id: 'm' } } as any;
-    expect((native as any).call(fakePaper, cellView, 'elementMove')).toBe(true);
+    // `() => true` is normalized to DEFAULT_INTERACTIVE so it matches the static
+    // `interactive={true}` shape.
+    expect((native as any).call(fakePaper, cellView, 'elementMove')).toEqual({
+      labelMove: false,
+      linkMove: false,
+    });
     expect(cb).toHaveBeenCalled();
+  });
+  it('function form normalizes object return — defaults merged under user keys', () => {
+    const native = toNativeCellInteractivity(() => ({ linkMove: true }) as any);
+    const fakePaper = { model: {} } as any;
+    const cellView = { model: { id: 'm' } } as any;
+    expect((native as any).call(fakePaper, cellView, 'linkMove')).toEqual({
+      labelMove: false,
+      linkMove: true,
+    });
+  });
+  it('function form passes false through', () => {
+    const native = toNativeCellInteractivity(() => false);
+    const fakePaper = { model: {} } as any;
+    const cellView = { model: { id: 'm' } } as any;
+    expect((native as any).call(fakePaper, cellView, 'elementMove')).toBe(false);
+  });
+  it('function form normalizes empty-object return to defaults', () => {
+    const native = toNativeCellInteractivity(() => ({}) as any);
+    const fakePaper = { model: {} } as any;
+    const cellView = { model: { id: 'm' } } as any;
+    expect((native as any).call(fakePaper, cellView, 'elementMove')).toEqual({
+      labelMove: false,
+      linkMove: false,
+    });
   });
   it('true returns defaults (linkMove/labelMove disabled, rest implicit true)', () => {
     expect(toNativeCellInteractivity(true)).toEqual({ linkMove: false, labelMove: false });

--- a/packages/joint-react/src/presets/cell-interactivity.ts
+++ b/packages/joint-react/src/presets/cell-interactivity.ts
@@ -41,32 +41,47 @@ const DEFAULT_INTERACTIVE: dia.CellView.InteractivityOptions = {
   linkMove: false,
 };
 
+type StaticInteractivity = boolean | dia.CellView.InteractivityOptions | undefined;
+
+/**
+ * Resolve a static `interactive` value to the native shape, applying
+ * `DEFAULT_INTERACTIVE` as the baseline so every shape that means
+ * "interactivity on" produces the same defaults.
+ */
+function normalizeStaticInteractivity(
+  value: StaticInteractivity
+): false | dia.CellView.InteractivityOptions {
+  if (value === false) return false;
+  if (value === true || value == null) return { ...DEFAULT_INTERACTIVE };
+  if (typeof value === 'object') return { ...DEFAULT_INTERACTIVE, ...value };
+  return { ...DEFAULT_INTERACTIVE };
+}
+
 /**
  * Adapt the `interactive` prop to the native form.
  *
  * - `undefined` → defaults (`labelMove`/`linkMove` disabled, rest implicit true).
- * - `true` → same defaults (`labelMove`/`linkMove` disabled, rest implicit true).
+ * - `true` → same defaults.
  * - `false` → pass through (every interaction disabled).
  * - object → defaults applied first, user keys win.
- * - function → wrapped so the user callback receives an `CellInteractivityParams`
- *   instead of the native positional `(cellView, interaction)` args.
- *   Defaults are NOT merged into the function return — function form is an
- *   explicit takeover.
+ * - function → wrapped so the user callback receives a `CellInteractivityParams`
+ *   instead of the native positional `(cellView, interaction)` args. The
+ *   callback's return value is normalized identically to the static shapes,
+ *   so `() => true` and `() => ({})` both resolve to `DEFAULT_INTERACTIVE`.
  * @param value - prop value
  * @returns native `dia.Paper.Options['interactive']`
  */
 export function toNativeCellInteractivity(
   value: CellInteractivity | undefined
 ): dia.Paper.Options['interactive'] {
-  if (value === undefined || value === true) return DEFAULT_INTERACTIVE;
-  if (value === false) return false;
-  if (typeof value === 'object') return { ...DEFAULT_INTERACTIVE, ...value };
+  if (typeof value !== 'function') return normalizeStaticInteractivity(value);
   return function (this: dia.Paper, cellView: dia.CellView, interaction: string) {
-    return value({
+    const result = value({
       model: cellView.model,
       interaction: interaction as CellInteraction,
       paper: this,
       graph: this.model,
     });
+    return normalizeStaticInteractivity(result as StaticInteractivity);
   };
 }


### PR DESCRIPTION
## Summary

- `<Paper interactive>` function form bypassed `DEFAULT_INTERACTIVE`. `() => true`, `() => ({})`, and `() => ({ elementMove: false })` all left `labelMove`/`linkMove` enabled — diverging from the static `interactive={true}` and `interactive={{}}` shapes that already normalize against `DEFAULT_INTERACTIVE = { labelMove: false, linkMove: false }`.
- `toNativeCellInteractivity()` now pipes the callback return value through the same `normalizeStaticInteractivity()` helper as the static shapes, so every form meaning "interactivity on" resolves to the same baseline.
- Updated JSDoc — function form is no longer an "explicit takeover".

## Behavior matrix (after fix)

| Shape | Resolves to |
|---|---|
| `undefined` / `true` / `() => true` / `() => ({})` | `{ labelMove: false, linkMove: false }` |
| `false` / `() => false` | `false` |
| `{ linkMove: true }` / `() => ({ linkMove: true })` | `{ labelMove: false, linkMove: true }` |

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn jest` (full suite) — 942/942 passing
- [x] Updated existing function-form test (`preset-coverage.test.ts`) that asserted the previous behavior
- [x] Added cases for `() => ({ linkMove: true })`, `() => false`, `() => ({})`
- [ ] Manual smoke in Storybook — toggle between static and function shapes, verify identical drag behavior on link labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)