### PR TITLE
chore(joint-eslint-config): make reusable in joint-react-plus

### DIFF
--- a/packages/joint-eslint-config/eslint.config.react.mjs
+++ b/packages/joint-eslint-config/eslint.config.react.mjs
@@ -14,10 +14,6 @@ import sonarjsPlugin from 'eslint-plugin-sonarjs';
 import unicornPlugin from 'eslint-plugin-unicorn';
 import tsEslint from 'typescript-eslint';
 
-import path from 'node:path';
-
-const tsConfigPath = path.resolve('./', 'tsconfig.json');
-
 /**
  * ESLint config to support all React files with .ts, .tsx extensions
  */
@@ -47,7 +43,9 @@ export const reactTsConfig = defineConfig([
                 ecmaVersion: 'latest',
                 ecmaFeatures: { jsx: true },
                 sourceType: 'module',
-                project: tsConfigPath,
+                // Resolve nearest `tsconfig.json` per file.
+                // - Lets type-aware linting work regardless of current working directory.
+                projectService: true,
             },
         },
         settings: {
@@ -160,6 +158,7 @@ export const reactTsConfig = defineConfig([
                         'expand',
                         'inline',
                         'hidden',
+                        'title',
                     ],
                 },
             ],


### PR DESCRIPTION
## Description

Uses `projectService` instead of `project` to specify that closest `tsconfig.json` should be used for linting, instead of a hardcoded one. This makes no difference for joint-react, but it works well with joint-plus-react.

Additionally fixes linting errors due to `@title` JSDoc tag addition being incompletely added in https://github.com/clientIO/joint/pull/3393.