### PR TITLE
fix(react): preserve joint classes on paper.el when className prop changes

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -68,6 +68,43 @@ describe('Paper', () => {
     });
   });
 
+  it('keeps joint classes on paper.el when the className prop changes', async () => {
+    // paper.el IS the React-rendered host div: dia.Paper imperatively adds
+    // `joint-paper joint-theme-default` to it after mount. A className prop
+    // change must not clobber those — React replacing the whole class
+    // attribute silently kills every class-based consumer (theme CSS, and any
+    // paper `guard` walking up to `.joint-paper`, which breaks wheel
+    // zoom/pan after e.g. an infinite→sheets mode switch).
+    function App({ mode }: Readonly<{ mode: string }>) {
+      return (
+        <GraphProvider initialCells={CELLS}>
+          <Paper
+            className={mode}
+            style={{ width: 100, height: 100 }}
+            renderElement={renderRectElement}
+          />
+        </GraphProvider>
+      );
+    }
+    const { container, rerender } = render(<App mode="mode-a" />);
+    await waitFor(() => {
+      const element = container.querySelector('.joint-paper');
+      expect(element).toBeTruthy();
+      expect(element!.classList.contains('mode-a')).toBe(true);
+    });
+
+    rerender(<App mode="mode-b" />);
+
+    await waitFor(() => {
+      const element = container.querySelector('.mode-b');
+      expect(element).toBeTruthy();
+      expect(element!.classList.contains('mode-a')).toBe(false);
+      // The imperative joint classes survive the React className update.
+      expect(element!.classList.contains('joint-paper')).toBe(true);
+      expect(element!.classList.contains('joint-theme-default')).toBe(true);
+    });
+  });
+
   it('throws when cellVisibility is set via the options escape hatch', () => {
     // `PaperOptions` excludes `cellVisibility` at the type level; cast around
     // it to simulate a plain-JS caller and assert the runtime guard.

--- a/packages/joint-react/src/components/paper/paper.tsx
+++ b/packages/joint-react/src/components/paper/paper.tsx
@@ -1,5 +1,5 @@
 import type { dia } from '@joint/core';
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { PaperStoreContext } from '../../context';
 import { useCreatePortalPaper } from '../../hooks/use-create-portal-paper';
@@ -35,6 +35,19 @@ function PaperBase(
   const portaledChildren =
     isReady && children && paper?.el ? createPortal(children, paper.el) : null;
 
+  // The host div IS `paper.el`: dia.Paper adds its own classes (`joint-paper`,
+  // theme) to it imperatively after mount, so `className` must not go through
+  // the JSX attribute — React would rewrite the whole class attribute and wipe
+  // the joint classes. Add the prop's tokens via classList instead; the effect
+  // cleanup removes them again, so a changed prop swaps only its own tokens.
+  useLayoutEffect(() => {
+    const element = paperHTMLElementRef.current;
+    if (!element || !className) return;
+    const tokens = className.split(/\s+/).filter(Boolean);
+    element.classList.add(...tokens);
+    return () => element.classList.remove(...tokens);
+  }, [className]);
+
   // When paper is externally managed (e.g. by PortalStencil), skip the host div —
   // the paper's DOM is already mounted elsewhere. Only render portal content.
   if (isExternalPaper) {
@@ -48,7 +61,8 @@ function PaperBase(
 
   return (
     <PaperStoreContext.Provider value={paperStore ?? null}>
-      <div className={className} ref={paperHTMLElementRef} style={style}>
+      {/* className intentionally NOT passed — see the classList effect above. */}
+      <div ref={paperHTMLElementRef} style={style}>
         {isReady && content}
       </div>
       {portaledChildren}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `grunt test` locally
* [ ] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

`<Paper className>` is now applied to the host element as classList tokens in a layout effect — tokens are added when the prop changes and removed in the effect cleanup — instead of going through the JSX `className` attribute.

The host `<div>` **is** `paper.el`: `dia.Paper` imperatively adds its own classes (`joint-paper`, `joint-theme-default`) to it after mount. When the `className` prop changed, React rewrote the entire `class` attribute from its own previous vdom value and wiped those joint classes.

Includes a regression test: changing `className` keeps `joint-paper` / `joint-theme-default` on the element while swapping only the prop's own tokens.

## Motivation and Context

Any app that changes `<Paper className>` dynamically silently lost the joint classes — breaking theme CSS and any logic keyed off `.joint-paper` (e.g. a paper `guard` walking up to the canvas boundary). In the AI workflow builder demo this surfaced as ctrl+wheel / cmd+wheel zoom (and wheel pan) dying after switching the canvas between infinite and sheets modes, because the mode switch changes the Paper `className`.

### Screenshots (if appropriate):