### PR TITLE
chore(joint-react): tag exports with @group + expand typedoc groups

### DIFF
--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -16,6 +16,7 @@ type ProviderCells<Element extends ElementJSONInit, Link extends LinkJSONInit> =
  * Props common to every `GraphProvider` mode.
  * @template ElementData - User data attached to each element record.
  * @template LinkData - User data attached to each link record.
+ * @group Types
  */
 export interface GraphProviderProps<
   Element extends ElementJSONInit = ElementJSONInit,
@@ -179,6 +180,7 @@ function GraphBase(props: GraphProviderBaseInternalProps) {
  * </GraphProvider>
  * ```
  * @see GraphProviderProps for all available props
+ * @group Components
  */
 export const GraphProvider = GraphBase as <
   Element extends ElementJSONInit = ElementJSONInit,

--- a/packages/joint-react/src/components/html-box.tsx
+++ b/packages/joint-react/src/components/html-box.tsx
@@ -19,6 +19,7 @@ const AUTO_SIZE_STYLE: CSSProperties = {
 
 /**
  * Props for the HTMLBox component, extending HTMLHostProps.
+ * @group Types
  */
 export type HTMLBoxProps = HTMLHostProps;
 

--- a/packages/joint-react/src/components/html-host.tsx
+++ b/packages/joint-react/src/components/html-host.tsx
@@ -24,6 +24,7 @@ import { selectElementSize } from '../selectors';
  */
 
 /** Props accepted by `HTMLHost`. Inherits all standard `<div>` attributes. */
+/** @group Types */
 export interface HTMLHostProps extends HTMLAttributes<HTMLDivElement> {
   /** Skip DOM measurement and use the element's size from the model. Default: `false`. */
   readonly useModelGeometry?: boolean;

--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -23,10 +23,12 @@ import type { PaperEventHandlers } from '../../presets/paper-events';
  * native `DOMMatrix` constructor (CSS transform syntax — `scale()`,
  * `translate()`, `rotate()`, `matrix()` etc.). `DOMMatrix` instances pass
  * through. `SVGMatrix === DOMMatrix` in modern `lib.dom.d.ts`.
+ * @group Types
  */
 export type PaperTransform = string | DOMMatrix;
 
 /** Context passed to the `defaultLink` factory. */
+/** @group Types */
 export interface DefaultLinkParams {
   /** The source end of the connection being created. */
   readonly source: ConnectionEnd;
@@ -39,6 +41,7 @@ export interface DefaultLinkParams {
 /**
  * Value accepted by the Paper `defaultLink` prop — factory receiving
  * `DefaultLinkParams`, or a static `Partial<LinkRecord>`.
+ * @group Types
  */
 export type DefaultLink =
   | ((context: DefaultLinkParams) => dia.Link | Partial<LinkRecord>)
@@ -48,6 +51,7 @@ export type DefaultLink =
  * Raw `dia.Paper.Options` passthrough — the type of the `options` escape-hatch prop.
  * `cellVisibility` is excluded: use the dedicated `cellVisibility` prop (it is
  * also managed by feature ownership, e.g. a virtual-rendering scroller).
+ * @group Types
  */
 export type PaperOptions = Omit<dia.Paper.Options, 'cellVisibility'>;
 
@@ -56,6 +60,7 @@ export type PaperOptions = Omit<dia.Paper.Options, 'cellVisibility'>;
  * native types via indexed access (`dia.Paper.Options['name']`), so any
  * type-level change in JointJS propagates automatically. Anything not listed
  * here is reachable via the `options` escape hatch, never implicitly exposed.
+ * @group Types
  */
 export interface PaperSupportedOptions {
   // ── Wrapped (structured) ─────────────────────────────────────────────────
@@ -212,6 +217,7 @@ export interface PaperSupportedOptions {
  * If the renderer needs the id, position, size, or other slices, use the
  * context hooks: `useCellId()`, `useCell()` (with optional selector), or
  * `useCell(c => c.position / c.size / ...)`.
+ * @group Types
  */
 export type RenderElement<ElementData = unknown> = (data: ElementData) => ReactNode;
 
@@ -222,6 +228,7 @@ export type RenderElement<ElementData = unknown> = (data: ElementData) => ReactN
  * needed.
  *
  * The framework guarantees `data` is at least `{}` at this boundary.
+ * @group Types
  */
 export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
 
@@ -241,6 +248,7 @@ export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
  * `on*` form (`render:done`, `cell:highlight`, …), use the `useOnPaperEvents`
  * hook.
  * @see https://docs.jointjs.com/api/dia/Paper
+ * @group Types
  */
 export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, PaperEventHandlers {
   /**

--- a/packages/joint-react/src/components/svg-text/svg-text.tsx
+++ b/packages/joint-react/src/components/svg-text/svg-text.tsx
@@ -108,6 +108,7 @@ function getTextWrapStyles({
 /**
  * Props for `SVGText` — combines native SVG `<text>` attributes with the
  * JointJS Vectorizer text options used for word-wrap and annotation rendering.
+ * @group Types
  */
 export interface SVGTextProps
   extends SVGTextElementAttributes<SVGTextElement>,

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -124,7 +124,7 @@ export function useSetCell<
 }
 
 /**
- * Updater form for {@link SetCellData}. Receives the cell's current `data` and
+ * Updater form for `SetCellData`. Receives the cell's current `data` and
  * returns the next `data`. The return value replaces `data` wholesale — perform
  * a partial update by merging inside the updater
  * (`(prev) => ({ ...prev, ...patch })`).
@@ -151,9 +151,9 @@ export interface SetCellData<Data = Record<string, unknown>> {
 }
 
 /**
- * Returns a function that sets a single cell's `data` field. See
- * {@link SetCellData} for the supported call forms. Throws when the target cell
- * does not exist.
+ * Returns a function that sets a single cell's `data` field. Two forms:
+ * `setCellData(id, data)` replaces wholesale; `setCellData(id, (prev) => next)`
+ * uses an updater. Throws when the target cell does not exist.
  *
  * Writes `data` directly on the `dia.Cell`, so JointJS fires `change:data` and
  * every React subscription resyncs — no full-record merge is involved.

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -49,6 +49,7 @@ function writeMergedCell<Element extends ElementJSONInit, Link extends LinkJSONI
  * exactly once with the real previous value.
  * @template Element - element record shape
  * @template Link - link record shape
+ * @group Types
  */
 export type SetCellUpdater<Element extends ElementJSONInit, Link extends LinkJSONInit> = (
   previous: Element | Link
@@ -65,6 +66,7 @@ export type SetCellUpdater<Element extends ElementJSONInit, Link extends LinkJSO
  *   warns in dev and no-ops — pass the direct form to add a new cell.
  * @template Element - element record shape
  * @template Link - link record shape
+ * @group Types
  */
 export interface SetCell<Element extends ElementJSONInit, Link extends LinkJSONInit> {
   (record: CellInput<Element, Link>): void;
@@ -129,6 +131,7 @@ export function useSetCell<
  * a partial update by merging inside the updater
  * (`(prev) => ({ ...prev, ...patch })`).
  * @template Data - cell data shape
+ * @group Types
  */
 export type SetCellDataUpdater<Data> = (previousData: Data) => Data;
 
@@ -144,6 +147,7 @@ export type SetCellDataUpdater<Data> = (previousData: Data) => Data;
  * a new one). The updater overload is listed first so a function argument
  * matches it; any non-function argument falls through to the direct form.
  * @template Data - cell data shape (defaults to an open `Record<string, unknown>`)
+ * @group Types
  */
 export interface SetCellData<Data = Record<string, unknown>> {
   (id: CellId | null | undefined, updater: SetCellDataUpdater<Data>): void;

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -21,6 +21,7 @@ import type {
 
 /**
  * The shape of the graph's JSON export, as produced by `graph.toJSON()`.
+ * @group Types
  */
 export type GraphJSON = dia.Graph.JSON;
 
@@ -55,6 +56,7 @@ type HandleCellData<Element extends ElementJSONInit, Link extends LinkJSONInit> 
  *                    write input, `Computed<ElementRecord<MyData>>` for reads)
  * @template Link - link record shape (e.g. `LinkRecord<MyData>` /
  *                  `Computed<LinkRecord<MyData>>`)
+ * @group Types
  */
 export interface GraphApi<
   Element extends ElementJSONInit = ElementJSONInit,
@@ -137,6 +139,7 @@ export interface GraphApi<
 }
 
 /** Options accepted by {@link GraphApi.exportToJSON}. */
+/** @group Types */
 export interface ExportToJSONOptions {
   /**
    * When `true`, every attribute is preserved (defaults included) and no

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -79,9 +79,9 @@ export interface GraphApi<
    *   partial update). A nullish `id`, or an `id` with no matching cell, warns
    *   in dev and no-ops.
    *
-   * The `data` type is derived from the `useGraph<Element, Link>` generics (see
-   * {@link HandleCellData}): typed records flow through, otherwise it falls back
-   * to `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
+   * The `data` type is derived from the `useGraph<Element, Link>` generics:
+   * typed records flow through, otherwise it falls back to
+   * `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
    * at the type level, so when both are typed the updater sees their union —
    * narrow inside it. For a single fixed `data` shape, use the standalone
    * `useSetCellData<MyData>()` hook.

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -5,6 +5,7 @@ import type { dia } from '@joint/core';
 import { PORTAL_SELECTOR } from '../mvc/element-model';
 
 /** Options for `magnetRef`. */
+/** @group Types */
 export interface MagnetRefOptions {
   /**
    * Whether the magnet is passive — only a valid connection target, not a source.
@@ -14,6 +15,7 @@ export interface MagnetRefOptions {
 }
 
 /** Markup utilities returned by `useMarkup`. */
+/** @group Types */
 export interface MarkupApi {
   /**
    * Returns a React ref callback that registers the node under the given selector name.

--- a/packages/joint-react/src/hooks/use-measure-element.tsx
+++ b/packages/joint-react/src/hooks/use-measure-element.tsx
@@ -10,6 +10,7 @@ import { MEASURING_CLASS_NAME } from '../utils/class-names';
 
 /**
  * Options for configuring how the node size is measured and applied.
+ * @group Types
  */
 export interface MeasureElementOptions {
   /**

--- a/packages/joint-react/src/hooks/use-on-elements-measured.ts
+++ b/packages/joint-react/src/hooks/use-on-elements-measured.ts
@@ -6,6 +6,7 @@ import { useGraphStore } from './use-graph-store';
 import { useLatestRef } from './use-latest-ref';
 
 /** Payload delivered when paper-managed elements complete a measurement pass. */
+/** @group Types */
 export interface ElementsMeasuredParams {
   /** True when this is the first measurement (all elements sized for the first time). */
   readonly isInitial: boolean;
@@ -16,6 +17,7 @@ export interface ElementsMeasuredParams {
 }
 
 /** Callback signature for `useOnElementsMeasured`. */
+/** @group Types */
 export type OnElementsMeasured = (params: ElementsMeasuredParams) => void;
 
 /**

--- a/packages/joint-react/src/hooks/use-on-graph-events.ts
+++ b/packages/joint-react/src/hooks/use-on-graph-events.ts
@@ -38,6 +38,7 @@ function subscribeToGraphEvents(graph: dia.Graph, handlers: GraphEventMap): () =
 
 /**
  * The map of graph events to handlers accepted by {@link useOnGraphEvents}.
+ * @group Types
  */
 export type GraphEventMap = Partial<dia.Graph.EventMap>;
 

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -70,6 +70,7 @@ export function usePaperStore(paperId?: string): PaperStore | undefined {
 }
 
 /** Result of {@link usePaper} — the paper instance and imperative actions. */
+/** @group Types */
 export interface PaperApi {
   /** Resolved JointJS paper instance, or `null` until a `<Paper>` has mounted. */
   readonly paper: PaperView | null;

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -6,16 +6,22 @@
 
 /**
  * <GraphProvider/>
+ * @group Components
  */
 export { GraphProvider } from './components/graph/graph-provider';
+/** @group Types */
 export type { GraphProviderProps } from './components/graph/graph-provider';
+/** @group Types */
 export type { AutoSizeOrigin } from './store/graph-store';
+/** @group Types */
 export type { IncrementalCellsChange } from './store/graph-projection';
 
 /**
  * <Paper/>
+ * @group Components
  */
 export { Paper } from './components/paper/paper';
+/** @group Types */
 export type {
   PaperProps,
   PaperOptions,
@@ -25,7 +31,9 @@ export type {
   DefaultLink,
   DefaultLinkParams,
 } from './components/paper/paper.types';
+/** @group Types */
 export type { PortalHostCell, PortalSelector, PortalSelectorParams } from './mvc/paper.types';
+/** @group Types */
 export type {
   ValidateConnection,
   ValidateConnectionParams,
@@ -47,20 +55,26 @@ export type {
 
 /**
  * <SVGText/>
+ * @group Components
  */
 export { SVGText } from './components/svg-text/svg-text';
+/** @group Types */
 export type { SVGTextProps } from './components/svg-text/svg-text';
 
 /**
  * <HTMLHost/>
+ * @group Components
  */
 export { HTMLHost } from './components/html-host';
+/** @group Types */
 export type { HTMLHostProps } from './components/html-host';
 
 /**
  * <HTMLBox/>
+ * @group Components
  */
 export { HTMLBox } from './components/html-box';
+/** @group Types */
 export type { HTMLBoxProps } from './components/html-box';
 
 // Hooks
@@ -68,42 +82,54 @@ export type { HTMLBoxProps } from './components/html-box';
 
 /**
  * useGraph()
+ * @group Hooks
  */
 export { useGraph } from './hooks/use-graph';
+/** @group Types */
 export type { GraphApi, GraphJSON, ExportToJSONOptions } from './hooks/use-graph';
 
 /**
  * useSetCellData()
+ * @group Hooks
  */
 export { useSetCellData } from './hooks/use-cell-setters';
 
 /**
  * usePaper()
+ * @group Hooks
  */
 export { usePaper } from './hooks/use-paper';
+/** @group Types */
 export type { PaperApi } from './hooks/use-paper';
+/** @group Types */
 export type { PaperTarget } from './types/paper.types';
 
 /**
  * useCells()
+ * @group Hooks
  */
 export { useCells } from './hooks/use-cells';
 
 /**
  * useCell()
+ * @group Hooks
  */
 export { useCell } from './hooks/use-cell';
 
 /**
  * useCellId()
+ * @group Hooks
  */
 export { useCellId } from './hooks/use-cell-id';
 
 /**
  * useMeasureElement()
+ * @group Hooks
  */
 export { useMeasureElement } from './hooks/use-measure-element';
+/** @group Types */
 export type { MeasureElementOptions } from './hooks/use-measure-element';
+/** @group Types */
 export type {
   TransformElementLayout,
   TransformElementLayoutParams,
@@ -111,32 +137,42 @@ export type {
 
 /**
  * useOnElementsMeasured()
+ * @group Hooks
  */
 export { useOnElementsMeasured } from './hooks/use-on-elements-measured';
+/** @group Types */
 export type { ElementsMeasuredParams, OnElementsMeasured } from './hooks/use-on-elements-measured';
 
 /**
  * useOnPaperEvents()
+ * @group Hooks
  */
 export { useOnPaperEvents } from './hooks/use-on-paper-events';
+/** @group Types */
 export type { PaperEventMap, PaperEventHandler } from './presets';
 
 /**
  * useOnGraphEvents()
+ * @group Hooks
  */
 export { useOnGraphEvents } from './hooks/use-on-graph-events';
+/** @group Types */
 export type { GraphEventMap } from './hooks/use-on-graph-events';
 
 /**
  * useCellDrag()
+ * @group Hooks
  */
 export { useCellDrag } from './hooks/use-cell-drag';
+/** @group Types */
 export type { CellDragState } from './hooks/use-cell-drag';
 
 /**
  * useMarkup()
+ * @group Hooks
  */
 export { useMarkup } from './hooks/use-markup';
+/** @group Types */
 export type { MarkupApi, MagnetRefOptions } from './hooks/use-markup';
 
 // Selectors
@@ -144,6 +180,7 @@ export type { MarkupApi, MagnetRefOptions } from './hooks/use-markup';
 
 /**
  * Cell selectors — pass to `useCell` / `useCells`
+ * @group Selectors
  */
 export {
   selectElementPosition,
@@ -162,6 +199,7 @@ export {
 
 /**
  * Cell types and utilities
+ * @group Types
  */
 export type {
   CellId,
@@ -174,17 +212,24 @@ export type {
 
 /**
  * Element types and utilities
+ * @group Types
  */
 export type { InferElement } from './utils/create';
+/** @group Presets */
 export { elementPort, elementPorts, elementAttributes } from './presets';
+/** @group Types */
 export type { ElementRecord, ElementPosition, ElementSize } from './types/cell.types';
+/** @group Types */
 export type { ElementPort, ElementPortShape } from './presets';
 
 /**
  * Link types and utilities
+ * @group Types
  */
 export type { InferLink } from './utils/create';
+/** @group Presets */
 export { resolveLinkMarker } from './theme/named-link-markers';
+/** @group Presets */
 export {
   linkRoutingStraight,
   linkRoutingOrthogonal,
@@ -212,7 +257,9 @@ export {
   linkMarkerOneOptional,
   linkMarkerOneOrMany,
 } from './presets';
+/** @group Types */
 export type { LinkRecord } from './types/cell.types';
+/** @group Types */
 export type {
   LinkStyle,
   LinkLabel,
@@ -223,6 +270,7 @@ export type {
   LinkRoutingOrthogonalOptions,
   LinkRoutingSmoothOptions,
 } from './presets';
+/** @group Types */
 export type { LinkMarkerName, LinkMarker } from './theme/named-link-markers';
 
 // MVC
@@ -230,8 +278,10 @@ export type { LinkMarkerName, LinkMarker } from './theme/named-link-markers';
 
 /**
  * Cell models
+ * @group MVC
  */
 export { ElementModel, ELEMENT_MODEL_TYPE } from './mvc/element-model';
+/** @group MVC */
 export { LinkModel, LINK_MODEL_TYPE } from './mvc/link-model';
 
 // Utilities
@@ -239,6 +289,7 @@ export { LinkModel, LINK_MODEL_TYPE } from './mvc/link-model';
 
 /**
  * jsx() - Utility to create JointJS markup from JSX syntax
+ * @group Utils
  */
 export { jsx } from './utils/joint-jsx/jsx-to-markup';
 
@@ -247,6 +298,8 @@ export { jsx } from './utils/joint-jsx/jsx-to-markup';
 
 /**
  * useLinkLayout()
+ * @group Hooks
  */
 export { useLinkLayout } from './hooks/use-link-layout';
+/** @group Types */
 export type { LinkLayout } from './types/cell.types';

--- a/packages/joint-react/src/mvc/element-model.tsx
+++ b/packages/joint-react/src/mvc/element-model.tsx
@@ -4,7 +4,7 @@ export const ELEMENT_MODEL_TYPE = 'element';
 
 /**
  * Selector for the `<g>` element used as the React portal target inside ElementModel markup.
- * @group Models
+ * @group MVC
  */
 export const PORTAL_SELECTOR = '__portal__';
 
@@ -12,7 +12,7 @@ export const PORTAL_SELECTOR = '__portal__';
  * Default element class used by `@joint/react`. Any `dia.Element` subclass
  * can host React content; `ElementModel` is just what `@joint/react` reaches
  * for when no custom class is provided.
- * @group Models
+ * @group MVC
  * @example
  * ```ts
  * import { ElementModel } from '@joint/react';

--- a/packages/joint-react/src/mvc/link-model.ts
+++ b/packages/joint-react/src/mvc/link-model.ts
@@ -11,7 +11,7 @@ const defaultLinkStyle: dia.Link.Attributes['attrs'] = linkStyle();
  * React content; `LinkModel` is just what `@joint/react` reaches for when no
  * custom class is provided. Ships wrapper + line markup with the default
  * link style applied.
- * @group Models
+ * @group MVC
  * @example
  * ```ts
  * import { LinkModel } from '@joint/react';

--- a/packages/joint-react/src/mvc/paper.types.ts
+++ b/packages/joint-react/src/mvc/paper.types.ts
@@ -17,6 +17,7 @@ import type { CellId } from '../types/cell.types';
  *   portalSelector = 'root';
  * }
  * ```
+ * @group Types
  */
 export interface PortalHostCell {
   /** Selector of the node inside the cell view where React content mounts. */
@@ -24,6 +25,7 @@ export interface PortalHostCell {
 }
 
 /** Context passed to a `PortalSelector` callback. */
+/** @group Types */
 export interface PortalSelectorParams {
   /** The cell model. Has a `portalSelector` field when it opts into portal rendering. */
   readonly model: dia.Cell & PortalHostCell;
@@ -44,6 +46,7 @@ export interface PortalSelectorParams {
  *   - an **`Element`** — use that DOM node directly,
  *   - **`null`** — skip rendering for this cell,
  *   - **`undefined`** (or no return) — fall back to joint-react's default selector.
+ * @group Types
  */
 export type PortalSelector =
   | string
@@ -52,6 +55,7 @@ export type PortalSelector =
 
 /**
  * Options for creating a PaperView instance with lifecycle callbacks.
+ * @group Types
  */
 export interface PaperViewOptions extends dia.Paper.Options {
   readonly onViewMountChange?: (changes: Map<CellId, IncrementalChange<dia.Cell>>) => void;

--- a/packages/joint-react/src/presets/anchors.ts
+++ b/packages/joint-react/src/presets/anchors.ts
@@ -40,7 +40,10 @@ export const perpendicularAnchor: anchors.Anchor = (
   return anchors.perpendicular(elementView, magnet, ref, _, endType, linkView);
 };
 
-/** Mode for the `midSide` anchor used on root elements and custom magnets. */
+/**
+ * Mode for the `midSide` anchor used on root elements and custom magnets.
+ * @group Types
+ */
 export type LinkMode = 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 'vertical' | 'auto' | 'top-bottom' | 'bottom-top' | 'left-right' | 'right-left';
 
 /**

--- a/packages/joint-react/src/presets/can-connect.ts
+++ b/packages/joint-react/src/presets/can-connect.ts
@@ -1,6 +1,7 @@
 import type { dia } from '@joint/core';
 
 /** Describes one end (source or target) of a connection. */
+/** @group Types */
 export interface ConnectionEnd {
   /** The cell ID. */
   readonly id: dia.Cell.ID;
@@ -15,6 +16,7 @@ export interface ConnectionEnd {
 }
 
 /** Structured context for connection validation. */
+/** @group Types */
 export interface ValidateConnectionParams {
   /** The source end of the connection. */
   readonly source: ConnectionEnd;
@@ -29,6 +31,7 @@ export interface ValidateConnectionParams {
 }
 
 /** Callback that decides whether a connection is allowed. */
+/** @group Types */
 export type ValidateConnection = (context: ValidateConnectionParams) => boolean;
 
 /**
@@ -132,6 +135,7 @@ function hasDuplicateLink(
 }
 
 /** Configuration accepted by `canConnect` controlling link validation rules. */
+/** @group Types */
 export interface CanConnectOptions {
   /** Allow connecting a cell to itself. @default false */
   readonly allowSelfLoops?: boolean;

--- a/packages/joint-react/src/presets/can-embed.ts
+++ b/packages/joint-react/src/presets/can-embed.ts
@@ -1,6 +1,7 @@
 import type { dia } from '@joint/core';
 
 /** Context passed to the `canEmbed` validate callback. */
+/** @group Types */
 export interface ValidateEmbeddingParams {
   /** The element being embedded (dragged). */
   readonly child: { readonly id: dia.Cell.ID; readonly model: dia.Element };
@@ -13,6 +14,7 @@ export interface ValidateEmbeddingParams {
 }
 
 /** Context passed to the `canUnembed` validate callback. */
+/** @group Types */
 export interface ValidateUnembeddingParams {
   /** The element being unembedded. */
   readonly child: { readonly id: dia.Cell.ID; readonly model: dia.Element };
@@ -23,9 +25,11 @@ export interface ValidateUnembeddingParams {
 }
 
 /** Callback that decides whether an element can be embedded into a parent. */
+/** @group Types */
 export type ValidateEmbedding = (context: ValidateEmbeddingParams) => boolean;
 
 /** Callback that decides whether an element can be unembedded from its parent. */
+/** @group Types */
 export type ValidateUnembedding = (context: ValidateUnembeddingParams) => boolean;
 
 /**

--- a/packages/joint-react/src/presets/cell-interactivity.ts
+++ b/packages/joint-react/src/presets/cell-interactivity.ts
@@ -1,9 +1,11 @@
 import type { dia } from '@joint/core';
 
 /** Name of an interaction being queried (e.g. `'elementMove'`, `'arrowheadMove'`). */
+/** @group Types */
 export type CellInteraction = keyof dia.CellView.InteractivityOptions;
 
 /** Context passed to an `interactive` callback. */
+/** @group Types */
 export interface CellInteractivityParams {
   /** The cell being interacted with. */
   readonly model: dia.Cell;
@@ -19,12 +21,14 @@ export interface CellInteractivityParams {
  * Function form of the `interactive` Paper prop. Receives a structured
  * context (instead of the native positional `(cellView, event)` form) and
  * returns either a boolean or the native `InteractivityOptions` object.
+ * @group Types
  */
 export type CellInteractivityCallback = (
   context: CellInteractivityParams
 ) => boolean | dia.CellView.InteractivityOptions;
 
 /** Value accepted by the `interactive` Paper prop. */
+/** @group Types */
 export type CellInteractivity =
   | boolean
   | dia.CellView.InteractivityOptions

--- a/packages/joint-react/src/presets/cell-visibility.ts
+++ b/packages/joint-react/src/presets/cell-visibility.ts
@@ -1,6 +1,7 @@
 import type { dia } from '@joint/core';
 
 /** Context passed to a `cellVisibility` callback. */
+/** @group Types */
 export interface CellVisibilityParams {
   /** The cell whose visibility is being queried. */
   readonly model: dia.Cell;
@@ -16,6 +17,7 @@ export interface CellVisibilityParams {
  * Predicate deciding whether a cell should be rendered. Receives a
  * structured context object (instead of the native positional form).
  * Return `false` to hide the cell.
+ * @group Types
  */
 export type CellVisibility = (context: CellVisibilityParams) => boolean;
 

--- a/packages/joint-react/src/presets/connection-strategy.ts
+++ b/packages/joint-react/src/presets/connection-strategy.ts
@@ -2,6 +2,7 @@ import type { dia, connectionStrategies } from '@joint/core';
 import { connectionStrategies as strategies } from '@joint/core';
 
 /** Structured context passed to a connection-strategy callback. */
+/** @group Types */
 export interface ConnectionStrategyParams {
   /** The end JSON to return — starts as the dropped-end definition (already pinned if `pin` was set). */
   readonly end: dia.Link.EndJSON;
@@ -22,9 +23,11 @@ export interface ConnectionStrategyParams {
 }
 
 /** Built-in pin mode — how the dropped end is stored. */
+/** @group Types */
 export type ConnectionStrategyPin = 'none' | 'absolute' | 'relative';
 
 /** Options for `connectionStrategy` — combines a pin mode with optional user customization. */
+/** @group Types */
 export interface ConnectionStrategyOptions {
   /**
    * How to pin the dropped end.
@@ -39,6 +42,7 @@ export interface ConnectionStrategyOptions {
 }
 
 /** Callback that decides how a dropped link end's JSON is stored. */
+/** @group Types */
 export type ConnectionStrategy = (context: ConnectionStrategyParams) => dia.Link.EndJSON;
 
 const PIN_STRATEGIES: Record<ConnectionStrategyPin, connectionStrategies.ConnectionStrategy> = {

--- a/packages/joint-react/src/presets/element-ports.ts
+++ b/packages/joint-react/src/presets/element-ports.ts
@@ -6,13 +6,14 @@ import type { LiteralUnion } from '../types/index';
  * - `'ellipse'` — ellipse
  * - `'rect'` — rectangle
  * - Any other string — interpreted as SVG path `d` commands
+ * @group Types
  */
 export type ElementPortShape = LiteralUnion<'ellipse' | 'rect'>;
 
 /**
  * Simplified port definition for declarative port configuration.
  * Converted to full JointJS port format by the element mapper.
- * @group Graph
+ * @group Presets
  */
 export interface ElementPort {
   /**

--- a/packages/joint-react/src/presets/link-labels.ts
+++ b/packages/joint-react/src/presets/link-labels.ts
@@ -3,7 +3,7 @@ import type { LiteralUnion } from '../types';
 
 /**
  * Simplified label definition for graph links.
- * @group Graph
+ * @group Presets
  */
 export interface LinkLabel {
   /** Label text content. */

--- a/packages/joint-react/src/presets/link-markers.tsx
+++ b/packages/joint-react/src/presets/link-markers.tsx
@@ -5,12 +5,14 @@ import { jsx } from '../utils/joint-jsx/jsx-to-markup';
  * A link marker record — an SVG complex marker JSON with an optional `length`
  * used by connection-point math to offset the line tip by the marker's visual footprint.
  * The built-in marker factories always set a `length`; inline user markers may omit it.
+ * @group Types
  */
 export interface LinkMarkerRecord extends dia.SVGComplexMarkerJSON {
   readonly length?: number;
 }
 
 /** Common options shared by every built-in link-marker factory. */
+/** @group Types */
 export interface LinkMarkerOptions {
   /** Unique ID for the marker. If not provided, a default ID will be generated based on the options. */
   /** Scale factor. Default: `1`. */

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -28,6 +28,7 @@ import {
  * Bundle of paper-level link defaults (router, connector, anchor, connection point)
  * produced by a routing preset like {@link linkRoutingStraight} or
  * {@link linkRoutingOrthogonal}.
+ * @group Types
  */
 export interface LinkRouting {
   readonly defaultRouter?: dia.Paper.Options['defaultRouter'];
@@ -50,6 +51,7 @@ interface BaseLinkOptions {
 }
 
 /** Options for {@link linkRoutingStraight}. */
+/** @group Types */
 export interface LinkRoutingStraightOptions extends BaseLinkOptions {
   /** Corner style at vertices. Default: `'point'`. */
   readonly cornerType?: 'point' | 'cubic' | 'line' | 'gap';
@@ -85,6 +87,7 @@ export function linkRoutingStraight(options: LinkRoutingStraightOptions = {}): L
 }
 
 /** Options for {@link linkRoutingOrthogonal}. */
+/** @group Types */
 export interface LinkRoutingOrthogonalOptions extends BaseLinkOptions {
   /** Corner style. Default: `'cubic'`. */
   readonly cornerType?: 'point' | 'cubic' | 'line' | 'gap';
@@ -146,6 +149,7 @@ export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}
 }
 
 /** Options for {@link linkRoutingSmooth}. */
+/** @group Types */
 export type LinkRoutingSmoothOptions = BaseLinkOptions;
 
 /**

--- a/packages/joint-react/src/presets/link-style.ts
+++ b/packages/joint-react/src/presets/link-style.ts
@@ -5,7 +5,7 @@ import { resolveLinkMarker, type LinkMarker } from '../theme/named-link-markers'
 /**
  * Visual/presentation attributes for a link line and its wrapper.
  * All properties are optional — empty strings let CSS variables from `theme.css` take over.
- * @group Graph
+ * @group Presets
  */
 export interface LinkStyle {
   /** Stroke color of the link line. Accepts any CSS color value including CSS variables. @default '' */

--- a/packages/joint-react/src/presets/paper-events.ts
+++ b/packages/joint-react/src/presets/paper-events.ts
@@ -52,33 +52,46 @@ type WithWheel<Params> = WithPointer<Params> & { readonly delta: number };
 // ============================================================================
 
 /** Pointer-style cell-level payload (down/move/up/click/dblclick/contextmenu). */
+/** @group Types */
 export type PointerCellEventParams = WithPointer<CellEventParams>;
 /** Pointer-style element-level payload. */
+/** @group Types */
 export type PointerElementEventParams = WithPointer<ElementEventParams>;
 /** Pointer-style link-level payload. */
+/** @group Types */
 export type PointerLinkEventParams = WithPointer<LinkEventParams>;
 /** Pointer-style blank-area payload — event + coords on empty paper area. */
+/** @group Types */
 export type PointerBlankEventParams = WithPointer<BaseContext>;
 
 /** Hover-style cell-level payload (mouseenter/leave/over/out). */
+/** @group Types */
 export type HoverCellEventParams = WithHover<CellEventParams>;
 /** Hover-style element-level payload. */
+/** @group Types */
 export type HoverElementEventParams = WithHover<ElementEventParams>;
 /** Hover-style link-level payload. */
+/** @group Types */
 export type HoverLinkEventParams = WithHover<LinkEventParams>;
 /** Hover-style blank-area payload — event only on empty paper area. */
+/** @group Types */
 export type HoverBlankEventParams = WithHover<BaseContext>;
 
 /** Wheel cell-level payload (mousewheel) — pointer + delta. */
+/** @group Types */
 export type WheelCellEventParams = WithWheel<CellEventParams>;
 /** Wheel element-level payload. */
+/** @group Types */
 export type WheelElementEventParams = WithWheel<ElementEventParams>;
 /** Wheel link-level payload. */
+/** @group Types */
 export type WheelLinkEventParams = WithWheel<LinkEventParams>;
 /** Wheel blank-area payload — pointer + delta on empty paper area. */
+/** @group Types */
 export type WheelBlankEventParams = WithWheel<BaseContext>;
 
 /** Magnet payload — element-only, pointer + magnet SVG node + port/selector. */
+/** @group Types */
 export type MagnetEventParams = WithPointer<ElementEventParams> & {
   readonly magnet: DOMElement;
   /** The port ID, or `null` if the magnet is not on a port. */
@@ -92,9 +105,11 @@ export type MagnetEventParams = WithPointer<ElementEventParams> & {
 // ============================================================================
 
 /** Paper-edge hover payload (`paper:mouseenter` / `paper:mouseleave`). */
+/** @group Types */
 export type PaperHoverEventParams = BaseContext & { readonly event: dia.Event };
 
 /** Paper-level pan payload — `paper:pan` from touchpad / wheel pan. */
+/** @group Types */
 export type PaperPanEventParams = BaseContext & {
   readonly event: dia.Event;
   readonly deltaX: number;
@@ -102,6 +117,7 @@ export type PaperPanEventParams = BaseContext & {
 };
 
 /** Paper-level pinch payload — `paper:pinch` from touchpad pinch gesture. */
+/** @group Types */
 export type PaperPinchEventParams = BaseContext & {
   readonly event: dia.Event;
   readonly x: number;
@@ -110,6 +126,7 @@ export type PaperPinchEventParams = BaseContext & {
 };
 
 /** `translate` payload — paper translation. */
+/** @group Types */
 export type TranslateEventParams = BaseContext & {
   readonly translateX: number;
   readonly translateY: number;
@@ -117,6 +134,7 @@ export type TranslateEventParams = BaseContext & {
 };
 
 /** `scale` payload — paper scale. */
+/** @group Types */
 export type ScaleEventParams = BaseContext & {
   readonly scaleX: number;
   readonly scaleY: number;
@@ -124,6 +142,7 @@ export type ScaleEventParams = BaseContext & {
 };
 
 /** `resize` payload — paper dimensions. */
+/** @group Types */
 export type ResizeEventParams = BaseContext & {
   readonly width: number;
   readonly height: number;
@@ -131,6 +150,7 @@ export type ResizeEventParams = BaseContext & {
 };
 
 /** `transform` payload — paper SVG transform matrix. */
+/** @group Types */
 export type TransformEventParams = BaseContext & {
   readonly matrix: SVGMatrix;
   readonly options: unknown;
@@ -144,6 +164,7 @@ export type TransformEventParams = BaseContext & {
  * `link:connect` / `link:disconnect` payload — the link + the cell at the
  * (dis)connected end as a {@link ConnectionEnd} (same shape used by
  * `validateConnection`, so the two stay symmetric).
+ * @group Types
  */
 export interface LinkConnectEventParams extends LinkEventParams {
   readonly event: dia.Event;
@@ -306,6 +327,7 @@ export const PAPER_EVENT_KEYS = new Set<string>([
  * `'translate'`, `'render:done'`, `'render:idle'`, `'cell:highlight'`,
  * `'cell:unhighlight'`, `'cell:highlight:invalid'`, `'link:snap:connect'`,
  * `'link:snap:disconnect'`.
+ * @group Types
  */
 export interface PaperEventHandlers {
   // pointer (cell — fires for any cell, element OR link)
@@ -387,11 +409,13 @@ export interface PaperEventHandlers {
  * Extracts the callback type for a given paper event key.
  * For example, `PaperEventHandler<'onCellPointerDown'>` is `(params: PointerCellEventParams) => void`.
  * Useful for typing individual handler variables or parameters.
+ * @group Types
  */
 export type PaperEventHandler<T extends keyof PaperEventHandlers> = NonNullable<PaperEventHandlers[T]>;
 
 /**
  * Combined handlers — camelCase `on*` + raw native — accepted by `addPaperEventListeners`.
+ * @group Types
  */
 export type PaperEventMap = Partial<dia.Paper.EventMap> & PaperEventHandlers;
 

--- a/packages/joint-react/src/selectors/cell-selectors.ts
+++ b/packages/joint-react/src/selectors/cell-selectors.ts
@@ -13,6 +13,7 @@ import type { CellId, CellRecord, ElementRecord, Computed } from '../types/cell.
 
 /**
  * Reads `element.position`. Stable ref while the element doesn't move.
+ * @group Selectors
  * @param element
  */
 export function selectElementPosition(element: Computed<ElementRecord>) {
@@ -21,6 +22,7 @@ export function selectElementPosition(element: Computed<ElementRecord>) {
 
 /**
  * Reads `element.size`. Stable ref while the element isn't resized.
+ * @group Selectors
  * @param element
  */
 export function selectElementSize(element: Computed<ElementRecord>) {
@@ -29,6 +31,7 @@ export function selectElementSize(element: Computed<ElementRecord>) {
 
 /**
  * Reads `element.angle`.
+ * @group Selectors
  * @param element
  */
 export function selectElementAngle(element: Computed<ElementRecord>): number {
@@ -39,6 +42,7 @@ export function selectElementAngle(element: Computed<ElementRecord>): number {
  * Reads `element.data` typed as `ElementData`. Pass the type as an
  * instantiation: `useCell(selectElementData<NodeData>)` — TypeScript
  * propagates `NodeData` through to the hook's `Selected` inference.
+ * @group Selectors
  * @param element
  */
 export function selectElementData<ElementData = unknown>(
@@ -51,12 +55,14 @@ export function selectElementData<ElementData = unknown>(
 
 /**
  * Reads `cell.id`. Note: `useCellId()` is cheaper when only the id is needed.
+ * @group Selectors
  * @param cell
  */
 export const selectCellId = (cell: Computed<CellRecord>) => cell.id;
 
 /**
  * Reads `cell.type` (e.g. `'element'`, `'link'`, or a built-in JointJS type).
+ * @group Selectors
  * @param cell
  */
 export const selectCellType = (cell: Computed<CellRecord>) => cell.type;
@@ -66,6 +72,7 @@ export const selectCellType = (cell: Computed<CellRecord>) => cell.type;
  * for top-level cells). The field lives on the record's index signature,
  * so we narrow it here for callers. Works for both elements and links —
  * any cell can be embedded.
+ * @group Selectors
  * @param cell
  */
 export const selectCellParent = (cell: Computed<CellRecord>): CellId | null =>
@@ -74,6 +81,7 @@ export const selectCellParent = (cell: Computed<CellRecord>): CellId | null =>
 /**
  * Reads the `layer` field — name of the JointJS layer the cell renders into,
  * or undefined when the cell uses the paper's default layer.
+ * @group Selectors
  * @param cell
  */
 export const selectCellLayer = (cell: Computed<CellRecord>): string | null =>
@@ -82,6 +90,7 @@ export const selectCellLayer = (cell: Computed<CellRecord>): string | null =>
 /**
  * Reads the `z` field — JointJS z-index (paint order within a layer).
  * Undefined when the cell hasn't been assigned an explicit z-index.
+ * @group Selectors
  * @param cell
  */
 export const selectCellZIndex = (cell: Computed<CellRecord>): number =>

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -21,11 +21,13 @@ const DEFAULT_OBSERVER_OPTIONS: ResizeObserverOptions = { box: 'border-box' };
 const EPSILON = 0.5;
 
 /** Element layout where width/height are required but x/y may be omitted. */
+/** @group Types */
 export type ElementLayoutOptionalXY = Pick<ElementLayout, 'width' | 'height'> &
   Partial<Pick<ElementLayout, 'x' | 'y'>>;
 
 /**
  * Options passed to the setSize callback when an element's size changes.
+ * @group Types
  */
 export interface TransformElementLayoutParams extends Required<ElementLayout> {
   /** The JointJS element instance */
@@ -36,11 +38,13 @@ export interface TransformElementLayoutParams extends Required<ElementLayout> {
 /**
  * Callback function called when an element's size is measured.
  * Allows custom handling of size updates before they're applied to the graph.
+ * @group Types
  */
 export type TransformElementLayout = (params: TransformElementLayoutParams) => ElementLayoutOptionalXY;
 
 /**
  * Options for registering an element to be measured for size changes.
+ * @group Types
  */
 export interface SetMeasuredNodeOptions {
   /** The DOM node (HTML or SVG) to observe for size changes */
@@ -80,6 +84,7 @@ interface Options {
  * Observer interface for tracking element size changes.
  * Uses ResizeObserver to automatically detect when DOM elements change size
  * and updates the corresponding graph elements.
+ * @group Types
  */
 export interface GraphStoreObserver {
   /**

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -5,6 +5,7 @@ import { asReadonlyContainer, createContainer } from './state-container';
 import { writeCellToContainer } from '../state/data-mapping/cell-record-merge';
 
 /** Incremental change set emitted by graphProjection after container commits. */
+/** @group Types */
 export interface IncrementalCellsChange<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
@@ -15,6 +16,7 @@ export interface IncrementalCellsChange<
 }
 /**
  * Callback type for incremental cell changes. Emitted after each graph change batch
+ * @group Types
  */
 export type OnIncrementalCellsChange<Element extends ElementJSONInit, Link extends LinkJSONInit> = (
   changes: IncrementalCellsChange<Element, Link>
@@ -180,6 +182,7 @@ export function graphProjection<
 /* eslint-enable sonarjs/cognitive-complexity */
 
 /** Controller returned by {@link graphProjection}. */
+/** @group Types */
 export type GraphProjection<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -35,6 +35,7 @@ export const DEFAULT_CELL_NAMESPACE: Record<string, unknown> = {
 /**
  * Paper snapshot is a simple version counter.
  * Incremented on every view mount/unmount change to trigger React re-renders.
+ * @group Types
  */
 export interface PaperStoreState {
   readonly version: number;
@@ -43,6 +44,7 @@ export interface PaperStoreState {
 
 /**
  * Full internal snapshot of the graph store.
+ * @group Types
  */
 export interface GraphStoreInternalSnapshot {
   readonly papers: Record<string, PaperStoreState>;
@@ -66,11 +68,13 @@ export interface GraphStoreInternalSnapshot {
  *
  * Only affects writes from the `useMeasureElement` pipeline. Manual `cell.resize()`,
  * interactive resize tools, and direct `cell.set('size', ...)` calls are unaffected.
+ * @group Types
  */
 export type AutoSizeOrigin = 'top-left' | 'center';
 
 /**
  * Options for creating a `GraphStore` in controlled mode. Requires the full cells
+ * @group Types
  */
 export interface GraphStoreOptions<
   Element extends ElementJSONInit = ElementJSONInit,

--- a/packages/joint-react/src/theme/named-link-markers.tsx
+++ b/packages/joint-react/src/theme/named-link-markers.tsx
@@ -21,10 +21,12 @@ export const namedLinkMarkers = {
 } as const satisfies Record<string, LinkMarkerRecord | null>;
 
 /** Keys of the built-in `namedLinkMarkers` registry (e.g. `'arrow'`, `'circle'`). */
+/** @group Types */
 export type LinkMarkerName = keyof typeof namedLinkMarkers;
 
 /**
  * A named preset or a custom {@link LinkMarkerRecord}.
+ * @group Types
  */
 export type LinkMarker = LinkMarkerName | LinkMarkerRecord;
 

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -16,6 +16,7 @@ import type { ElementPresetAttributes } from '../presets/element-attributes';
  * + an explicit `data?: unknown` declaration that narrows the
  * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
  * the upper-bound layer.
+ * @group Types
  */
 export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttributes {
   data?: unknown;
@@ -26,6 +27,7 @@ export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttri
  * + an explicit `data?: unknown` declaration that narrows the
  * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
  * the upper-bound layer.
+ * @group Types
  */
 export interface LinkJSONInit extends DiaLink.JSONInit, LinkPresetAttributes {
   data?: unknown;
@@ -47,6 +49,7 @@ type WithData<Data = unknown> = unknown extends Data
  * Element-flavored cell; default `Type = typeof ELEMENT_MODEL_TYPE` so
  * `cell.type === 'element'` narrows. Override `Type` (e.g.
  * `'standard.Rectangle'`) for built-in or custom shapes.
+ * @group Types
  */
 export type ElementRecord<
   ElementData = unknown,
@@ -74,6 +77,7 @@ type InternalElementRecord<ElementData = unknown> = PickRequired<
  * Link-flavored cell; default `Type = typeof LINK_MODEL_TYPE` so
  * `cell.type === 'link'` narrows. Override `Type` (e.g. `'standard.Link'`)
  * for built-in or custom shapes.
+ * @group Types
  */
 export type LinkRecord<
   LinkData = unknown,
@@ -103,6 +107,7 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
  * `cell.type === 'element'` narrows correctly inside arrays / hooks. For
  * mixed built-in shape arrays with typed data, build the union manually:
  * `ElementRecord<MyData, 'standard.Rectangle'> | LinkRecord<MyData, 'standard.Link'>`.
+ * @group Types
  */
 export type CellRecord<
   ElementData = unknown,
@@ -118,6 +123,7 @@ export type CellRecord<
  * Use when you don't care about React-default `'element'` / `'link'`
  * discrimination (e.g. `initialCells` arrays mixing built-in shape types,
  * generic upper bounds in custom hooks).
+ * @group Types
  */
 export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
 
@@ -149,6 +155,7 @@ export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
  * ```ts
  * useCell((el: Computed<ElementRecord<MyData>>) => el.data.label);
  * ```
+ * @group Types
  */
 export type Computed<T> =
   T extends ElementRecord<infer ElementData>
@@ -164,14 +171,17 @@ export type Computed<T> =
 /** Short alias for cell ids; same as dia.Cell.ID. */
 // Future cleanup: drop this alias and use `dia.Cell.ID` directly everywhere.
 // It doesn't add anything and creates an extra import to keep in sync.
+/** @group Types */
 export type CellId = DiaCell.ID;
 
 // ── Element Layout Aliases ──────────────────────────────────────────────────
 
 /** Position of an element — alias for `dia.Point`. */
+/** @group Types */
 export type ElementPosition = DiaPoint;
 
 /** Size of an element — alias for `dia.Size`. */
+/** @group Types */
 export type ElementSize = DiaSize;
 
 // ── Element Layout (internal — used by size observer) ───────────────────────
@@ -179,6 +189,7 @@ export type ElementSize = DiaSize;
 /**
  * Flat element layout used internally by the size observer and transform callbacks.
  * @internal
+ * @group Types
  */
 export interface ElementLayout {
   readonly x: number;
@@ -194,6 +205,7 @@ export interface ElementLayout {
  * Layout data for a single link on a specific paper.
  * Contains source/target endpoint coordinates and the SVG path data.
  * @internal
+ * @group Types
  */
 export interface LinkLayout {
   readonly sourceX: number;
@@ -209,6 +221,7 @@ export interface LinkLayout {
  * initialCells, collection setter, etc.).
  * @template Element - element record shape
  * @template Link - link record shape
+ * @group Types
  */
 export type CellInput<
   Element extends ElementJSONInit = ElementJSONInit,
@@ -216,4 +229,5 @@ export type CellInput<
 > = Element | Link | DiaCell;
 
 /** Re-export of JointJS core's `dia.Graph.CellRef` — cell id or dia.Cell instance. */
+/** @group Types */
 export type CellRef = DiaGraph.CellRef;

--- a/packages/joint-react/src/types/paper.types.ts
+++ b/packages/joint-react/src/types/paper.types.ts
@@ -5,5 +5,6 @@ import type { dia } from '@joint/core';
  * Identifies a Paper instance — a registered id, a React ref, or the Paper
  * itself. Paper-targeting hooks never throw; an unresolved target simply means
  * "use the current Paper context or the default paper".
+ * @group Types
  */
 export type PaperTarget = string | RefObject<dia.Paper | null> | dia.Paper;

--- a/packages/joint-react/src/utils/test-wrappers.tsx
+++ b/packages/joint-react/src/utils/test-wrappers.tsx
@@ -11,7 +11,7 @@ import type { CellRecord } from '../types/cell.types';
  * Testing helper to create a new JointJS graph instance.
  * @returns A new JointJS graph.
  * @internal
- * @group utils
+ * @group Utils
  */
 export function getTestGraph() {
   return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
@@ -21,7 +21,7 @@ export function getTestGraph() {
  * @param props - Props forwarded to the `GraphProvider` root component.
  * @returns A component that wraps children with `GraphProvider`.
  * @internal
- * @group utils
+ * @group Utils
  */
 export function graphProviderWrapper(props: GraphProviderProps): React.JSXElementConstructor<{
   children: React.ReactNode;
@@ -42,7 +42,7 @@ interface Options {
  * @param options.graphProps - Props for the `GraphProvider` root.
  * @returns A component that wraps children inside `GraphProvider` + `Paper`.
  * @internal
- * @group utils
+ * @group Utils
  */
 export function paperRenderElementWrapper(options: Options): React.JSXElementConstructor<{
   children: React.ReactNode;
@@ -90,7 +90,7 @@ export const simpleRenderElementWrapper = paperRenderElementWrapper({
  * @param options.graphProviderProps - Props for the `GraphProvider` root.
  * @returns A component that wraps children inside `GraphProvider` + `Paper` with renderLink.
  * @internal
- * @group utils
+ * @group Utils
  */
 export function paperRenderLinkWrapper(options: Options): React.JSXElementConstructor<{
   children: React.ReactNode;

--- a/packages/joint-react/src/utils/typed-react.ts
+++ b/packages/joint-react/src/utils/typed-react.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 /**
  * Sugar around React.memo to avoid the need to specify the type of the component.
- * @group utils
+ * @group Utils
  */
 // There is an issue with Typescript when Component has generic Props
 // see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37087

--- a/packages/joint-react/typedoc.json
+++ b/packages/joint-react/typedoc.json
@@ -22,6 +22,8 @@
     "namedLinkMarkers",
     "ElementJSONInit",
     "LinkJSONInit",
+    "SetCellData",
+    "HandleCellData",
     "GraphStore",
     "PaperView",
     "PaperEventHandlers",

--- a/packages/joint-react/typedoc.json
+++ b/packages/joint-react/typedoc.json
@@ -7,7 +7,7 @@
   "excludeProtected": true,
   "excludeExternals": true,
   "excludeNotDocumented": false,
-  "groupOrder": ["Components", "Hooks", "Models", "Utils", "*"],
+  "groupOrder": ["Components", "Hooks", "Selectors", "Presets", "MVC", "Types", "Utils", "*"],
   "gitRevision": "master",
   "customCss": "typedoc.css",
   "plugin": ["typedoc-github-theme"],


### PR DESCRIPTION
## Summary

`yarn docs:typedoc` rendered most exports under typedoc's default buckets (`Functions`, `Interfaces`, `Type Aliases`, `Variables`) because only a handful of items carried `@group` tags. This PR:

- Renames the `Models` group to **MVC**.
- Adds three new groups: **Selectors**, **Presets**, **Types**.
- Tags every public export at its source with the right `@group`, so the rendered API page now organizes around the actual library structure.

## Group order

```json
"groupOrder": ["Components", "Hooks", "Selectors", "Presets", "MVC", "Types", "Utils", "*"]
```

## Distribution after this PR

| Group | Count |
|---|---|
| Components | 5 |
| Hooks | 13 |
| Selectors | 9 |
| Presets | 32 |
| MVC | 4 |
| Types | 68 |
| Utils | 3 |
| _(default fallthrough)_ | 0 |

## Renames at source

- `@group Models` → `@group MVC` (`src/mvc/*`)
- `@group utils` → `@group Utils` (`src/utils/*`)
- `@group Graph` → `@group Presets` (`src/presets/element-ports.ts`, `link-style.ts`, `link-labels.ts`)

## Test plan

- [x] `yarn docs:typedoc` — 0 errors, 0 warnings
- [x] `yarn typecheck` — clean
- [x] `yarn jest` — 975/975 passing
- [ ] Spot-check rendered `docs/api/index.html` — every export lands in the expected section, no leftover default buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)