### PR TITLE
refactor(react): unexport useSetCellData

### DIFF
--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -136,8 +136,8 @@ export function useSetCell<
 type SetCellDataUpdater<Data> = (previousData: Data) => Data;
 
 /**
- * Function exposed by {@link GraphApi}.setCellData and returned by
- * {@link useSetCellData}. Two forms, both keyed by cell id:
+ * Function exposed by {@link GraphApi}.setCellData. Two forms, both keyed by
+ * cell id:
  * - `setCellData(id, data)`, replaces the cell's `data` with `data`.
  * - `setCellData(id, (prev) => next)`, updater form; `prev` is the current
  *   `data`, the return value replaces it.
@@ -154,31 +154,17 @@ export interface SetCellData<Data = Record<string, unknown>> {
 }
 
 /**
- * Returns a function that sets a single cell's `data` field. Two forms:
- * `setCellData(id, data)` replaces wholesale; `setCellData(id, (prev) => next)`
- * uses an updater. A nullish `id`, or an `id` with no matching cell, warns
- * in dev and no-ops.
+ * Internal hook that returns a function to set a single cell's `data` field.
+ * Two forms: `setCellData(id, data)` replaces wholesale;
+ * `setCellData(id, (prev) => next)` uses an updater. A nullish `id`, or an
+ * `id` with no matching cell, warns in dev and no-ops.
  *
  * Writes `data` directly on the `dia.Cell`, so JointJS fires `change:data` and
- * every React subscription resyncs, no full-record merge is involved. Read the
- * value back with {@link useCell}.
+ * every React subscription resyncs, no full-record merge is involved. Consumed
+ * by {@link useGraph} to expose `setCellData` on the {@link GraphApi}.
  * @template Data - cell data shape (defaults to an open `Record<string, unknown>`)
  * @returns memoized setCellData setter
- * @group Hooks
- * @example
- * ```tsx
- * import { useSetCellData } from '@joint/react';
- *
- * function DoneToggle({ id }: { id: string }) {
- *   const setCellData = useSetCellData<{ done: boolean }>();
- *   // Updater form: flip the `done` flag on the cell's data.
- *   return (
- *     <button onClick={() => setCellData(id, (prev) => ({ ...prev, done: !prev.done }))}>
- *       Toggle
- *     </button>
- *   );
- * }
- * ```
+ * @internal
  */
 export function useSetCellData<Data = Record<string, unknown>>(): SetCellData<Data> {
   const store = useGraphStore();

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -81,8 +81,7 @@ export interface GraphApi<
    * typed records flow through, otherwise it falls back to
    * `Record<string, unknown>`. A cell id can't be narrowed to element-vs-link
    * at the type level, so when both are typed the updater sees their union.
-   * Narrow inside it. For a single fixed `data` shape, use the standalone
-   * `useSetCellData<MyData>()` hook.
+   * Narrow inside it.
    */
   readonly setCellData: SetCellData<HandleCellData<Element, Link>>;
   /**

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -89,12 +89,6 @@ export { useGraph } from './hooks/use-graph';
 export type { GraphApi, GraphJSON, ExportToJSONOptions } from './hooks/use-graph';
 
 /**
- * useSetCellData()
- * @group Hooks
- */
-export { useSetCellData } from './hooks/use-cell-setters';
-
-/**
  * usePaper()
  * @group Hooks
  */

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -28,7 +28,7 @@ export { FeaturesProvider } from './components';
 
 // Store Classes
 export { GraphStore, DEFAULT_CELL_NAMESPACE, AUTO_SIZE_OPTION } from './store/graph-store';
-export type { GraphStoreInternalSnapshot, PaperStoreState, AutoSizeOptions } from './store/graph-store';
+export type { GraphStoreInternalSnapshot, PaperStoreState } from './store/graph-store';
 export type { GraphStoreOptions } from './store/graph-store';
 export { PaperStore } from './store/paper-store';
 export type { PaperStoreOptions, AddPaperOptions } from './store/paper-store';

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -27,8 +27,8 @@ export type { FeaturesContext as FeaturesContextType } from './context';
 export { FeaturesProvider } from './components';
 
 // Store Classes
-export { GraphStore, DEFAULT_CELL_NAMESPACE } from './store/graph-store';
-export type { GraphStoreInternalSnapshot, PaperStoreState } from './store/graph-store';
+export { GraphStore, DEFAULT_CELL_NAMESPACE, AUTO_SIZE_OPTION } from './store/graph-store';
+export type { GraphStoreInternalSnapshot, PaperStoreState, AutoSizeOptions } from './store/graph-store';
 export type { GraphStoreOptions } from './store/graph-store';
 export { PaperStore } from './store/paper-store';
 export type { PaperStoreOptions, AddPaperOptions } from './store/paper-store';

--- a/packages/joint-react/src/store/graph-changes.ts
+++ b/packages/joint-react/src/store/graph-changes.ts
@@ -86,7 +86,7 @@ export function graphChanges(options: Options) {
    * @param cell - The cell that changed.
    * @param type - Kind of change.
    * @param sync - Notify synchronously instead of coalescing onto a microtask.
-   *   Used for `data` edits ({@link useSetCellData} / `useSetCell`) so a controlled
+   *   Used for `data` edits (`setCellData` / `useSetCell`) so a controlled
    *   input bound to cell data updates in the same tick as the keystroke —
    *   otherwise its caret jumps to the end. High-frequency changes (drags, bulk)
    *   stay coalesced.

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -33,6 +33,18 @@ export const DEFAULT_CELL_NAMESPACE: Record<string, unknown> = {
 };
 
 /**
+ * `dia.Cell.set()` option key used to mark writes that originate from the
+ * auto-size / measurement pipeline. `change:size` listeners can read it to
+ * distinguish measurement writes from external ones (controlled-mode sync,
+ * `cell.resize`, interactive tools) and avoid feedback loops. Exported for
+ * plugin authors and `@joint/react-plus` via `@joint/react/internal`.
+ */
+export const AUTO_SIZE_OPTION = 'autoSize';
+
+/** Option shape accepted by `dia.Cell.set()` writes from the auto-size pipeline. */
+export type AutoSizeOptions = { [AUTO_SIZE_OPTION]?: boolean };
+
+/**
  * Paper snapshot is a simple version counter.
  * Incremented on every view mount/unmount change to trigger React re-renders.
  * @group Types
@@ -105,7 +117,7 @@ export class GraphStore<
   private observer: GraphStoreObserver;
   private onIncrementalCellsChange?: OnIncrementalCellsChange<Element, Link>;
   // dev-only `change:size` listener that warns about resizing auto-sized elements.
-  private warnAutoSizeResize?: (cell: dia.Cell, size: dia.Size, opt?: { autoSize?: boolean }) => void;
+  private warnAutoSizeResize?: (cell: dia.Cell, size: dia.Size, opt?: AutoSizeOptions) => void;
 
   constructor(public readonly config: GraphStoreOptions<Element, Link>) {
     const {
@@ -196,7 +208,7 @@ export class GraphStore<
             };
           }
 
-          model.set(attributes, { autoSize: true });
+          model.set(attributes, { [AUTO_SIZE_OPTION]: true });
           // Top-left auto-size (default): don't write position — the cell's
           // top-left stays put implicitly and it grows right/down.
         }
@@ -234,7 +246,7 @@ export class GraphStore<
     // immediately overwritten by the measured content size.
     if (process.env.NODE_ENV !== 'production') {
       this.warnAutoSizeResize = (cell, _size, opt) => {
-        if (opt?.autoSize) return; // our own measurement write
+        if (opt?.[AUTO_SIZE_OPTION]) return; // our own measurement write
         if (!this.observer.has(cell.id)) return; // not auto-sized → resize is honored
         warnResizeOnAutoSizedElement(cell.id);
       };

--- a/packages/joint-react/src/store/graph-store.ts
+++ b/packages/joint-react/src/store/graph-store.ts
@@ -42,7 +42,7 @@ export const DEFAULT_CELL_NAMESPACE: Record<string, unknown> = {
 export const AUTO_SIZE_OPTION = 'autoSize';
 
 /** Option shape accepted by `dia.Cell.set()` writes from the auto-size pipeline. */
-export type AutoSizeOptions = { [AUTO_SIZE_OPTION]?: boolean };
+type AutoSizeOptions = { [AUTO_SIZE_OPTION]?: boolean };
 
 /**
  * Paper snapshot is a simple version counter.


### PR DESCRIPTION
## Summary
- Remove `useSetCellData` from the `@joint/react` public export list.
- `setCellData` remains available via the `GraphApi` returned by `useGraph`, which was already the intended surface.
- Demote the hook to an internal helper: strip `@group Hooks`, drop the public example, and remove `{@link useSetCellData}` references in adjacent JSDoc (`SetCellData` interface, `useGraph` `setCellData` doc, `graph-changes` comment).

## Test plan
- [ ] `yarn typecheck` in `packages/joint-react` passes.
- [ ] `yarn jest` in `packages/joint-react` still green (existing `useSetCellData` tests import from the module directly, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)