### PR TITLE
feat(joint-react)!: canConnect linkLimit tri-state (replaces allowMultiLinks)

### DIFF
--- a/packages/joint-react/src/presets/__tests__/can-connect.test.ts
+++ b/packages/joint-react/src/presets/__tests__/can-connect.test.ts
@@ -175,7 +175,7 @@ describe('presets / can-connect / canConnect built-in rules', () => {
     expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(true);
   });
 
-  it('allows multiple links when configured', () => {
+  it('allows multiple links when linkLimit is none', () => {
     const existing = {
       source: () => ({ id: 's' }),
       target: () => ({ id: 't' }),
@@ -183,8 +183,73 @@ describe('presets / can-connect / canConnect built-in rules', () => {
     const sourceView = makeCellView({ id: 's', paperLinks: [existing] });
     const targetView = makeCellView({ id: 't' });
     const linkView = { model: {} } as any;
-    const function_ = canConnect({ allowMultiLinks: true });
+    const function_ = canConnect({ linkLimit: 'none' });
     expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(true);
+  });
+
+  it('one-per-direction (default) allows the reverse-direction link', () => {
+    // Existing link goes t→s; the new link goes s→t (opposite direction).
+    const reverseLink = {
+      source: () => ({ id: 't', port: null }),
+      target: () => ({ id: 's', port: null }),
+    };
+    const sourceView = makeCellView({ id: 's', paperLinks: [reverseLink] });
+    const targetView = makeCellView({ id: 't' });
+    const linkView = { model: {} } as any;
+    const function_ = canConnect();
+    expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(true);
+  });
+
+  it('one-per-pair blocks the reverse-direction link', () => {
+    const reverseLink = {
+      source: () => ({ id: 't', port: null }),
+      target: () => ({ id: 's', port: null }),
+    };
+    const sourceView = makeCellView({ id: 's', paperLinks: [reverseLink] });
+    const targetView = makeCellView({ id: 't' });
+    const linkView = { model: {} } as any;
+    const function_ = canConnect({ linkLimit: 'one-per-pair' });
+    expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(false);
+  });
+
+  it('one-per-pair still blocks the same-direction duplicate', () => {
+    const forwardLink = {
+      source: () => ({ id: 's', port: null }),
+      target: () => ({ id: 't', port: null }),
+    };
+    const sourceView = makeCellView({ id: 's', paperLinks: [forwardLink] });
+    const targetView = makeCellView({ id: 't' });
+    const linkView = { model: {} } as any;
+    const function_ = canConnect({ linkLimit: 'one-per-pair' });
+    expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(false);
+  });
+
+  it('linkLimit none skips both same- and reverse-direction checks', () => {
+    const reverseLink = {
+      source: () => ({ id: 't', port: null }),
+      target: () => ({ id: 's', port: null }),
+    };
+    const sourceView = makeCellView({ id: 's', paperLinks: [reverseLink] });
+    const targetView = makeCellView({ id: 't' });
+    const linkView = { model: {} } as any;
+    const function_ = canConnect({ linkLimit: 'none' });
+    expect(function_(sourceView, undefined, targetView, undefined, 'target', linkView)).toBe(true);
+  });
+
+  it('one-per-pair allows a reverse link on a different port pair', () => {
+    // Existing reverse link uses ports t:p1 → s:p1; the new s→t link uses
+    // different ports (s:p2 → t:p2), so it is not the same connection.
+    const reverseLink = {
+      source: () => ({ id: 't', port: 'p1' }),
+      target: () => ({ id: 's', port: 'p1' }),
+    };
+    const sourceView = makeCellView({ id: 's', paperLinks: [reverseLink] });
+    const targetView = makeCellView({ id: 't' });
+    const linkView = { model: {} } as any;
+    const sourceMagnet = makeMagnet({ port: 'p2' });
+    const targetMagnet = makeMagnet({ port: 'p2' });
+    const function_ = canConnect({ linkLimit: 'one-per-pair' });
+    expect(function_(sourceView, sourceMagnet, targetView, targetMagnet, 'target', linkView)).toBe(true);
   });
 
   it('treats different ids as non-duplicate', () => {

--- a/packages/joint-react/src/presets/can-connect.ts
+++ b/packages/joint-react/src/presets/can-connect.ts
@@ -130,18 +130,25 @@ function endMatches(
 }
 
 /**
- * Returns `true` if a duplicate link already exists between the two ends
- * (ignoring the link currently being validated).
+ * Returns `true` if a link already exists between the two ends (ignoring the
+ * link currently being validated). Matches on element id + port/magnet at both
+ * ends.
+ *
+ * When `singlePerPair` is `false`, only a same-direction link counts (source→
+ * target). When `true`, the reverse-direction link (target→source) counts too,
+ * so at most one link may exist between the pair regardless of orientation.
  * @param sourceView
  * @param sourceNode
  * @param targetView
  * @param targetNode
  * @param linkView
+ * @param singlePerPair - also match the reverse-direction link
  */
 function hasDuplicateLink(
   sourceView: dia.CellView, sourceNode: SVGElement | undefined,
   targetView: dia.CellView, targetNode: SVGElement | undefined,
   linkView: dia.LinkView,
+  singlePerPair: boolean,
 ): boolean {
   const sourceId = sourceView.model.id;
   const targetId = targetView.model.id;
@@ -149,15 +156,25 @@ function hasDuplicateLink(
   const targetPort = getEndPort(targetView, targetNode);
   const sourceMagnet = getEndMagnetSelector(sourceNode);
   const targetMagnet = getEndMagnetSelector(targetNode);
+  // `getConnectedLinks` returns links where our source node is either endpoint,
+  // so a reverse-direction link (target→source) is already in this set.
   const links = sourceView.paper!.model.getConnectedLinks(sourceView.model);
   for (const link of links) {
     if (link === linkView.model) continue;
     const ls = link.source();
     const lt = link.target();
-    if (ls.id !== sourceId || lt.id !== targetId) continue;
-    if (!endMatches(ls, sourcePort, sourceMagnet)) continue;
-    if (!endMatches(lt, targetPort, targetMagnet)) continue;
-    return true;
+    const forward =
+      ls.id === sourceId && lt.id === targetId &&
+      endMatches(ls, sourcePort, sourceMagnet) &&
+      endMatches(lt, targetPort, targetMagnet);
+    if (forward) return true;
+    if (singlePerPair) {
+      const reverse =
+        ls.id === targetId && lt.id === sourceId &&
+        endMatches(ls, targetPort, targetMagnet) &&
+        endMatches(lt, sourcePort, sourceMagnet);
+      if (reverse) return true;
+    }
   }
   return false;
 }
@@ -190,8 +207,17 @@ export interface CanConnectOptions {
   readonly allowSelfLoops?: boolean;
   /** Allow links to start or end on another link, not just on elements. @default false */
   readonly allowLinkToLink?: boolean;
-  /** Allow more than one link between the same source+port and target+port. @default false */
-  readonly allowMultiLinks?: boolean;
+  /**
+   * How many links may connect the same source+port and target+port. Matching
+   * is port/magnet aware, so links on different ports never collide.
+   * - `'none'` — no limit; any number of links, in either direction.
+   * - `'one-per-direction'` — one link each way: a second `A→B` is blocked, but
+   *   the reverse `B→A` is allowed.
+   * - `'one-per-pair'` — one link per element pair: `A→B` blocks both another
+   *   `A→B` and the reverse `B→A`.
+   * @default 'one-per-direction'
+   */
+  readonly linkLimit?: 'none' | 'one-per-direction' | 'one-per-pair';
   /**
    * Whether a link may attach to an element's root (its body) instead of a port or magnet.
    * - `true` — always allow root connections.
@@ -206,9 +232,10 @@ export interface CanConnectOptions {
 /**
  * Creates a JointJS-native `validateConnection` function with configurable rules.
  *
- * By default, rejects self-loops, link-to-link connections, and multi-links.
- * An optional `validate` callback receives a structured `{ source, target, paper, graph }`
- * context and runs only after the built-in checks pass.
+ * By default, rejects self-loops, link-to-link connections, and same-direction
+ * duplicate links (`linkLimit: 'one-per-direction'`). An optional `validate`
+ * callback receives a structured `{ source, target, paper, graph }` context and
+ * runs only after the built-in checks pass.
  * @param options - Rules and optional custom validator.
  * @returns A JointJS-compatible `validateConnection` function.
  */
@@ -216,7 +243,7 @@ export function canConnect(options: CanConnectOptions = {}) {
   const {
     allowSelfLoops = false,
     allowLinkToLink = false,
-    allowMultiLinks = false,
+    linkLimit = 'one-per-direction',
     allowRootConnection = 'auto',
     validate,
   } = options;
@@ -231,7 +258,10 @@ export function canConnect(options: CanConnectOptions = {}) {
     if (!allowLinkToLink && (!sourceView.model.isElement() || !targetView.model.isElement())) return false;
     if (isRootBlocked(sourceView, sourceNode, allowRootConnection)) return false;
     if (isRootBlocked(targetView, targetNode, allowRootConnection)) return false;
-    if (!allowMultiLinks && hasDuplicateLink(sourceView, sourceNode, targetView, targetNode, linkView)) {
+    if (
+      linkLimit !== 'none' &&
+      hasDuplicateLink(sourceView, sourceNode, targetView, targetNode, linkView, linkLimit === 'one-per-pair')
+    ) {
       return false;
     }
     if (validate) {

--- a/packages/joint-react/stories/examples/fixed-connection-points/code.tsx
+++ b/packages/joint-react/stories/examples/fixed-connection-points/code.tsx
@@ -422,7 +422,7 @@ function Main() {
           id: end.id,
         };
       }}
-      validateConnection={{ allowMultiLinks: true }}
+      validateConnection={{ linkLimit: 'none' }}
       snapLinks
       defaultLink={DEFAULT_LINK}
       // Highlighting configuration


### PR DESCRIPTION
## Summary

The `canConnect` preset's `allowMultiLinks?: boolean` only expressed two policies. Replace it with a tri-state `linkLimit` so all three are explicit:

```ts
linkLimit?: 'none' | 'one-per-direction' | 'one-per-pair'   // default 'one-per-direction'
```

- **`'none'`** — any number of links between a pair, either direction (was `allowMultiLinks: true`).
- **`'one-per-direction'`** — one link each way: a second `A→B` is blocked, but the reverse `B→A` is allowed (was `allowMultiLinks: false`, and the new default).
- **`'one-per-pair'`** — one link per element pair: `A→B` blocks both another `A→B` and the reverse `B→A`. **New behavior.**

Matching stays port/magnet aware (links on different ports never collide). `hasDuplicateLink` gains a `singlePerPair` flag that additionally matches the reverse-direction link — no extra graph query, since `getConnectedLinks(source)` already returns links where the source node is either endpoint.

## Breaking change

`CanConnectOptions.allowMultiLinks` is removed. Migrate:
- `allowMultiLinks: true` → `linkLimit: 'none'`
- `allowMultiLinks: false` → `linkLimit: 'one-per-direction'` (or omit — it's the default)

Runtime default is unchanged, so omitting the option behaves exactly as before.

## Test plan
- [x] `yarn typecheck` in `packages/joint-react` — passes (the removed boolean surfaces at the one in-repo call site, a story, which is migrated).
- [x] `yarn jest --testPathPatterns=can-connect` — existing tests renamed to `linkLimit`; added coverage for reverse-direction allow/block across all three modes + port-level reverse.
- [x] `yarn jest` in `packages/joint-react` — 1023 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)