### PR TITLE
refactor(joint-react): usePaper().paper is PaperView | null

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-measure-element.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-measure-element.test.tsx
@@ -28,7 +28,7 @@ import { LINK_MODEL_TYPE } from '../../mvc/link-model';
 import type { CellRecord } from '../../types/cell.types';
 
 let capturedGraph: dia.Graph | null = null;
-let capturedPaper: dia.Paper | undefined;
+let capturedPaper: dia.Paper | null = null;
 
 const initialCells: readonly CellRecord[] = [
   {
@@ -105,7 +105,7 @@ const renderNoNodeProbe = () => <NoNodeProbe />;
 describe('useMeasureElement', () => {
   it('adds .jj-is-measuring on mount and removes it on the next paper render:done', async () => {
     capturedGraph = null;
-    capturedPaper = undefined;
+    capturedPaper = null;
     const { container } = renderProbe();
     // Class is applied by useMeasureElement in a layout effect; wait until it lands.
     await waitFor(() => {

--- a/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-paper.test.tsx
@@ -102,10 +102,10 @@ describe('usePaper', () => {
     await waitFor(() => expect(result.current.paper).toBeDefined());
   });
 
-  it('returns { paper: undefined } outside Paper context', () => {
+  it('returns { paper: null } outside Paper context', () => {
     const wrapper = graphProviderWrapper({ initialCells: [] });
     const { result } = renderHook(() => usePaper(), { wrapper });
-    expect(result.current.paper).toBeUndefined();
+    expect(result.current.paper).toBeNull();
   });
 
   it('looks up paper by id', async () => {

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -71,8 +71,8 @@ export function usePaperStore(paperId?: string): PaperStore | undefined {
 
 /** Result of {@link usePaper} — the paper instance and imperative actions. */
 export interface PaperApi {
-  /** Resolved JointJS paper instance, or `undefined` until a `<Paper>` has mounted. */
-  readonly paper?: PaperView;
+  /** Resolved JointJS paper instance, or `null` until a `<Paper>` has mounted. */
+  readonly paper: PaperView | null;
   /**
    * Trigger a render pass on the paper. Forwards to `paper.wakeUp()`.
    * No-op when the paper isn't resolved yet.
@@ -85,16 +85,16 @@ export interface PaperApi {
  * Returns the active `PaperView` instance from context, by ID, or via the
  * default paper. Resolves the paper store and exposes `wakeUp()`.
  *
- * The returned object is always stable; only `paper` is `undefined` until the
+ * The returned object is always stable; only `paper` is `null` until the
  * `<Paper>` view has mounted.
  * @param paperId - An explicit paper id, or omitted for the context/default paper.
- * @returns A stable object with the resolved `paper` (or `undefined`) and a `wakeUp` action.
+ * @returns A stable object with the resolved `paper` (or `null`) and a `wakeUp` action.
  * @see https://docs.jointjs.com/learn/quickstart/paper
  * @group Hooks
  */
 export function usePaper(paperId?: string): PaperApi {
   const paperStore = usePaperStore(paperId);
-  const paper = paperStore?.paper ?? undefined;
+  const paper = paperStore?.paper ?? null;
   const wakeUp = useCallback(() => {
     paper?.wakeUp();
   }, [paper]);


### PR DESCRIPTION
## Why

Align the "view not available" representation across the React hooks. `usePaper().paper` was an optional `?` (→ `undefined`); other instance handles vary. Unify to a **required key with a `T | null` value**, matching `useRef().current` semantics for an imperative instance that attaches on mount.

## What

- `PaperApi.paper`: `paper?: PaperView` → `paper: PaperView | null`.
- `usePaper()` returns `paper: … ?? null`.
- Docs + the two affected tests updated.

Companion: `@joint/react-plus` unifies its view handles to `T | null` in clientIO/joint-plus#727.

## Verification

- `yarn typecheck` — clean
- `yarn jest` — 975/975
- changed files lint clean (one pre-existing unrelated lint error in `use-create-portal-paper.tsx` on `dev`)
- `yarn dist` rebuilt; `@joint/react-plus` typecheck stays green against the new type

🤖 Generated with [Claude Code](https://claude.com/claude-code)