### PR TITLE
chore(joint-react): silence typedoc warnings for internal types

### DIFF
--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -124,7 +124,7 @@ export function useSetCell<
 }
 
 /**
- * Updater form for {@link SetCellData}. Receives the cell's current `data` and
+ * Updater form for `SetCellData`. Receives the cell's current `data` and
  * returns the next `data`. The return value replaces `data` wholesale — perform
  * a partial update by merging inside the updater
  * (`(prev) => ({ ...prev, ...patch })`).
@@ -151,9 +151,9 @@ export interface SetCellData<Data = Record<string, unknown>> {
 }
 
 /**
- * Returns a function that sets a single cell's `data` field. See
- * {@link SetCellData} for the supported call forms. Throws when the target cell
- * does not exist.
+ * Returns a function that sets a single cell's `data` field. Two forms:
+ * `setCellData(id, data)` replaces wholesale; `setCellData(id, (prev) => next)`
+ * uses an updater. Throws when the target cell does not exist.
  *
  * Writes `data` directly on the `dia.Cell`, so JointJS fires `change:data` and
  * every React subscription resyncs — no full-record merge is involved.

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -79,9 +79,9 @@ export interface GraphApi<
    *   partial update). A nullish `id`, or an `id` with no matching cell, warns
    *   in dev and no-ops.
    *
-   * The `data` type is derived from the `useGraph<Element, Link>` generics (see
-   * {@link HandleCellData}): typed records flow through, otherwise it falls back
-   * to `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
+   * The `data` type is derived from the `useGraph<Element, Link>` generics:
+   * typed records flow through, otherwise it falls back to
+   * `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
    * at the type level, so when both are typed the updater sees their union —
    * narrow inside it. For a single fixed `data` shape, use the standalone
    * `useSetCellData<MyData>()` hook.

--- a/packages/joint-react/typedoc.json
+++ b/packages/joint-react/typedoc.json
@@ -22,6 +22,8 @@
     "namedLinkMarkers",
     "ElementJSONInit",
     "LinkJSONInit",
+    "SetCellData",
+    "HandleCellData",
     "GraphStore",
     "PaperView",
     "PaperEventHandlers",


### PR DESCRIPTION
## Summary

- `yarn docs:typedoc` emitted warnings about `SetCellData` and `HandleCellData` being referenced from public API (`GraphApi.setCellData`, `useSetCellData`) without being exported. Both are implementation details, not public surface.
- Added them to `intentionallyNotExported` in `typedoc.json` — same pattern used for `ElementJSONInit`, `LinkJSONInit`, `GraphStore`, etc.
- Dropped `{@link SetCellData}` / `{@link HandleCellData}` JSDoc references that pointed at internal symbols; replaced with inline backtick names so typedoc has nothing to resolve.

## Test plan

- [x] `yarn docs:typedoc` — 0 errors, 0 warnings
- [x] `yarn typecheck` — clean
- [ ] Spot-check generated `docs/api/` HTML renders `GraphApi.setCellData` description without broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)