### PR TITLE
docs(react): markdown typedoc config + API docs polish for docs site

### DIFF
--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -50,7 +50,7 @@
     "lint-fix": "yarn run lint --fix",
     "format": "prettier --write \"./**/*.{js,jsx,json,ts,tsx}\"",
     "docs:typedoc": "typedoc --router group --out docs/api src",
-    "docs:typedoc-md": "typedoc --plugin typedoc-plugin-markdown --router group --out docs/api-md src",
+    "docs:typedoc-md": "typedoc --options typedoc.config.mjs",
     "bench": "jest --selectProjects default --testMatch '<rootDir>/bench/**/*.{test,spec}.ts?(x)'"
   },
   "exports": {

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -11,6 +11,7 @@ import type { AnyCellRecord, CellId, CellRecord, Computed } from '../types/cell.
  *
  * Throws when used outside of a Paper render context, or when the id no longer
  * resolves to a cell in the store (e.g. deleted mid-render).
+ * @title Read the current cell
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  * @group Hooks
@@ -21,6 +22,7 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(): Ce
  * only when `isEqual(prev, next)` returns false.
  *
  * Throws if no cell resolves, never returns `undefined`.
+ * @title Select from the current cell
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `Cell`)
  * @param selector - derive a value from the current resolved cell record
@@ -37,6 +39,7 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>, Selec
  *
  * Cannot be unified with the `(selector)` overload because the argument type
  * (`CellId` vs function) drives the return shape (record vs selected value).
+ * @title Read a cell by id
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns the resolved cell record
@@ -49,6 +52,7 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * Subscribe to a specific cell by id and derive a value from it. Works
  * anywhere, does not require `CellIdContext`. Throws when the id does not
  * resolve to a cell.
+ * @title Select from a cell by id
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `Cell`)
  * @param id - cell id to track

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -107,6 +107,7 @@ function computeNext<Cell extends AnyCellRecord, Selected>(
  * (`add`/`remove`/`reset`) and reads cell records from the GraphProvider's
  * container. Cells not in the graph (e.g. `ui.Clipboard` clones) fall back to
  * the collection's own `dia.Cell` instances, converted to records on demand.
+ * @title Subscribe to a collection
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param collection - JointJS collection whose member IDs drive the subscription
  * @returns readonly resolved cells array filtered by collection membership
@@ -118,6 +119,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
 ): readonly Cell[];
 /**
  * Subscribe to a collection's cells with a selector.
+ * @title Select from a collection
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type
  * @param collection - JointJS collection whose member IDs drive the subscription
@@ -138,12 +140,14 @@ export function useCells<
  *
  * Returned array reference is stable across data-only mutations (the internal
  * container mutates items in-place). Size changes produce a new snapshot token.
+ * @title Subscribe to all cells
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns readonly resolved cells array
  */
 export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(): readonly Cell[];
 /**
  * Subscribe to a single cell by id.
+ * @title Subscribe to a cell by id
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns current resolved cell, or undefined when missing
@@ -156,6 +160,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * only to that id so unrelated mutations don't trigger re-renders. A nullish
  * `id` resolves to no cell, so the selector runs against `undefined`, handy
  * for optional selection state (`useCells(selectedId, ...)`) with no `?? ''`.
+ * @title Select from a cell by id
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `Cell | undefined`)
  * @param id - cell id to track (nullish → selector receives `undefined`)
@@ -176,6 +181,7 @@ export function useCells<
  * (not the full container) so unrelated mutations don't trigger re-renders.
  * Returns the picked cells in the order they appear in `ids`; missing ids
  * are skipped. The array reference is stable when no picked cell changed.
+ * @title Subscribe to specific cells
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param ids - cell ids to track
  * @returns array of resolved cells (only those that exist; missing ids are skipped)
@@ -187,6 +193,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
 /**
  * Subscribe to a specific set of cells by id and derive a value from them.
  * Subscribes only to those ids; the selector receives the picked cells array.
+ * @title Select from specific cells
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `readonly Cell[]`)
  * @param ids - cell ids to track
@@ -205,6 +212,7 @@ export function useCells<
 ): Selected;
 /**
  * Subscribe via a selector. Runs on every commit; return equal values to skip re-render.
+ * @title Subscribe via a selector
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `readonly Cell[]`)
  * @param selector - derive a value from the resolved cells array

--- a/packages/joint-react/src/hooks/use-on-elements-measured.ts
+++ b/packages/joint-react/src/hooks/use-on-elements-measured.ts
@@ -32,6 +32,7 @@ export type OnElementsMeasured = (params: ElementsMeasuredParams) => void;
  *
  * The callback receives `{ isInitial: boolean }` to distinguish the
  * first measurement from subsequent ones.
+ * @title On the current paper
  * @param callback - Called each time element sizes are measured.
  * @group Hooks
  * @example
@@ -44,6 +45,13 @@ export type OnElementsMeasured = (params: ElementsMeasuredParams) => void;
  * ```
  */
 export function useOnElementsMeasured(callback: OnElementsMeasured): void;
+/**
+ * Calls a callback when element sizes are measured, on a specific paper.
+ * @title On a specific paper
+ * @param paperTarget - Paper reference (string ID, dia.Paper instance, or ref).
+ * @param callback - Called each time element sizes are measured.
+ * @group Hooks
+ */
 export function useOnElementsMeasured(paperTarget: PaperTarget, callback: OnElementsMeasured): void;
 export function useOnElementsMeasured(
   paperTargetOrCallback: PaperTarget | OnElementsMeasured,

--- a/packages/joint-react/src/hooks/use-on-graph-events.ts
+++ b/packages/joint-react/src/hooks/use-on-graph-events.ts
@@ -38,6 +38,8 @@ function subscribeToGraphEvents(graph: dia.Graph, handlers: GraphEventMap): () =
 
 /**
  * The map of graph events to handlers accepted by {@link useOnGraphEvents}.
+ * See [JointJS graph events](https://docs.jointjs.com/api/dia/Graph#events)
+ * for the available event names and their arguments.
  * @group Types
  */
 export type GraphEventMap = Partial<dia.Graph.EventMap>;
@@ -49,6 +51,7 @@ export type GraphEventMap = Partial<dia.Graph.EventMap>;
  * each event reads the current handler, so inline maps and closures need no
  * `useCallback`. Re-subscription happens only when the graph or the set of
  * event names changes.
+ * @title On the current graph
  * @param handlers - Event handlers map keyed by JointJS graph event names.
  * @group Hooks
  * @example
@@ -63,6 +66,7 @@ export type GraphEventMap = Partial<dia.Graph.EventMap>;
 export function useOnGraphEvents(handlers: GraphEventMap): void;
 /**
  * Subscribes to graph events on the given graph instance.
+ * @title On a specific graph
  * @param graph - Graph instance to subscribe on.
  * @param handlers - Event handlers map keyed by JointJS graph event names.
  * @group Hooks

--- a/packages/joint-react/src/hooks/use-on-paper-events.ts
+++ b/packages/joint-react/src/hooks/use-on-paper-events.ts
@@ -54,12 +54,14 @@ export function subscribeToPaperEvents(
  * The `on*` params object omits the React-store `record`, to read the
  * record shape, call `useCell(id, selector)` from your own
  * component (the handler closure has access to the `id` it emits).
+ * @title On the current paper
  * @param handlers - Event handlers map.
  * @group Hooks
  */
 export function useOnPaperEvents(handlers: PaperEventMap): void;
 /**
  * Subscribes to paper events on the given paper target.
+ * @title On a specific paper
  * @param paperTarget - Paper reference (string ID, dia.Paper instance, or ref).
  * @param handlers - Event handlers map.
  * @group Hooks

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -26,6 +26,18 @@ export interface ElementAttributes extends dia.Element.Attributes, ElementPreset
  * supplied.
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.
+ * @example
+ * ```tsx
+ * import { elementAttributes } from '@joint/react';
+ *
+ * const attrs = elementAttributes({
+ *   type: 'standard.Rectangle',
+ *   position: { x: 10, y: 20 },
+ *   size: { width: 120, height: 40 },
+ *   // React-preset shorthand: declarative ports
+ *   portMap: { in: { color: '#fff', cx: 0, cy: 0.5 } },
+ * });
+ * ```
  * @group Presets
  */
 export function elementAttributes(element: ElementAttributes): dia.Element.Attributes {

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -27,16 +27,36 @@ export interface ElementAttributes extends dia.Element.Attributes, ElementPreset
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.
  * @example
+ * Expand the declarative preset input into native attributes and hand them to
+ * a cell model:
  * ```tsx
- * import { elementAttributes } from '@joint/react';
+ * import { ElementModel, elementAttributes } from '@joint/react';
  *
- * const attrs = elementAttributes({
- *   type: 'standard.Rectangle',
- *   position: { x: 10, y: 20 },
- *   size: { width: 120, height: 40 },
- *   // React-preset shorthand: declarative ports
- *   portMap: { in: { color: '#fff', cx: 0, cy: 0.5 } },
- * });
+ * const element = new ElementModel(
+ *   elementAttributes({
+ *     type: 'standard.Rectangle',
+ *     position: { x: 10, y: 20 },
+ *     size: { width: 120, height: 40 },
+ *     portMap: { in: { color: '#fff', cx: 0, cy: 0.5 } }, // preset shorthand
+ *   })
+ * );
+ * ```
+ * @example
+ * Or build the defaults of a custom cell model class:
+ * ```tsx
+ * import { ElementModel, elementAttributes } from '@joint/react';
+ *
+ * class RectShape extends ElementModel {
+ *   defaults() {
+ *     return {
+ *       ...super.defaults(),
+ *       ...elementAttributes({
+ *         type: 'standard.Rectangle',
+ *         size: { width: 120, height: 40 },
+ *       }),
+ *     };
+ *   }
+ * }
  * ```
  * @group Presets
  */

--- a/packages/joint-react/src/presets/element-ports.ts
+++ b/packages/joint-react/src/presets/element-ports.ts
@@ -83,7 +83,7 @@ const defaultPortStyle = {
  *
  * When `cx`/`cy` are provided, the port uses absolute positioning.
  * When omitted, position is left to the port group (e.g. `'left'`, `'right'`).
- * @param port
+ * @param port - the simplified port definition to convert
  * @example
  * ```ts
  * // Absolute positioned
@@ -185,8 +185,8 @@ const PORT_GROUP = 'main';
 /**
  * Converts a record of simplified ElementPort definitions to the full JointJS ports object.
  * Each port gets absolute positioning under the `'main'` group.
- * @param ports
- * @param portStyle
+ * @param ports - map of port id to port definition
+ * @param portStyle - optional style merged into every port
  * @example
  * ```ts
  * elementPorts({ out: { cx: 'calc(w)', cy: 'calc(h/2)' } })

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -32,16 +32,19 @@ export interface LinkAttributes extends dia.Link.Attributes, LinkPresetAttribute
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
  * @example
+ * Expand the declarative preset input into native attributes and hand them to
+ * a cell model:
  * ```tsx
- * import { linkAttributes } from '@joint/react';
+ * import { LinkModel, linkAttributes } from '@joint/react';
  *
- * const attrs = linkAttributes({
- *   source: { id: 'a' },
- *   target: { id: 'b' },
- *   // React-preset shorthand: line style + labels
- *   style: { color: '#333', width: 2 },
- *   labelMap: { mid: { text: 'edge', position: 0.5 } },
- * });
+ * const link = new LinkModel(
+ *   linkAttributes({
+ *     source: { id: 'a' },
+ *     target: { id: 'b' },
+ *     style: { color: '#333', width: 2 },           // preset shorthand
+ *     labelMap: { mid: { text: 'edge', position: 0.5 } },
+ *   })
+ * );
  * ```
  * @group Presets
  */

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -31,6 +31,18 @@ export interface LinkAttributes extends dia.Link.Attributes, LinkPresetAttribute
  * - Both `labelMap` and `labels` → throws.
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
+ * @example
+ * ```tsx
+ * import { linkAttributes } from '@joint/react';
+ *
+ * const attrs = linkAttributes({
+ *   source: { id: 'a' },
+ *   target: { id: 'b' },
+ *   // React-preset shorthand: line style + labels
+ *   style: { color: '#333', width: 2 },
+ *   labelMap: { mid: { text: 'edge', position: 0.5 } },
+ * });
+ * ```
  * @group Presets
  */
 export function linkAttributes(link: LinkAttributes): dia.Link.Attributes {

--- a/packages/joint-react/src/presets/link-labels.ts
+++ b/packages/joint-react/src/presets/link-labels.ts
@@ -59,7 +59,7 @@ const defaultLabelStyle = {
 /**
  * Converts a simplified `LinkLabel` (text, color, position, …) into the JSON
  * shape JointJS expects in `link.labels`.
- * @param label
+ * @param label - the simplified link label to convert
  * @example
  * ```ts
  * linkLabel({ text: 'Hello', color: '#333', position: 0.5 })
@@ -159,8 +159,8 @@ export function linkLabel(label: LinkLabel): dia.Link.Label {
 
 /**
  * Converts a record of simplified LinkLabel definitions to an array of JointJS labels.
- * @param labels
- * @param labelStyle
+ * @param labels - map of label name to label definition
+ * @param labelStyle - optional style merged into every label
  * @example
  * ```ts
  * linkLabels({ main: { text: 'Hello', fontSize: 12 } })

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -66,7 +66,7 @@ export interface LinkRoutingStraightOptions extends BaseLinkOptions {
 /**
  * Straight-line links between elements.
  * The shortest path with no routing, a single line from source to target.
- * @param options
+ * @param options - straight routing options
  * @group Presets
  */
 export function linkRoutingStraight(options: LinkRoutingStraightOptions = {}): LinkRouting {
@@ -107,7 +107,7 @@ export interface LinkRoutingOrthogonalOptions extends BaseLinkOptions {
 /**
  * Orthogonal (right-angle) links between elements.
  * Routes links with horizontal and vertical segments only, avoiding element overlap.
- * @param options
+ * @param options - orthogonal routing options
  * @group Presets
  */
 export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}): LinkRouting {
@@ -163,7 +163,7 @@ export type LinkRoutingSmoothOptions = BaseLinkOptions;
 /**
  * Smooth curved links between elements.
  * Renders links as bezier curves for a softer, more organic look.
- * @param options
+ * @param options - smooth routing options
  * @group Presets
  */
 export function linkRoutingSmooth(options: LinkRoutingSmoothOptions = {}): LinkRouting {

--- a/packages/joint-react/src/presets/link-style.ts
+++ b/packages/joint-react/src/presets/link-style.ts
@@ -50,7 +50,7 @@ const defaultLinkStyle: Readonly<Required<LinkStyle>> = {
  * SVG attributes for the link's visible line, derived from a `LinkStyle`.
  * Resolves stroke color/width, source/target markers, dash pattern, and the
  * `line` selector's CSS class.
- * @param style
+ * @param style - link style to convert to SVG attributes
  * @group Presets
  */
 export function linkStyleLine(style: LinkStyle = {}): Nullable<attributes.SVGAttributes> {
@@ -106,7 +106,7 @@ export function linkStyleLine(style: LinkStyle = {}): Nullable<attributes.SVGAtt
 /**
  * SVG attributes for the link's hit-area (the invisible wrapper around the
  * visible line, used for pointer interaction), derived from a `LinkStyle`.
- * @param style
+ * @param style - link style to convert to SVG attributes
  * @group Presets
  */
 export function linkStyleWrapper(style: LinkStyle = {}): Nullable<attributes.SVGAttributes> {
@@ -132,7 +132,7 @@ export function linkStyleWrapper(style: LinkStyle = {}): Nullable<attributes.SVG
 
 /**
  * Converts a `LinkStyle` into JointJS SVG `attrs` for `line` and `wrapper` selectors.
- * @param style
+ * @param style - link style to convert to SVG attributes
  * @example
  * ```ts
  * const attrs = linkStyle({ color: '#333', width: 2, targetMarker: 'arrow' });

--- a/packages/joint-react/src/selectors/cell-selectors.ts
+++ b/packages/joint-react/src/selectors/cell-selectors.ts
@@ -14,7 +14,7 @@ import type { CellId, CellRecord, ElementRecord, Computed } from '../types/cell.
 /**
  * Reads `element.position`. Stable ref while the element doesn't move.
  * @group Selectors
- * @param element
+ * @param element - the resolved element record
  * @example
  * ```tsx
  * const { x, y } = useCell(elementId, selectElementPosition);
@@ -27,7 +27,7 @@ export function selectElementPosition(element: Computed<ElementRecord>) {
 /**
  * Reads `element.size`. Stable ref while the element isn't resized.
  * @group Selectors
- * @param element
+ * @param element - the resolved element record
  * @example
  * ```tsx
  * const { width, height } = useCell(elementId, selectElementSize);
@@ -40,7 +40,7 @@ export function selectElementSize(element: Computed<ElementRecord>) {
 /**
  * Reads `element.angle`.
  * @group Selectors
- * @param element
+ * @param element - the resolved element record
  * @example
  * ```tsx
  * const angle = useCell(elementId, selectElementAngle);
@@ -55,7 +55,7 @@ export function selectElementAngle(element: Computed<ElementRecord>): number {
  * instantiation: `useCell(selectElementData<NodeData>)`, TypeScript
  * propagates `NodeData` through to the hook's `Selected` inference.
  * @group Selectors
- * @param element
+ * @param element - the resolved element record
  * @example
  * ```tsx
  * type NodeData = { label: string };
@@ -73,7 +73,7 @@ export function selectElementData<ElementData = unknown>(
 /**
  * Reads `cell.id`. Note: `useCellId()` is cheaper when only the id is needed.
  * @group Selectors
- * @param cell
+ * @param cell - the resolved cell record
  * @example
  * ```tsx
  * const id = useCell(selectCellId);
@@ -84,7 +84,7 @@ export const selectCellId = (cell: Computed<CellRecord>) => cell.id;
 /**
  * Reads `cell.type` (e.g. `'element'`, `'link'`, or a built-in JointJS type).
  * @group Selectors
- * @param cell
+ * @param cell - the resolved cell record
  * @example
  * ```tsx
  * const type = useCell(selectCellType);
@@ -98,7 +98,7 @@ export const selectCellType = (cell: Computed<CellRecord>) => cell.type;
  * narrow it here for callers. Works for both elements and links, any cell
  * can be embedded.
  * @group Selectors
- * @param cell
+ * @param cell - the resolved cell record
  * @example
  * ```tsx
  * const parentId = useCell(cellId, selectCellParent);
@@ -111,7 +111,7 @@ export const selectCellParent = (cell: Computed<CellRecord>): CellId | null =>
  * Reads the `layer` field, name of the JointJS layer the cell renders into,
  * or `null` when the cell uses the paper's default layer.
  * @group Selectors
- * @param cell
+ * @param cell - the resolved cell record
  * @example
  * ```tsx
  * const layer = useCell(cellId, selectCellLayer);
@@ -124,7 +124,7 @@ export const selectCellLayer = (cell: Computed<CellRecord>): string | null =>
  * Reads the `z` field, JointJS z-index (paint order within a layer).
  * Falls back to `0` when the cell has no explicit z-index.
  * @group Selectors
- * @param cell
+ * @param cell - the resolved cell record
  * @example
  * ```tsx
  * const z = useCell(cellId, selectCellZIndex);

--- a/packages/joint-react/src/utils/create.ts
+++ b/packages/joint-react/src/utils/create.ts
@@ -13,7 +13,7 @@ type CellArrayMember<Cells> = Cells extends ReadonlyArray<infer Member> ? Member
  *
  * Custom shapes (a `type` other than `'element'`) are excluded, type the
  * record union manually for those, as documented on `CellRecord`.
- * @group Utils
+ * @group Types
  * @example
  * ```ts
  * const cells = [
@@ -33,7 +33,7 @@ export type InferElement<Cells> = Extract<
 /**
  * Infer the link record type from a cells collection, the link counterpart of
  * {@link InferElement}. Selects the member whose `type` is `'link'`.
- * @group Utils
+ * @group Types
  * @example
  * ```ts
  * const cells = [

--- a/packages/joint-react/typedoc.config.mjs
+++ b/packages/joint-react/typedoc.config.mjs
@@ -1,0 +1,28 @@
+import { OptionDefaults } from 'typedoc';
+import { createRequire } from 'node:module';
+
+// Markdown build config for the docs site's typedoc-to-docusaurus generator.
+// Reuses the base (HTML) typedoc.json and adapts it:
+// - swap the github HTML theme for typedoc-plugin-markdown
+// - register a custom `@title` block tag (appended to defaults via
+//   OptionDefaults, so @param/@returns/etc. keep working) — used by the docs
+//   normalizer for per-signature headings
+// - emit docusaurus-friendly markdown (no sources, code-block signatures,
+//   table params/type-declarations)
+//
+// Run with: typedoc --options typedoc.config.mjs
+const base = createRequire(import.meta.url)('./typedoc.json');
+
+/** @type {Partial<import('typedoc').TypeDocOptions>} */
+export default {
+  ...base,
+  entryPoints: ['src/index.ts'],
+  out: 'docs/api-md',
+  plugin: ['typedoc-plugin-markdown'],
+  router: 'group',
+  blockTags: [...OptionDefaults.blockTags, '@title'],
+  disableSources: true,
+  useCodeBlocks: true,
+  parametersFormat: 'table',
+  typeDeclarationFormat: 'table',
+};


### PR DESCRIPTION
Prepares `@joint/react` for the docs site's typedoc-to-docusaurus generator and polishes the source TSDoc the generator surfaces.

- `typedoc.config.mjs`: markdown build (`docs:typedoc-md`) tuned for the docs generator — `typedoc-plugin-markdown`, custom `@title` block tag (per-signature headings), `--disableSources`, code-block signatures, table params/type-declarations.
- `@title` on overloaded hooks (`useCell`, `useCells`, `useOn*Events`) for readable per-signature headings.
- `@param` descriptions for selectors/presets that were blank; clearer `elementAttributes`/`linkAttributes` examples (passed to a cell-model constructor / custom class).
- `GraphEventMap` links to the core graph-events docs.
- group `InferElement`/`InferLink` under `Types` (they are type aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)