### PR TITLE
refactor(joint-react): paper preset + transaction API cleanup

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -72,9 +72,9 @@ describe('Paper', () => {
     // paper.el IS the React-rendered host div: dia.Paper imperatively adds
     // `jj-paper` to it after mount. A className prop change must not clobber
     // it — React replacing the whole class attribute silently kills every
-    // class-based consumer (theme CSS, and any paper `guard` walking up to
-    // `.jj-paper`, which breaks wheel zoom/pan after e.g. an
-    // infinite→sheets mode switch).
+    // class-based consumer (paper CSS keyed off `.jj-paper`, and any
+    // downstream `.jj-paper .foo` selectors) after e.g. an infinite→sheets
+    // mode switch.
     function App({ mode }: Readonly<{ mode: string }>) {
       return (
         <GraphProvider initialCells={CELLS}>

--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -70,10 +70,10 @@ describe('Paper', () => {
 
   it('keeps joint classes on paper.el when the className prop changes', async () => {
     // paper.el IS the React-rendered host div: dia.Paper imperatively adds
-    // `joint-paper joint-theme-default` to it after mount. A className prop
+    // `jj-paper joint-theme-default` to it after mount. A className prop
     // change must not clobber those — React replacing the whole class
     // attribute silently kills every class-based consumer (theme CSS, and any
-    // paper `guard` walking up to `.joint-paper`, which breaks wheel
+    // paper `guard` walking up to `.jj-paper`, which breaks wheel
     // zoom/pan after e.g. an infinite→sheets mode switch).
     function App({ mode }: Readonly<{ mode: string }>) {
       return (
@@ -88,7 +88,7 @@ describe('Paper', () => {
     }
     const { container, rerender } = render(<App mode="mode-a" />);
     await waitFor(() => {
-      const element = container.querySelector('.joint-paper');
+      const element = container.querySelector('.jj-paper');
       expect(element).toBeTruthy();
       expect(element!.classList.contains('mode-a')).toBe(true);
     });
@@ -100,7 +100,7 @@ describe('Paper', () => {
       expect(element).toBeTruthy();
       expect(element!.classList.contains('mode-a')).toBe(false);
       // The imperative joint classes survive the React className update.
-      expect(element!.classList.contains('joint-paper')).toBe(true);
+      expect(element!.classList.contains('jj-paper')).toBe(true);
       expect(element!.classList.contains('joint-theme-default')).toBe(true);
     });
   });

--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -69,12 +69,10 @@ describe('Paper', () => {
   });
 
   it('keeps joint classes on paper.el when the className prop changes', async () => {
-    // paper.el IS the React-rendered host div: dia.Paper imperatively adds
-    // `jj-paper` to it after mount. A className prop change must not clobber
-    // it — React replacing the whole class attribute silently kills every
-    // class-based consumer (paper CSS keyed off `.jj-paper`, and any
-    // downstream `.jj-paper .foo` selectors) after e.g. an infinite→sheets
-    // mode switch.
+    // paper.el IS the React-rendered host div: `mvc.View` adds `jj-paper`
+    // to it imperatively after mount. A className prop change must not
+    // clobber it — React replaces the whole `class` attribute, so the
+    // imperatively-added class has to be re-applied by the Paper wrapper.
     function App({ mode }: Readonly<{ mode: string }>) {
       return (
         <GraphProvider initialCells={CELLS}>

--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -70,11 +70,11 @@ describe('Paper', () => {
 
   it('keeps joint classes on paper.el when the className prop changes', async () => {
     // paper.el IS the React-rendered host div: dia.Paper imperatively adds
-    // `jj-paper joint-theme-default` to it after mount. A className prop
-    // change must not clobber those — React replacing the whole class
-    // attribute silently kills every class-based consumer (theme CSS, and any
-    // paper `guard` walking up to `.jj-paper`, which breaks wheel
-    // zoom/pan after e.g. an infinite→sheets mode switch).
+    // `jj-paper` to it after mount. A className prop change must not clobber
+    // it — React replacing the whole class attribute silently kills every
+    // class-based consumer (theme CSS, and any paper `guard` walking up to
+    // `.jj-paper`, which breaks wheel zoom/pan after e.g. an
+    // infinite→sheets mode switch).
     function App({ mode }: Readonly<{ mode: string }>) {
       return (
         <GraphProvider initialCells={CELLS}>
@@ -99,9 +99,8 @@ describe('Paper', () => {
       const element = container.querySelector('.mode-b');
       expect(element).toBeTruthy();
       expect(element!.classList.contains('mode-a')).toBe(false);
-      // The imperative joint classes survive the React className update.
+      // The imperative joint class survives the React className update.
       expect(element!.classList.contains('jj-paper')).toBe(true);
-      expect(element!.classList.contains('joint-theme-default')).toBe(true);
     });
   });
 

--- a/packages/joint-react/src/components/paper/paper.tsx
+++ b/packages/joint-react/src/components/paper/paper.tsx
@@ -35,7 +35,7 @@ function PaperBase(
   const portaledChildren =
     isReady && children && paper?.el ? createPortal(children, paper.el) : null;
 
-  // The host div IS `paper.el`: dia.Paper adds its own classes (`joint-paper`,
+  // The host div IS `paper.el`: dia.Paper adds its own classes (`jj-paper`,
   // theme) to it imperatively after mount, so `className` must not go through
   // the JSX attribute — React would rewrite the whole class attribute and wipe
   // the joint classes. Add the prop's tokens via classList instead; the effect

--- a/packages/joint-react/src/hooks/__tests__/use-graph-transaction.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph-transaction.test.tsx
@@ -104,7 +104,7 @@ describe('useGraph().transaction', () => {
             storeRef!.graph.getCell('a')!.set('position', { x: 999, y: 999 });
             throw new Error('boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).toThrow('boom');
       await flush();
@@ -115,7 +115,7 @@ describe('useGraph().transaction', () => {
     expect(storeRef!.graphProjection.cells.get('a')?.position).toEqual({ x: 0, y: 0 });
   });
 
-  it('keeps partial edits by default (rollback off)', async () => {
+  it('keeps partial edits by default (rollbackOnError off)', async () => {
     await renderUncontrolled();
 
     await act(async () => {
@@ -156,7 +156,7 @@ describe('useGraph().transaction', () => {
             await flush();
             throw new Error('async boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).rejects.toThrow('async boom');
       await flush();
@@ -176,7 +176,7 @@ describe('useGraph().transaction', () => {
             cellA().set('size', { width: 999, height: 999 });
             throw new Error('boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).toThrow('boom');
       await flush();
@@ -197,7 +197,7 @@ describe('useGraph().transaction', () => {
             cellA().prop('data/label', 'changed');
             throw new Error('boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).toThrow('boom');
       await flush();
@@ -218,7 +218,7 @@ describe('useGraph().transaction', () => {
             cellA().prop('data/nested/count', 99);
             throw new Error('boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).toThrow('boom');
       await flush();
@@ -241,7 +241,7 @@ describe('useGraph().transaction', () => {
             cellA().set('size', { width: 333, height: 444 });
             throw new Error('boom');
           },
-          { rollback: true }
+          { rollbackOnError: true }
         )
       ).toThrow('boom');
       await flush();

--- a/packages/joint-react/src/hooks/__tests__/use-graph-transaction.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-graph-transaction.test.tsx
@@ -299,7 +299,7 @@ const keyedCalls = (spy: jest.SpyInstance) =>
     .length;
 
 describe('useGraph().transaction — paper freezing', () => {
-  it('freezes every bound paper and unfreezes on close when freezePapers is set', async () => {
+  it('freezes every bound paper and unfreezes on close when deferPaint is set', async () => {
     await renderWithPaper();
     const paper = firstPaper();
     const freezeSpy = jest.spyOn(paper, 'freeze');
@@ -310,7 +310,7 @@ describe('useGraph().transaction — paper freezing', () => {
         () => {
           cellA().set('position', { x: 5, y: 5 });
         },
-        { freezePapers: true }
+        { deferPaint: true }
       );
       await flush();
     });

--- a/packages/joint-react/src/hooks/use-graph-transaction.ts
+++ b/packages/joint-react/src/hooks/use-graph-transaction.ts
@@ -30,11 +30,11 @@ export interface TransactionOptions {
    */
   readonly rollback?: boolean;
   /**
-   * Freeze every paper bound to the graph for the duration, so all views repaint
-   * once when the transaction closes instead of on every edit. Disabled by
-   * default; pass `true` to coalesce the repaint (hides intermediate frames).
+   * Defer paint on every paper bound to the graph for the duration, so all views
+   * repaint once when the transaction closes instead of on every edit. Disabled
+   * by default; pass `true` to coalesce the repaint (hides intermediate frames).
    */
-  readonly freezePapers?: boolean;
+  readonly deferPaint?: boolean;
   /**
    * Name of the JointJS batch used to group the edits — drives undo grouping and
    * identifies the batch on `batch:start` / `batch:stop`. Defaults to `'transaction'`.
@@ -49,8 +49,8 @@ export interface TransactionOptions {
  *
  * Pass `rollback: true` to restore the graph to its pre-transaction state when
  * the callback throws or rejects (the error is always re-thrown), and
- * `freezePapers: true` to freeze every bound paper so views repaint once, on
- * close. The callback may be sync or `async`; an async callback is awaited
+ * `deferPaint: true` to defer paint on every bound paper so views repaint once,
+ * on close. The callback may be sync or `async`; an async callback is awaited
  * before the transaction closes and the call returns the pending promise.
  * @group Types
  */
@@ -79,16 +79,16 @@ export function useGraphTransaction(): Transaction {
 
   return useCallback(
     <TResult>(callback: () => TResult, options?: TransactionOptions): TResult => {
-      const { rollback, freezePapers, name } = options ?? {};
+      const { rollback, deferPaint, name } = options ?? {};
       const { graph, graphProjection, paperStores } = store;
       const batchName = name ?? DEFAULT_BATCH_NAME;
 
       // Immutable records + shallow copy = a fast, correct pre-transaction snapshot
       // (container slots are replaced on change, never mutated in place). Opt-in.
       const snapshot = rollback === true ? [...graphProjection.cells.getAll()] : null;
-      // Opt-in: freeze every bound paper so the whole transaction repaints once, on close.
+      // Opt-in: defer paint on every bound paper so the whole transaction repaints once, on close.
       const papers =
-        freezePapers === true
+        deferPaint === true
           ? [...paperStores.values()].map((paperStore) => paperStore.paper)
           : [];
 

--- a/packages/joint-react/src/hooks/use-graph-transaction.ts
+++ b/packages/joint-react/src/hooks/use-graph-transaction.ts
@@ -27,8 +27,13 @@ export interface TransactionOptions {
    * Restore the graph to its pre-transaction state when the callback throws or
    * its promise rejects. Disabled by default; pass `true` to roll back on error
    * (otherwise partial edits are kept). The error is always re-thrown.
+   *
+   * Comes with an up-front overhead: enabling it snapshots the full cells
+   * array at transaction start (an `O(n)` shallow copy over every cell in the
+   * graph), even when the callback succeeds and no rollback is needed. Leave
+   * off for large graphs where the callback is trusted not to throw.
    */
-  readonly rollback?: boolean;
+  readonly rollbackOnError?: boolean;
   /**
    * Defer paint on every paper bound to the graph for the duration, so all views
    * repaint once when the transaction closes instead of on every edit. Disabled
@@ -47,8 +52,8 @@ export interface TransactionOptions {
  * collapses into a single undo entry and a single React update (async edits
  * split across `await`s coalesce too).
  *
- * Pass `rollback: true` to restore the graph to its pre-transaction state when
- * the callback throws or rejects (the error is always re-thrown), and
+ * Pass `rollbackOnError: true` to restore the graph to its pre-transaction
+ * state when the callback throws or rejects (the error is always re-thrown), and
  * `deferPaint: true` to defer paint on every bound paper so views repaint once,
  * on close. The callback may be sync or `async`; an async callback is awaited
  * before the transaction closes and the call returns the pending promise.
@@ -79,13 +84,13 @@ export function useGraphTransaction(): Transaction {
 
   return useCallback(
     <TResult>(callback: () => TResult, options?: TransactionOptions): TResult => {
-      const { rollback, deferPaint, name } = options ?? {};
+      const { rollbackOnError, deferPaint, name } = options ?? {};
       const { graph, graphProjection, paperStores } = store;
       const batchName = name ?? DEFAULT_BATCH_NAME;
 
       // Immutable records + shallow copy = a fast, correct pre-transaction snapshot
       // (container slots are replaced on change, never mutated in place). Opt-in.
-      const snapshot = rollback === true ? [...graphProjection.cells.getAll()] : null;
+      const snapshot = rollbackOnError === true ? [...graphProjection.cells.getAll()] : null;
       // Opt-in: defer paint on every bound paper so the whole transaction repaints once, on close.
       const papers =
         deferPaint === true

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -143,8 +143,10 @@ export interface GraphApi<
   /**
    * Run a callback as one atomic transaction: every edit inside collapses into
    * a single undo entry and (for sync callbacks) a single re-render. Pass
-   * `{ rollback: true }` to restore the graph on error (off by default —
-   * partial edits stay). See {@link Transaction}.
+   * `{ rollbackOnError: true }` to restore the graph on error (off by default —
+   * partial edits stay; enabling it snapshots the full cells array up-front,
+   * so leave off for large graphs when the callback is trusted). See
+   * {@link Transaction}.
    */
   readonly transaction: Transaction;
 }

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -142,8 +142,9 @@ export interface GraphApi<
   readonly importFromJSON: (json: GraphJSON) => void;
   /**
    * Run a callback as one atomic transaction: every edit inside collapses into
-   * a single undo entry and (for sync callbacks) a single re-render, and the
-   * graph is restored on error unless `rollback: false`. See {@link Transaction}.
+   * a single undo entry and (for sync callbacks) a single re-render. Pass
+   * `{ rollback: true }` to restore the graph on error (off by default —
+   * partial edits stay). See {@link Transaction}.
    */
   readonly transaction: Transaction;
 }

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -66,6 +66,7 @@ export type { ElementJSONInit, LinkJSONInit } from './types/cell.types';
 export { assignOptions, pickValues, makeOptions } from './utils/object-utilities';
 export { resolvePaper, resolvePaperId, isPaperTarget } from './utils/resolve-paper-target';
 export { isRecord } from './utils/is';
+export { wheelGuard, SCROLLABLE_ATTRIBUTE } from './utils/wheel-guard';
 
 // Constants
 export { ELEMENT_MODEL_TYPE, PORTAL_SELECTOR } from './mvc/element-model';

--- a/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
+++ b/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
@@ -388,3 +388,29 @@ describe('presets / paper module / Paper', () => {
     }
   });
 });
+
+// `theme` + `defaultTheme` cleared on the Paper preset so `mvc.View.initialize`
+// skips `addThemeClassName` and no `joint-theme-*` class lands on `paper.el`.
+describe('presets / theme suppression', () => {
+  it('does not add joint-theme-* class to paper.el', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const graph = new dia.Graph({}, { cellNamespace: shapes });
+    const paper = new Paper({
+      el: container,
+      model: graph,
+      cellViewNamespace: shapes,
+      width: 100,
+      height: 100,
+    });
+
+    try {
+      for (const className of Array.from(paper.el.classList)) {
+        expect(className.startsWith('joint-theme-')).toBe(false);
+      }
+    } finally {
+      paper.remove();
+      container.remove();
+    }
+  });
+});

--- a/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
+++ b/packages/joint-react/src/presets/__tests__/extra-coverage.test.ts
@@ -382,7 +382,6 @@ describe('presets / paper module / Paper', () => {
     try {
       expect(paper).toBeInstanceOf(dia.Paper);
       expect(paper.el.classList.contains('jj-paper')).toBe(true);
-      expect(paper.el.classList.contains('joint-paper')).toBe(true);
     } finally {
       paper.remove();
       container.remove();

--- a/packages/joint-react/src/presets/link-view.ts
+++ b/packages/joint-react/src/presets/link-view.ts
@@ -13,6 +13,16 @@ const SNAPPED_CLASS_NAME = 'jj-is-snapped';
  * - `jj-is-snapped`, while the arrowhead is snapped to a valid target
  */
 export class LinkView extends dia.LinkView {
+  // Suppress the `joint-theme-default` class that `mvc.View.initialize` would
+  // otherwise add via `setTheme(this.options.theme || this.defaultTheme)`.
+  // `preinitialize` runs BEFORE `initialize` in Backbone's View constructor,
+  // so the instance defaults are set in time for `setTheme` to read them.
+  // Empty strings are falsy — `addThemeClassName` bails without adding a class.
+  preinitialize() {
+    this.theme = '';
+    this.defaultTheme = '';
+  }
+
   _beforeArrowheadMove(data: unknown) {
     // @ts-expect-error Protected method override
     super._beforeArrowheadMove(data);

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -3,6 +3,7 @@ import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
 import { MagnetHighlighter, MAGNET_HIGHLIGHTER_NAME } from './magnet-highlighter';
+import { wheelGuard } from '../utils/wheel-guard';
 
 // ---------------------------------------------------------------------------
 // PointerEvents migration
@@ -21,6 +22,7 @@ type ProtectedPaperPrototype = {
   readonly pointermove: (event: dia.Event) => void;
   readonly pointerup: (event: dia.Event) => void;
   readonly startListening: () => void;
+  readonly guard: (event: dia.Event, view: dia.CellView) => boolean;
 };
 
 const protectedProto = dia.Paper.prototype as unknown as ProtectedPaperPrototype;
@@ -174,6 +176,20 @@ export const Paper = dia.Paper.extend(
         // Capture can fail if the element isn't connected — safe to ignore;
         // the drag still works via `documentEvents`.
       }
+    },
+
+    /**
+     * Compose {@link wheelGuard} onto joint-core's `guard`: a wheel over a
+     * scrollable node body (native `<textarea>` or an element marked
+     * `data-joint-scrollable`, both with actual overflow) short-circuits the
+     * paper's mousewheel pipeline so the region scrolls natively.
+     * `Ctrl`/`Cmd`+wheel is never guarded — pinch-zoom keeps working. The
+     * caller's own `options.guard` still runs via the super call.
+     * @param event - Event delivered to the paper's dispatch.
+     * @param view - View resolved from the event target, if any.
+     */
+    guard(this: dia.Paper, event: dia.Event, view: dia.CellView) {
+      return protectedProto.guard.call(this, event, view) || wheelGuard(event);
     },
 
     /**

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -130,6 +130,8 @@ export const Paper = dia.Paper.extend(
   {
     className: 'jj-paper',
     classNamePrefix: '',
+    theme: null,
+    defaultTheme: null,
 
     documentEvents: POINTER_DOCUMENT_EVENTS,
 

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -130,8 +130,8 @@ export const Paper = dia.Paper.extend(
   {
     className: 'jj-paper',
     classNamePrefix: '',
-    theme: null,
-    defaultTheme: null,
+    theme: '',
+    defaultTheme: '',
 
     documentEvents: POINTER_DOCUMENT_EVENTS,
 

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -128,8 +128,9 @@ function getGridPatterns(): Record<string, dia.Paper.PatternOptions[]> {
 
 export const Paper = dia.Paper.extend(
   {
-    className: 'jj-paper joint-paper',
+    className: 'jj-paper',
     classNamePrefix: '',
+
     documentEvents: POINTER_DOCUMENT_EVENTS,
 
     /**

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -181,7 +181,7 @@ export const Paper = dia.Paper.extend(
     /**
      * Compose {@link wheelGuard} onto joint-core's `guard`: a wheel over a
      * scrollable node body (native `<textarea>` or an element marked
-     * `data-joint-scrollable`, both with actual overflow) short-circuits the
+     * `data-jj-scrollable`, both with actual overflow) short-circuits the
      * paper's mousewheel pipeline so the region scrolls natively.
      * `Ctrl`/`Cmd`+wheel is never guarded — pinch-zoom keeps working. The
      * caller's own `options.guard` still runs via the super call.

--- a/packages/joint-react/src/store/paper-store.ts
+++ b/packages/joint-react/src/store/paper-store.ts
@@ -10,6 +10,7 @@ import type { PaperStoreState } from './graph-store';
 import { simpleScheduler } from '../utils/scheduler';
 import { toSVGMatrix } from '../utils/transform';
 import type { PaperTransform } from '../components/paper/paper.types';
+import { wheelGuard } from '../utils/wheel-guard';
 
 /**
  * Options for adding a new paper instance to the graph store.
@@ -169,6 +170,17 @@ export class PaperStore {
           graphStore.setPaperViews(this.paperId, changes);
         },
       });
+
+      // Compose `wheelGuard` over the caller's `guard` so a wheel over a
+      // scrollable region (`<textarea>` or `data-joint-scrollable`) short-
+      // circuits `paper:pan` / `paper:pinch` and lets the region scroll
+      // natively. Caller's guard runs first via OR-composition; ours only
+      // fires when theirs would have let the wheel through. Adopted papers
+      // skip this — the external owner manages its own guard.
+      const previousGuard = paper.options.guard;
+      paper.options.guard = previousGuard
+        ? (evt, view) => previousGuard.call(paper, evt, view) || wheelGuard(evt)
+        : (evt) => wheelGuard(evt);
 
       this.paper = paper;
     }

--- a/packages/joint-react/src/store/paper-store.ts
+++ b/packages/joint-react/src/store/paper-store.ts
@@ -10,7 +10,6 @@ import type { PaperStoreState } from './graph-store';
 import { simpleScheduler } from '../utils/scheduler';
 import { toSVGMatrix } from '../utils/transform';
 import type { PaperTransform } from '../components/paper/paper.types';
-import { wheelGuard } from '../utils/wheel-guard';
 
 /**
  * Options for adding a new paper instance to the graph store.
@@ -170,17 +169,6 @@ export class PaperStore {
           graphStore.setPaperViews(this.paperId, changes);
         },
       });
-
-      // Compose `wheelGuard` over the caller's `guard` so a wheel over a
-      // scrollable region (`<textarea>` or `data-joint-scrollable`) short-
-      // circuits `paper:pan` / `paper:pinch` and lets the region scroll
-      // natively. Caller's guard runs first via OR-composition; ours only
-      // fires when theirs would have let the wheel through. Adopted papers
-      // skip this — the external owner manages its own guard.
-      const previousGuard = paper.options.guard;
-      paper.options.guard = previousGuard
-        ? (evt, view) => previousGuard.call(paper, evt, view) || wheelGuard(evt)
-        : (evt) => wheelGuard(evt);
 
       this.paper = paper;
     }

--- a/packages/joint-react/src/utils/__tests__/wheel-guard.test.ts
+++ b/packages/joint-react/src/utils/__tests__/wheel-guard.test.ts
@@ -1,0 +1,133 @@
+import { SCROLLABLE_ATTRIBUTE, wheelGuard } from '../wheel-guard';
+
+interface FakeEvent {
+  readonly type: string;
+  readonly target: EventTarget | null;
+  readonly ctrlKey?: boolean;
+  readonly metaKey?: boolean;
+}
+
+function fakeWheel(target: EventTarget | null, overrides: Partial<FakeEvent> = {}): FakeEvent {
+  return { type: 'wheel', target, ...overrides };
+}
+
+/** Attaches an element to the document so the browser reports non-zero client/scroll dims. */
+function mount(element: Element): void {
+  document.body.append(element);
+}
+
+function makeOverflowingDiv(): HTMLDivElement {
+  const div = document.createElement('div');
+  div.setAttribute(SCROLLABLE_ATTRIBUTE, '');
+  // JSDOM doesn't run layout; stub the geometry getters so `overflows()` sees a scroll gap.
+  Object.defineProperty(div, 'scrollHeight', { value: 200, configurable: true });
+  Object.defineProperty(div, 'clientHeight', { value: 100, configurable: true });
+  Object.defineProperty(div, 'scrollWidth', { value: 0, configurable: true });
+  Object.defineProperty(div, 'clientWidth', { value: 0, configurable: true });
+  return div;
+}
+
+function makeFlatDiv(): HTMLDivElement {
+  const div = document.createElement('div');
+  div.setAttribute(SCROLLABLE_ATTRIBUTE, '');
+  Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true });
+  Object.defineProperty(div, 'clientHeight', { value: 100, configurable: true });
+  Object.defineProperty(div, 'scrollWidth', { value: 0, configurable: true });
+  Object.defineProperty(div, 'clientWidth', { value: 0, configurable: true });
+  return div;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('wheelGuard', () => {
+  test('returns false for non-wheel events', () => {
+    const div = makeOverflowingDiv();
+    mount(div);
+    expect(wheelGuard({ type: 'click', target: div })).toBe(false);
+    expect(wheelGuard({ type: 'pointerdown', target: div })).toBe(false);
+  });
+
+  test('returns false when ctrlKey is set (pinch-zoom passthrough)', () => {
+    const div = makeOverflowingDiv();
+    mount(div);
+    expect(wheelGuard(fakeWheel(div, { ctrlKey: true }))).toBe(false);
+  });
+
+  test('returns false when metaKey is set (pinch-zoom passthrough)', () => {
+    const div = makeOverflowingDiv();
+    mount(div);
+    expect(wheelGuard(fakeWheel(div, { metaKey: true }))).toBe(false);
+  });
+
+  test('returns false when target is null', () => {
+    expect(wheelGuard(fakeWheel(null))).toBe(false);
+  });
+
+  test('returns false when target is not an Element (e.g. document)', () => {
+    expect(wheelGuard(fakeWheel(document))).toBe(false);
+  });
+
+  test('returns true for wheel over an overflowing marked div', () => {
+    const div = makeOverflowingDiv();
+    mount(div);
+    expect(wheelGuard(fakeWheel(div))).toBe(true);
+  });
+
+  test('returns false for wheel over a non-overflowing marked div', () => {
+    const div = makeFlatDiv();
+    mount(div);
+    expect(wheelGuard(fakeWheel(div))).toBe(false);
+  });
+
+  test('returns true for wheel over an overflowing textarea', () => {
+    const textarea = document.createElement('textarea');
+    Object.defineProperty(textarea, 'scrollHeight', { value: 200, configurable: true });
+    Object.defineProperty(textarea, 'clientHeight', { value: 100, configurable: true });
+    Object.defineProperty(textarea, 'scrollWidth', { value: 0, configurable: true });
+    Object.defineProperty(textarea, 'clientWidth', { value: 0, configurable: true });
+    mount(textarea);
+    expect(wheelGuard(fakeWheel(textarea))).toBe(true);
+  });
+
+  test('returns false for a non-overflowing textarea', () => {
+    const textarea = document.createElement('textarea');
+    Object.defineProperty(textarea, 'scrollHeight', { value: 20, configurable: true });
+    Object.defineProperty(textarea, 'clientHeight', { value: 20, configurable: true });
+    Object.defineProperty(textarea, 'scrollWidth', { value: 0, configurable: true });
+    Object.defineProperty(textarea, 'clientWidth', { value: 0, configurable: true });
+    mount(textarea);
+    expect(wheelGuard(fakeWheel(textarea))).toBe(false);
+  });
+
+  test('walks up marked ancestors when the inner one does not overflow', () => {
+    const outer = makeOverflowingDiv();
+    const inner = document.createElement('textarea');
+    // Inner does not overflow — should fall through to outer, which does.
+    Object.defineProperty(inner, 'scrollHeight', { value: 10, configurable: true });
+    Object.defineProperty(inner, 'clientHeight', { value: 10, configurable: true });
+    Object.defineProperty(inner, 'scrollWidth', { value: 0, configurable: true });
+    Object.defineProperty(inner, 'clientWidth', { value: 0, configurable: true });
+    outer.append(inner);
+    mount(outer);
+    expect(wheelGuard(fakeWheel(inner))).toBe(true);
+  });
+
+  test('returns false when target is outside any marked ancestor', () => {
+    const outside = document.createElement('span');
+    mount(outside);
+    expect(wheelGuard(fakeWheel(outside))).toBe(false);
+  });
+
+  test('detects horizontal overflow', () => {
+    const div = document.createElement('div');
+    div.setAttribute(SCROLLABLE_ATTRIBUTE, '');
+    Object.defineProperty(div, 'scrollHeight', { value: 0, configurable: true });
+    Object.defineProperty(div, 'clientHeight', { value: 0, configurable: true });
+    Object.defineProperty(div, 'scrollWidth', { value: 300, configurable: true });
+    Object.defineProperty(div, 'clientWidth', { value: 100, configurable: true });
+    mount(div);
+    expect(wheelGuard(fakeWheel(div))).toBe(true);
+  });
+});

--- a/packages/joint-react/src/utils/wheel-guard.ts
+++ b/packages/joint-react/src/utils/wheel-guard.ts
@@ -1,0 +1,49 @@
+// Paper `guard` composed into every `<Paper>`'s `dia.Paper.options.guard` so a
+// wheel over a scrollable node body scrolls the box instead of firing the
+// paper's own `paper:pan` / `paper:pinch` events. Regions opt in with
+// `data-joint-scrollable`; native `<textarea>` is covered free.
+// `Ctrl`/`Cmd`+wheel is the paper's pinch-zoom modifier — never guarded.
+interface GuardEvent {
+  readonly type: string;
+  readonly target: EventTarget | null;
+  readonly ctrlKey?: boolean;
+  readonly metaKey?: boolean;
+}
+
+/**
+ * DOM attribute that opts an element into the wheel-guard: a wheel whose target
+ * sits inside a marked element that has actual overflow tells `dia.Paper` that
+ * the element owns the wheel input, so `paper:pan` / `paper:pinch` do not fire.
+ * @group Constants
+ */
+export const SCROLLABLE_ATTRIBUTE = 'data-joint-scrollable';
+
+const SCROLLABLE_SELECTOR = `textarea, [${SCROLLABLE_ATTRIBUTE}]`;
+
+function overflows(el: Element): boolean {
+  return el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth;
+}
+
+/**
+ * Predicate for `dia.Paper.options.guard`. Returns `true` when a wheel event
+ * targets a scrollable region (native `<textarea>` or an element carrying
+ * {@link SCROLLABLE_ATTRIBUTE} — both with actual overflow), so the paper
+ * ignores it and the region scrolls natively. `Ctrl`/`Cmd`+wheel is always
+ * allowed through so the paper's pinch-zoom keeps working.
+ * @param event - wheel-like event dispatched to `paper.guard`
+ * @returns `true` to short-circuit the paper's mousewheel pipeline
+ * @group Utils
+ */
+export function wheelGuard(event: GuardEvent): boolean {
+  if (!/wheel/i.test(event.type)) return false;
+  if (event.ctrlKey || event.metaKey) return false;
+  if (!(event.target instanceof Element)) return false;
+  for (
+    let el: Element | null = event.target.closest(SCROLLABLE_SELECTOR);
+    el;
+    el = el.parentElement?.closest(SCROLLABLE_SELECTOR) ?? null
+  ) {
+    if (overflows(el)) return true;
+  }
+  return false;
+}

--- a/packages/joint-react/src/utils/wheel-guard.ts
+++ b/packages/joint-react/src/utils/wheel-guard.ts
@@ -1,7 +1,7 @@
 // Paper `guard` composed into every `<Paper>`'s `dia.Paper.options.guard` so a
 // wheel over a scrollable node body scrolls the box instead of firing the
 // paper's own `paper:pan` / `paper:pinch` events. Regions opt in with
-// `data-joint-scrollable`; native `<textarea>` is covered free.
+// `data-jj-scrollable`; native `<textarea>` is covered free.
 // `Ctrl`/`Cmd`+wheel is the paper's pinch-zoom modifier — never guarded.
 interface GuardEvent {
   readonly type: string;
@@ -16,7 +16,7 @@ interface GuardEvent {
  * the element owns the wheel input, so `paper:pan` / `paper:pinch` do not fire.
  * @group Constants
  */
-export const SCROLLABLE_ATTRIBUTE = 'data-joint-scrollable';
+export const SCROLLABLE_ATTRIBUTE = 'data-jj-scrollable';
 
 const SCROLLABLE_SELECTOR = `textarea, [${SCROLLABLE_ATTRIBUTE}]`;
 

--- a/packages/joint-react/stories/examples/transaction/code.tsx
+++ b/packages/joint-react/stories/examples/transaction/code.tsx
@@ -156,7 +156,7 @@ function Controls() {
           }
           throw new Error('layout rejected');
         },
-        { rollback: withRollback }
+        { rollbackOnError: withRollback }
       );
     } catch {
       setTone('fail');
@@ -179,7 +179,7 @@ function Controls() {
           }));
         }
       },
-      { rollback: false }
+      { rollbackOnError: false }
     );
     setTone('idle');
     setMessage('Back to the neat row.');

--- a/packages/joint-react/stories/examples/transaction/code.tsx
+++ b/packages/joint-react/stories/examples/transaction/code.tsx
@@ -126,7 +126,7 @@ function Controls() {
 
   // Async: awaited writes still commit once, when the transaction closes.
   // Papers stay live by default, so the cascade is visible (pass
-  // `freezePapers: true` to instead coalesce the repaint to the end).
+  // `deferPaint: true` to instead coalesce the repaint to the end).
   async function cascadeAsync() {
     setIsRunning(true);
     setTone('idle');

--- a/packages/joint-react/stories/examples/transaction/docs.mdx
+++ b/packages/joint-react/stories/examples/transaction/docs.mdx
@@ -20,8 +20,8 @@ Three things happen for the whole block, not per edit:
 
 - **One undo entry.** Every write collapses into a single command (grouped via a JointJS batch).
 - **One React update.** Synchronous edits already coalesce; a transaction also coalesces **async** edits split across `await`s into a single commit.
-- **Opt-in single repaint.** Pass `{ freezePapers: true }` to freeze every bound paper for the duration so views repaint once, on close. Off by default, so the async demos below stay live and you can watch each step.
-- **Automatic rollback.** If the callback throws or its promise rejects, the graph is restored to its pre-transaction state, then the error re-throws. Opt out with `{ rollback: false }`.
+- **Opt-in single repaint.** Pass `{ deferPaint: true }` to defer paint on every bound paper for the duration so views repaint once, on close. Off by default, so the async demos below stay live and you can watch each step.
+- **Opt-in rollback.** Pass `{ rollback: true }` to restore the graph to its pre-transaction state when the callback throws or its promise rejects; the error is always re-thrown. Off by default — partial edits stay.
 
 ## Try it
 

--- a/packages/joint-react/stories/examples/transaction/docs.mdx
+++ b/packages/joint-react/stories/examples/transaction/docs.mdx
@@ -21,7 +21,7 @@ Three things happen for the whole block, not per edit:
 - **One undo entry.** Every write collapses into a single command (grouped via a JointJS batch).
 - **One React update.** Synchronous edits already coalesce; a transaction also coalesces **async** edits split across `await`s into a single commit.
 - **Opt-in single repaint.** Pass `{ deferPaint: true }` to defer paint on every bound paper for the duration so views repaint once, on close. Off by default, so the async demos below stay live and you can watch each step.
-- **Opt-in rollback.** Pass `{ rollback: true }` to restore the graph to its pre-transaction state when the callback throws or its promise rejects; the error is always re-thrown. Off by default — partial edits stay.
+- **Opt-in rollback.** Pass `{ rollbackOnError: true }` to restore the graph to its pre-transaction state when the callback throws or its promise rejects; the error is always re-thrown. Off by default — partial edits stay. Enabling it snapshots the full cells array up-front (an `O(n)` shallow copy) even when the callback succeeds, so leave off for large graphs when the callback is trusted.
 
 ## Try it
 

--- a/packages/joint-react/stories/examples/transaction/story.tsx
+++ b/packages/joint-react/stories/examples/transaction/story.tsx
@@ -14,7 +14,7 @@ export default {
     code: CodeRaw,
     description:
       '`useGraph().transaction` runs many graph edits as one atomic step: a single undo entry, ' +
-      'a single React update (even across `await`s), and automatic rollback if the callback throws.',
+      'a single React update (even across `await`s), and opt-in rollback (`{ rollback: true }`) if the callback throws.',
   }),
 } satisfies Meta<typeof Code>;
 

--- a/packages/joint-react/stories/examples/transaction/story.tsx
+++ b/packages/joint-react/stories/examples/transaction/story.tsx
@@ -14,7 +14,7 @@ export default {
     code: CodeRaw,
     description:
       '`useGraph().transaction` runs many graph edits as one atomic step: a single undo entry, ' +
-      'a single React update (even across `await`s), and opt-in rollback (`{ rollback: true }`) if the callback throws.',
+      'a single React update (even across `await`s), and opt-in rollback (`{ rollbackOnError: true }`) if the callback throws.',
   }),
 } satisfies Meta<typeof Code>;
 


### PR DESCRIPTION
## Summary

Bundle of small `@joint/react` cleanups/renames around the paper preset, transaction API, and wheel handling.

### Wheel guard on every `<Paper>`
- New internal `wheelGuard(event)` + `SCROLLABLE_ATTRIBUTE = 'data-jj-scrollable'`, re-exported from `@joint/react/internal`.
- Paper preset's `guard()` method composes it: `super.guard() || wheelGuard(event)`. A wheel over a scrollable node body (native `<textarea>` or an element marked `data-jj-scrollable`, both with actual overflow) short-circuits the paper's mousewheel pipeline — `paper:pan` / `paper:pinch` don't fire, native scroll takes over. `Ctrl`/`Cmd`+wheel is never guarded so pinch-zoom keeps working.
- Method override (not runtime option mutation), so user-supplied `options.guard` still runs first.

### Transaction API polish
- `freezePapers` → **`deferPaint`**: option name now describes the outcome, not the joint-core `paper.freeze()` mechanism.
- `rollback` → **`rollbackOnError`**: the old name left the trigger ambiguous. Also documented the up-front cost — enabling it snapshots the full cells array (O(n) shallow copy) at transaction start, paid on every transaction. Stale storybook docs claiming rollback was automatic-with-opt-out fixed to match the opt-in code.

### Paper preset DOM cleanup
- Drop legacy `joint-paper` class from the preset; only `jj-paper` remains.
- Suppress the automatic `joint-theme-default` class on preset view classes (Paper via `theme: '' / defaultTheme: ''` in the extend block; LinkView via `preinitialize()`). Empty-string falsy avoids a joint-core type gap (`theme: string`).
- Test coverage: new `presets / theme suppression` block asserts no `joint-theme-*` class lands on `paper.el`; existing paper.test.tsx assertions updated to `jj-paper`.

## Test plan
- [x] `yarn typecheck` in `packages/joint-react` — passes.
- [x] `yarn jest` in `packages/joint-react` — 1018 tests pass (12 new wheel-guard tests + 1 new theme-suppression test).
- [ ] Downstream `@joint/react-plus` PR consumes `wheelGuard` from `@joint/react/internal`, drops its local copy, and applies the same theme suppression to `.extend()`/ES-class presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)