### PR TITLE
docs(react): link call-form symbol refs + HTMLBoxProps interface

### DIFF
--- a/packages/joint-react/src/components/html-box.tsx
+++ b/packages/joint-react/src/components/html-box.tsx
@@ -22,7 +22,7 @@ const AUTO_SIZE_STYLE: CSSProperties = {
  * @expand
  * @group Types
  */
-export type HTMLBoxProps = HTMLHostProps;
+export interface HTMLBoxProps extends HTMLHostProps {}
 
 /**
  * Default themed HTML host that applies the `jj-box` CSS class. Use inside

--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -217,7 +217,7 @@ interface PaperSupportedOptions {
  * for built-in JointJS shapes that ship without a `data` field.
  *
  * If the renderer needs the id, position, size, or other slices, use the
- * context hooks: `useCellId()`, `useCell()` (with optional selector), or
+ * context hooks: {@link useCellId}(), {@link useCell}() (with optional selector), or
  * `useCell(c => c.position / c.size / ...)`.
  * @group Types
  */
@@ -225,7 +225,7 @@ export type RenderElement<ElementData = unknown> = (data: ElementData) => ReactN
 
 /**
  * Render function for links. Receives the link's `data` slice only, same
- * performance rationale as {@link RenderElement}. Use `useCell()` (with an
+ * performance rationale as {@link RenderElement}. Use {@link useCell}() (with an
  * optional selector) inside the renderer when source / target / id are
  * needed.
  *

--- a/packages/joint-react/src/components/paper/render-element/paper-element-item.tsx
+++ b/packages/joint-react/src/components/paper/render-element/paper-element-item.tsx
@@ -62,7 +62,7 @@ function useElementDataSnapshot(id: CellId): Record<string, unknown> | undefined
  * portal wrappers can mount a 0×0 container synchronously rather than
  * crashing. Callers must tolerate optional `position` / `size`.
  *
- * Contrast with the public `useCell()` hook, which returns the
+ * Contrast with the public {@link useCell}() hook, which returns the
  * `Computed<ElementRecord>` (position/size/angle/data required) and throws
  * when the cell is missing.
  * @param id - cell id to subscribe to

--- a/packages/joint-react/src/hooks/use-cell-drag.utils.ts
+++ b/packages/joint-react/src/hooks/use-cell-drag.utils.ts
@@ -1,9 +1,9 @@
 /**
- * Drag-tracking infrastructure for `useCellDrag()`.
+ * Drag-tracking infrastructure for {@link useCellDrag}().
  *
  * Architecture:
  *   WeakMap<dia.Paper, Atom<CellDragState>>
- *   , one atom per paper, lazily created on first `useCellDrag()` call.
+ *   , one atom per paper, lazily created on first {@link useCellDrag}() call.
  *   , garbage-collected when the paper is disposed (WeakMap).
  *
  *   WeakSet<dia.Paper>
@@ -13,7 +13,7 @@
  *       to the atom. Subsequent calls are no-ops.
  *   , Listeners are cleaned up when `paper.remove()` is called.
  *
- *   `useCellDrag()` (in use-dragging.ts) reads the atom via
+ *   {@link useCellDrag}() (in use-dragging.ts) reads the atom via
  *   `useSyncExternalStoreWithSelector`. Each element's selector derives
  *   `isDragging = snap.draggingCellId === myCellId`. Only the dragged
  *   element re-renders, non-dragged elements return a frozen IDLE ref.

--- a/packages/joint-react/src/hooks/use-cell-id.ts
+++ b/packages/joint-react/src/hooks/use-cell-id.ts
@@ -7,7 +7,7 @@ import type { CellId } from '../types/cell.types';
  * `<Paper />` around every `renderElement` / `renderLink` invocation.
  *
  * Use this inside a render callback (or any component mounted from one) when
- * you only need the id, it's cheaper than `useCell()` since
+ * you only need the id, it's cheaper than {@link useCell}() since
  * it never subscribes to store updates. Throws when used outside a Paper
  * render context.
  * @returns the current cell id

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -56,7 +56,7 @@ type SetCellUpdater<Element extends ElementJSONInit, Link extends LinkJSONInit> 
 ) => Element | Link;
 
 /**
- * Function exposed by `GraphApi.setCell`. Three forms:
+ * Function exposed by {@link GraphApi}.setCell. Three forms:
  * - `setCell(record)`, direct form. `record.id` names the target. Cell
  *   exists: attributes merge over it. Cell missing: cell is added.
  * - `setCell(diaCell)`, dia.Cell form. The cell is converted to a record
@@ -136,7 +136,7 @@ export function useSetCell<
 type SetCellDataUpdater<Data> = (previousData: Data) => Data;
 
 /**
- * Function exposed by `GraphApi.setCellData` and returned by
+ * Function exposed by {@link GraphApi}.setCellData and returned by
  * {@link useSetCellData}. Two forms, both keyed by cell id:
  * - `setCellData(id, data)`, replaces the cell's `data` with `data`.
  * - `setCellData(id, (prev) => next)`, updater form; `prev` is the current

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -70,7 +70,7 @@ function pickCells<Cell extends AnyCellRecord>(
 
 /**
  * Builds the next selector result for {@link useCells}. Module-scoped so the
- * closure does not nest deeply inside `useCells.select`.
+ * closure does not nest deeply inside {@link useCells}.select.
  */
 function computeNext<Cell extends AnyCellRecord, Selected>(
   container: ReadonlyContainer<Cell>,

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -135,7 +135,7 @@ function createDefaultLinkCallback(defaultLink: DefaultLink | undefined) {
  * Portals custom link content into the resolved link view container.
  * Subscribes only to the link's `data` slice, source / target / endpoint
  * updates don't re-invoke the user renderer. If a renderer needs the full
- * link record (source/target/id), use `useCell()` or `useCellId()` from
+ * link record (source/target/id), use {@link useCell}() or {@link useCellId}() from
  * inside it.
  * @param props - Link props.
  * @param props.portalElement - Link portal container element.

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -32,7 +32,7 @@ type TypedData<Data> = unknown extends Data ? never : Data;
  * `data` type for the GraphApi's `setCellData`, derived from {@link useGraph}'s
  * `Element` / `Link` generics by reusing each record's `['data']`:
  * - both sides untyped → open `Record<string, unknown>` (keeps the no-generic
- *   `useGraph()` spreadable)
+ *   {@link useGraph}() spreadable)
  * - one side typed → that side's data
  * - both sides typed → their union (narrow inside the updater)
  *
@@ -135,7 +135,7 @@ export interface GraphApi<
 }
 
 /**
- * Options accepted by `GraphApi.exportToJSON`.
+ * Options accepted by {@link GraphApi}.exportToJSON.
  * @group Types
  */
 export interface ExportToJSONOptions {

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -22,7 +22,7 @@ export interface ElementAttributes extends dia.Element.Attributes, ElementPreset
 /**
  * Normalizes element configuration into JointJS-compatible cell attributes.
  * Expands the React-preset `portMap` shorthand into native `ports` via
- * `elementPorts()`; passes native `ports` through; throws when both are
+ * {@link elementPorts}(); passes native `ports` through; throws when both are
  * supplied.
  * @param element - The element record to convert.
  * @returns JointJS-compatible cell attributes.

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -26,7 +26,7 @@ export interface LinkAttributes extends dia.Link.Attributes, LinkPresetAttribute
  * Converts a `LinkAttributes` record to JointJS cell attributes.
  *
  * - `style` → converted to SVG `attrs` via `linkStyle()`.
- * - `labelMap` → converted to native `labels` array via `linkLabels()`.
+ * - `labelMap` → converted to native `labels` array via {@link linkLabels}().
  * - `labels` (array) → passed through as-is.
  * - Both `labelMap` and `labels` → throws.
  * @param link - The link record to convert.

--- a/packages/joint-react/src/selectors/cell-selectors.ts
+++ b/packages/joint-react/src/selectors/cell-selectors.ts
@@ -71,7 +71,7 @@ export function selectElementData<ElementData = unknown>(
 // ── Cell-level selectors (work for both elements and links) ───────────────
 
 /**
- * Reads `cell.id`. Note: `useCellId()` is cheaper when only the id is needed.
+ * Reads `cell.id`. Note: {@link useCellId}() is cheaper when only the id is needed.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example


### PR DESCRIPTION
Follow-up to the merged #3396 (TSDoc cross-reference links).

- Link backtick refs written as calls or member access (`useCell()`, `useCellId().x`, …) with `{@link}` so they render as links; intra-package symbols only.
- Make `HTMLBoxProps` an interface extending `HTMLHostProps` so the HTMLBox API page lists its props (the alias rendered no members).

Comments/types only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)