### PR TITLE
docs(react): accurate, consistent, example-rich public-API JSDoc

### DIFF
--- a/packages/joint-eslint-config/eslint.config.react.mjs
+++ b/packages/joint-eslint-config/eslint.config.react.mjs
@@ -62,7 +62,7 @@ export const reactTsConfig = defineConfig([
         },
         rules: {
             // General JS rules
-            'no-console': 'error',
+            'no-console': ['error', { allow: ['warn', 'error'] }],
             'no-nested-ternary': 'warn',
             'no-shadow': 'error',
             'no-unused-vars': 'off',
@@ -73,6 +73,7 @@ export const reactTsConfig = defineConfig([
 
             // TypeScript rules
             '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+            '@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'with-single-extends' }],
             '@typescript-eslint/no-shadow': 'error',
             '@typescript-eslint/no-non-null-assertion': 'off',
             '@typescript-eslint/strict-boolean-expressions': 'off',

--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -13,9 +13,10 @@ type ProviderCells<Element extends ElementJSONInit, Link extends LinkJSONInit> =
 >;
 
 /**
- * Props common to every {@link GraphProvider} mode.
- * @template ElementData - User data attached to each element record.
- * @template LinkData - User data attached to each link record.
+ * Props for {@link GraphProvider} — pick the graph source (existing
+ * instance, initial cells, or a controlled cells array) and subscribe to changes.
+ * @template Element - Shape of the element cells stored in the graph.
+ * @template Link - Shape of the link cells stored in the graph.
  * @expand
  * @group Types
  */
@@ -32,11 +33,18 @@ export interface GraphProviderProps<
   /** React children rendered inside the provider, typically a `<Paper />`. */
   readonly children?: React.ReactNode;
   /**
-   * Cell namespace passed through to `new dia.Graph`. Defaults to JointJS
-   * built-in shapes plus the `@joint/react` ElementModel and LinkModel.
+   * Cell namespace passed to `new dia.Graph`. Your entries are merged on top of
+   * the built-ins, so JointJS shapes and the `@joint/react` {@link ElementModel}
+   * / {@link LinkModel} stay available even when you register custom shapes.
+   * @default JointJS `shapes` plus the `@joint/react` cell models
    */
   readonly cellNamespace?: unknown;
-  /** Custom cell model used as the base class for all cells in the graph. */
+  /**
+   * Base model class used for every cell the graph constructs from JSON. Maps to
+   * the (deprecated) `cellModel` option of `dia.Graph`; prefer `cellNamespace`,
+   * which registers shapes by `type` and supports per-type model classes.
+   * @see https://docs.jointjs.com/api/dia/Graph
+   */
   readonly cellModel?: typeof dia.Cell;
   /**
    * Reference point that stays fixed when an auto-sized element's measured
@@ -56,15 +64,29 @@ export interface GraphProviderProps<
   readonly store?: GraphStore<Element, Link>;
 
   /**
-   * Initial cells for uncontrolled mode. Ignored if `cells` is provided. Should not
+   * Cells used to seed the graph once, at mount, for uncontrolled mode. Later
+   * changes to this array are not applied. Ignored when `cells` is provided.
+   * @see {@link CellInput}
    */
   readonly initialCells?: ReadonlyArray<CellInput<Element, Link>>;
+  /**
+   * Controlled cells array. Whenever this array changes, the graph is re-synced
+   * to match it (and `initialCells` is ignored); passing the same reference on a
+   * re-render does not re-sync. Pair it with `onCellsChange` to mirror user edits
+   * back into your own state.
+   */
   readonly cells?: ProviderCells<Element, Link>;
-  /** Notification-only callback, React state is NOT pushed back into the graph. */
+  /**
+   * Fires after each graph change with the full, updated cells array. Use it to
+   * keep external React state in sync with the graph; it is notification only
+   * and does not itself write anything back into the graph.
+   */
   readonly onCellsChange?: (newCells: ProviderCells<Element, Link>) => void;
   /**
-   * Notification fired with granular `added` / `changed` / `removed` sets
-   * after each commit. Independent of controlled/uncontrolled mode.
+   * Fires after each commit with the granular `added` / `changed` / `removed`
+   * delta, so you can apply just the change to an external store (Redux, Zustand,
+   * etc.). Works in both controlled and uncontrolled mode.
+   * @see {@link IncrementalCellsChange}
    */
   readonly onIncrementalCellsChange?: OnIncrementalCellsChange<Element, Link>;
 }
@@ -153,32 +175,55 @@ function GraphBase(props: Readonly<GraphProviderBaseInternalProps>): React.React
 }
 
 /**
- * GraphProvider supplies graph context to its children.
+ * Creates (or adopts) a JointJS graph and shares it with every `<Paper>` and
+ * graph hook rendered inside it. Mount it near the root of your diagram: hooks
+ * like {@link useGraph}, {@link useCells}, and {@link useCell} read the graph
+ * from its context and throw when used outside a provider.
  *
- * **Modes of operation:**
- *
- * 1. **Uncontrolled** (JointJS owns the graph after mount):
+ * It works in three modes, depending on which props you pass: pass
+ * `initialCells` to let JointJS own the graph after mount (uncontrolled), pass
+ * `cells` + `onCellsChange` to drive the graph from React state (controlled), or
+ * pass `onIncrementalCellsChange` to forward deltas to an external store.
+ * @example
+ * @title Uncontrolled — seed once, JointJS owns the graph
  * ```tsx
- * <GraphProvider initialCells={[...]}>
- *   <Paper />
+ * import { GraphProvider, Paper } from '@joint/react';
+ *
+ * // `renderElement` receives the element's `data` slice only — not its
+ * // geometry. Read position/size with the context hooks (e.g. useCell) when
+ * // you need them.
+ * <GraphProvider
+ *   initialCells={[{ id: '1', type: 'element', position: { x: 20, y: 20 }, size: { width: 80, height: 40 }, data: { label: 'A' } }]}
+ * >
+ *   <Paper renderElement={(data) => <rect width={80} height={40} rx={4} fill="#4763ff" />} />
  * </GraphProvider>
  * ```
- *
- * 2. **Controlled** (React owns the cells array):
+ * @example
+ * @title Controlled — React state owns the cells
  * ```tsx
- * const [cells, setCells] = useState<readonly CellRecord[]>([...]);
+ * import { useState } from 'react';
+ * import { GraphProvider, Paper, type CellRecord } from '@joint/react';
+ *
+ * const [cells, setCells] = useState<readonly CellRecord[]>([]);
  * <GraphProvider cells={cells} onCellsChange={setCells}>
  *   <Paper />
  * </GraphProvider>
  * ```
- *
- * 3. **Incremental-notification** (external store, Redux/Zustand):
+ * @example
+ * @title Incremental — forward deltas to an external store
  * ```tsx
- * <GraphProvider onIncrementalCellsChange={(c) => dispatch(c)}>
+ * import { GraphProvider, Paper } from '@joint/react';
+ *
+ * <GraphProvider
+ *   onIncrementalCellsChange={(delta) => {
+ *     // forward the { added, changed, removed } delta to your external store
+ *     store.apply(delta);
+ *   }}
+ * >
  *   <Paper />
  * </GraphProvider>
  * ```
- * @see GraphProviderProps for all available props
+ * @see {@link GraphProviderProps} for the full list of props.
  * @group Components
  */
 export const GraphProvider = GraphBase as <

--- a/packages/joint-react/src/components/html-box.tsx
+++ b/packages/joint-react/src/components/html-box.tsx
@@ -18,22 +18,33 @@ const AUTO_SIZE_STYLE: CSSProperties = {
 };
 
 /**
- * Props for the HTMLBox component, extending HTMLHostProps.
+ * Props for {@link HTMLBox}. Same shape as {@link HTMLHostProps}: `className` is
+ * merged with the `jj-box` class and `style` is layered on top of the default
+ * box styling before reaching the underlying {@link HTMLHost}; the rest pass
+ * through unchanged.
  * @expand
  * @group Types
  */
 export interface HTMLBoxProps extends HTMLHostProps {}
 
 /**
- * Default themed HTML host that applies the `jj-box` CSS class. Use inside
- * `<Paper renderElement={...}>` to render a graph element.
+ * Renders a graph element as a pre-styled HTML box. Reach for this inside
+ * `<Paper renderElement={...}>` when you want elements that already look good
+ * without writing any CSS.
  *
- * Wraps {@link HTMLHost} (style-neutral foreignObject + measured div) and adds
- * the `jj-box` class for default styling via `--jj-box-*` CSS variables. All
- * props are forwarded to {@link HTMLHost}. Use {@link HTMLHost} directly when you want
- * full control without default styles.
+ * Wraps {@link HTMLHost} and adds the `jj-box` class, which themes the box
+ * through `--jj-box-*` CSS variables (background, border, radius, padding,
+ * font). Like {@link HTMLHost}, it measures its content and syncs the size back
+ * to the element by default; set `useModelGeometry` to size it from the model
+ * instead. All props reach the underlying {@link HTMLHost}; `className` is merged
+ * with the `jj-box` class and `style` is layered on top of the default box
+ * styling, while the rest pass through unchanged. Use {@link HTMLHost} directly
+ * when you want a blank host with no default styling.
  * @example
  * ```tsx
+ * import { Paper, HTMLBox } from '@joint/react';
+ *
+ * // Each element renders as a ready-styled box showing its label.
  * <Paper renderElement={({ label }) => <HTMLBox>{label}</HTMLBox>} />
  * ```
  * @group Components

--- a/packages/joint-react/src/components/html-host.tsx
+++ b/packages/joint-react/src/components/html-host.tsx
@@ -10,9 +10,10 @@ import { selectElementSize } from '../selectors';
  */
 export interface HTMLHostProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Skip measuring the rendered content and use the graph element's stored
-   * size instead. Cheaper, but the cell won't auto-resize when the React
-   * subtree changes. Default: `false`.
+   * Skip measuring the rendered content and size the host from the graph
+   * element's stored geometry instead. Cheaper, but the element no longer
+   * auto-resizes when the React subtree changes.
+   * @default false
    */
   readonly useModelGeometry?: boolean;
 }
@@ -43,19 +44,23 @@ function HTMLFrame({ nodeRef, width, height, style, ...rest }: Readonly<HTMLFram
 }
 
 /**
- * Style-neutral element host: a `<div>` inside a `<foreignObject>`. Use inside
- * `<Paper renderElement={...}>` to render a graph element.
+ * Renders a graph element as an unstyled HTML node you fully control. Reach for
+ * this inside `<Paper renderElement={...}>` when you want plain DOM (a `<div>`,
+ * inputs, your own components) instead of SVG shapes, with no default theme.
  *
  * All props are spread onto the inner `<div>` (`children`, `style`,
  * `className`, event handlers, `data-*`, etc.). By default the host measures
- * its content via {@link useMeasureElement} and syncs the size back to the graph
- * element; set `useModelGeometry` to skip measurement and use the element's
- * size from the model instead.
+ * its content via {@link useMeasureElement} and syncs that size back to the
+ * graph element; set `useModelGeometry` to skip measurement and size the host
+ * from the element's model geometry instead.
  *
- * Does **not** apply any default theme class. For themed styling via
- * `--jj-box-*` CSS variables, use {@link HTMLBox} instead.
+ * Applies no default styling. For a ready-themed box driven by `--jj-box-*` CSS
+ * variables, use {@link HTMLBox} instead.
  * @example
  * ```tsx
+ * import { Paper, HTMLHost } from '@joint/react';
+ *
+ * // Render each element as your own HTML node and style it via CSS.
  * <Paper renderElement={({ label }) => (
  *   <HTMLHost className="my-node">{label}</HTMLHost>
  * )} />

--- a/packages/joint-react/src/components/paper/paper.tsx
+++ b/packages/joint-react/src/components/paper/paper.tsx
@@ -63,6 +63,31 @@ function PaperBase(
  * (selection, drag, link creation, zoom/pan), and lets you customize each
  * cell with your own React components. Mount inside a `<GraphProvider>` and
  * size it with CSS. The canvas fills its parent.
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper, HTMLBox, type CellRecord } from '@joint/react';
+ *
+ * interface NodeData {
+ *   label: string;
+ * }
+ *
+ * const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
+ *   { id: '1', type: 'element', position: { x: 40, y: 40 }, data: { label: 'Hello' } },
+ *   { id: '2', type: 'element', position: { x: 280, y: 180 }, data: { label: 'World' } },
+ *   { id: 'edge', type: 'link', source: { id: '1' }, target: { id: '2' } },
+ * ];
+ *
+ * function Diagram() {
+ *   return (
+ *     <GraphProvider initialCells={initialCells}>
+ *       <Paper
+ *         style={{ width: '100%', height: 600 }}
+ *         renderElement={(data: NodeData) => <HTMLBox>{data.label}</HTMLBox>}
+ *       />
+ *     </GraphProvider>
+ *   );
+ * }
+ * ```
  * @see {@link PaperProps} for the full prop surface.
  * @group Components
  */

--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -19,16 +19,17 @@ import type { LinkRouting } from '../../presets/link-routing';
 import type { PaperEventHandlers } from '../../presets/paper-events';
 
 /**
- * Value accepted by the Paper `transform` prop. Strings are parsed via the
- * native `DOMMatrix` constructor (CSS transform syntax, `scale()`,
- * `translate()`, `rotate()`, `matrix()` etc.). `DOMMatrix` instances pass
- * through. `SVGMatrix === DOMMatrix` in modern `lib.dom.d.ts`.
+ * Viewport transform accepted by the `<Paper>` `transform` prop: either a CSS
+ * transform string (e.g. `'scale(0.5)'`, `'translate(10px, 20px) rotate(15deg)'`)
+ * or a `DOMMatrix`. Strings are parsed with the native `DOMMatrix` constructor.
  * @group Types
  */
 export type PaperTransform = string | DOMMatrix;
 
 /**
- * Context passed to the `defaultLink` factory.
+ * Context handed to a {@link DefaultLink} factory while the user drags a new
+ * connection from a port or element.
+ * @expand
  * @group Types
  */
 export interface DefaultLinkParams {
@@ -41,8 +42,10 @@ export interface DefaultLinkParams {
 }
 
 /**
- * Value accepted by the Paper `defaultLink` prop, factory receiving
- * {@link DefaultLinkParams}, or a static `Partial<LinkRecord>`.
+ * Defines the link created when the user drags a new connection from a port or
+ * element. Either a factory receiving {@link DefaultLinkParams} (returning a
+ * `dia.Link` or a partial {@link LinkRecord}) or a static partial
+ * {@link LinkRecord}.
  * @group Types
  */
 export type DefaultLink =
@@ -50,9 +53,10 @@ export type DefaultLink =
   | Partial<LinkRecord>;
 
 /**
- * Raw `dia.Paper.Options` passthrough, the type of the `options` escape-hatch prop.
- * `cellVisibility` is excluded: use the dedicated `cellVisibility` prop (it is
- * also managed by feature ownership, e.g. a virtual-rendering scroller).
+ * Raw `dia.Paper.Options` accepted by the {@link PaperProps} `options` escape
+ * hatch, for any native option joint-react does not expose as a dedicated prop.
+ * `cellVisibility` is excluded: use the dedicated `cellVisibility` prop instead
+ * (it is also managed by feature ownership, e.g. a virtual-rendering scroller).
  * @group Types
  */
 export type PaperOptions = Omit<dia.Paper.Options, 'cellVisibility'>;
@@ -62,7 +66,6 @@ export type PaperOptions = Omit<dia.Paper.Options, 'cellVisibility'>;
  * native types via indexed access (`dia.Paper.Options['name']`), so any
  * type-level change in JointJS propagates automatically. Anything not listed
  * here is reachable via the `options` escape hatch, never implicitly exposed.
- * @group Types
  */
 interface PaperSupportedOptions {
   // ── Wrapped (structured) ─────────────────────────────────────────────────
@@ -116,39 +119,133 @@ interface PaperSupportedOptions {
   // by host CSS (`className` / `style`); `paper.getComputedSize()` falls
   // back to `el.clientWidth/clientHeight` when `options.width/height` are
   // not numeric (see `dia.Paper.getComputedSize`).
+  /**
+   * Draws a grid pattern on the paper background. Pass `true` for the default
+   * grid or an object to style it (e.g. `{ color: 'red', thickness: 2 }`).
+   * @default true
+   */
   readonly drawGrid?: dia.Paper.Options['drawGrid'];
+  /**
+   * Spacing of the rendered grid lines in px. Falls back to `gridSize` when not
+   * set.
+   * @default matches `gridSize`
+   */
   readonly drawGridSize?: dia.Paper.Options['drawGridSize'];
+  /**
+   * Grid step in px that element positions snap to while dragging.
+   * @default 10
+   */
   readonly gridSize?: dia.Paper.Options['gridSize'];
+  /**
+   * Paper background color, image, or pattern. Pass an object such as
+   * `{ color: 'lightblue', image: '/bg.png', repeat: 'flip-xy' }`.
+   * @default false
+   */
   readonly background?: dia.Paper.Options['background'];
+  /**
+   * Renders link labels into a dedicated top layer (so they are not occluded by
+   * later cells). Pass `true`, or a layer name to target a specific layer.
+   * @default false
+   */
   readonly labelsLayer?: dia.Paper.Options['labelsLayer'];
+  /**
+   * Lets cell content spill outside the paper viewport instead of being clipped.
+   * @default false
+   */
   readonly overflow?: dia.Paper.Options['overflow'];
 
   // ── Interactions ─────────────────────────────────────────────────────────
   /**
-   * CellInteraction permissions. Accepts:
-   * - `boolean`, enable/disable all interactions.
-   * - `InteractivityOptions`, granular toggle per interaction kind.
-   * - Function, receives `{ model, interaction, paper, graph }` and returns either form.
-   * Native `(cellView, event)` callback is reachable via the `options` escape hatch.
+   * Which pointer interactions are enabled on cells. Accepts a boolean to toggle
+   * everything, an `InteractivityOptions` object for granular control per
+   * interaction kind, or a {@link CellInteractivity} callback returning either
+   * form per cell. The native `(cellView, event)` callback is reachable via the
+   * `options` escape hatch.
+   * @default { labelMove: false, linkMove: false }
    */
   readonly interactive?: CellInteractivity;
+  /**
+   * Highlighter definitions keyed by highlight type (connecting, embedding,
+   * magnet/element availability). Override to restyle these visual cues.
+   * @default joint-react's themed highlighters
+   */
   readonly highlighting?: dia.Paper.Options['highlighting'];
+  /**
+   * Snaps a dragged link label to the closest point on the link path.
+   * @default false
+   */
   readonly snapLabels?: dia.Paper.Options['snapLabels'];
+  /**
+   * Snaps a dragged link end to nearby ports/elements. Pass `{ radius }` to set
+   * the snapping distance in px.
+   * @default { radius: 15 }
+   */
   readonly snapLinks?: dia.Paper.Options['snapLinks'];
+  /**
+   * Allows a link end to snap to its own source/target element.
+   * @default false
+   */
   readonly snapLinksSelf?: dia.Paper.Options['snapLinksSelf'];
+  /**
+   * Highlights valid drop targets (magnets and elements) while a link is being
+   * dragged.
+   * @default true
+   */
   readonly markAvailable?: dia.Paper.Options['markAvailable'];
+  /**
+   * Allows dropping a link end on blank paper, pinning it to a fixed point
+   * instead of requiring an element/port.
+   * @default false
+   */
   readonly linkPinning?: dia.Paper.Options['linkPinning'];
 
   // ── Event thresholds / prevention ────────────────────────────────────────
+  /**
+   * Maximum pointer travel (in px) still treated as a click rather than a drag.
+   * @default 5
+   */
   readonly clickThreshold?: dia.Paper.Options['clickThreshold'];
+  /**
+   * Pointer travel (in px) required before `pointermove` events start firing.
+   * @default 0
+   */
   readonly moveThreshold?: dia.Paper.Options['moveThreshold'];
+  /**
+   * Pointer travel (in px) before a link is created from a magnet, or
+   * `'onleave'` to create it once the pointer leaves the magnet.
+   * @default 'onleave'
+   */
   readonly magnetThreshold?: dia.Paper.Options['magnetThreshold'];
+  /**
+   * Suppresses the browser context menu over the paper so `contextmenu` events
+   * can drive your own UI.
+   * @default true
+   */
   readonly preventContextMenu?: dia.Paper.Options['preventContextMenu'];
+  /**
+   * Prevents the browser default action on cell pointer events.
+   * @default true
+   */
   readonly preventDefaultViewAction?: dia.Paper.Options['preventDefaultViewAction'];
+  /**
+   * Prevents the browser default action on blank-area pointer events.
+   * @default false
+   */
   readonly preventDefaultBlankAction?: dia.Paper.Options['preventDefaultBlankAction'];
 
   // ── Embedding ────────────────────────────────────────────────────────────
+  /**
+   * Enables embedding: dropping an element onto another re-parents it (the
+   * child then moves with its parent). Pair with the `validateEmbedding` prop to
+   * control which parents are allowed.
+   * @default false
+   */
   readonly embeddingMode?: dia.Paper.Options['embeddingMode'];
+  /**
+   * When embedding, only the frontmost element under the pointer is considered a
+   * parent; otherwise candidates are tested front-to-back.
+   * @default true
+   */
   readonly frontParentOnly?: dia.Paper.Options['frontParentOnly'];
 
   // ── Cell visibility ──────────────────────────────────────────────────────
@@ -160,13 +257,45 @@ interface PaperSupportedOptions {
   readonly cellVisibility?: CellVisibility;
 
   // ── Namespaces ───────────────────────────────────────────────────────────
+  /**
+   * Namespace of cell-view constructors used to resolve a cell's view by type.
+   * @default JointJS built-in cell views
+   */
   readonly cellViewNamespace?: dia.Paper.Options['cellViewNamespace'];
+  /**
+   * Namespace of layer-view constructors used to resolve custom paper layers.
+   * @default JointJS built-in layer views
+   */
   readonly layerViewNamespace?: dia.Paper.Options['layerViewNamespace'];
+  /**
+   * Namespace used to resolve router names referenced by links.
+   * @default JointJS built-in `routers`
+   */
   readonly routerNamespace?: dia.Paper.Options['routerNamespace'];
+  /**
+   * Namespace used to resolve connector names referenced by links.
+   * @default JointJS built-in `connectors`
+   */
   readonly connectorNamespace?: dia.Paper.Options['connectorNamespace'];
+  /**
+   * Namespace used to resolve highlighter names referenced by `highlighting`.
+   * @default JointJS built-in highlighters plus joint-react's magnet highlighter
+   */
   readonly highlighterNamespace?: dia.Paper.Options['highlighterNamespace'];
+  /**
+   * Namespace used to resolve element anchor names.
+   * @default JointJS built-in `anchors`
+   */
   readonly anchorNamespace?: dia.Paper.Options['anchorNamespace'];
+  /**
+   * Namespace used to resolve link anchor names.
+   * @default JointJS built-in `linkAnchors`
+   */
   readonly linkAnchorNamespace?: dia.Paper.Options['linkAnchorNamespace'];
+  /**
+   * Namespace used to resolve connection point names.
+   * @default JointJS built-in `connectionPoints`
+   */
   readonly connectionPointNamespace?: dia.Paper.Options['connectionPointNamespace'];
 
   // ── Link routing bundle ──────────────────────────────────────────────────
@@ -204,8 +333,8 @@ interface PaperSupportedOptions {
 }
 
 /**
- * Render function for elements. Receives the element's `data` slice only.
- * so the renderer re-runs ONLY when `data` changes, not when `position`,
+ * Render function for elements. Receives the element's `data` slice only, so
+ * the renderer re-runs ONLY when `data` changes, not when `position`,
  * `size`, `angle`, or other cell attributes update. Position and size are
  * applied by JointJS's view layer without touching React at all (SVG mode)
  * or by a thin wrapper div that doesn't invoke the renderer (HTML mode).
@@ -235,8 +364,9 @@ export type RenderElement<ElementData = unknown> = (data: ElementData) => ReactN
 export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
 
 /**
- * The props for the Paper component. Extend the `dia.Paper.Options` interface.
- * For more information, see the JointJS documentation.
+ * Props for {@link Paper} — the React-friendly surface over
+ * `dia.Paper.Options`, plus joint-react extras such as custom cell rendering, a
+ * controlled viewport `transform`, and portal targeting.
  *
  * Paper events are exposed directly as props
  * (`onBlankContextMenu`, `onElementPointerClick`, `onLinkMouseEnter`, …).
@@ -255,27 +385,26 @@ export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
  */
 export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, PaperEventHandlers {
   /**
-   * A function that renders the element.
+   * Renders each element from its `data` slice.
    *
    * Note: JointJS works with SVG by default, so `renderElement` is appended inside an SVG node.
    * To render HTML elements, use the experimental `useHTMLOverlay` prop or an SVG `foreignObject`.
    *
    * Receives the element's `data` slice only. Derive its type from your cells
    * with `InferElement<typeof cells>['data']`.
-   * @example
-   * Example with `global component`:
+   * @example Global component
    * ```tsx
    * type NodeData = InferElement<typeof initialCells>['data']
+   * // HTML content lives inside <HTMLBox> so it renders correctly in SVG mode.
    * function RenderElement(data: NodeData) {
-   *  return <div className="node">{data.label}</div>
+   *   return <HTMLBox className="node">{data.label}</HTMLBox>
    * }
    * ```
-   * @example
-   * Example with `local component`:
+   * @example Local component
    * ```tsx
    * type NodeData = InferElement<typeof initialCells>['data']
    * const renderElement: RenderElement<NodeData> = useCallback(
-   *     (data) => <div className="node">{data.label}</div>,
+   *     (data) => <HTMLBox className="node">{data.label}</HTMLBox>,
    *     []
    * )
    * ```
@@ -284,26 +413,39 @@ export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, Pa
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly renderElement?: RenderElement<any>;
   /**
-   * A function that renders the link.
+   * Renders each link's content from its `data` slice. Re-runs when the link's
+   * `data` changes.
    *
    * Note: JointJS works with SVG by default, so `renderLink` content is appended inside an SVG node.
    * To render HTML elements, use an SVG `foreignObject`.
+   *
+   * Receives the link's `data` slice only. Derive its type from your cells with
+   * `InferLink<typeof cells>['data']`. When you need the source, target, or id,
+   * read them with {@link useCell}() from inside the renderer.
    * @experimental - this feature is experimental and may have limitations or issues. Use at your own risk.
-   * This is called when the link data changes.
-   * @example
-   * Example with `global component`:
+   * @example Global component
    * ```tsx
-   * function RenderLink({ id, ...data }: Link) {
-   *   return <text>Link {id}</text>;
+   * type LinkData = InferLink<typeof initialCells>['data']
+   * function RenderLink(data: LinkData) {
+   *   return <text>{data.label}</text>;
    * }
    * ```
-   * @example
-   * Example with `local component`:
+   * @example Local component
    * ```tsx
-   * const renderLink: RenderLink<Link> = useCallback(
-   *   (link) => <text>{link.source} → {link.target}</text>,
+   * type LinkData = InferLink<typeof initialCells>['data']
+   * const renderLink: RenderLink<LinkData> = useCallback(
+   *   (data) => <text>{data.label}</text>,
    *   []
    * )
+   * ```
+   * @example Reading the id alongside the data slice
+   * ```tsx
+   * type LinkData = InferLink<typeof initialCells>['data']
+   * function RenderLink(data: LinkData) {
+   *   // source / target / id live on the context, not the data slice
+   *   const id = useCellId();
+   *   return <text>{data.label} ({id})</text>;
+   * }
    * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -325,22 +467,26 @@ export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, Pa
    * `'translate(10px, 20px) rotate(15deg)'`) or a `DOMMatrix`. Useful for
    * zoom, minimap, and arbitrary viewport transforms.
    * @example
-   * transform="scale(0.4)"
-   * transform={new DOMMatrix().scale(2).translate(10, 20)}
+   * ```tsx
+   * <Paper transform="scale(0.4)" />
+   * <Paper transform={new DOMMatrix().scale(2).translate(10, 20)} />
+   * ```
    */
   readonly transform?: PaperTransform;
 
   /**
-   * The threshold for click events in pixels.
-   * If the mouse moves more than this distance, it will be considered a drag event.
-   * @default 10
+   * Maximum pointer travel (in px) still treated as a click rather than a drag.
+   * Moving farther than this between press and release suppresses the
+   * `pointerclick` event.
+   * @default 5
    */
   readonly clickThreshold?: number;
 
   /**
-   * Enabled if renderElements is render to pure HTML elements.
-   * By default, `joint/react` renderElements to SVG elements, so for using HTML elements without this prop, you need to use `foreignObject` element.
-   * @experimental - this feature is still experimental and there are known issues with HTML elements rendering. Use at your own risk.
+   * Renders elements as real HTML in an overlay instead of inside an SVG node.
+   * By default `renderElement` output is mounted in SVG, so plain HTML needs a
+   * `foreignObject` (or an {@link HTMLBox}); enable this to skip that wrapping.
+   * @experimental Known issues with HTML element rendering — use at your own risk.
    * @default false
    */
   readonly useHTMLOverlay?: boolean;
@@ -375,9 +521,13 @@ export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, Pa
   readonly portalSelector?: PortalSelector;
 
   /**
-   * Pre-created PaperView instance to adopt.
+   * Pre-created paper instance to adopt.
    * When provided, the Paper component wraps this paper instead of creating a new one.
    * The paper's DOM is assumed to be managed externally (e.g. by a stencil).
+   *
+   * `PaperView` is an internally-managed instance, not a public, importable type;
+   * you normally receive it from another joint-react construct (such as a stencil)
+   * rather than constructing it yourself.
    */
   readonly paper?: PaperView;
 }

--- a/packages/joint-react/src/components/svg-text/svg-text.tsx
+++ b/packages/joint-react/src/components/svg-text/svg-text.tsx
@@ -106,22 +106,30 @@ function getTextWrapStyles({
 }
 
 /**
- * Props for {@link SVGText}, combines native SVG `<text>` attributes with the
- * JointJS Vectorizer text options used for word-wrap and annotation rendering.
+ * Props for {@link SVGText}: native SVG `<text>` attributes plus the JointJS
+ * Vectorizer text options (end-of-line marker, vertical anchor, line height,
+ * text-on-path, annotations) and opt-in word wrapping.
  * @expand
  * @group Types
  */
 export interface SVGTextProps
   extends SVGTextElementAttributes<SVGTextElement>,
     Vectorizer.TextOptions {
-  /** Box width for the `textWrap` pass. */
+  /**
+   * Wrapping width in pixels for the `textWrap` pass. Falls back to the graph
+   * element's current width when omitted.
+   */
   readonly width?: number;
-  /** Box height for the `textWrap` pass. */
+  /**
+   * Maximum height in pixels for the `textWrap` pass; lines that overflow it
+   * are dropped.
+   */
   readonly height?: number;
   /**
-   * Enable word-wrapping using the Vectorizer break-text algorithm.
-   * Pass `true` for default behavior or an options object to fine-tune
-   * (ellipsis, break-word, max-line-count, …).
+   * Wrap the text to the available `width` using the JointJS `util.breakText`
+   * algorithm. Pass `true` for the defaults, or an options object to fine-tune
+   * wrapping (ellipsis, max line count, hyphenation, …).
+   * @default false
    */
   readonly textWrap?: boolean | util.BreakTextOptions;
 }
@@ -227,58 +235,53 @@ function Component(props: SVGTextProps, ref: React.ForwardedRef<SVGTextElement>)
 }
 
 /**
- * SVG text wrapper with Vectorizer-powered rendering and annotations.
- * Render anywhere under an SVG context.
+ * Renders an SVG `<text>` element with JointJS-quality text layout: word
+ * wrapping, custom line breaks, vertical alignment, line height, text-on-path,
+ * and rich annotations. Use it inside `<Paper renderElement={...}>` to label or
+ * caption an element; its children must be a single string.
  *
- * Supports end-of-line characters, vertical anchor, line height, and text
- * wrapping via the Vectorizer text options.
- * @see Vectorizer
- * @see Vectorizer.TextOptions
+ * The text is laid out with the JointJS Vectorizer (`V(...).text()`), and
+ * `textWrap` runs `util.breakText` so long strings wrap to the element's width.
+ * See {@link SVGTextProps} for every supported option.
  * @group Components
  * @example
- * Basic usage:
+ * @title Basic label
  * ```tsx
- * import { SVGText } from '@joint/react';
+ * import { Paper, SVGText } from '@joint/react';
  *
- * function RenderElement() {
- *   return (
- *     <SVGText x={10} y={20}>
- *       Hello World
- *     </SVGText>
- *   );
- * }
+ * // Label each element with a static caption.
+ * <Paper renderElement={() => <SVGText x={10} y={20}>Hello World</SVGText>} />
  * ```
  * @example
- * With text wrapping:
+ * @title Wrap text to a fixed width
  * ```tsx
- * import { SVGText } from '@joint/react';
+ * import { Paper, SVGText } from '@joint/react';
  *
- * function RenderElement() {
- *   return (
+ * // Wrap a long caption to the element's current width.
+ * <Paper
+ *   renderElement={() => (
  *     <SVGText x={10} y={20} width={100} textWrap>
  *       This is a long text that will wrap to multiple lines
  *     </SVGText>
- *   );
- * }
+ *   )}
+ * />
  * ```
  * @example
- * With custom text options:
+ * @title Vertical anchor, line height, and line breaks
  * ```tsx
- * import { SVGText } from '@joint/react';
+ * import { Paper, SVGText } from '@joint/react';
  *
- * function RenderElement() {
- *   return (
- *     <SVGText
- *       x={10}
- *       y={20}
- *       textVerticalAnchor="middle"
- *       lineHeight={1.5}
- *       eol="\n"
- *     >
- *       Line 1\nLine 2
+ * // A real "\n" in the string is what splits the content into two lines, so
+ * // pass it through an expression container (not raw JSX text, where "\n"
+ * // stays literal). textVerticalAnchor centers the block and lineHeight sets
+ * // the spacing between the lines.
+ * <Paper
+ *   renderElement={() => (
+ *     <SVGText x={10} y={20} textVerticalAnchor="middle" lineHeight={1.5}>
+ *       {'Line 1\nLine 2'}
  *     </SVGText>
- *   );
- * }
+ *   )}
+ * />
  * ```
  */
 export const SVGText = forwardRef(Component) as (

--- a/packages/joint-react/src/hooks/use-cell-drag.ts
+++ b/packages/joint-react/src/hooks/use-cell-drag.ts
@@ -14,19 +14,19 @@ import { usePaper } from './use-paper';
 interface CellDragStateBase {
   /** True when cell is being dragged. */
   readonly isDragging: boolean;
-  /** True when the drop area is within the paper area. */
+  /** Reserved drop-validity flag; currently always `true` (not yet computed). */
   readonly canDrop: boolean;
   /** True when cell is a preview. */
   readonly isPreview: boolean;
-  /** Bounding rect of dragged cell in coords. */
+  /** Bounding box of the dragged cell, in paper coordinates. */
   readonly dropArea?: g.Rect;
-  /** Latest event during drag. */
+  /** Pointer event for this drag frame. */
   readonly event?: dia.Event;
-  /** Paper instance for dragging cell */
+  /** The paper the cell is being dragged on. */
   readonly paper?: dia.Paper;
-  /** Graph model for dragging cell */
+  /** Convenience alias for `paper.model`. */
   readonly graph?: dia.Graph;
-  /** ID of the dragged cell */
+  /** ID of the cell being dragged. */
   readonly cellId?: dia.Cell.ID;
 }
 
@@ -37,9 +37,10 @@ interface CellDragStateIdle extends CellDragStateBase {
   isDragging: false;
 }
 /**
- * Drag state for the current cell. When `isDragging` is `true`, the active
- * fields (`event`, `dropArea`, `canDrop`, `paper`, `graph`) carry the
- * in-progress drag; when `false`, those fields are present but inert.
+ * Drag state for the current cell, returned by {@link useCellDrag}. While a
+ * drag is in progress (`isDragging` is `true`), the active fields (`event`,
+ * `dropArea`, `paper`, `graph`, `cellId`) carry the live drag; when `false`
+ * they are `undefined`. `isPreview` and `canDrop` are always present.
  * @group Types
  */
 export type CellDragState = CellDragStateDragging | CellDragStateIdle;
@@ -68,16 +69,19 @@ const NOOP_CLEANUP = () => {};
 const NOOP_SUBSCRIBE = () => NOOP_CLEANUP;
 
 /**
- * Returns reactive drag state for the current cell. Self-contained, lazily
- * attaches paper event listeners on first subscription per paper.
+ * Tracks the live drag state of the current cell while the user drags it
+ * across the paper. Read `isDragging` to dim the element, or `canDrop` /
+ * `dropArea` to render a drop indicator. Use it inside a `renderElement`
+ * callback.
  *
- * Only the dragged element re-renders, all other elements receive a frozen
- * idle reference.
- * Used inside `renderElement`.
+ * Only the cell being dragged re-renders; every other cell receives a shared,
+ * frozen idle reference, so large diagrams stay cheap to render.
  * @group Hooks
- * @returns Drag state scoped to the current cell.
+ * @returns the {@link CellDragState} scoped to the current cell
  * @example
  * ```tsx
+ * import { Paper, useCellDrag } from '@joint/react';
+ *
  * function MyElement({ label }: { label: string }) {
  *   const { isDragging } = useCellDrag();
  *   return (
@@ -86,6 +90,8 @@ const NOOP_SUBSCRIBE = () => NOOP_CLEANUP;
  *     </div>
  *   );
  * }
+ *
+ * <Paper renderElement={(el) => <MyElement label={String(el.id)} />} />;
  * ```
  */
 export function useCellDrag(): CellDragState {

--- a/packages/joint-react/src/hooks/use-cell-id.ts
+++ b/packages/joint-react/src/hooks/use-cell-id.ts
@@ -14,6 +14,8 @@ import type { CellId } from '../types/cell.types';
  * @group Hooks
  * @example
  * ```tsx
+ * import { useCellId } from '@joint/react';
+ *
  * function MyElement() {
  *   const id = useCellId();
  *   return <text>{id}</text>;

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -144,8 +144,7 @@ type SetCellDataUpdater<Data> = (previousData: Data) => Data;
  *
  * A nullish `id`, or an `id` with no matching cell, warns in dev and no-ops.
  * updating data implies the cell is already on the graph (use `setCell` to add
- * a new one). The updater overload is listed first so a function argument
- * matches it; any non-function argument falls through to the direct form.
+ * a new one).
  * @template Data - cell data shape (defaults to an open `Record<string, unknown>`)
  * @group Types
  */
@@ -161,10 +160,25 @@ export interface SetCellData<Data = Record<string, unknown>> {
  * in dev and no-ops.
  *
  * Writes `data` directly on the `dia.Cell`, so JointJS fires `change:data` and
- * every React subscription resyncs, no full-record merge is involved.
+ * every React subscription resyncs, no full-record merge is involved. Read the
+ * value back with {@link useCell}.
  * @template Data - cell data shape (defaults to an open `Record<string, unknown>`)
  * @returns memoized setCellData setter
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { useSetCellData } from '@joint/react';
+ *
+ * function DoneToggle({ id }: { id: string }) {
+ *   const setCellData = useSetCellData<{ done: boolean }>();
+ *   // Updater form: flip the `done` flag on the cell's data.
+ *   return (
+ *     <button onClick={() => setCellData(id, (prev) => ({ ...prev, done: !prev.done }))}>
+ *       Toggle
+ *     </button>
+ *   );
+ * }
+ * ```
  */
 export function useSetCellData<Data = Record<string, unknown>>(): SetCellData<Data> {
   const store = useGraphStore();

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -15,6 +15,18 @@ import type { AnyCellRecord, CellId, CellRecord, Computed } from '../types/cell.
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns the current resolved cell record
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { Paper, useCell } from '@joint/react';
+ *
+ * function NodeLabel() {
+ *   // The id comes from the <Paper> render callback context.
+ *   const cell = useCell();
+ *   return <text>{String(cell.id)}</text>;
+ * }
+ *
+ * <Paper renderElement={() => <NodeLabel />} />;
+ * ```
  */
 export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(): Cell;
 /**
@@ -26,8 +38,19 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(): Ce
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `Cell`)
  * @param selector - derive a value from the current resolved cell record
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
+ * @example
+ * ```tsx
+ * import { useCell, selectElementData } from '@joint/react';
+ *
+ * function NodeLabel() {
+ *   type NodeData = { label: string };
+ *   // Re-renders only when this element's data changes.
+ *   const data = useCell(selectElementData<NodeData>);
+ *   return <text>{data.label}</text>;
+ * }
+ * ```
  */
 export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>, Selected = Cell>(
   selector: (cell: Cell) => Selected,
@@ -36,13 +59,20 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>, Selec
 /**
  * Subscribe to a specific cell by id. Works anywhere, does not require
  * `CellIdContext`. Throws when the id does not resolve to a cell.
- *
- * Cannot be unified with the `(selector)` overload because the argument type
- * ({@link CellId} vs function) drives the return shape (record vs selected value).
  * @title Read a cell by id
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @param id - cell id to track
  * @returns the resolved cell record
+ * @example
+ * ```tsx
+ * import { useCell } from '@joint/react';
+ *
+ * function CellTypeBadge({ id }: { id: string }) {
+ *   // Works outside a render callback too — subscribes to this id anywhere.
+ *   const cell = useCell(id);
+ *   return <span>{cell.type}</span>;
+ * }
+ * ```
  */
 export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
@@ -57,7 +87,7 @@ export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * @template Selected - selector return type (defaults to `Cell`)
  * @param id - cell id to track
  * @param selector - derive a value from the resolved cell record
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
  */
 export function useCell<Cell extends AnyCellRecord = Computed<CellRecord>, Selected = Cell>(

--- a/packages/joint-react/src/hooks/use-cells.ts
+++ b/packages/joint-react/src/hooks/use-cells.ts
@@ -124,7 +124,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * @template Selected - selector return type
  * @param collection - JointJS collection whose member IDs drive the subscription
  * @param selector - derive a value from the picked resolved cells array
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
  */
 export function useCells<
@@ -143,6 +143,15 @@ export function useCells<
  * @title Subscribe to all cells
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @returns readonly resolved cells array
+ * @example
+ * ```tsx
+ * import { useCells } from '@joint/react';
+ *
+ * function CellCount() {
+ *   const cells = useCells();
+ *   return <span>{cells.length} cells</span>;
+ * }
+ * ```
  */
 export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(): readonly Cell[];
 /**
@@ -165,7 +174,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * @template Selected - selector return type (defaults to `Cell | undefined`)
  * @param id - cell id to track (nullish → selector receives `undefined`)
  * @param selector - derive a value from the cell (or `undefined` when missing)
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
  */
 export function useCells<
@@ -198,7 +207,7 @@ export function useCells<Cell extends AnyCellRecord = Computed<CellRecord>>(
  * @template Selected - selector return type (defaults to `readonly Cell[]`)
  * @param ids - cell ids to track
  * @param selector - derive a value from the picked resolved cells array
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
  */
 export function useCells<
@@ -216,8 +225,20 @@ export function useCells<
  * @template Cell - resolved cell record shape (defaults to Computed<CellRecord>)
  * @template Selected - selector return type (defaults to `readonly Cell[]`)
  * @param selector - derive a value from the resolved cells array
- * @param isEqual - equality test used to short-circuit re-renders (defaults to Object.is)
+ * @param isEqual - equality test used to short-circuit re-renders (defaults to a shallow, array-aware comparison that falls back to Object.is for scalar results)
  * @returns selected value
+ * @example
+ * ```tsx
+ * import { useCells } from '@joint/react';
+ *
+ * function ElementCount() {
+ *   // Counts cells whose type is the default 'element' and re-renders only when
+ *   // that count changes; shape-typed elements (e.g. 'standard.Rectangle') are
+ *   // not included.
+ *   const count = useCells((cells) => cells.filter((cell) => cell.type === 'element').length);
+ *   return <span>{count} elements</span>;
+ * }
+ * ```
  */
 export function useCells<
   Cell extends AnyCellRecord = Computed<CellRecord>,

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -81,7 +81,7 @@ export interface GraphApi<
    * typed records flow through, otherwise it falls back to
    * `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
    * at the type level, so when both are typed the updater sees their union.
-   * narrow inside it. For a single fixed `data` shape, use the standalone
+   * Narrow inside it. For a single fixed `data` shape, use the standalone
    * `useSetCellData<MyData>()` hook.
    */
   readonly setCellData: SetCellData<HandleCellData<Element, Link>>;
@@ -103,16 +103,14 @@ export interface GraphApi<
   ) => void;
   /**
    * Predicate / type guard: true when the input resolves to an element cell.
-   * Delegates to `GraphStore.isElement`, consults the graph's type registry
-   * so any `dia.Element` subclass (including custom shapes) is recognised,
-   * not just our default {@link ElementModel}.
+   * Consults the graph's type registry so any `dia.Element` subclass (including
+   * custom shapes) is recognised, not just the default {@link ElementModel}.
    */
   readonly isElement: (input: Element | Link) => input is Element;
   /**
    * Predicate / type guard: true when the input resolves to a link cell.
-   * Delegates to `GraphStore.isLink`, consults the graph's type registry so
-   * any `dia.Link` subclass (including custom shapes) is recognised, not just
-   * our default {@link LinkModel}.
+   * Consults the graph's type registry so any `dia.Link` subclass (including
+   * custom shapes) is recognised, not just the default {@link LinkModel}.
    */
   readonly isLink: (input: Element | Link) => input is Link;
   /**
@@ -135,26 +133,65 @@ export interface GraphApi<
 }
 
 /**
- * Options accepted by {@link GraphApi}.exportToJSON.
+ * Options for {@link GraphApi}'s `exportToJSON`.
+ * @expand
  * @group Types
  */
 export interface ExportToJSONOptions {
   /**
-   * When `true`, every attribute is preserved (defaults included) and no
-   * empty-attribute pruning is applied. Defaults to `false`, minimal output:
-   * defaults stripped, empties pruned (except `attrs.*.*`).
+   * When `true`, every attribute is kept (defaults included) and no
+   * empty-attribute pruning is applied. The default minimal output strips
+   * attributes that match each cell's `defaults` and prunes empty `{}`
+   * (except inside `attrs` at depth 3, e.g. `attrs.text.textWrap: {}`, which
+   * JointJS treats as a meaningful reset marker).
+   * @default false
    */
   readonly includeDefaults?: boolean;
 }
 
 /**
- * Access the graph and its imperative cell-mutation API. Must be called
- * inside a `<GraphProvider>`.
+ * Access the graph together with its imperative cell-mutation API for adding,
+ * updating, removing, and serializing cells. Call this inside a
+ * {@link GraphProvider}.
  * @template Element - element record shape (use `ElementRecord<MyData>` for input,
  *                    `Computed<ElementRecord<MyData>>` for read shapes)
  * @template Link - link record shape (use `LinkRecord<MyData>` /
  *                  `Computed<LinkRecord<MyData>>`)
+ * @returns The {@link GraphApi}: the `dia.Graph` instance plus `setCell`,
+ *          `setCellData`, `removeCell`, `resetCells`, `exportToJSON`, and the
+ *          other cell actions.
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper, useGraph } from '@joint/react';
+ *
+ * function Toolbar() {
+ *   const { setCell, exportToJSON } = useGraph();
+ *   return (
+ *     <button
+ *       onClick={() =>
+ *         setCell({
+ *           id: 'node-1',
+ *           type: 'standard.Rectangle',
+ *           position: { x: 40, y: 40 },
+ *           size: { width: 120, height: 60 },
+ *         })
+ *       }
+ *     >
+ *       Add node
+ *     </button>
+ *   );
+ * }
+ *
+ * function App() {
+ *   return (
+ *     <GraphProvider>
+ *       <Paper />
+ *       <Toolbar />
+ *     </GraphProvider>
+ *   );
+ * }
+ * ```
  */
 export function useGraph<
   Element extends ElementJSONInit = ElementJSONInit,

--- a/packages/joint-react/src/hooks/use-link-layout.ts
+++ b/packages/joint-react/src/hooks/use-link-layout.ts
@@ -25,30 +25,42 @@ function isSameLayout(a: LinkLayout | undefined, b: LinkLayout | undefined): boo
 }
 
 /**
- * Read the current link's rendered geometry from the paper it lives on.
- * `{ sourceX, sourceY, targetX, targetY, d }`, where `d` is the serialised
- * SVG path computed by JointJS's `LinkView`.
+ * Returns the current link's rendered geometry, its source and target endpoint
+ * coordinates plus the SVG path string (`{ sourceX, sourceY, targetX, targetY,
+ * d }`, where `d` is the path computed by JointJS). Use it to draw custom link
+ * decorations, labels, or overlays that need to follow the link's actual route.
  *
- * Paper-scoped because link geometry is not a property of the graph record.
- * a single link can appear on multiple papers (e.g. main canvas + minimap)
- * with different routing. The layout is read from the paper context via
- * `usePaperStore()` and re-read whenever the paper finishes a render pass
- * (JointJS's `render:done` event), which covers every case that can change
- * a link's geometry, drag, programmatic position change, source/target
- * reconnection, resize, etc.
+ * Geometry is per-paper: the same link can render with different routing on
+ * different papers (e.g. the main canvas and a minimap), so the hook reports the
+ * geometry on the paper it is mounted under. The value stays in sync, it
+ * re-reads after every render pass, covering drags, programmatic position
+ * changes, source/target reconnections, and resizes.
  *
- * Must be called inside `renderLink` (or a component mounted from one) so
- * `CellIdContext` resolves the target link id. Returns `undefined` while the
- * link view is still being created or when the link's source / target are
- * not yet positioned.
- *
- * The snapshot is memoised by structural equality, which is required by
- * `useSyncExternalStore`, returning a fresh object on every read would
- * trigger an infinite re-render loop because `Object.is` would see every
- * render as a store change.
- * @returns the current link's layout, or undefined when unavailable
+ * Call it inside `renderLink` (or a component mounted from one) so the target
+ * link id resolves from context. Returns `undefined` only until the link view
+ * exists — no paper has mounted yet, or the view is still being created. Once the
+ * view appears the value is always defined; it may briefly report zeroed
+ * coordinates and an empty path string until JointJS computes the first route.
+ * @returns The current link's layout, or `undefined` while no link view exists yet.
  * @experimental Depends on `renderLink`, which is itself experimental.
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper, useLinkLayout } from '@joint/react';
+ *
+ * // A badge that tracks the midpoint of the link as it is routed.
+ * function LinkMidpointBadge() {
+ *   const layout = useLinkLayout();
+ *   if (!layout) return null;
+ *   const midX = (layout.sourceX + layout.targetX) / 2;
+ *   const midY = (layout.sourceY + layout.targetY) / 2;
+ *   return <circle cx={midX} cy={midY} r={4} fill="tomato" />;
+ * }
+ *
+ * <GraphProvider>
+ *   <Paper renderLink={() => <LinkMidpointBadge />} />
+ * </GraphProvider>
+ * ```
  */
 export function useLinkLayout(): LinkLayout | undefined {
   const id = useCellId();

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -5,13 +5,15 @@ import type { dia } from '@joint/core';
 import { PORTAL_SELECTOR } from '../mvc/element-model';
 
 /**
- * Options for `magnetRef`.
+ * Options for {@link MarkupApi}'s `magnetRef`.
+ * @expand
  * @group Types
  */
 export interface MagnetRefOptions {
   /**
-   * Whether the magnet is passive, only a valid connection target, not a source.
-   * When `false` (default), the magnet is `active` and links can start from it.
+   * When `true`, the magnet is passive: a valid connection target but not a
+   * source. When `false`, it is active and links can also start from it.
+   * @default false
    */
   readonly passive?: boolean;
 }
@@ -23,11 +25,10 @@ export interface MagnetRefOptions {
  */
 export interface MarkupApi {
   /**
-   * Returns a React ref callback that registers the node under the given selector name.
-   * Sets the `joint-selector` attribute on the node and adds it to `elementView.selectors`
-   * so links and tools can target it by name.
+   * Returns a React ref callback that registers the node under the given selector
+   * name so links and tools can target it by name.
    * @param selector - Unique selector name within the element (e.g. `'body'`, `'item-0'`).
-   * @throws If `selector` equals the reserved portal selector name.
+   * @throws If `selector` is one of the reserved names (`__portal__`, `root`, `portRoot`).
    */
   readonly selectorRef: (selector: string) => (node: Element | null) => void;
   /**
@@ -35,7 +36,7 @@ export interface MarkupApi {
    * AND marks it as a JointJS magnet, a valid endpoint for link connections.
    * @param selector - Unique selector name within the element (e.g. `'port-in'`, `'row-0'`).
    * @param options - Magnet behavior options.
-   * @throws If `selector` equals the reserved portal selector name.
+   * @throws If `selector` is one of the reserved names (`__portal__`, `root`, `portRoot`).
    */
   readonly magnetRef: (
     selector: string,
@@ -48,20 +49,25 @@ export interface MarkupApi {
  * the current element view, so links and tools can target named parts of a
  * React-rendered element. Must be used inside `renderElement`.
  * @group Hooks
+ * @returns The {@link MarkupApi}: a `selectorRef` factory that tags an SVG node
+ * under a named selector so links and tools can target it, and a `magnetRef`
+ * factory that does the same and also marks the node as a connectable magnet.
  * @example
  * ```tsx
  * import { useMarkup } from '@joint/react';
  *
- * function MyComponent({ labels }) {
+ * function MyComponent({ labels }: { labels: string[] }) {
  *   const { selectorRef, magnetRef } = useMarkup();
  *   return (
- *     <>
+ *     // Tag the group as the 'body' selector so tools can target it.
+ *     <g ref={selectorRef('body')}>
  *       {labels.map((label, index) => (
+ *         // Each row is a magnet, so links can connect to it.
  *         <g ref={magnetRef(`item-${index}`)} key={label}>
  *           <text>{label}</text>
  *         </g>
  *       ))}
- *     </>
+ *     </g>
  *   );
  * }
  * ```

--- a/packages/joint-react/src/hooks/use-measure-element.tsx
+++ b/packages/joint-react/src/hooks/use-measure-element.tsx
@@ -9,22 +9,22 @@ import { selectElementSize } from '../selectors';
 import { MEASURING_CLASS_NAME } from '../utils/class-names';
 
 /**
- * Options for configuring how the node size is measured and applied.
+ * Options for {@link useMeasureElement}, controlling how the measured DOM size is
+ * turned into the graph element's size.
  * @group Types
+ * @expand
  */
 export interface MeasureElementOptions {
   /**
-   * Custom transform function to modify the measured size before applying it to the graph element.
-   *
-   * This function receives the measured dimensions from the DOM node and the current graph element,
-   * allowing you to add padding, apply scaling, or perform other transformations.
-   * @param options - The measured size and the graph element instance (width, height, x, y, element)
-   * @returns The size values to apply to the graph element. Must include `width` and `height`.
-   * @default By default, the measured size is applied directly via `element.set('size', {width, height})`
+   * Adjusts the measured size before it is written to the graph element, e.g. to
+   * add padding or reserve space for a header. Receives the measured dimensions
+   * plus the element's current layout ({@link TransformElementLayoutParams}) and
+   * returns the `width`/`height` (and optionally `x`/`y`) to apply.
+   * @default When omitted, the measured `width`/`height` are applied to the element unchanged.
    * @example
    * ```tsx
    * const transform = ({ width, height }) => ({
-   *   width: width + 20, // Add 10px padding on each side
+   *   width: width + 20, // 10px padding on each side
    *   height: height + 20,
    * });
    * useMeasureElement(nodeRef, { transform });
@@ -36,84 +36,78 @@ export interface MeasureElementOptions {
 const EMPTY_OBJECT: MeasureElementOptions = {};
 
 /**
- * Custom hook to automatically measure the size of a DOM element and synchronize it with the graph element's size.
+ * Measures a rendered DOM node and keeps the graph element's size in sync with
+ * it. Point `nodeRef` at the HTML or SVG node that defines the element's size;
+ * whenever that node resizes, the matching graph element is resized to match
+ * (optionally adjusted by a `transform`, see {@link MeasureElementOptions}), and
+ * the element's current `width`/`height` are returned for your own layout math.
  *
- * This hook uses the ResizeObserver API to monitor size changes of the referenced DOM element
- * and automatically updates the corresponding graph element's size. The returned values represent
- * the current size of the graph element (which may differ from the measured DOM size if a custom
- * `transform` function is provided).
- *
- * **How it works:**
- * 1. Observes the DOM element referenced by `nodeRef` for size changes
- * 2. When the DOM element's size changes, applies the size (or transformed size) to the graph element
- * 3. Returns the current graph element's dimensions, which are always defined
- *
- * **Important constraints:**
- * - When multiple `useMeasureElement` hooks target the same element, the most recently mounted hook
- *   takes precedence. When it unmounts, the previous hook becomes active again (stack semantics).
- * - Must be used within a `renderElement` function or a component rendered from within it.
- * - The returned values are always defined (width and height default to 0 if not set).
- *
- * **Anti-pattern, do not combine with `useCell(selectElementSize)`:**
- * Do not pair this hook with `useCell((cell) => cell.size)` (or the equivalent
- * {@link selectElementSize} selector) in the same component. This hook already
- * synchronizes the measured size to the graph element and returns the live
- * `width` / `height`. Reading the value back through {@link useCell} adds a redundant
- * subscription and an extra render. Prefer the returned `width`/`height` from
- * this hook directly.
- * @param nodeRef - A reference to the HTML or SVG element to measure. The element must be rendered
- *                     in the DOM when the hook runs.
- * @param options - Optional configuration for measuring and transforming the node size.
- * @returns An object containing the current graph element's dimensions:
- *   - `width`: The current width of the graph element in pixels (defaults to 0)
- *   - `height`: The current height of the graph element in pixels (defaults to 0)
- *   - `x`: The current x position of the graph element (defaults to 0)
- *   - `y`: The current y position of the graph element (defaults to 0)
- *   - `angle`: The current angle of the graph element (defaults to 0)
- * @throws {Error} If the cell is not a valid element.
- *
- * **Important:** Do not combine with `useCell((cell) => cell.size)` (or
- * {@link selectElementSize} / similar selectors) in the same component. This hook
- * already synchronizes the measured size to the graph element. Use the
- * returned `width` / `height` from this hook directly rather than reading
- * the value back from the model, combining both creates a redundant
- * round-trip and can fight on the first measurement.
+ * Reach for it when an element's size is driven by its rendered content rather
+ * than fixed up front, e.g. text that wraps or a list that grows.
+ * @remarks
+ * - Call this inside a `renderElement` callback (or a component rendered from
+ *   one); it reads the current cell from context and throws otherwise.
+ * - When several `useMeasureElement` calls target the same element, the most
+ *   recently mounted one wins. When it unmounts, the previous one takes over
+ *   again.
+ * - Do not also read the size back with the {@link selectElementSize} selector
+ *   (or `useCell((cell) => cell.size)`) in the same component. This hook already
+ *   syncs the size and returns the live `width`/`height`; reading it again only
+ *   adds a redundant subscription and an extra render.
+ * @param nodeRef - Ref to the HTML or SVG node to measure. It must be mounted in
+ *   the DOM while the hook runs.
+ * @param options - Optional {@link MeasureElementOptions}; the main option is a
+ *   `transform` that adjusts the measured size before it is applied.
+ * @returns The graph element's current `width` and `height` (always defined).
+ * @throws If used outside a `renderElement` context, or if the current cell is a
+ *   link rather than an element.
  * @group Hooks
  * @example
- * Basic usage with SVG element:
+ * @title Basic usage
  * ```tsx
  * import { useMeasureElement } from '@joint/react';
  * import { useRef } from 'react';
  *
- * function RenderElement() {
- *   const rectRef = useRef<SVGRectElement>(null);
- *   const { width, height } = useMeasureElement(rectRef);
- *
- *   return (
- *     <rect ref={rectRef} width={80} height={120} fill="#333" />
- *   );
- * }
- * ```
- * @example
- * Using returned values for calculations:
- * ```tsx
- * function Card() {
- *   const frameRef = useRef<SVGRectElement>(null);
- *   const { width, height } = useMeasureElement(frameRef);
- *   const gap = 10;
- *   const imageWidth = Math.max(width - gap * 2, 0);
- *   const imageHeight = Math.max(height - gap * 2, 0);
+ * // The element grows to fit its text label.
+ * function LabelElement() {
+ *   const textRef = useRef<SVGTextElement>(null);
+ *   const { width, height } = useMeasureElement(textRef);
  *
  *   return (
  *     <>
- *       <rect ref={frameRef} width={80} height={120} fill="#333" />
- *       <image href={iconURL} x={gap} y={gap} width={imageWidth} height={imageHeight} />
+ *       <rect width={width} height={height} fill="#333" />
+ *       <text ref={textRef} x={4} y={16} fill="#fff">Hello world</text>
  *     </>
  *   );
  * }
  * ```
  * @example
- * With custom transform to add padding:
+ * @title Use the returned size
+ * ```tsx
+ * import { useMeasureElement } from '@joint/react';
+ * import { useRef } from 'react';
+ *
+ * const iconURL = 'https://example.com/icon.svg';
+ *
+ * // Size follows the HTML content; use the returned size to place an icon inside.
+ * function Card() {
+ *   const contentRef = useRef<HTMLDivElement>(null);
+ *   const { width, height } = useMeasureElement(contentRef);
+ *   const iconSize = 16;
+ *
+ *   return (
+ *     <>
+ *       <rect width={width} height={height} fill="#333" />
+ *       <image href={iconURL} x={width - iconSize} y={0} width={iconSize} height={iconSize} />
+ *       <foreignObject width={width} height={height}>
+ *         <div ref={contentRef} style={{ padding: 8, color: '#fff' }}>Card content</div>
+ *       </foreignObject>
+ *     </>
+ *   );
+ * }
+ * ```
+ * @example
+ * @title Adjust size with a transform
  * ```tsx
  * import { useMeasureElement, type TransformElementLayout } from '@joint/react';
  * import { useRef, useCallback } from 'react';

--- a/packages/joint-react/src/hooks/use-on-elements-measured.ts
+++ b/packages/joint-react/src/hooks/use-on-elements-measured.ts
@@ -6,20 +6,23 @@ import { useGraphStore } from './use-graph-store';
 import { useLatestRef } from './use-latest-ref';
 
 /**
- * Payload delivered when paper-managed elements complete a measurement pass.
+ * Payload passed to the {@link useOnElementsMeasured} callback after a
+ * measurement pass.
  * @group Types
+ * @expand
  */
 export interface ElementsMeasuredParams {
-  /** True when this is the first measurement (all elements sized for the first time). */
+  /** True on the first measurement pass (at least one element has been sized). */
   readonly isInitial: boolean;
-  /** The paper instance that triggered the event. */
+  /** The paper this hook is bound to (the surrounding `<Paper>` context, or the paper passed via `paperTarget`). */
   readonly paper: dia.Paper;
   /** The graph model associated with the paper. */
   readonly graph: dia.Graph;
 }
 
 /**
- * Callback signature for {@link useOnElementsMeasured}.
+ * Callback invoked by {@link useOnElementsMeasured} after each measurement pass;
+ * receives the {@link ElementsMeasuredParams} payload.
  * @group Types
  */
 export type OnElementsMeasured = (params: ElementsMeasuredParams) => void;
@@ -27,30 +30,52 @@ export type OnElementsMeasured = (params: ElementsMeasuredParams) => void;
 /**
  * Calls a callback when element sizes are measured or re-measured.
  *
- * Fires on initial measurement (all elements have `width` and `height`)
- * and on subsequent size changes detected by the paper.
+ * Fires on the first measurement pass (at least one element has been sized)
+ * and again whenever an element is resized.
  *
- * The callback receives `{ isInitial: boolean }` to distinguish the
- * first measurement from subsequent ones.
+ * The callback receives {@link ElementsMeasuredParams}; check `isInitial` to
+ * distinguish the first measurement from later ones.
  * @title On the current paper
  * @param callback - Called each time element sizes are measured.
  * @group Hooks
  * @example
  * ```tsx
- * // Using a paper ref
- * const paperRef = useRef<dia.Paper>(null);
- * useOnElementsMeasured(paperRef, () => {
- *   paperRef.current?.transformToFitContent({ padding: 20 });
- * });
+ * import { useOnElementsMeasured } from '@joint/react';
+ *
+ * // Mount inside a <Paper>: fit the surrounding paper once everything is sized.
+ * function FitOnMeasure() {
+ *   useOnElementsMeasured(({ paper, isInitial }) => {
+ *     if (isInitial) {
+ *       paper.transformToFitContent({ padding: 20 });
+ *     }
+ *   });
+ *   return null;
+ * }
  * ```
  */
 export function useOnElementsMeasured(callback: OnElementsMeasured): void;
 /**
- * Calls a callback when element sizes are measured, on a specific paper.
+ * Calls a callback when element sizes are measured, targeting a specific paper
+ * instead of the surrounding context. Useful when several papers share one graph.
  * @title On a specific paper
- * @param paperTarget - Paper reference (string ID, dia.Paper instance, or ref).
+ * @param paperTarget - Which paper to watch: a registered paper id, a
+ *   `dia.Paper` instance, or a React ref to one.
  * @param callback - Called each time element sizes are measured.
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { useOnElementsMeasured } from '@joint/react';
+ * import { useRef } from 'react';
+ * import type { dia } from '@joint/core';
+ *
+ * function FitSpecificPaper() {
+ *   const paperRef = useRef<dia.Paper>(null);
+ *   useOnElementsMeasured(paperRef, ({ paper }) => {
+ *     paper.transformToFitContent({ padding: 20 });
+ *   });
+ *   return null;
+ * }
+ * ```
  */
 export function useOnElementsMeasured(paperTarget: PaperTarget, callback: OnElementsMeasured): void;
 export function useOnElementsMeasured(

--- a/packages/joint-react/src/hooks/use-on-graph-events.ts
+++ b/packages/joint-react/src/hooks/use-on-graph-events.ts
@@ -37,39 +37,70 @@ function subscribeToGraphEvents(graph: dia.Graph, handlers: GraphEventMap): () =
 }
 
 /**
- * The map of graph events to handlers accepted by {@link useOnGraphEvents}.
- * See [JointJS graph events](https://docs.jointjs.com/api/dia/Graph#events)
- * for the available event names and their arguments.
+ * Maps JointJS graph event names to their handler callbacks, the shape
+ * {@link useOnGraphEvents} accepts. Every entry is optional, list only the
+ * events you want to react to. Keys and handler arguments mirror
+ * [`dia.Graph` events](https://docs.jointjs.com/api/dia/Graph#events) one to one
+ * (`'add'`, `'remove'`, `'change:position'`, …).
  * @group Types
  */
 export type GraphEventMap = Partial<dia.Graph.EventMap>;
 
 /**
- * Subscribes to graph events using original JointJS event names.
+ * Subscribes to graph events by their native JointJS names, so you can react to
+ * cells being added, removed, moved, or otherwise changed without wiring up
+ * listeners by hand. This form reads the graph from the surrounding
+ * `<GraphProvider>` and throws when used outside one.
  *
- * Handlers are **always-latest**: the subscription is established once and
- * each event reads the current handler, so inline maps and closures need no
- * `useCallback`. Re-subscription happens only when the graph or the set of
- * event names changes.
+ * Handlers are **always-latest**: the subscription is established once and each
+ * event reads the current handler, so inline maps and closures need no
+ * `useCallback`. Re-subscription happens only when the graph or the set of event
+ * names changes.
+ *
+ * See {@link GraphEventMap} for the available event names and their arguments.
  * @title On the current graph
- * @param handlers - Event handlers map keyed by JointJS graph event names.
+ * @param handlers - Map of JointJS graph event names to callbacks.
  * @group Hooks
  * @example
  * ```tsx
- * useOnGraphEvents({
- *   'add': (cell) => console.log('added', cell.id),
- *   'remove': (cell) => console.log('removed', cell.id),
- *   'change:position': (cell) => console.log('moved', cell.id),
- * });
+ * import { GraphProvider, useOnGraphEvents } from '@joint/react';
+ *
+ * function CellLogger() {
+ *   useOnGraphEvents({
+ *     add: (cell) => console.log('added', cell.id),
+ *     remove: (cell) => console.log('removed', cell.id),
+ *     'change:position': (cell) => console.log('moved', cell.id),
+ *   });
+ *   return null;
+ * }
+ *
+ * // Mount inside a <GraphProvider> so the hook can find the graph.
+ * <GraphProvider>
+ *   <CellLogger />
+ * </GraphProvider>
  * ```
  */
 export function useOnGraphEvents(handlers: GraphEventMap): void;
 /**
- * Subscribes to graph events on the given graph instance.
+ * Subscribes to graph events on a graph instance you pass in explicitly. Reach
+ * for this when you hold a `dia.Graph` outside of any `<GraphProvider>` (e.g. a
+ * graph you created yourself). Same always-latest handler semantics as the
+ * context form.
  * @title On a specific graph
- * @param graph - Graph instance to subscribe on.
- * @param handlers - Event handlers map keyed by JointJS graph event names.
+ * @param graph - The graph instance to listen on.
+ * @param handlers - Map of JointJS graph event names to callbacks.
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { dia } from '@joint/core';
+ * import { useOnGraphEvents } from '@joint/react';
+ *
+ * function useGraphLogger(graph: dia.Graph) {
+ *   useOnGraphEvents(graph, {
+ *     add: (cell) => console.log('added', cell.id),
+ *   });
+ * }
+ * ```
  */
 export function useOnGraphEvents(graph: dia.Graph, handlers: GraphEventMap): void;
 export function useOnGraphEvents(

--- a/packages/joint-react/src/hooks/use-on-paper-events.ts
+++ b/packages/joint-react/src/hooks/use-on-paper-events.ts
@@ -8,11 +8,12 @@ import { useOnEvents } from './use-on-events';
 const EMPTY_HANDLERS: PaperEventMap = {};
 
 /**
- * Subscribes all handlers to a paper, delegating runtime wiring to
- * {@link addPaperEventListeners}.
+ * Subscribes all handlers to a paper, delegating runtime wiring to the
+ * `addPaperEventListeners` runtime.
  * @param paperStore - Paper store to subscribe on.
  * @param handlers - Event handlers map.
  * @returns Cleanup callback that stops all listeners.
+ * @internal
  */
 export function subscribeToPaperEvents(
   paperStore: PaperStore,
@@ -22,10 +23,15 @@ export function subscribeToPaperEvents(
 }
 
 /**
- * Subscribes to paper events. The paper argument is optional, when omitted
- * the hook reads the active paper from the surrounding {@link Paper} context (it
- * throws if no {@link Paper} context is available). Two key forms can be mixed in
- * the same handlers map:
+ * Subscribes to `dia.Paper` events, pointer clicks, hovers, drags, link
+ * connections, zoom/pan, and more, so you can respond to user interaction on the
+ * canvas. When no paper argument is given, the hook targets the paper from the
+ * surrounding {@link Paper} context (or the single default paper). Mount it
+ * inside a `<GraphProvider>`. Unlike {@link useOnGraphEvents}, it tolerates a
+ * paper that has not mounted yet — it does not throw while waiting and
+ * subscribes once a paper becomes available.
+ *
+ * Two key forms can be mixed in the same handlers map:
  *
  * **CamelCase form**: `on<Category><Event>` keys deliver a single params
  * object with named properties.
@@ -54,17 +60,52 @@ export function subscribeToPaperEvents(
  * The `on*` params object omits the React-store `record`, to read the
  * record shape, call `useCell(id, selector)` from your own
  * component (the handler closure has access to the `id` it emits).
+ *
+ * See {@link PaperEventMap} for every accepted key, and {@link PaperEventHandler}
+ * for typing an individual handler.
  * @title On the current paper
- * @param handlers - Event handlers map.
+ * @param handlers - Map of paper events to callbacks (camelCase `on*` and/or raw).
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper, useOnPaperEvents } from '@joint/react';
+ *
+ * function SelectionLogger() {
+ *   useOnPaperEvents({
+ *     onElementPointerClick: ({ id }) => console.log('clicked element', id),
+ *     onBlankPointerClick: ({ x, y }) => console.log('clicked blank at', x, y),
+ *   });
+ *   return null;
+ * }
+ *
+ * <GraphProvider>
+ *   <Paper renderElement={() => <rect width={80} height={40} fill="#3498db" />} />
+ *   <SelectionLogger />
+ * </GraphProvider>
+ * ```
  */
 export function useOnPaperEvents(handlers: PaperEventMap): void;
 /**
- * Subscribes to paper events on the given paper target.
+ * Subscribes to paper events on a specific paper you name, by registered id,
+ * `dia.Paper` instance, or React ref. Use this to target one paper when several
+ * are mounted (e.g. a main canvas plus a minimap). Same camelCase/raw handler
+ * forms and always-latest semantics as the context form.
  * @title On a specific paper
- * @param paperTarget - Paper reference (string ID, dia.Paper instance, or ref).
- * @param handlers - Event handlers map.
+ * @param paperTarget - The paper to listen on, see {@link PaperTarget}.
+ * @param handlers - Map of paper events to callbacks (camelCase `on*` and/or raw).
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { useOnPaperEvents } from '@joint/react';
+ *
+ * // Target a paper by its registered id.
+ * function MinimapLogger() {
+ *   useOnPaperEvents('minimap', {
+ *     onBlankPointerClick: ({ x, y }) => console.log('minimap click', x, y),
+ *   });
+ *   return null;
+ * }
+ * ```
  */
 export function useOnPaperEvents(paperTarget: PaperTarget, handlers: PaperEventMap): void;
 export function useOnPaperEvents(

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -48,7 +48,7 @@ export function useResolvePaperId(paperTarget: PaperTarget | undefined): string 
  * 2. `DEFAULT_PAPER_ID` lookup (when a single `<Paper>` exists without an explicit `id`)
  * @param paperId - An explicit paper id, or omitted for the context/default paper.
  * @returns The resolved paper store, or `undefined` when no paper is mounted yet.
- * @group Hooks
+ * @internal
  */
 export function usePaperStore(paperId?: string): PaperStore | undefined {
   const contextStore = useContext(PaperStoreContext);
@@ -86,15 +86,37 @@ export interface PaperApi {
 }
 
 /**
- * Returns the active `PaperView` instance from context, by ID, or via the
- * default paper. Resolves the paper store and exposes `wakeUp()`.
+ * Access the JointJS paper (`dia.Paper`) instance for the surrounding `<Paper>`,
+ * a specific paper by id, or the default paper. Use it to drive the paper
+ * imperatively, scale, fit content, or wake it up, from anywhere under a
+ * {@link GraphProvider}.
  *
- * The returned object is always stable; only `paper` is `null` until the
- * `<Paper>` view has mounted.
+ * The returned object is referentially stable for a given resolved paper; its
+ * `paper` is `null` until the `<Paper>` view has mounted, so guard calls with
+ * `paper?.`.
  * @param paperId - An explicit paper id, or omitted for the context/default paper.
- * @returns A stable object with the resolved `paper` (or `null`) and a `wakeUp` action.
+ * @returns The {@link PaperApi}: the resolved `paper` (or `null`) and a `wakeUp` action.
  * @see https://docs.jointjs.com/learn/quickstart/paper
  * @group Hooks
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper, usePaper } from '@joint/react';
+ *
+ * function FitButton() {
+ *   const { paper } = usePaper();
+ *   // `paper` is null until the <Paper> view has mounted.
+ *   return <button onClick={() => paper?.transformToFitContent({ padding: 20 })}>Fit</button>;
+ * }
+ *
+ * function App() {
+ *   return (
+ *     <GraphProvider>
+ *       <Paper />
+ *       <FitButton />
+ *     </GraphProvider>
+ *   );
+ * }
+ * ```
  */
 export function usePaper(paperId?: string): PaperApi {
   const paperStore = usePaperStore(paperId);

--- a/packages/joint-react/src/mvc/element-model.tsx
+++ b/packages/joint-react/src/mvc/element-model.tsx
@@ -1,24 +1,26 @@
 import { dia } from '@joint/core';
 import type { PortalHostCell } from './paper.types';
 /**
- * Type discriminator for {@link ElementModel}, matches `dia.Cell.type` to
- * identify React-element cells when iterating the graph.
+ * The `type` value `@joint/react` stamps on every {@link ElementModel}
+ * (`'element'`). Match it against a cell's `type` to single out React elements
+ * when iterating the graph.
  * @group MVC
  */
 export const ELEMENT_MODEL_TYPE = 'element';
 
 /**
  * Selector for the `<g>` element used as the React portal target inside ElementModel markup.
- * @group MVC
+ * @internal
  */
 export const PORTAL_SELECTOR = '__portal__';
 
 /**
- * Default element class used by `@joint/react`. Any `dia.Cell` subclass
- * implementing {@link PortalHostCell} can host React content; this one is
- * what `@joint/react` reaches for when no custom element class is provided.
- * Adds a dedicated `<g>` group to its markup where `renderElement` mounts,
- * placed under ports and highlighters by default so they paint on top.
+ * The element class `@joint/react` registers and uses by default for every
+ * element you add to the graph. Its markup carries a dedicated `<g>` group (the
+ * `'__portal__'` selector) where your {@link RenderElement} output is mounted, so
+ * React content renders beneath the element's ports and highlighters. Extend it
+ * to customize the markup or default attributes, or supply any `dia.Element`
+ * subclass that implements {@link PortalHostCell} to host React content yourself.
  * @group MVC
  * @example
  * ```ts
@@ -35,14 +37,15 @@ export class ElementModel<
   Attributes extends dia.Element.Attributes = dia.Element.Attributes
 > extends dia.Element<Attributes> implements PortalHostCell {
   /**
-   * Selector of the node that serves as the React portal target inside this cell.
-   * Read by `PaperView` to locate where `renderElement` mounts.
+   * Selector of the node in this cell's view where `@joint/react` mounts your
+   * {@link RenderElement} content, the `'__portal__'` `<g>` group.
    */
   portalSelector = PORTAL_SELECTOR;
 
   /**
-   * Markup containing a dedicated `<g>` group for React portal rendering.
-   * Ports and highlighters are appended after this group, ensuring correct stacking order.
+   * Markup with a single `<g>` group (`'__portal__'`) that hosts the React
+   * portal. JointJS appends ports and highlighters after this group, so they
+   * paint on top of your React content.
    */
   markup: dia.MarkupJSON = [
     {
@@ -52,7 +55,8 @@ export class ElementModel<
   ];
 
   /**
-   * Sets the default attributes for the ElementModel.
+   * Default attributes applied to every ElementModel: the `'element'` type, a
+   * 0x0 size, and an empty `data` object.
    * @returns The default attributes.
    */
   defaults(): Attributes {

--- a/packages/joint-react/src/mvc/link-model.ts
+++ b/packages/joint-react/src/mvc/link-model.ts
@@ -3,8 +3,9 @@ import { linkStyle } from '../presets/link-style';
 import type { PortalHostCell } from './paper.types';
 
 /**
- * Type discriminator for {@link LinkModel}, matches `dia.Cell.type` to
- * identify React-link cells when iterating the graph.
+ * The `type` value `@joint/react` stamps on every {@link LinkModel} (`'link'`).
+ * Match it against a cell's `type` to single out React links when iterating the
+ * graph.
  * @group MVC
  */
 export const LINK_MODEL_TYPE = 'link';
@@ -12,11 +13,12 @@ export const LINK_MODEL_TYPE = 'link';
 const defaultLinkStyle: dia.Link.Attributes['attrs'] = linkStyle();
 
 /**
- * Default link class used by `@joint/react`. Any `dia.Cell` subclass
- * implementing {@link PortalHostCell} can host React content; this one is
- * what `@joint/react` reaches for when no custom link class is provided.
- * Ships wrapper + line markup and mounts `renderLink` into the link's root
- * `<g>`.
+ * The link class `@joint/react` registers and uses by default for every link you
+ * add to the graph. Its markup has two paths, a wide transparent `wrapper` that
+ * widens the pointer hit area and the visible `line`, and it mounts the
+ * experimental {@link RenderLink} output into the link's root `<g>`. Extend it to
+ * customize the markup or default attributes, or supply any `dia.Link` subclass
+ * that implements {@link PortalHostCell} to host React content yourself.
  * @group MVC
  * @example
  * ```ts
@@ -24,8 +26,8 @@ const defaultLinkStyle: dia.Link.Attributes['attrs'] = linkStyle();
  *
  * const link = new LinkModel({
  *   id: 'link-1',
- *   source: '1',
- *   target: '2',
+ *   source: { id: '1' },
+ *   target: { id: '2' },
  * });
  * ```
  */
@@ -33,16 +35,17 @@ export class LinkModel<
   Attributes extends dia.Link.Attributes = dia.Link.Attributes
 > extends dia.Link<Attributes> implements PortalHostCell {
   /**
-   * Selector of the node that serves as the React portal target inside this cell.
-   * Links render into their root `<g>`, the experimental `renderLink` mounts
-   * there when enabled. No dedicated portal group is kept in the markup so
-   * React-less links stay lean.
+   * Selector of the node in this cell's view where `@joint/react` mounts React
+   * content, the link's root `<g>` (`'root'`). The markup keeps no dedicated
+   * portal group so React-less links stay lean; the experimental
+   * {@link RenderLink} mounts here when enabled.
    */
   portalSelector = 'root';
 
   /**
-   * Markup with wrapper and line paths. The wrapper is used for hit testing and has a wider stroke, while the line is used for visual display.
-   * React content (if any) is rendered into the root `<g>` via `renderLink`.
+   * Markup with two paths: a wide, transparent `wrapper` that widens the pointer
+   * hit area, and the visible `line`. React content (if any) mounts into the
+   * link's root `<g>` via {@link RenderLink}.
    */
   markup: dia.MarkupJSON = [
     {
@@ -68,8 +71,9 @@ export class LinkModel<
   ];
 
   /**
-   * Sets the default attributes for the LinkModel.
-   * Includes `connection: true` attrs which are required for JointJS to compute link paths.
+   * Default attributes for every LinkModel: the `'link'` type, the default link
+   * styling, and an empty `data` object. The styling sets `connection: true` on
+   * the `line`/`wrapper` paths, which JointJS needs to compute the link path.
    * @returns The default attributes.
    */
   defaults(): Attributes {

--- a/packages/joint-react/src/mvc/paper.types.ts
+++ b/packages/joint-react/src/mvc/paper.types.ts
@@ -26,6 +26,7 @@ export interface PortalHostCell {
 
 /**
  * Context passed to a {@link PortalSelector} callback.
+ * @expand
  * @group Types
  */
 export interface PortalSelectorParams {
@@ -57,9 +58,9 @@ export type PortalSelector =
 
 /**
  * Options for creating a PaperView instance with lifecycle callbacks.
- * @group Types
  */
 export interface PaperViewOptions extends dia.Paper.Options {
+  /** Called when cell views mount or unmount, with the per-cell incremental changes. */
   readonly onViewMountChange?: (changes: Map<CellId, IncrementalChange<dia.Cell>>) => void;
   /**
    * Selector used to locate the React portal target node inside a cell view.

--- a/packages/joint-react/src/presets/anchors.ts
+++ b/packages/joint-react/src/presets/anchors.ts
@@ -41,7 +41,12 @@ export const perpendicularAnchor: anchors.Anchor = (
 };
 
 /**
- * Mode for the `midSide` anchor used on root elements and custom magnets.
+ * Chooses which side of an element or port a link attaches to when using the
+ * mid-side anchor. `'auto'` picks the side nearest the other end; `'horizontal'`
+ * and `'vertical'` lock to left/right or top/bottom; the `'prefer-*'` variants
+ * favor one axis but fall back to the other; and the directional pairs
+ * (`'top-bottom'`, `'left-right'`, etc.) pin the source and target to opposite
+ * sides.
  * @group Types
  */
 export type LinkMode = 'prefer-horizontal' | 'prefer-vertical' | 'horizontal' | 'vertical' | 'auto' | 'top-bottom' | 'bottom-top' | 'left-right' | 'right-left';

--- a/packages/joint-react/src/presets/can-connect.ts
+++ b/packages/joint-react/src/presets/can-connect.ts
@@ -1,42 +1,64 @@
 import type { dia } from '@joint/core';
 
 /**
- * Describes one end (source or target) of a connection.
+ * One end (source or target) of a link: the cell it attaches to and the exact
+ * port or magnet within that cell. Shared by {@link ValidateConnectionParams}
+ * and emitted on `link:connect` / `link:disconnect` events, so validation and
+ * event payloads describe a connection the same way.
  * @group Types
+ * @expand
  */
 export interface ConnectionEnd {
-  /** The cell ID. */
+  /** ID of the cell this end attaches to. */
   readonly id: dia.Cell.ID;
-  /** The cell model (element or link). */
+  /** The cell model (element or link) this end attaches to. */
   readonly model: dia.Cell;
-  /** The port ID, or `null` if not connected to a port. */
+  /** ID of the port the end attaches to, or `null` when it attaches to the cell body. */
   readonly port: string | null;
-  /** The SVG magnet element, or `null` when connecting to the root element. */
+  /** The SVG magnet node the end attaches to, or `null` when attaching to the cell's root. */
   readonly magnet: Element | null;
-  /** The `joint-selector` attribute of the magnet, or `null`. */
+  /** Value of the magnet's `joint-selector` attribute, or `null` when it has none. */
   readonly selector: string | null;
 }
 
 /**
- * Structured context for connection validation.
+ * Context handed to a {@link ValidateConnection} callback (and to the `validate`
+ * option of {@link CanConnectOptions}) while the user drags a link end. Describes
+ * both ends of the pending connection along with the paper and graph it lives in.
  * @group Types
+ * @expand
  */
 export interface ValidateConnectionParams {
-  /** The source end of the connection. */
+  /** The source end of the pending connection. */
   readonly source: ConnectionEnd;
-  /** The target end of the connection. */
+  /** The target end of the pending connection. */
   readonly target: ConnectionEnd;
-  /** Which end of the link is being dragged (`'source'` or `'target'`). */
+  /** Which end the user is dragging: `'source'` or `'target'`. */
   readonly endType: dia.LinkEnd;
-  /** The paper instance. */
+  /** The paper the link is being drawn on. */
   readonly paper: dia.Paper;
-  /** The graph instance. */
+  /** The graph the link belongs to. */
   readonly graph: dia.Graph;
 }
 
 /**
- * Callback that decides whether a connection is allowed.
+ * Decides whether a link may connect its source end to its target end. Return
+ * `true` to allow the connection, `false` to reject it. Pass it (or a
+ * {@link CanConnectOptions} object) to the `validateConnection` prop of `<Paper>`;
+ * the callback receives a structured {@link ValidateConnectionParams} context.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { ValidateConnection } from '@joint/react';
+ *
+ * // Only accept links that end on a port named "in".
+ * const validate: ValidateConnection = ({ target }) => target.port === 'in';
+ *
+ * <GraphProvider>
+ *   <Paper validateConnection={validate} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type ValidateConnection = (context: ValidateConnectionParams) => boolean;
 
@@ -141,25 +163,43 @@ function hasDuplicateLink(
 }
 
 /**
- * Configuration accepted by `canConnect` controlling link validation rules.
+ * Options for the `validateConnection` prop of `<Paper>` — declarative rules
+ * that toggle the common connection constraints (self-loops, link-to-link,
+ * duplicate links, root connections) and optionally layer your own check on top.
+ * Reach for this object instead of a {@link ValidateConnection} callback when the
+ * built-in rules already cover what you need.
  * @group Types
+ * @expand
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ *
+ * <GraphProvider>
+ *   <Paper
+ *     validateConnection={{
+ *       allowSelfLoops: true,
+ *       validate: ({ target }) => target.port === 'in',
+ *     }}
+ *     renderElement={() => <rect width={80} height={40} />}
+ *   />
+ * </GraphProvider>;
+ * ```
  */
 export interface CanConnectOptions {
-  /** Allow connecting a cell to itself. @default false */
+  /** Allow a cell to connect to itself. @default false */
   readonly allowSelfLoops?: boolean;
-  /** Allow connecting to or from links (not just elements). @default false */
+  /** Allow links to start or end on another link, not just on elements. @default false */
   readonly allowLinkToLink?: boolean;
-  /** Allow multiple links between the same source+port and target+port. @default false */
+  /** Allow more than one link between the same source+port and target+port. @default false */
   readonly allowMultiLinks?: boolean;
   /**
-   * Whether connecting to the root element (not a port/magnet) is allowed.
-   * - `true`, always allow root connections
-   * - `false`, never allow root (only ports/magnets)
-   * - `'auto'`, allow root only if the element has no ports
-   * @default 'auto'
+   * Whether a link may attach to an element's root (its body) instead of a port or magnet.
+   * - `true` — always allow root connections.
+   * - `false` — never allow them; require a port or magnet.
+   * - `'auto'` — allow a root connection only when the element has no ports. @default 'auto'
    */
   readonly allowRootConnection?: boolean | 'auto';
-  /** Custom validation on top of the built-in rules. Runs only if built-in checks pass. */
+  /** Extra check run only after every built-in rule passes; receives the same {@link ValidateConnectionParams} context as {@link ValidateConnection}. */
   readonly validate?: (context: ValidateConnectionParams) => boolean;
 }
 
@@ -171,17 +211,6 @@ export interface CanConnectOptions {
  * context and runs only after the built-in checks pass.
  * @param options - Rules and optional custom validator.
  * @returns A JointJS-compatible `validateConnection` function.
- * @example
- * ```ts
- * // Default rules
- * paper.options.validateConnection = canConnect();
- *
- * // Allow self-loops + custom logic
- * paper.options.validateConnection = canConnect({
- *   allowSelfLoops: true,
- *   validate: ({ source, target }) => target.port === 'in',
- * });
- * ```
  */
 export function canConnect(options: CanConnectOptions = {}) {
   const {

--- a/packages/joint-react/src/presets/can-embed.ts
+++ b/packages/joint-react/src/presets/can-embed.ts
@@ -1,42 +1,77 @@
 import type { dia } from '@joint/core';
 
 /**
- * Context passed to the `canEmbed` validate callback.
+ * Context handed to a {@link ValidateEmbedding} callback while an element is
+ * dragged over a candidate parent. Use it to compare the dragged `child` against
+ * the `parent` it would drop into.
  * @group Types
+ * @expand
  */
 export interface ValidateEmbeddingParams {
-  /** The element being embedded (dragged). */
+  /** The element being dragged (the would-be child). */
   readonly child: { readonly id: dia.Cell.ID; readonly model: dia.Element };
-  /** The candidate parent element. */
+  /** The element it would be embedded into (the would-be parent). */
   readonly parent: { readonly id: dia.Cell.ID; readonly model: dia.Element };
-  /** The paper instance. */
+  /** The paper the elements live on. */
   readonly paper: dia.Paper;
-  /** The graph instance. */
+  /** The graph the elements belong to. */
   readonly graph: dia.Graph;
 }
 
 /**
- * Context passed to the `canUnembed` validate callback.
+ * Context handed to a {@link ValidateUnembedding} callback when an embedded
+ * element is dragged out of its parent.
  * @group Types
+ * @expand
  */
 export interface ValidateUnembeddingParams {
-  /** The element being unembedded. */
+  /** The embedded element being dragged out of its parent. */
   readonly child: { readonly id: dia.Cell.ID; readonly model: dia.Element };
-  /** The paper instance. */
+  /** The paper the element lives on. */
   readonly paper: dia.Paper;
-  /** The graph instance. */
+  /** The graph the element belongs to. */
   readonly graph: dia.Graph;
 }
 
 /**
- * Callback that decides whether an element can be embedded into a parent.
+ * Decides whether a dragged element may be embedded into a parent element.
+ * Return `true` to allow the drop, `false` to reject it. Pass it to the
+ * `validateEmbedding` prop of `<Paper>`; the callback receives a structured
+ * {@link ValidateEmbeddingParams} context.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { ValidateEmbedding } from '@joint/react';
+ *
+ * // Only "container" elements may accept children.
+ * const validate: ValidateEmbedding = ({ parent }) => parent.model.get('type') === 'container';
+ *
+ * <GraphProvider>
+ *   <Paper validateEmbedding={validate} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type ValidateEmbedding = (context: ValidateEmbeddingParams) => boolean;
 
 /**
- * Callback that decides whether an element can be unembedded from its parent.
+ * Decides whether an embedded element may be detached from its parent. Return
+ * `true` to allow detaching, `false` to keep it embedded. Pass it to the
+ * `validateUnembedding` prop of `<Paper>`; the callback receives a structured
+ * {@link ValidateUnembeddingParams} context.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { ValidateUnembedding } from '@joint/react';
+ *
+ * // Keep "locked" elements embedded; everything else can be dragged out.
+ * const validate: ValidateUnembedding = ({ child }) => !child.model.get('locked');
+ *
+ * <GraphProvider>
+ *   <Paper validateUnembedding={validate} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type ValidateUnembedding = (context: ValidateUnembeddingParams) => boolean;
 
@@ -54,12 +89,6 @@ function toEmbeddingInfo(view: dia.ElementView) {
  * `{ child, parent, paper, graph }` context for the validate callback.
  * @param validate - Optional custom validation. Defaults to `() => true`.
  * @returns A JointJS-compatible `validateEmbedding` function.
- * @example
- * ```ts
- * paper.options.validateEmbedding = canEmbed(
- *   ({ parent }) => parent.model.get('type') === 'container'
- * );
- * ```
  */
 export function canEmbed(validate?: (context: ValidateEmbeddingParams) => boolean) {
   if (!validate) return () => true;
@@ -80,12 +109,6 @@ export function canEmbed(validate?: (context: ValidateEmbeddingParams) => boolea
  * `{ child, paper, graph }` context for the validate callback.
  * @param validate - Optional custom validation. Defaults to `() => true`.
  * @returns A JointJS-compatible `validateUnembedding` function.
- * @example
- * ```ts
- * paper.options.validateUnembedding = canUnembed(
- *   ({ child }) => !child.model.get('locked')
- * );
- * ```
  */
 export function canUnembed(validate?: (context: ValidateUnembeddingParams) => boolean) {
   if (!validate) return () => true;

--- a/packages/joint-react/src/presets/cell-interactivity.ts
+++ b/packages/joint-react/src/presets/cell-interactivity.ts
@@ -1,26 +1,40 @@
 import type { dia } from '@joint/core';
 
-/** Name of an interaction being queried (e.g. `'elementMove'`, `'arrowheadMove'`). */
+/** Name of a cell interactivity feature (e.g. `'elementMove'`, `'labelMove'`, `'linkMove'`). */
 type CellInteraction = keyof dia.CellView.InteractivityOptions;
 
 /**
- * Context passed to an `interactive` callback.
+ * Context handed to the function form of {@link CellInteractivity}. JointJS calls
+ * the callback once per cell with that cell, then reads the specific interactivity
+ * flag it needs from the value you return. In practice only `model` is reliably
+ * populated — see the individual fields.
  * @group Types
+ * @expand
  */
 export interface CellInteractivityParams {
-  /** The cell being interacted with. */
+  /** The cell whose interactivity is being resolved. */
   readonly model: dia.Cell;
-  /** The interaction being queried. */
+  /**
+   * Always `undefined` at runtime: JointJS does not pass an interaction name to the
+   * callback. It reads the relevant flag from the value you return instead.
+   */
   readonly interaction: CellInteraction;
-  /** The paper hosting the cell. */
+  /**
+   * The cell's paper. JointJS binds the callback to the cell view's options rather
+   * than to the `dia.Paper`, so this is not guaranteed to be the paper; capture the
+   * `dia.Paper` from your own scope if you need it.
+   */
   readonly paper: dia.Paper;
-  /** The graph the cell belongs to. */
+  /**
+   * The graph the cell belongs to. Derived from `paper`, so it carries the same
+   * caveat; capture the `dia.Graph` from your own scope if you need it.
+   */
   readonly graph: dia.Graph;
 }
 
 /**
  * Function form of the `interactive` Paper prop. Receives a structured
- * context (instead of the native positional `(cellView, event)` form) and
+ * context (instead of the native positional `(cellView)` form) and
  * returns either a boolean or the native `InteractivityOptions` object.
  * @group Types
  */
@@ -29,8 +43,26 @@ type CellInteractivityCallback = (
 ) => boolean | dia.CellView.InteractivityOptions;
 
 /**
- * Value accepted by the `interactive` Paper prop.
+ * Controls which pointer interactions (moving, linking, label dragging, …) are
+ * enabled on cells. Accepts a boolean to switch everything on or off, an
+ * `InteractivityOptions` object to toggle individual interactions, or a function
+ * that returns either form per cell from a {@link CellInteractivityParams}
+ * context. Pass it to the `interactive` prop of `<Paper>`. By default, label
+ * dragging (`labelMove`) and moving links (`linkMove`) stay disabled; link
+ * endpoints (`arrowheadMove`) remain draggable.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { CellInteractivity } from '@joint/react';
+ *
+ * // Lock cells flagged as readonly; leave the rest interactive.
+ * const interactive: CellInteractivity = ({ model }) => !model.get('readonly');
+ *
+ * <GraphProvider>
+ *   <Paper interactive={interactive} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type CellInteractivity =
   | boolean
@@ -41,7 +73,8 @@ export type CellInteractivity =
  * joint-react defaults applied when the user supplies no `interactive` prop,
  * passes `interactive={true}`, or as the base merged under user-supplied object
  * values. Preserves the JointJS native `labelMove: false` and adds
- * `linkMove: false` so link endpoints don't drag by default.
+ * `linkMove: false` so moving the whole link is disabled by default (link
+ * endpoints, governed by `arrowheadMove`, stay draggable).
  */
 const DEFAULT_INTERACTIVE: dia.CellView.InteractivityOptions = {
   labelMove: false,
@@ -72,7 +105,7 @@ function normalizeStaticInteractivity(
  * - `false` → pass through (every interaction disabled).
  * - object → defaults applied first, user keys win.
  * - function → wrapped so the user callback receives a {@link CellInteractivityParams}
- *   instead of the native positional `(cellView, interaction)` args. The
+ *   instead of the native positional `(cellView)` argument. The
  *   callback's return value is normalized identically to the static shapes,
  *   so `() => true` and `() => ({})` both resolve to `DEFAULT_INTERACTIVE`.
  * @param value - prop value

--- a/packages/joint-react/src/presets/cell-visibility.ts
+++ b/packages/joint-react/src/presets/cell-visibility.ts
@@ -1,13 +1,15 @@
 import type { dia } from '@joint/core';
 
 /**
- * Context passed to a `cellVisibility` callback.
+ * Context handed to a {@link CellVisibility} callback each time the paper decides
+ * whether to render a cell.
  * @group Types
+ * @expand
  */
 export interface CellVisibilityParams {
-  /** The cell whose visibility is being queried. */
+  /** The cell whose visibility is being decided. */
   readonly model: dia.Cell;
-  /** Whether the cell currently has a mounted view in the paper. */
+  /** Whether the cell currently has a view mounted in the paper. */
   readonly isMounted: boolean;
   /** The paper rendering the cell. */
   readonly paper: dia.Paper;
@@ -16,10 +18,24 @@ export interface CellVisibilityParams {
 }
 
 /**
- * Predicate deciding whether a cell should be rendered. Receives a
- * structured context object (instead of the native positional form).
- * Return `false` to hide the cell.
+ * Decides whether a cell is rendered on the paper. Return `false` to skip
+ * rendering it (handy for viewport culling or hiding cells by state), `true` to
+ * render it. Pass it to the `cellVisibility` prop of `<Paper>`; the callback
+ * receives a structured {@link CellVisibilityParams} context instead of the
+ * native positional arguments.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { CellVisibility } from '@joint/react';
+ *
+ * // Hide every cell flagged as collapsed.
+ * const cellVisibility: CellVisibility = ({ model }) => !model.get('collapsed');
+ *
+ * <GraphProvider>
+ *   <Paper cellVisibility={cellVisibility} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type CellVisibility = (context: CellVisibilityParams) => boolean;
 

--- a/packages/joint-react/src/presets/connection-strategy.ts
+++ b/packages/joint-react/src/presets/connection-strategy.ts
@@ -2,54 +2,80 @@ import type { dia, connectionStrategies } from '@joint/core';
 import { connectionStrategies as strategies } from '@joint/core';
 
 /**
- * Structured context passed to a connection-strategy callback.
+ * Context handed to a {@link ConnectionStrategy} `customize` callback after a
+ * link end is dropped. Describes where the end landed (cell, magnet, drop point)
+ * so the callback can return the final end definition.
  * @group Types
+ * @expand
  */
 export interface ConnectionStrategyParams {
-  /** The end JSON to return, starts as the dropped-end definition (already pinned if `pin` was set). */
+  /** The end definition to return, pre-filled by the selected pin mode (or the dropped end when pinning is off). */
   readonly end: dia.Link.EndJSON;
-  /** The cell model the link end was dropped on. */
+  /** The cell the end was dropped on. */
   readonly model: dia.Cell;
   /** The magnet element the end was dropped on. */
   readonly magnet: Element;
   /** Paper-space point where the end was dropped. */
   readonly dropPoint: dia.Point;
-  /** Which end is being dropped. */
+  /** Which end was dropped: `'source'` or `'target'`. */
   readonly endType: dia.LinkEnd;
-  /** The link being modified. */
+  /** The link being reconnected. */
   readonly link: dia.Link;
-  /** The paper instance. */
+  /** The paper the link is drawn on. */
   readonly paper: dia.Paper;
-  /** The graph instance. */
+  /** The graph the link belongs to. */
   readonly graph: dia.Graph;
 }
 
 /**
- * Built-in pin mode, how the dropped end is stored.
+ * How a dropped link end is anchored to its target:
+ * - `'none'` — keep the JointJS defaults (attach to the cell/port, no fixed anchor).
+ * - `'absolute'` — pin the end at a fixed pixel offset within the target.
+ * - `'relative'` — pin the end at an offset given as a percentage of the target's size, so it tracks resizing.
  * @group Types
  */
 export type ConnectionStrategyPin = 'none' | 'absolute' | 'relative';
 
 /**
- * Options for `connectionStrategy`, combines a pin mode with optional user customization.
+ * Options for the `connectionStrategy` prop of `<Paper>`: pick how a dropped link
+ * end is pinned and, optionally, post-process the resulting end definition.
  * @group Types
+ * @expand
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ *
+ * // Pin dropped ends at a relative (%) offset of their target.
+ * <GraphProvider>
+ *   <Paper connectionStrategy={{ pin: 'relative' }} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export interface ConnectionStrategyOptions {
-  /**
-   * How to pin the dropped end.
-   * - `'none'`, no pinning; delegates to `connectionStrategies.useDefaults` (default).
-   * - `'absolute'`, pins with `pinAbsolute` (anchor in paper coords).
-   * - `'relative'`, pins with `pinRelative` (anchor as % of target).
-   * @default 'none'
-   */
+  /** How to anchor the dropped end, see {@link ConnectionStrategyPin}. @default 'none' */
   readonly pin?: ConnectionStrategyPin;
-  /** Runs after `pin`. Receives `end` already pinned (or original when `pin` is `'none'`). */
+  /** Runs after pinning; receives the already-pinned end (or the original when `pin` is `'none'`) and returns the final end definition. */
   readonly customize?: ConnectionStrategy;
 }
 
 /**
- * Callback that decides how a dropped link end's JSON is stored.
+ * Computes the final end definition stored on a link after one of its ends is
+ * dropped. Pass it (or a {@link ConnectionStrategyOptions} object) to the
+ * `connectionStrategy` prop of `<Paper>`; the callback receives a structured
+ * {@link ConnectionStrategyParams} context and returns the end JSON to save.
  * @group Types
+ * @example
+ * ```tsx
+ * import { GraphProvider, Paper } from '@joint/react';
+ * import type { ConnectionStrategy } from '@joint/react';
+ *
+ * // Snap the dropped end exactly to the pointer position.
+ * const strategy: ConnectionStrategy = ({ end, dropPoint }) => ({ ...end, x: dropPoint.x, y: dropPoint.y });
+ *
+ * <GraphProvider>
+ *   <Paper connectionStrategy={strategy} renderElement={() => <rect width={80} height={40} />} />
+ * </GraphProvider>;
+ * ```
  */
 export type ConnectionStrategy = (context: ConnectionStrategyParams) => dia.Link.EndJSON;
 
@@ -66,14 +92,6 @@ const PIN_STRATEGIES: Record<ConnectionStrategyPin, connectionStrategies.Connect
  * pinned `EndJSON` into the optional `customize` callback as a structured context.
  * @param options - Pin preset and/or a custom post-processor.
  * @returns A JointJS-compatible `connectionStrategy` callback.
- * @example
- * ```ts
- * paper.options.connectionStrategy = connectionStrategy({ pin: 'relative' });
- *
- * paper.options.connectionStrategy = connectionStrategy({
- *   customize: ({ end, dropPoint }) => ({ ...end, x: dropPoint.x, y: dropPoint.y }),
- * });
- * ```
  */
 export function connectionStrategy(
   options: ConnectionStrategyOptions = {},

--- a/packages/joint-react/src/presets/element-attributes.ts
+++ b/packages/joint-react/src/presets/element-attributes.ts
@@ -7,28 +7,35 @@ import type { ElementPort } from './element-ports';
  * React-side declarative fields the preset adds on top of `dia.Element.Attributes`.
  * Composed orthogonally into both `ElementAttributes` (preset input) and
  * `ElementJSONInit` (record/mapper boundary).
+ * @group Types
  */
 export interface ElementPresetAttributes {
+  /** Ports keyed by id; each value is an {@link ElementPort} expanded into native `ports` by {@link elementPorts}, and its key becomes the port id. */
   portMap?: Record<string, ElementPort>;
+  /** Shared {@link ElementPort} styling merged into every `portMap` entry before that entry's own values. */
   portStyle?: Partial<ElementPort>;
 }
 
 /**
  * Loose preset input, no `type` required. `dia.Element.Attributes` plus the
  * React preset extras (`portMap`, `portStyle`).
+ * @expand
+ * @group Types
  */
 export interface ElementAttributes extends dia.Element.Attributes, ElementPresetAttributes {}
 
 /**
- * Normalizes element configuration into JointJS-compatible cell attributes.
- * Expands the React-preset `portMap` shorthand into native `ports` via
- * {@link elementPorts}(); passes native `ports` through; throws when both are
- * supplied.
- * @param element - The element record to convert.
- * @returns JointJS-compatible cell attributes.
+ * Normalizes a declarative element description into JointJS cell attributes.
+ * The `portMap` shorthand is expanded into native `ports` via {@link elementPorts}
+ * (and kept on the result as `portMap`); a native `ports` value is passed through
+ * untouched. Use it when feeding a {@link ElementModel} or building a model's
+ * `defaults()`.
+ * @param element - The declarative element description to convert.
+ * @returns Attributes ready to pass to an element model.
+ * @throws TypeError when `element` is not a plain object.
+ * @throws Error when both `portMap` and `ports` are supplied.
  * @example
- * Expand the declarative preset input into native attributes and hand them to
- * a cell model:
+ * Feed an element model:
  * ```tsx
  * import { ElementModel, elementAttributes } from '@joint/react';
  *
@@ -42,7 +49,7 @@ export interface ElementAttributes extends dia.Element.Attributes, ElementPreset
  * );
  * ```
  * @example
- * Or build the defaults of a custom cell model class:
+ * Build a custom model's defaults:
  * ```tsx
  * import { ElementModel, elementAttributes } from '@joint/react';
  *

--- a/packages/joint-react/src/presets/element-ports.ts
+++ b/packages/joint-react/src/presets/element-ports.ts
@@ -2,63 +2,64 @@ import { type dia } from '@joint/core';
 import type { LiteralUnion } from '../types/index';
 
 /**
- * Shape of a port.
- * - `'ellipse'`, ellipse
- * - `'rect'`, rectangle
- * - Any other string, interpreted as SVG path `d` commands
+ * Shape of a port's body.
+ * - `'ellipse'` renders an ellipse.
+ * - `'rect'` renders a rectangle.
+ * - Any other string is used directly as the SVG path `d` attribute.
  * @group Types
  */
 export type ElementPortShape = LiteralUnion<'ellipse' | 'rect'>;
 
 /**
- * Simplified port definition for declarative port configuration.
- * Converted to full JointJS port format by the element mapper.
- * @group Presets
+ * Declarative port description for {@link elementPort} and {@link elementPorts}.
+ * Captures the common port styling and label options in a flat shape, which the
+ * presets expand into a full `dia.Element.Port`.
+ * @group Types
  */
 export interface ElementPort {
   /**
-   * X position of the port (absolute positioning).
-   * Supports calc() expressions (e.g., 'calc(w)').
-   * Optional when using group-based positioning.
+   * Horizontal position of the port, relative to the element, for absolute
+   * placement. Accepts a number or a `calc()` expression such as `'calc(w)'`.
+   * Omit to let the port group position the port instead.
    */
   cx?: number | string;
   /**
-   * Y position of the port (absolute positioning).
-   * Supports calc() expressions (e.g., 'calc(h)').
-   * Optional when using group-based positioning.
+   * Vertical position of the port, relative to the element, for absolute
+   * placement. Accepts a number or a `calc()` expression such as `'calc(h)'`.
+   * Omit to let the port group position the port instead.
    */
   cy?: number | string;
-  /** Width of the port shape. @default 10 */
+  /** Width of the port shape, in pixels. @default 8 */
   width?: number;
-  /** Height of the port shape. @default 10 */
+  /** Height of the port shape, in pixels. @default 8 */
   height?: number;
-  /** Fill color of the port shape. @default '#333333' */
+  /** Fill color of the port shape. Any CSS color; when empty the port inherits the `jj-port` stylesheet fill. @default '' */
   color?: string;
-  /** Shape of the port. @default 'ellipse' */
+  /** Shape of the port body. @default 'ellipse' */
   shape?: ElementPortShape;
-  /** Outline color of the port shape. Accepts any CSS color. @default 'transparent' */
+  /** Outline (stroke) color of the port shape. Any CSS color; when empty the stroke comes from the stylesheet. @default '' */
   outline?: string;
-  /** Outline width of the port shape in px. @default 0 */
+  /** Outline (stroke) width of the port shape, in pixels. Empty leaves the stroke width unset. @default '' */
   outlineWidth?: number;
-  /** CSS class name to apply to the port shape. */
+  /** Extra CSS class added to the port shape alongside the built-in `jj-port` class. @default '' */
   className?: string;
-  /** Whether the port is limited to only being a target (not source) for links. @default false */
+  /** Restricts the port to being a link target only; links cannot be started from it. @default false */
   passive?: boolean;
-  /** Label displayed next to the port. */
+  /** Text label rendered next to the port. Omit for an unlabeled port. */
   label?: string;
-  /** Position of the port label. @default 'outside' */
+  /** Placement of the label relative to the port, e.g. `'outside'`, `'inside'`, or a side name. @default 'outside' */
   labelPosition?: string;
-  /** Color of the port label text. @default '#333333' */
+  /** Color of the label text. Any CSS color; when empty the color comes from the stylesheet. @default '' */
   labelColor?: string;
-  /** Font size of the port label text. */
+  /** Font size of the label text, in pixels. When empty the size comes from the stylesheet. @default '' */
   labelFontSize?: number;
-  /** Font family of the port label text. */
+  /** Font family of the label text. When empty the family comes from the stylesheet. @default '' */
   labelFontFamily?: string;
-  /** CSS class name to apply to the port label. */
+  /** Extra CSS class added to the label alongside the built-in `jj-port-label` class. @default '' */
   labelClassName?: string;
-  /** Horizontal offset of the port label in pixels. */
+  /** Horizontal offset of the label from its computed position, in pixels. */
   labelOffsetX?: number;
-  /** Vertical offset of the port label in pixels. */
+  /** Vertical offset of the label from its computed position, in pixels. */
   labelOffsetY?: number;
 }
 
@@ -79,18 +80,20 @@ const defaultPortStyle = {
 } as const;
 
 /**
- * Creates a JointJS port definition from simplified options.
- *
- * When `cx`/`cy` are provided, the port uses absolute positioning.
- * When omitted, position is left to the port group (e.g. `'left'`, `'right'`).
- * @param port - the simplified port definition to convert
+ * Builds a full `dia.Element.Port` from a declarative {@link ElementPort}.
+ * When `cx`/`cy` are set the port is placed absolutely; when they are omitted the
+ * port relies on the positioning of whatever group it is placed in.
+ * @param port - The declarative port description to expand.
+ * @returns A JointJS port object ready to drop into an element's `ports.items`.
  * @example
- * ```ts
- * // Absolute positioned
- * elementPort({ cx: 'calc(w)', cy: 'calc(h/2)', color: 'red' })
+ * ```tsx
+ * import { elementPort } from '@joint/react';
  *
- * // Group-positioned (no cx/cy)
- * elementPort({ color: 'blue', shape: 'rect', width: 12, height: 12 })
+ * // Absolute placement via calc() expressions, relative to the element size.
+ * const outlet = elementPort({ cx: 'calc(w)', cy: 'calc(h/2)', color: 'red' });
+ *
+ * // No cx/cy: the port group decides where it sits.
+ * const inlet = elementPort({ shape: 'rect', width: 12, height: 12 });
  * ```
  * @group Presets
  */
@@ -183,13 +186,18 @@ export function elementPort(port: ElementPort): dia.Element.Port {
 const PORT_GROUP = 'main';
 
 /**
- * Converts a record of simplified ElementPort definitions to the full JointJS ports object.
- * Each port gets absolute positioning under the `'main'` group.
- * @param ports - map of port id to port definition
- * @param portStyle - optional style merged into every port
+ * Expands a map of declarative {@link ElementPort}s into a full JointJS `ports`
+ * object (a `groups` definition plus the `items` array). Every port is placed
+ * absolutely under a single `'main'` group, keyed by its map id.
+ * @param ports - Map of port id to its {@link ElementPort} description.
+ * @param portStyle - Shared defaults merged under each port; per-port values win.
+ * @returns The `ports` object to assign to an element's attributes.
  * @example
- * ```ts
- * elementPorts({ out: { cx: 'calc(w)', cy: 'calc(h/2)' } })
+ * ```tsx
+ * import { elementPorts } from '@joint/react';
+ *
+ * // One output port on the right edge, vertically centered.
+ * const ports = elementPorts({ out: { cx: 'calc(w)', cy: 'calc(h/2)' } });
  * ```
  * @group Presets
  */

--- a/packages/joint-react/src/presets/link-attributes.ts
+++ b/packages/joint-react/src/presets/link-attributes.ts
@@ -6,31 +6,39 @@ import type { LinkStyle } from './link-style';
 import type { LinkLabel } from './link-labels';
 
 /**
- * React-side declarative fields the preset adds on top of `dia.Link.Attributes`.
- * Composed orthogonally into both `LinkAttributes` (preset input) and
- * `LinkJSONInit` (record/mapper boundary).
+ * Extra declarative link fields the React presets understand on top of a native
+ * `dia.Link.Attributes`: `style`, `labelMap`, and `labelStyle`.
+ * @group Types
  */
 export interface LinkPresetAttributes {
+  /** Visual styling for the link's line and markers, expanded into `attrs` by {@link linkStyle}. */
   style?: LinkStyle;
+  /** Labels keyed by id; each value is a {@link LinkLabel} expanded by {@link linkLabels}, and its key becomes the label's stable `id`. */
   labelMap?: Record<string, LinkLabel>;
+  /** Shared {@link LinkLabel} styling merged into every `labelMap` entry before that entry's own values. */
   labelStyle?: Partial<LinkLabel>;
 }
 
 /**
- * Loose preset input, no `type` required. `dia.Link.Attributes` plus the
- * React preset extras (`style`, `labelMap`, `labelStyle`).
+ * A link description for {@link linkAttributes}: native `dia.Link.Attributes`
+ * plus the React preset shorthands `style`, `labelMap`, and `labelStyle`. No
+ * `type` is required.
+ * @expand
+ * @group Types
  */
 export interface LinkAttributes extends dia.Link.Attributes, LinkPresetAttributes {}
 
 /**
- * Converts a `LinkAttributes` record to JointJS cell attributes.
+ * Expands the declarative React link shorthand (`style`, `labelMap`) into the
+ * native attributes JointJS understands, so you can describe a link with the
+ * friendly preset fields instead of raw `attrs` and `labels`.
  *
- * - `style` → converted to SVG `attrs` via `linkStyle()`.
- * - `labelMap` → converted to native `labels` array via {@link linkLabels}().
- * - `labels` (array) → passed through as-is.
- * - Both `labelMap` and `labels` → throws.
+ * - `style` → SVG `attrs` via {@link linkStyle}.
+ * - `labelMap` → a native `labels` array via {@link linkLabels}.
+ * - `labels` (array) → passed through unchanged.
  * @param link - The link record to convert.
  * @returns JointJS-compatible cell attributes.
+ * @throws When `link` is not an object, or when both `labelMap` and `labels` are set on the same link.
  * @example
  * Expand the declarative preset input into native attributes and hand them to
  * a cell model:

--- a/packages/joint-react/src/presets/link-labels.ts
+++ b/packages/joint-react/src/presets/link-labels.ts
@@ -2,43 +2,43 @@ import { type dia, util } from '@joint/core';
 import type { LiteralUnion } from '../types';
 
 /**
- * Simplified label definition for graph links.
- * @group Presets
+ * A simplified link label, text plus optional styling, that {@link linkLabel}
+ * expands into the raw `dia.Link.Label` markup and attrs JointJS expects.
+ * @group Types
  */
 export interface LinkLabel {
-  /** Label text content. */
+  /** The text shown on the link. */
   text: string;
-  /** Position along the link. 0–1 is a ratio, >1 is absolute distance in px. */
+  /** Where the label sits along the link: 0–1 is a fraction of the path, values above 1 are an absolute distance in px. @default 0.5 */
   position?: number;
-  /** Offset perpendicular to the link path. A number or `{ x, y }` object. */
+  /** Shift the label off the path. A number nudges it perpendicular to the line; `{ x, y }` moves it freely. */
   offset?: number | { x: number; y: number };
-  /** Text color. */
+  /** Text color. Empty inherits the theme default. @default '' */
   color?: string;
-  /** Background color of the label rectangle. */
+  /** Fill color of the label background. Empty inherits the theme default. @default '' */
   backgroundColor?: string;
   /**
-   * Padding between text and background.
-   * A number (applied on both axes) or `{ horizontal, vertical }`.
-   * @default { horizontal: 4, vertical: 2 }
+   * Padding between the text and the edge of its background. A number applies to
+   * both axes; an object sets each axis. @default `{ horizontal: 4, vertical: 2 }`
    */
   backgroundPadding?: number | { horizontal?: number; vertical?: number };
-  /** Font size of the label text. */
+  /** Font size of the label text, in px. Empty inherits the theme default. @default '' */
   fontSize?: number;
-  /** Font family of the label text. */
+  /** Font family of the label text. Empty inherits the theme default. @default '' */
   fontFamily?: string;
-  /** CSS class name applied to the label text element. */
+  /** Extra CSS class added to the label text element. @default '' */
   className?: string;
-  /** Outline (stroke) color of the label background. */
+  /** Outline (stroke) color of the label background. Empty for no outline. @default '' */
   backgroundOutline?: string;
-  /** Outline (stroke) width of the label background. */
+  /** Outline (stroke) width of the label background, in px. @default '' */
   backgroundOutlineWidth?: number;
-  /** Border radius of the label background. */
+  /** Corner radius of the label background, in px. Applies to the `'rect'` shape. @default 4 */
   backgroundBorderRadius?: number;
-  /** Opacity of the label background (0–1). */
+  /** Opacity of the label background, from 0 (transparent) to 1 (opaque). */
   backgroundOpacity?: number;
-  /** CSS class name applied to the label background. */
+  /** Extra CSS class added to the label background element. @default '' */
   backgroundClassName?: string;
-  /** Shape of the label background: `'rect'`, `'ellipse'`, or SVG path `d` commands. @default 'rect' */
+  /** Background outline shape: `'rect'`, `'ellipse'`, or a raw SVG path `d` string. @default 'rect' */
   backgroundShape?: LiteralUnion<'rect' | 'ellipse'>;
 }
 
@@ -57,12 +57,19 @@ const defaultLabelStyle = {
 } as const;
 
 /**
- * Converts a simplified {@link LinkLabel} (text, color, position, …) into the JSON
- * shape JointJS expects in `link.labels`.
- * @param label - the simplified link label to convert
+ * Converts a simplified {@link LinkLabel} (text, color, position, …) into the
+ * `dia.Link.Label` JSON JointJS expects in a link's `labels` array.
+ * @param label - The simplified link label to convert.
+ * @returns A JointJS label entry ready to drop into `link.labels`.
  * @example
  * ```ts
- * linkLabel({ text: 'Hello', color: '#333', position: 0.5 })
+ * import { LinkModel, linkLabel } from '@joint/react';
+ *
+ * const link = new LinkModel({
+ *   source: { id: 'a' },
+ *   target: { id: 'b' },
+ *   labels: [linkLabel({ text: 'flows to', color: '#333', position: 0.5 })],
+ * });
  * ```
  * @group Presets
  */
@@ -158,12 +165,25 @@ export function linkLabel(label: LinkLabel): dia.Link.Label {
 }
 
 /**
- * Converts a record of simplified LinkLabel definitions to an array of JointJS labels.
- * @param labels - map of label name to label definition
- * @param labelStyle - optional style merged into every label
+ * Converts a keyed map of {@link LinkLabel} definitions into the array of JointJS
+ * labels a link expects, running each through {@link linkLabel}. The map key
+ * becomes the label's stable `id`, so you can address a label later without
+ * relying on array order.
+ * @param labels - The map of label id to its simplified definition.
+ * @param labelStyle - Shared styling merged into every label before its own values.
+ * @returns The labels array — each entry is a JointJS label whose `id` is its map key.
  * @example
  * ```ts
- * linkLabels({ main: { text: 'Hello', fontSize: 12 } })
+ * import { LinkModel, linkLabels } from '@joint/react';
+ *
+ * const link = new LinkModel({
+ *   source: { id: 'a' },
+ *   target: { id: 'b' },
+ *   labels: linkLabels(
+ *     { name: { text: 'orders' }, card: { text: '1..*', position: 0.9 } },
+ *     { fontSize: 12 } // applied to every label
+ *   ),
+ * });
  * ```
  * @group Presets
  */

--- a/packages/joint-react/src/presets/link-markers.tsx
+++ b/packages/joint-react/src/presets/link-markers.tsx
@@ -2,37 +2,44 @@ import type { dia } from '@joint/core';
 import { jsx } from '../utils/joint-jsx/jsx-to-markup';
 
 /**
- * A link marker record, an SVG complex marker JSON with an optional `length`
- * used by connection-point math to offset the line tip by the marker's visual footprint.
- * The built-in marker factories always set a `length`; inline user markers may omit it.
+ * A link endpoint marker, an SVG complex-marker JSON plus an optional `length`.
+ * Attach one to a {@link LinkStyle}'s `sourceMarker` / `targetMarker`. The
+ * built-in `linkMarker*` factories return this shape, or you can hand-write one.
  * @group Types
  */
 export interface LinkMarkerRecord extends dia.SVGComplexMarkerJSON {
+  /**
+   * The marker's visual length along the link, in px. Connection-point math pulls
+   * the line tip back by this much so the line meets the marker instead of poking
+   * through it. Omit it to apply no offset (treated as `0`).
+   */
   readonly length?: number;
 }
 
 /**
- * Sizing, color, and stroke options shared by every built-in `linkMarker*` factory.
+ * Sizing, color, and stroke options shared by every built-in `linkMarker*`
+ * factory. Build a marker, then attach it to a {@link LinkStyle}.
  * @group Types
  * @example
  * ```ts
- * // see: stories/examples/link-markers/code.tsx
- * linkStyle({
+ * import { linkStyle, linkMarkerArrow, linkMarkerCircle } from '@joint/react';
+ *
+ * const attrs = linkStyle({
  *   sourceMarker: linkMarkerCircle({ scale: 1.2 }),
  *   targetMarker: linkMarkerArrow({ fill: 'none' }),
  * });
  * ```
  */
 export interface LinkMarkerOptions {
-  /** Uniform scale factor applied to the marker geometry. Default: `1`. */
+  /** Uniform scale factor applied to the marker geometry. @default 1 */
   readonly scale?: number;
-  /** Fill color. Default inherits the link's stroke. Use `'none'` for an outline-only marker. */
+  /** Fill color. Defaults to inheriting the link's stroke; use `'none'` for an outline-only marker. @default 'inherit' */
   readonly fill?: string;
-  /** Stroke color. Default inherits the link's stroke. */
+  /** Stroke (outline) color. Defaults to inheriting the link's stroke. @default 'inherit' */
   readonly stroke?: string;
-  /** Stroke width in pixels. Default: `2`. */
+  /** Stroke width, in px. @default 2 */
   readonly strokeWidth?: number;
-  /** Optional CSS class applied to the marker root. */
+  /** Optional CSS class added to the marker root. */
   readonly className?: string;
 }
 /** Default fill color for markers. */
@@ -57,7 +64,14 @@ function defaults(options: LinkMarkerOptions = {}) {
 }
 
 /**
- * Filled triangle marker for link endpoints. The classic directed-edge arrow.
+ * Filled triangle marker for link endpoints, the classic directed-edge arrow.
+ * @returns A marker record for a {@link LinkStyle}'s `sourceMarker` / `targetMarker`
+ * @example
+ * ```ts
+ * import { linkStyle, linkMarkerArrow } from '@joint/react';
+ *
+ * const attrs = linkStyle({ targetMarker: linkMarkerArrow() });
+ * ```
  * @group Presets
  */
 export function linkMarkerArrow(options?: LinkMarkerOptions): LinkMarkerRecord {
@@ -135,8 +149,8 @@ export function linkMarkerArrowQuill(options?: LinkMarkerOptions): LinkMarkerRec
 }
 
 /**
- * Double arrow marker, two nested triangles, useful for "fast-forward" or
- * "strong direction" semantics.
+ * Double arrow marker, two stacked triangles drawn one behind the other along
+ * the link, useful for "fast-forward" or "strong direction" semantics.
  * @group Presets
  */
 export function linkMarkerArrowDouble(options?: LinkMarkerOptions): LinkMarkerRecord {

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -12,61 +12,68 @@ import {
 } from './wrappers';
 
 /**
- * Ready-made Paper configurations for common link routing styles.
- * Each preset is a function that returns a `LinkRouting` bundle for router,
- * connector, anchor, and connection point. Call with no args for defaults,
- * or pass options to customize.
- * @example
- * ```tsx
- * import { linkRoutingOrthogonal } from '@joint/react';
- *
- * <Paper linkRouting={linkRoutingOrthogonal()} />
- * ```
- */
-
-/**
  * Bundle of paper-level link defaults (router, connector, anchor, connection point)
  * produced by a routing preset like {@link linkRoutingStraight} or
  * {@link linkRoutingOrthogonal}.
  * @group Types
  */
 export interface LinkRouting {
+  /** Paper-level default router this preset installs for links that don't set their own. */
   readonly defaultRouter?: dia.Paper.Options['defaultRouter'];
+  /** Paper-level default connector that draws the routed points into the link's path. */
   readonly defaultConnector?: dia.Paper.Options['defaultConnector'];
+  /** Paper-level default anchor that decides where on an element each link end attaches. */
   readonly defaultAnchor?: dia.Paper.Options['defaultAnchor'];
+  /** Paper-level default connection point where the link meets the element boundary. */
   readonly defaultConnectionPoint?: dia.Paper.Options['defaultConnectionPoint'];
 }
 
 interface BaseLinkOptions {
-  /** Anchor mode for root elements and custom magnets. Passed to `midSide`. */
+  /** Which side of an element or port each link end attaches to; see {@link LinkMode} for how each value behaves. @default 'auto' */
   readonly mode?: LinkMode;
-  /** Offset (in px) applied to the connection point at the source end. Default: `0`. */
+  /** Offset (in px) applied to the connection point at the source end. @default 0 */
   readonly sourceOffset?: number;
-  /** Offset (in px) applied to the connection point at the target end. Default: `0`. */
+  /** Offset (in px) applied to the connection point at the target end. @default 0 */
   readonly targetOffset?: number;
-  /** Use straight-line routing when an end is not connected. Default: `true`. */
+  /** Fall back to a straight line while either end is still unconnected (e.g. mid-drag). @default true */
   readonly straightWhenDisconnected?: boolean;
-  /** The attrs selector that holds the marker definitions. Default: `'line'`. */
+  /** The attrs selector that holds the marker definitions. @default 'line' */
   readonly markerSelector?: string;
 }
 
 /**
  * Options for {@link linkRoutingStraight}.
+ * @remarks The inherited `mode` and `straightWhenDisconnected` options have no
+ * effect on straight routing; they apply only to {@link linkRoutingOrthogonal}
+ * and {@link linkRoutingSmooth}.
  * @group Types
+ * @expand
  */
 export interface LinkRoutingStraightOptions extends BaseLinkOptions {
-  /** Corner style at vertices. Default: `'point'`. */
+  /** Corner style applied at manual vertices. @default 'point' */
   readonly cornerType?: 'point' | 'cubic' | 'line' | 'gap';
-  /** Corner radius at vertices (in px). Default: `0`. */
+  /** Corner radius at vertices, in px. @default 0 */
   readonly cornerRadius?: number;
-  /** Use perpendicular anchor instead of center. Default: `false`. */
+  /** Anchor links perpendicular to the element edge instead of at its center. @default false */
   readonly perpendicular?: boolean;
 }
 
 /**
- * Straight-line links between elements.
- * The shortest path with no routing, a single line from source to target.
- * @param options - straight routing options
+ * Straight-line routing: links are drawn as a direct line from source to target,
+ * with no obstacle avoidance. The simplest, lowest-overhead routing.
+ *
+ * Returns a `LinkRouting` bundle for the {@link Paper} `linkRouting` prop that
+ * sets the paper's router, connector, anchor, and connection point in one step.
+ * For other looks, reach for {@link linkRoutingOrthogonal} (right-angle segments
+ * that steer around elements) or {@link linkRoutingSmooth} (curved links).
+ * @param options - overrides for corner style, anchor, and connection-point offsets
+ * @returns Paper link defaults for straight routing
+ * @example
+ * ```tsx
+ * import { Paper, linkRoutingStraight } from '@joint/react';
+ *
+ * <Paper linkRouting={linkRoutingStraight()} />
+ * ```
  * @group Presets
  */
 export function linkRoutingStraight(options: LinkRoutingStraightOptions = {}): LinkRouting {
@@ -92,22 +99,34 @@ export function linkRoutingStraight(options: LinkRoutingStraightOptions = {}): L
 /**
  * Options for {@link linkRoutingOrthogonal}.
  * @group Types
+ * @expand
  */
 export interface LinkRoutingOrthogonalOptions extends BaseLinkOptions {
-  /** Corner style. Default: `'cubic'`. */
+  /** Corner style at each bend. @default 'cubic' */
   readonly cornerType?: 'point' | 'cubic' | 'line' | 'gap';
-  /** Corner radius for the rounded connector (in px). Default: `8`. */
+  /** Corner radius of the rounded bends, in px. @default 8 */
   readonly cornerRadius?: number;
-  /** Minimum distance (in px) the link keeps from elements when routing. */
+  /** Distance, in px, the route keeps clear of elements as it steers around them. @default 20 */
   readonly margin?: number;
-  /** Minimum length (in px) of each link segment. Default: `margin / 4`. */
+  /** Smallest distance, in px, the router travels before it can turn. @default margin / 4 */
   readonly minPathMargin?: number;
 }
 
 /**
- * Orthogonal (right-angle) links between elements.
- * Routes links with horizontal and vertical segments only, avoiding element overlap.
- * @param options - orthogonal routing options
+ * Orthogonal routing: links travel in horizontal and vertical segments only and
+ * steer around elements, the right-angle look common in flowcharts and ER
+ * diagrams.
+ *
+ * Returns a `LinkRouting` bundle for the {@link Paper} `linkRouting` prop.
+ * @param options - overrides for corner style/radius, routing margins, and anchors
+ * @returns Paper link defaults for orthogonal routing
+ * @example
+ * ```tsx
+ * import { Paper, linkRoutingOrthogonal } from '@joint/react';
+ *
+ * // round the bends and keep links 24px clear of elements
+ * <Paper linkRouting={linkRoutingOrthogonal({ cornerRadius: 12, margin: 24 })} />
+ * ```
  * @group Presets
  */
 export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}): LinkRouting {
@@ -157,13 +176,23 @@ export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}
 /**
  * Options for {@link linkRoutingSmooth}.
  * @group Types
+ * @expand
  */
-export type LinkRoutingSmoothOptions = BaseLinkOptions;
+export interface LinkRoutingSmoothOptions extends BaseLinkOptions {}
 
 /**
- * Smooth curved links between elements.
- * Renders links as bezier curves for a softer, more organic look.
- * @param options - smooth routing options
+ * Smooth routing: links are drawn as soft bezier curves instead of straight or
+ * right-angle segments, for a more organic look.
+ *
+ * Returns a `LinkRouting` bundle for the {@link Paper} `linkRouting` prop.
+ * @param options - overrides for anchor and connection-point offsets
+ * @returns Paper link defaults for smooth routing
+ * @example
+ * ```tsx
+ * import { Paper, linkRoutingSmooth } from '@joint/react';
+ *
+ * <Paper linkRouting={linkRoutingSmooth()} />
+ * ```
  * @group Presets
  */
 export function linkRoutingSmooth(options: LinkRoutingSmoothOptions = {}): LinkRouting {

--- a/packages/joint-react/src/presets/link-style.ts
+++ b/packages/joint-react/src/presets/link-style.ts
@@ -3,32 +3,33 @@ import type { Nullable, LiteralUnion } from '../types';
 import { resolveLinkMarker, type LinkMarker } from '../theme/named-link-markers';
 
 /**
- * Visual/presentation attributes for a link line and its wrapper.
- * All properties are optional, empty strings let CSS variables from `theme.css` take over.
- * @group Presets
+ * Visual styling for a link, the visible line plus its invisible pointer
+ * hit-area wrapper. Hand it to {@link linkStyle} (or a link record's `style`
+ * field); empty-string values fall back to the CSS variables in `theme.css`.
+ * @group Types
  */
 export interface LinkStyle {
-  /** Stroke color of the link line. Accepts any CSS color value including CSS variables. @default '' */
+  /** Stroke color of the visible line. Any CSS color, including CSS variables. Empty inherits the theme default. @default '' */
   color?: string;
-  /** Stroke width of the link line. Accepts a number (px) or CSS value string. @default '' */
+  /** Stroke width of the visible line, a number (px) or CSS length string. Empty inherits the theme default. @default '' */
   width?: number | string;
-  /** Source marker name or custom marker definition. Use `'none'` for no marker. @default 'none' */
+  /** Marker at the source end: a {@link LinkMarkerName}, a {@link LinkMarkerRecord}, or `'none'` for no marker. @default 'none' */
   sourceMarker?: LinkMarker;
-  /** Target marker name or custom marker definition. Use `'none'` for no marker. @default 'none' */
+  /** Marker at the target end: a {@link LinkMarkerName}, a {@link LinkMarkerRecord}, or `'none'` for no marker. @default 'none' */
   targetMarker?: LinkMarker;
-  /** CSS class name to apply to the link line. @default '' */
+  /** Extra CSS class added to the visible line. @default '' */
   className?: string;
-  /** Stroke dash pattern (SVG `stroke-dasharray` syntax, e.g. `'5,5'`). @default '' */
+  /** Dash pattern in SVG `stroke-dasharray` syntax, e.g. `'5,5'` for a dashed line. @default '' */
   dasharray?: string;
-  /** Stroke line cap for the link line. @default '' */
+  /** Stroke line cap of the line ends. @default '' */
   linecap?: LiteralUnion<'butt' | 'round' | 'square'>;
-  /** Stroke line join for the link line. @default '' */
+  /** Stroke line join at the line's corners. @default '' */
   linejoin?: LiteralUnion<'miter' | 'round' | 'bevel'>;
-  /** Stroke width of the link wrapper (hit area) in pixels. @default 10 */
+  /** Stroke width, in px, of the transparent wrapper that widens the pointer hit area. @default 10 */
   wrapperWidth?: number;
-  /** Stroke color of the link wrapper (outline). @default 'transparent' */
+  /** Stroke color of the wrapper. Usually transparent, set it to make the hit area visible while debugging. @default 'transparent' */
   wrapperColor?: string;
-  /** CSS class name to apply to the link wrapper (outline). @default '' */
+  /** Extra CSS class added to the wrapper. @default '' */
   wrapperClassName?: string;
 }
 
@@ -47,10 +48,22 @@ const defaultLinkStyle: Readonly<Required<LinkStyle>> = {
 };
 
 /**
- * SVG attributes for the link's visible line, derived from a {@link LinkStyle}.
- * Resolves stroke color/width, source/target markers, dash pattern, and the
- * `line` selector's CSS class.
+ * Builds the SVG `attrs` for a link's visible `line` from a {@link LinkStyle}:
+ * stroke color and width, source/target markers, dash pattern, and the line's
+ * CSS class. This is the `line` half of {@link linkStyle}; reach for it when you
+ * style the line and wrapper selectors separately.
  * @param style - link style to convert to SVG attributes
+ * @returns SVG attributes for the `line` selector
+ * @example
+ * ```ts
+ * import { LinkModel, linkStyleLine, linkStyleWrapper } from '@joint/react';
+ *
+ * const style = { color: '#333', width: 2 };
+ * const link = new LinkModel({
+ *   source: { id: 'a' }, target: { id: 'b' },
+ *   attrs: { line: linkStyleLine(style), wrapper: linkStyleWrapper(style) },
+ * });
+ * ```
  * @group Presets
  */
 export function linkStyleLine(style: LinkStyle = {}): Nullable<attributes.SVGAttributes> {
@@ -104,9 +117,22 @@ export function linkStyleLine(style: LinkStyle = {}): Nullable<attributes.SVGAtt
 }
 
 /**
- * SVG attributes for the link's hit-area (the invisible wrapper around the
- * visible line, used for pointer interaction), derived from a {@link LinkStyle}.
+ * Builds the SVG `attrs` for a link's `wrapper`, the wide invisible path around
+ * the visible line that catches pointer events, from a {@link LinkStyle}. This is
+ * the `wrapper` half of {@link linkStyle}; reach for it when you style the line
+ * and wrapper selectors separately.
  * @param style - link style to convert to SVG attributes
+ * @returns SVG attributes for the `wrapper` selector
+ * @example
+ * ```ts
+ * import { LinkModel, linkStyleLine, linkStyleWrapper } from '@joint/react';
+ *
+ * const style = { color: '#333', width: 2 };
+ * const link = new LinkModel({
+ *   source: { id: 'a' }, target: { id: 'b' },
+ *   attrs: { line: linkStyleLine(style), wrapper: linkStyleWrapper(style) },
+ * });
+ * ```
  * @group Presets
  */
 export function linkStyleWrapper(style: LinkStyle = {}): Nullable<attributes.SVGAttributes> {
@@ -131,11 +157,20 @@ export function linkStyleWrapper(style: LinkStyle = {}): Nullable<attributes.SVG
 }
 
 /**
- * Converts a {@link LinkStyle} into JointJS SVG `attrs` for `line` and `wrapper` selectors.
+ * Converts a {@link LinkStyle} into the JointJS SVG `attrs` object a link needs,
+ * keyed by the `line` and `wrapper` selectors. Use it to set a link's `attrs`
+ * directly, or rely on the `style` shorthand handled by {@link linkAttributes}.
  * @param style - link style to convert to SVG attributes
+ * @returns An `attrs` object with `line` and `wrapper` entries
  * @example
  * ```ts
- * const attrs = linkStyle({ color: '#333', width: 2, targetMarker: 'arrow' });
+ * import { LinkModel, linkStyle } from '@joint/react';
+ *
+ * const link = new LinkModel({
+ *   source: { id: 'a' },
+ *   target: { id: 'b' },
+ *   attrs: linkStyle({ color: '#333', width: 2, targetMarker: 'arrow' }),
+ * });
  * ```
  * @group Presets
  */

--- a/packages/joint-react/src/presets/paper-events.ts
+++ b/packages/joint-react/src/presets/paper-events.ts
@@ -386,9 +386,11 @@ export interface PaperEventHandlers {
 }
 
 /**
- * Extracts the callback type for a given paper event key.
- * For example, `PaperEventHandler<'onCellPointerDown'>` is `(params: PointerCellEventParams) => void`.
- * Useful for typing individual handler variables or parameters.
+ * The handler signature for a single paper event, looked up by its camelCase
+ * name. For example `PaperEventHandler<'onCellPointerDown'>` resolves to
+ * `(params: PointerCellEventParams) => void`. Handy for typing a standalone
+ * handler before adding it to a {@link PaperEventMap}.
+ * @template T - The event key to look up (a camelCase `on*` key of the paper's React event handlers, see {@link PaperEventMap}).
  * @group Types
  */
 export type PaperEventHandler<T extends keyof PaperEventHandlers> = NonNullable<
@@ -396,7 +398,9 @@ export type PaperEventHandler<T extends keyof PaperEventHandlers> = NonNullable<
 >;
 
 /**
- * Combined handlers, camelCase `on*` + raw native, accepted by `addPaperEventListeners`.
+ * Every paper-event handler accepted by {@link useOnPaperEvents}: the typed
+ * camelCase `on*` handlers (each delivering a single params object) plus any raw
+ * native event name with its positional arguments. Mix both freely in one map.
  * @group Types
  */
 export type PaperEventMap = Partial<dia.Paper.EventMap> & PaperEventHandlers;

--- a/packages/joint-react/src/selectors/cell-selectors.ts
+++ b/packages/joint-react/src/selectors/cell-selectors.ts
@@ -1,22 +1,25 @@
 import type { CellId, CellRecord, ElementRecord, Computed } from '../types/cell.types';
 
 /**
- * Selector helpers to pass into {@link useCell} / {@link useCells}.
+ * Ready-made selectors to pass into {@link useCell} / {@link useCells}.
  *
- * Each selector reads a single slice of the resolved record. The store
- * preserves slice reference identity across unrelated cell changes (see
- * `mergeCellRecord`), so `Object.is` short-circuits re-renders when only
- * other slices changed.
+ * Each one picks a single field off the resolved cell record so a component
+ * re-renders only when that field changes, not on every unrelated cell update.
+ * Reach for them when you want to subscribe to just the position, size, data,
+ * or another slice of a cell.
  */
 
 // ── Element slice selectors ────────────────────────────────────────────────
 
 /**
- * Reads `element.position`. Stable ref while the element doesn't move.
+ * Selects an element's top-left position `{ x, y }`. A subscribed component
+ * re-renders only when the element moves.
  * @group Selectors
  * @param element - the resolved element record
  * @example
  * ```tsx
+ * import { useCell, selectElementPosition } from '@joint/react';
+ *
  * const { x, y } = useCell(elementId, selectElementPosition);
  * ```
  */
@@ -25,11 +28,14 @@ export function selectElementPosition(element: Computed<ElementRecord>) {
 }
 
 /**
- * Reads `element.size`. Stable ref while the element isn't resized.
+ * Selects an element's bounding-box size `{ width, height }`. A subscribed
+ * component re-renders only when the element is resized.
  * @group Selectors
  * @param element - the resolved element record
  * @example
  * ```tsx
+ * import { useCell, selectElementSize } from '@joint/react';
+ *
  * const { width, height } = useCell(elementId, selectElementSize);
  * ```
  */
@@ -38,11 +44,14 @@ export function selectElementSize(element: Computed<ElementRecord>) {
 }
 
 /**
- * Reads `element.angle`.
+ * Selects an element's rotation in degrees, falling back to `0` when the
+ * element has no explicit angle.
  * @group Selectors
  * @param element - the resolved element record
  * @example
  * ```tsx
+ * import { useCell, selectElementAngle } from '@joint/react';
+ *
  * const angle = useCell(elementId, selectElementAngle);
  * ```
  */
@@ -51,13 +60,16 @@ export function selectElementAngle(element: Computed<ElementRecord>): number {
 }
 
 /**
- * Reads `element.data` typed as `ElementData`. Pass the type as an
- * instantiation: `useCell(selectElementData<NodeData>)`, TypeScript
- * propagates `NodeData` through to the hook's `Selected` inference.
+ * Selects an element's custom `data` payload, typed as `ElementData`. Supply
+ * the type when you call it (`selectElementData<NodeData>`) and TypeScript
+ * carries `NodeData` through to the value {@link useCell} returns.
  * @group Selectors
+ * @template ElementData - shape of the custom `data` payload carried on the element
  * @param element - the resolved element record
  * @example
  * ```tsx
+ * import { useCell, selectElementData } from '@joint/react';
+ *
  * type NodeData = { label: string };
  * const data = useCell(elementId, selectElementData<NodeData>);
  * ```
@@ -71,36 +83,43 @@ export function selectElementData<ElementData = unknown>(
 // ── Cell-level selectors (work for both elements and links) ───────────────
 
 /**
- * Reads `cell.id`. Note: {@link useCellId}() is cheaper when only the id is needed.
+ * Selects a cell's id. Prefer {@link useCellId} when the id is all you need —
+ * it skips the selector machinery.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example
  * ```tsx
- * const id = useCell(selectCellId);
+ * import { useCell, selectCellId } from '@joint/react';
+ *
+ * const id = useCell(cellId, selectCellId);
  * ```
  */
 export const selectCellId = (cell: Computed<CellRecord>) => cell.id;
 
 /**
- * Reads `cell.type` (e.g. `'element'`, `'link'`, or a built-in JointJS type).
+ * Selects a cell's `type` discriminator — `'element'` for React elements or
+ * `'link'` for React links. Handy for branching on the kind of cell.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example
  * ```tsx
- * const type = useCell(selectCellType);
+ * import { useCell, selectCellType } from '@joint/react';
+ *
+ * const type = useCell(cellId, selectCellType);
  * ```
  */
 export const selectCellType = (cell: Computed<CellRecord>) => cell.type;
 
 /**
- * Reads the `parent` field, cell id of the embedding parent, or `null` for
- * top-level cells. The field lives on the record's index signature, so we
- * narrow it here for callers. Works for both elements and links, any cell
- * can be embedded.
+ * Selects the id of the cell this one is embedded in, or `null` for a
+ * top-level cell. Works for elements and links alike, since any cell can be
+ * embedded.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example
  * ```tsx
+ * import { useCell, selectCellParent } from '@joint/react';
+ *
  * const parentId = useCell(cellId, selectCellParent);
  * ```
  */
@@ -108,12 +127,14 @@ export const selectCellParent = (cell: Computed<CellRecord>): CellId | null =>
   cell.parent ?? null;
 
 /**
- * Reads the `layer` field, name of the JointJS layer the cell renders into,
- * or `null` when the cell uses the paper's default layer.
+ * Selects the name of the paper layer the cell renders into, or `null` when it
+ * sits on the paper's default layer.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example
  * ```tsx
+ * import { useCell, selectCellLayer } from '@joint/react';
+ *
  * const layer = useCell(cellId, selectCellLayer);
  * ```
  */
@@ -121,12 +142,14 @@ export const selectCellLayer = (cell: Computed<CellRecord>): string | null =>
   cell.layer ?? null;
 
 /**
- * Reads the `z` field, JointJS z-index (paint order within a layer).
- * Falls back to `0` when the cell has no explicit z-index.
+ * Selects a cell's z-index — its paint order within a layer, where higher
+ * values draw on top. Falls back to `0` when the cell has no explicit z-index.
  * @group Selectors
  * @param cell - the resolved cell record
  * @example
  * ```tsx
+ * import { useCell, selectCellZIndex } from '@joint/react';
+ *
  * const z = useCell(cellId, selectCellZIndex);
  * ```
  */

--- a/packages/joint-react/src/store/create-elements-size-observer.ts
+++ b/packages/joint-react/src/store/create-elements-size-observer.ts
@@ -25,18 +25,36 @@ type ElementLayoutOptionalXY = Pick<ElementLayout, 'width' | 'height'> &
   Partial<Pick<ElementLayout, 'x' | 'y'>>;
 
 /**
- * Options passed to the setSize callback when an element's size changes.
+ * The element's measurement, passed to a {@link TransformElementLayout} callback.
+ * Carries the element's current `x`, `y`, and `angle` together with the freshly
+ * measured `width` and `height`, plus the underlying model and cell id.
+ * @expand
  * @group Types
  */
 export interface TransformElementLayoutParams extends Required<ElementLayout> {
-  /** The JointJS element instance */
+  /** The JointJS `dia.Element` instance being measured. */
   readonly model: dia.Element;
+  /** Id of the cell being measured. */
   readonly id: CellId;
 }
 
 /**
- * Callback function called when an element's size is measured.
- * Allows custom handling of size updates before they're applied to the graph.
+ * Adjusts a measured element layout before it is written to the graph. Receives
+ * the element's current geometry plus its newly measured size, and returns the
+ * `width`/`height` (and optionally `x`/`y`) to apply — use it to clamp sizes,
+ * snap to a grid, or reposition while auto-sizing. Pass it via the `transform`
+ * option of {@link useMeasureElement}.
+ * @example
+ * ```tsx
+ * import type { TransformElementLayout } from '@joint/react';
+ *
+ * // Never let a measured element shrink below 80px wide.
+ * const transform: TransformElementLayout = ({ width, height }) => ({
+ *   width: Math.max(width, 80),
+ *   height,
+ * });
+ * ```
+ * @see {@link TransformElementLayoutParams}
  * @group Types
  */
 export type TransformElementLayout = (
@@ -90,7 +108,7 @@ interface Options {
 export interface GraphStoreObserver {
   /**
    * Adds an element to be observed for size changes.
-   * @param options - Configuration for the measured node
+   * @param options - Options for measuring the element
    * @returns Cleanup function to stop observing
    */
   readonly add: (options: SetMeasuredNodeOptions) => () => void;

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -5,15 +5,23 @@ import { asReadonlyContainer, createContainer } from './state-container';
 import { writeCellToContainer } from '../state/data-mapping/cell-record-merge';
 
 /**
- * Incremental change set emitted by graphProjection after container commits.
+ * A batch of cell changes reported after each graph update, delivered to the
+ * `onIncrementalCellsChange` callback of {@link GraphProviderProps}. Lets you
+ * apply just the delta to an external store instead of diffing the whole graph.
+ * @template Element - Shape of the element cells stored in the graph.
+ * @template Link - Shape of the link cells stored in the graph.
+ * @expand
  * @group Types
  */
 export interface IncrementalCellsChange<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,
 > {
+  /** Cells added since the last commit, keyed by cell id. */
   readonly added: Map<CellId, Element | Link>;
+  /** Cells whose attributes changed since the last commit, keyed by cell id. */
   readonly changed: Map<CellId, Element | Link>;
+  /** Ids of cells removed since the last commit (including a removed element's links). */
   readonly removed: Set<CellId>;
 }
 /**
@@ -24,7 +32,7 @@ export type OnIncrementalCellsChange<Element extends ElementJSONInit, Link exten
   changes: IncrementalCellsChange<Element, Link>
 ) => void;
 
-/** Configuration for {@link graphProjection}. */
+/** Options for {@link graphProjection}. */
 interface GraphProjectionState<
   Element extends ElementJSONInit = ElementJSONInit,
   Link extends LinkJSONInit = LinkJSONInit,

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -53,13 +53,6 @@ export interface GraphStoreInternalSnapshot {
 }
 
 /**
- * Options common to all `GraphStore` constructor variants.
- *
- * The controlled / uncontrolled split is modelled with a discriminated union
- * to rule out the nonsensical combination of `cells` and `initialCells`
- * being passed together.
- */
-/**
  * Reference point that stays fixed when an auto-sized element's measured size
  * changes. Mirrors CSS `transform-origin` semantics.
  *
@@ -73,7 +66,9 @@ export interface GraphStoreInternalSnapshot {
 export type AutoSizeOrigin = 'top-left' | 'center';
 
 /**
- * Options for creating a `GraphStore` in controlled mode. Requires the full cells
+ * Options for constructing a {@link GraphStore}: an optional existing `dia.Graph`,
+ * cell namespace/model overrides, the auto-size origin, and `initialCells` used to
+ * seed the graph once on creation.
  * @group Types
  */
 export interface GraphStoreOptions<
@@ -262,14 +257,14 @@ export class GraphStore<
   }
 
   /**
-   * Type guard: does the input resolve to an element cell?
+   * Type guard: does this cell record resolve to an element?
    *
-   * Accepts a cell record, an existing cell id, or a bare type name. Falls
+   * Reads `cell.type` and classifies it via the graph's type registry. Falls
    * back to `graph.getTypeConstructor(type).prototype.isElement()` when the
    * type is not our default {@link ElementModel}, so any `dia.Element` subclass
    * registered in the cell namespace (`standard.Rectangle`, custom shapes,
    * etc.) is correctly recognised.
-   * @param cell - cell record, cell id, or type name
+   * @param cell - the cell record to classify
    * @returns `true` when the resolved type extends `dia.Element`
    */
   public isElement = (cell: Element | Link): cell is Element => {
@@ -278,13 +273,13 @@ export class GraphStore<
   };
 
   /**
-   * Type guard: does the input resolve to a link cell?
+   * Type guard: does this cell record resolve to a link?
    *
-   * Accepts a cell record, an existing cell id, or a bare type name. Falls
+   * Reads `cell.type` and classifies it via the graph's type registry. Falls
    * back to `graph.getTypeConstructor(type).prototype.isLink()` when the type
    * is not our default {@link LinkModel}, so any `dia.Link` subclass registered in
    * the cell namespace is correctly recognised.
-   * @param cell - cell record, cell id, or type name
+   * @param cell - the cell record to classify
    * @returns `true` when the resolved type extends `dia.Link`
    */
   public isLink = (cell: Element | Link): cell is Link => {

--- a/packages/joint-react/src/theme/named-link-markers.tsx
+++ b/packages/joint-react/src/theme/named-link-markers.tsx
@@ -21,21 +21,34 @@ export const namedLinkMarkers = {
 } as const satisfies Record<string, LinkMarkerRecord | null>;
 
 /**
- * Keys of the built-in `namedLinkMarkers` registry (e.g. `'arrow'`, `'circle'`).
+ * The names of the built-in link markers you can pass to a {@link LinkStyle}:
+ * `'arrow'`, `'arrow-open'`, `'arrow-sunken'`, `'circle'`, `'diamond'`, or
+ * `'none'`.
  * @group Types
  */
 export type LinkMarkerName = keyof typeof namedLinkMarkers;
 
 /**
- * A named preset or a custom {@link LinkMarkerRecord}.
+ * A link endpoint marker, either a built-in {@link LinkMarkerName} or a custom
+ * {@link LinkMarkerRecord}.
  * @group Types
  */
 export type LinkMarker = LinkMarkerName | LinkMarkerRecord;
 
 /**
- * Resolves a LinkMarker to a {@link LinkMarkerRecord} or null.
- * @param marker - The LinkMarker to resolve
- * @returns The resolved marker or null
+ * Normalizes a {@link LinkMarker} into a concrete {@link LinkMarkerRecord}. Looks
+ * up a built-in name (`'arrow'`, `'circle'`, …) in the marker registry, passes a
+ * custom record through unchanged, and returns `null` for `'none'`, `undefined`,
+ * or an unknown name, meaning "draw no marker".
+ * @param marker - a marker name, a custom marker record, `'none'`, or `undefined`
+ * @returns The resolved marker record, or `null` when no marker should be drawn
+ * @example
+ * ```ts
+ * import { resolveLinkMarker } from '@joint/react';
+ *
+ * resolveLinkMarker('arrow'); // built-in arrow record
+ * resolveLinkMarker('none');  // null
+ * ```
  * @group Presets
  */
 export function resolveLinkMarker(marker: LinkMarker | undefined): LinkMarkerRecord | null {

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -12,22 +12,18 @@ import type { LinkPresetAttributes } from '../presets/link-attributes';
 import type { ElementPresetAttributes } from '../presets/element-attributes';
 
 /**
- * `dia.Element.JSONInit` (id?, type, visual attrs) + React preset extras
- * + an explicit `data?: unknown` declaration that narrows the
- * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
- * the upper-bound layer.
- * @group Types
+ * Loose element shape accepted at the record/mapper boundary: a `dia.Element`
+ * JSON init (optional `id`, plus `type` and visual attrs) with the React preset
+ * extras and an optional typed `data` payload.
  */
 export interface ElementJSONInit extends DiaElement.JSONInit, ElementPresetAttributes {
   data?: unknown;
 }
 
 /**
- * `dia.Link.JSONInit` (id?, type, visual attrs) + React preset extras
- * + an explicit `data?: unknown` declaration that narrows the
- * `Cell.Attributes` index signature (`[customAttribute: string]: any`) at
- * the upper-bound layer.
- * @group Types
+ * Loose link shape accepted at the record/mapper boundary: a `dia.Link` JSON
+ * init (optional `id`, plus `type` and visual attrs) with the React preset
+ * extras and an optional typed `data` payload.
  */
 export interface LinkJSONInit extends DiaLink.JSONInit, LinkPresetAttributes {
   data?: unknown;
@@ -46,9 +42,17 @@ type WithData<Data = unknown> = unknown extends Data
   : { readonly data: Data };
 
 /**
- * Element-flavored cell; default `Type = typeof ELEMENT_MODEL_TYPE` so
- * `cell.type === 'element'` narrows. Override `Type` (e.g.
- * `'standard.Rectangle'`) for built-in or custom shapes.
+ * Plain-object description of one element: your custom `data` plus the visual
+ * fields JointJS understands (`position`, `size`, `angle`, `attrs`, ports, and
+ * the `portMap`/`portStyle` preset extras). Use it for `initialCells` entries
+ * and when adding or updating cells; reading hooks hand back its
+ * `Computed<ElementRecord>` form (fields the store always populates are required).
+ *
+ * `Type` defaults to `'element'` so `cell.type === 'element'` narrows the
+ * {@link CellRecord} union; set it to a shape name (e.g. `'standard.Rectangle'`)
+ * for a built-in or custom shape.
+ * @template ElementData - shape of the custom `data` payload carried on the element
+ * @template Type - the `type` discriminator literal
  * @group Types
  */
 export type ElementRecord<
@@ -74,9 +78,17 @@ type InternalElementRecord<ElementData = unknown> = PickRequired<
 >;
 
 /**
- * Link-flavored cell; default `Type = typeof LINK_MODEL_TYPE` so
- * `cell.type === 'link'` narrows. Override `Type` (e.g. `'standard.Link'`)
- * for built-in or custom shapes.
+ * Plain-object description of one link: your custom `data` plus the visual
+ * fields JointJS understands (`source`, `target`, `attrs`, labels, and the
+ * `style`/`labelMap`/`labelStyle` preset extras). Use it for `initialCells`
+ * entries and when adding or updating cells; reading hooks hand back its
+ * `Computed<LinkRecord>` form (fields the store always populates are required).
+ *
+ * `Type` defaults to `'link'` so `cell.type === 'link'` narrows the
+ * {@link CellRecord} union; set it to a shape name (e.g. `'standard.Link'`) for
+ * a built-in or custom shape.
+ * @template LinkData - shape of the custom `data` payload carried on the link
+ * @template Type - the `type` discriminator literal
  * @group Types
  */
 export type LinkRecord<
@@ -100,13 +112,19 @@ type InternalLinkRecord<LinkData = unknown> = PickRequired<
   'id' | 'type' | 'source' | 'target' | 'data'
 >;
 /**
- * Discriminated union over the React default `type` literals:
+ * One cell — either an {@link ElementRecord} or a {@link LinkRecord} — as a
+ * discriminated union on `type`:
  * - `type === 'element'` → {@link ElementRecord}
  * - `type === 'link'`    → {@link LinkRecord}
  *
- * `cell.type === 'element'` narrows correctly inside arrays / hooks. For
- * mixed built-in shape arrays with typed data, build the union manually:
+ * Because it discriminates on `type`, `if (cell.type === 'element')` narrows
+ * correctly inside arrays and hooks. For mixed built-in shape arrays with typed
+ * data, build the union yourself:
  * `ElementRecord<MyData, 'standard.Rectangle'> | LinkRecord<MyData, 'standard.Link'>`.
+ * @template ElementData - shape of the custom `data` payload on elements
+ * @template LinkData - shape of the custom `data` payload on links
+ * @template ElementType - the element `type` discriminator literal
+ * @template LinkType - the link `type` discriminator literal
  * @group Types
  */
 export type CellRecord<
@@ -119,10 +137,10 @@ export type CellRecord<
   | LinkRecord<LinkData, LinkType>;
 
 /**
- * Loose alias of {@link CellRecord}, `data` is `unknown`, `type` is any string.
- * Use when you don't care about React-default `'element'` / `'link'`
- * discrimination (e.g. `initialCells` arrays mixing built-in shape types,
- * generic upper bounds in custom hooks).
+ * The most permissive {@link CellRecord}: `data` is `unknown` and `type` is any
+ * string. Reach for it when you don't need the default `'element'` / `'link'`
+ * discrimination — for example an `initialCells` array mixing built-in shape
+ * types, or a generic upper bound in a custom hook.
  * @group Types
  */
 export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
@@ -138,22 +156,29 @@ export type AnyCellRecord = CellRecord<unknown, unknown, string, string>;
  * |------------------------------------|-----------------------------------|
  * | `Computed<ElementRecord<D>>`       | element with required fields      |
  * | `Computed<LinkRecord<D>>`          | link with required fields         |
- * | `Computed<ElementAttributes>`      | element with `data: unknown`      |
- * | `Computed<LinkAttributes>`         | link with `data: unknown`         |
  * | `Computed<CellRecord<E, L>>`       | resolved element or resolved link |
- * | `Computed<CellAttributes>`         | resolved element or resolved link |
- * | `Internal` (default)               | `Computed<CellRecord>`            |
  *
- * Custom records (with their own `type` literal that doesn't match
- * {@link ElementRecord} / {@link LinkRecord}) pass through unchanged so the store shape
- * can be composed: `Computed<CellRecord> | MyCustomRecord`.
+ * To keep a custom record's exact shape, compose it OUTSIDE the wrapper, e.g.
+ * `Computed<CellRecord> | MyCustomRecord`. Passing a custom element- or
+ * link-shaped record (any object with a `type` field) directly through
+ * `Computed` re-maps it to the internal element/link record, because it
+ * structurally matches the same branch as {@link ElementRecord} /
+ * {@link LinkRecord}.
  *
  * Reading hooks ({@link useCell}, {@link useCells}) yield the `Computed` variant so
  * consumers don't need `?? {}` / `?? 0` fallbacks for fields the store
  * always populates.
+ * @template T - the input cell shape (record or union) to resolve
  * @example
  * ```ts
- * useCell((el: Computed<ElementRecord<MyData>>) => el.data.label);
+ * import { useCell } from '@joint/react';
+ * import type { Computed, ElementRecord } from '@joint/react';
+ *
+ * interface MyData {
+ *   label: string;
+ * }
+ *
+ * const label = useCell((el: Computed<ElementRecord<MyData>>) => el.data.label);
  * ```
  * @group Types
  */
@@ -179,13 +204,13 @@ export type CellId = DiaCell.ID;
 // ── Element Layout Aliases ──────────────────────────────────────────────────
 
 /**
- * Position of an element, alias for `dia.Point`.
+ * An element's top-left position, `{ x, y }`. Alias for `dia.Point`.
  * @group Types
  */
 export type ElementPosition = DiaPoint;
 
 /**
- * Size of an element, alias for `dia.Size`.
+ * An element's bounding-box size, `{ width, height }`. Alias for `dia.Size`.
  * @group Types
  */
 export type ElementSize = DiaSize;
@@ -195,7 +220,6 @@ export type ElementSize = DiaSize;
 /**
  * Flat element layout used internally by the size observer and transform callbacks.
  * @internal
- * @group Types
  */
 export interface ElementLayout {
   readonly x: number;
@@ -208,23 +232,28 @@ export interface ElementLayout {
 // ── Link Layout (internal) ──────────────────────────────────────────────────
 
 /**
- * Layout data for a single link on a specific paper.
- * Contains source/target endpoint coordinates and the SVG path data.
- * @internal
+ * Resolved geometry of one link on a specific paper: the source and target
+ * endpoint coordinates plus the rendered SVG path. Returned by
+ * {@link useLinkLayout} so you can draw or measure alongside a link.
  * @group Types
  */
 export interface LinkLayout {
+  /** X coordinate of the link's source endpoint, in paper coordinates. */
   readonly sourceX: number;
+  /** Y coordinate of the link's source endpoint, in paper coordinates. */
   readonly sourceY: number;
+  /** X coordinate of the link's target endpoint, in paper coordinates. */
   readonly targetX: number;
+  /** Y coordinate of the link's target endpoint, in paper coordinates. */
   readonly targetY: number;
+  /** SVG path data (the `d` attribute) for the link's rendered route. */
   readonly d: string;
 }
 
 /**
- * Cell setter input: a plain record or a dia.Cell instance.
- * Shared across all cell-mutation entry points (setCell, resetCells,
- * initialCells, collection setter, etc.).
+ * What you may pass when handing a cell to the library: either a plain element
+ * or link record, or a live `dia.Cell` instance. Accepted by every
+ * cell-mutation entry point — `initialCells`, `resetCells`, and the cell setters.
  * @template Element - element record shape
  * @template Link - link record shape
  * @group Types
@@ -235,7 +264,8 @@ export type CellInput<
 > = Element | Link | DiaCell;
 
 /**
- * Re-export of JointJS core's `dia.Graph.CellRef`, a cell id or `dia.Cell` instance.
+ * A reference to a cell — either its {@link CellId} or the `dia.Cell` instance
+ * itself. Alias for JointJS core's `dia.Graph.CellRef`.
  * @group Types
  */
 export type CellRef = DiaGraph.CellRef;

--- a/packages/joint-react/src/types/paper.types.ts
+++ b/packages/joint-react/src/types/paper.types.ts
@@ -2,9 +2,12 @@ import type { RefObject } from 'react';
 import type { dia } from '@joint/core';
 
 /**
- * Identifies a Paper instance, a registered id, a React ref, or the Paper
- * itself. Paper-targeting hooks never throw; an unresolved target simply means
- * "use the current Paper context or the default paper".
+ * Identifies which paper a paper-targeting hook should resolve: a registered
+ * paper id, a React ref to a paper, or a `dia.Paper` instance directly. These
+ * hooks never throw — an unresolved target falls back to the current Paper
+ * context or the default paper.
+ * @see {@link useOnPaperEvents}
+ * @see {@link useOnElementsMeasured}
  * @group Types
  */
 export type PaperTarget = string | RefObject<dia.Paper | null> | dia.Paper;

--- a/packages/joint-react/src/utils/create.ts
+++ b/packages/joint-react/src/utils/create.ts
@@ -13,9 +13,12 @@ type CellArrayMember<Cells> = Cells extends ReadonlyArray<infer Member> ? Member
  *
  * Custom shapes (a `type` other than `'element'`) are excluded, type the
  * record union manually for those, as documented on {@link CellRecord}.
+ * @template Cells - the cells collection to infer from, usually `typeof cells`
  * @group Types
  * @example
  * ```ts
+ * import type { InferElement } from '@joint/react';
+ *
  * const cells = [
  *   { id: 'a', type: 'element', data: { label: 'A' } },
  *   { id: 'e', type: 'link', source: { id: 'a' }, target: { id: 'b' }, data: { weight: 2 } },
@@ -33,9 +36,12 @@ export type InferElement<Cells> = Extract<
 /**
  * Infer the link record type from a cells collection, the link counterpart of
  * {@link InferElement}. Selects the member whose `type` is `'link'`.
+ * @template Cells - the cells collection to infer from, usually `typeof cells`
  * @group Types
  * @example
  * ```ts
+ * import type { InferLink } from '@joint/react';
+ *
  * const cells = [
  *   { id: 'a', type: 'element', data: { label: 'A' } },
  *   { id: 'e', type: 'link', source: { id: 'a' }, target: { id: 'b' }, data: { weight: 2 } },

--- a/packages/joint-react/src/utils/joint-jsx/jsx-to-markup.ts
+++ b/packages/joint-react/src/utils/joint-jsx/jsx-to-markup.ts
@@ -105,14 +105,28 @@ function jsxToMarkupWithArray(element: JSX.Element, markups: dia.MarkupJSON = []
 }
 
 /**
- * Convert JSX into JointJS markup (static `dia.MarkupJSON`). Only intrinsic
- * SVG / HTML tags are emitted as nodes; component types are treated as
- * fragments, their children flow through but the wrapper itself is dropped.
- * No hooks, no state, purely static.
- * @param element JSX element.
- * @returns JointJS markup.
+ * Converts a JSX tree into static JointJS markup (`dia.MarkupJSON`), ready to
+ * assign as a cell's `markup`. Intrinsic SVG/HTML tags become markup nodes;
+ * function components are rendered once and their output is converted; fragments
+ * (and any non-string element type) are unwrapped so their children flow through
+ * without a wrapper node.
+ *
+ * Text, number, boolean, and `null` children become text content; any other
+ * child type throws. This is a one-time, static conversion with no hooks, no
+ * state, and no React lifecycle, so author plain markup here rather than
+ * interactive components.
+ * @param element - The JSX tree to convert, typically authored inline as `<g>…</g>`.
+ * @returns The equivalent JointJS markup array.
+ * @remarks
+ * Two prop conventions are translated for you:
+ * - `className` is emitted as the SVG `class` attribute.
+ * - Any `joint-*` prop is lifted onto the markup node itself, e.g.
+ *   `joint-selector="body"` sets the node's `selector` (the same selector names
+ *   that {@link useMarkup} registers at runtime).
  * @example
  * ```tsx
+ * import { jsx } from '@joint/react';
+ *
  * const markup = jsx(
  *   <g>
  *     <rect width={80} height={40} fill="white" stroke="black" />

--- a/packages/joint-react/stories/demos/collaboration/code.tsx
+++ b/packages/joint-react/stories/demos/collaboration/code.tsx
@@ -302,7 +302,7 @@ function createPeerManager(callbacks: {
     connectTo(incomingConn.peer);
   });
   peer.on('error', (error) => {
-    console.error('PeerJS:', error); // eslint-disable-line no-console
+    console.error('PeerJS:', error);
     onStatus('disconnected');
   });
 

--- a/packages/joint-react/stories/tutorials/step-by-step/code-controlled-mode-peerjs.tsx
+++ b/packages/joint-react/stories/tutorials/step-by-step/code-controlled-mode-peerjs.tsx
@@ -198,7 +198,6 @@ function createPeerJSManager(callbacks: {
   });
 
   peer.on('error', (error) => {
-    // eslint-disable-next-line no-console
     console.error('PeerJS error:', error);
     if (error.type === 'peer-unavailable') {
       onConnectionStatusChange('disconnected');
@@ -259,7 +258,6 @@ function createPeerJSManager(callbacks: {
     });
 
     conn.on('error', (error) => {
-      // eslint-disable-next-line no-console
       console.error('Connection error:', error);
       onConnectionStatusChange('disconnected');
     });
@@ -368,7 +366,6 @@ function Main() {
           setCopyFeedback(false);
         }, 2000);
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.error('Failed to copy ID:', error);
       }
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Rewrites and standardizes the public-API JSDoc/TSDoc across `@joint/react` so the TypeDoc-generated API reference is accurate, complete, and consistent with `@joint/react-plus`.

For every public component, hook, type, preset, selector, and model:
- Descriptions now describe **user-facing behavior** (what it does and how to use it) — removed comments that described internal implementation, were inaccurate, or were missing.
- React-library voice throughout (e.g. `*Props` read as "Props for `<X>`", `*Options` as "Options for `<X>`"; never "Configuration for").
- Correct, consistent `@group`.
- `@example` added to **every component and every hook**, importing from the public entry with real props.
- `@default` on optional props with a real default; `@expand` on consumed props/options interfaces.
- Related symbols cross-linked with `{@link}`.

Also aligns the shared React ESLint config (`@joint/eslint-config`) so the packages stay lint-clean: allow `console.warn`/`console.error`, and allow single-extends empty interfaces (used for `@expand`).

## Motivation and Context

The API docs users read are generated from this JSDoc via TypeDoc. Several descriptions were missing, described internals, or diverged in wording between `@joint/react` and `@joint/react-plus`. This pass makes the reference read like polished React documentation and keeps both packages consistent.

`yarn test` passes (typecheck + lint + knip + jest); TypeDoc markdown generates with 0 errors.

### Screenshots (if appropriate):