### PR TITLE
Release v4.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 07-07-2026 (v4.3.0)
 
-@joint/react
+  @joint/react
   * new package - idiomatic React components and hooks for JointJS, built directly on the core engine
 
-@joint/core
+  @joint/core
   * dia.Paper - add `originX` and `originY` options to `getFitToContentArea()`
   * dia.Paper - add typed `EventMap` for IDE autocomplete and type-checking on `on()` calls
   * dia.Paper - `resolveViewClass` factory now receives the resolved namespace view class as a second argument

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,32 @@
+07-07-2026 (v4.3.0)
+
+@joint/react
+  * new package - idiomatic React components and hooks for JointJS, built directly on the core engine
+
+@joint/core
+  * dia.Paper - add `originX` and `originY` options to `getFitToContentArea()`
+  * dia.Paper - add typed `EventMap` for IDE autocomplete and type-checking on `on()` calls
+  * dia.Paper - `resolveViewClass` factory now receives the resolved namespace view class as a second argument
+  * dia.Paper - add `getCellView()` method for strict view lookup
+  * dia.Paper - add `setDragging()` and `isDragging()` methods for drag-state access
+  * dia.Paper - auto-emit `resize` event when the host container is resized via CSS
+  * dia.Paper - fix stale cell views when cells become hidden during a batch update
+  * dia.Paper - `elementView` / `linkView` factory options now receive the namespace view class as a second argument
+  * dia.GridLayerView - read built-in grid patterns from the paper constructor's static field
+  * dia.CellView - `getNodeBoundingRect()` and new `computeNodeBoundingRect()` support HTML elements
+  * dia.Graph - add `getCellNamespace()`, `setCellNamespace()`, `getTypeConstructor()`, `getTypeDefaults()`; deprecate `CellCollection.cellNamespace` setter
+  * dia.Graph - add typed `EventMap` for IDE autocomplete and type-checking on `on()` calls
+  * dia.Graph - add `port` and `magnet` options to `getConnectedLinks()`
+  * dia.Cell - support predicate function for `ignoreEmptyAttributes` option of `toJSON()`
+  * dia.Cell - add `Cell.JSON` and `Cell.JSONInit` types; deprecate `GenericAttributes`
+  * anchors.midSide - add `'top-bottom'`, `'bottom-top'`, `'left-right'`, `'right-left'` direction modes
+  * highlighters - add HTML element support to the mask highlighter
+  * routers.rightAngle - fix anchor point excluded from clearance bounding-box union
+  * routers.rightAngle - add `minPathMargin`, `sourceMargin`, and `targetMargin` options
+  * mvc.View - add `classNamePrefix` instance property to override the `joint-` CSS class prefix
+  * config - add `storeEmbeds` option to suppress the `embeds` attribute
+  * Vectorizer - fix `getRelativeTransformation()` when the screen CTM is non-invertible
+
 11-06-2026 (v4.2.5)
 
   @joint/core

--- a/examples/absolute-port-layout-dynamic-port-sizes-js/package.json
+++ b/examples/absolute-port-layout-dynamic-port-sizes-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-absolute-port-layout-dynamic-port-sizes-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/activity-diagram-js/package.json
+++ b/examples/activity-diagram-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-activity-diagram-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/anchors-ts/package.json
+++ b/examples/anchors-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-anchors-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/angular-element-view-ts/package.json
+++ b/examples/angular-element-view-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-angular-element-view-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/examples/animated-process-flow-diagram-js/package.json
+++ b/examples/animated-process-flow-diagram-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-animated-process-flow-diagram-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/bezier-js/package.json
+++ b/examples/bezier-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-bezier-js",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/callouts-js/package.json
+++ b/examples/callouts-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-callouts-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/chatgpt-timeline-js/package.json
+++ b/examples/chatgpt-timeline-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-chatgpt-timeline-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/circular-layout-js/package.json
+++ b/examples/circular-layout-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-circular-layout-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/connection-points-ts/package.json
+++ b/examples/connection-points-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-connection-points-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/connector-arrows-js/package.json
+++ b/examples/connector-arrows-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-connector-arrows-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/container/package.json
+++ b/examples/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-container",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "dist/bundle.js",
   "author": {
     "name": "client IO",

--- a/examples/content-driven-shapes-js/package.json
+++ b/examples/content-driven-shapes-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-content-driven-shapes-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/control-tool-js/package.json
+++ b/examples/control-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-control-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/counters-js/package.json
+++ b/examples/counters-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-counters-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/curve-connector-js/package.json
+++ b/examples/curve-connector-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-curve-connector-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-decorators",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/different-views-of-the-same-graph-js/package.json
+++ b/examples/different-views-of-the-same-graph-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-different-views-of-the-same-graph-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/drop-image-as-shape-js/package.json
+++ b/examples/drop-image-as-shape-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-drop-image-as-shape-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-dwdm",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/dynamic-font-size-js/package.json
+++ b/examples/dynamic-font-size-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-dynamic-font-size-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/dynamic-status-icons-js/package.json
+++ b/examples/dynamic-status-icons-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-dynamic-status-icons-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/electric-generator-js/package.json
+++ b/examples/electric-generator-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-electric-generator-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-connect-tool-js/package.json
+++ b/examples/element-connect-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-element-connect-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-port-and-link-label-markup-js/package.json
+++ b/examples/element-port-and-link-label-markup-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-element-port-and-link-label-markup-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-tags-and-badges-js/package.json
+++ b/examples/element-tags-and-badges-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-element-tags-and-badges-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/external-svg-images-js/package.json
+++ b/examples/external-svg-images-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-external-svg-images-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fault-tree-analysis-js/package.json
+++ b/examples/fault-tree-analysis-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-fault-tree-analysis-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fills-js/package.json
+++ b/examples/fills-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-fills-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/find-all-cells-between-2-elements-js/package.json
+++ b/examples/find-all-cells-between-2-elements-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-find-all-cells-between-2-elements-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/foreign-object-magnet-js/package.json
+++ b/examples/foreign-object-magnet-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-foreign-object-magnet-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fta-js/package.json
+++ b/examples/fta-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-fta-js",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/genogram-ts/package.json
+++ b/examples/genogram-ts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-genogram-directed-graph-ts",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hexagonal-grid-js/package.json
+++ b/examples/hexagonal-grid-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-hexagonal-grid-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hierarchical-diagrams-js/package.json
+++ b/examples/hierarchical-diagrams-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-hierarchical-diagrams-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/highlighterview-update-attribute-js/package.json
+++ b/examples/highlighterview-update-attribute-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-highlighterview-update-attribute-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hover-element-connect-tool-js/package.json
+++ b/examples/hover-element-connect-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-hover-element-connect-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hover-link-connect-tool-js/package.json
+++ b/examples/hover-link-connect-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-hover-link-connect-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-isometric",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-directed-graph/package.json
+++ b/examples/layout-directed-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-directed-graph",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - Directed Graph Layout Demo",
   "main": "./index.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-elk-ts/package.json
+++ b/examples/layout-elk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-elk-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - ELK Layout Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-msagl/package.json
+++ b/examples/layout-msagl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-layout-msagl",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - MSAGL Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-libavoid",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/link-connect-tool-js/package.json
+++ b/examples/link-connect-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-link-connect-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/link-labels-ts/package.json
+++ b/examples/link-labels-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-link-labels-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-list",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/microsoft-adaptive-cards-js/package.json
+++ b/examples/microsoft-adaptive-cards-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-microsoft-adaptive-cards-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/nodejs-milestones-timeline-js/package.json
+++ b/examples/nodejs-milestones-timeline-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-nodejs-milestones-timeline-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/offscreen-rendering/package.json
+++ b/examples/offscreen-rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-offscreen-rendering",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/optional-ports-js/package.json
+++ b/examples/optional-ports-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-optional-ports-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/port-reordering-tool-js/package.json
+++ b/examples/port-reordering-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-port-reordering-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/preserve-spaces-in-text-wrap-js/package.json
+++ b/examples/preserve-spaces-in-text-wrap-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-preserve-spaces-in-text-wrap-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/rectangular-layout-js/package.json
+++ b/examples/rectangular-layout-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-rectangular-layout-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/resize-control-tool-js/package.json
+++ b/examples/resize-control-tool-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-resize-control-tool-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/right-angle-playground-js/package.json
+++ b/examples/right-angle-playground-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-right-angle-playground-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/roi-calculator-js/package.json
+++ b/examples/roi-calculator-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-roi-calculator-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/scale-option-for-tools-js/package.json
+++ b/examples/scale-option-for-tools-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-scale-option-for-tools-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/scale-svgmarker-js/package.json
+++ b/examples/scale-svgmarker-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-scale-svgmarker-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/serpentine-layout-js/package.json
+++ b/examples/serpentine-layout-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-serpentine-layout-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/shapes-drawing-js/package.json
+++ b/examples/shapes-drawing-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-shapes-drawing-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-shapes-general",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/snap-links-to-themselves-js/package.json
+++ b/examples/snap-links-to-themselves-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-snap-links-to-themselves-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/spreadsheet-shapes-with-handsontable-js/package.json
+++ b/examples/spreadsheet-shapes-with-handsontable-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-spreadsheet-shapes-with-handsontable-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-of-life",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "main": "src/index.ts",
   "author": {
     "name": "client IO",

--- a/examples/tree-shake/package.json
+++ b/examples/tree-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-tree-shake",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - Tree Shake Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/examples/use-case-diagram-js/package.json
+++ b/examples/use-case-diagram-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-use-case-diagram-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/working-with-ports-js/package.json
+++ b/examples/working-with-ports-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@joint/demo-working-with-ports-js",
     "private": true,
-    "version": "4.3.0-beta.2",
+    "version": "4.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "sideEffects": false,
   "homepage": "https://jointjs.com",
   "author": {

--- a/packages/joint-core/demo/custom-shapes/package.json
+++ b/packages/joint-core/demo/custom-shapes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-custom-shapes",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - Custom Shapes Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/elk/package.json
+++ b/packages/joint-core/demo/elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-elk-graph",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - Eclipse Layout Kernel Graph Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/rough/package.json
+++ b/packages/joint-core/demo/rough/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-rough",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - RoughJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/ts-demo/package.json
+++ b/packages/joint-core/demo/ts-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-ts",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - TypeScript Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/demo/vuejs/package.json
+++ b/packages/joint-core/demo/vuejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joint/demo-vuejs",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JointJS - VueJS Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/packages/joint-core/package.json
+++ b/packages/joint-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/core",
   "title": "JointJS",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "JavaScript diagramming library",
   "sideEffects": false,
   "main": "./dist/joint.min.js",

--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/decorators",
   "title": "JointJS Decorators",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "Decorators module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-eslint-config/package.json
+++ b/packages/joint-eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/eslint-config",
   "title": "JointJS ESLintConfig",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "ESLintConfig module for JointJS",
   "sideEffects": false,
   "type": "module",

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-directed-graph",
   "title": "JointJS LayoutDirectedGraph",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "LayoutDirectedGraph module for JointJS",
   "main": "dist/DirectedGraph.js",
   "module": "./DirectedGraph.mjs",

--- a/packages/joint-layout-msagl/package.json
+++ b/packages/joint-layout-msagl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-msagl",
   "title": "JointJS LayoutMSAGL",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "LayoutMSAGL module for JointJS",
   "sideEffects": false,
   "main": "./dist/esm/index.mjs",

--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/react",
   "title": "JointJS React",
-  "version": "1.0.0-beta.1",
+  "version": "4.3.0",
   "description": "React bindings and hooks for JointJS to build interactive diagrams and graphs.",
   "type": "module",
   "sideEffects": [

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general-tools",
   "title": "JointJS General Shapes Tools",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "General Shapes Tools module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general",
   "title": "JointJS General Shapes",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0",
   "description": "General Shapes module for JointJS",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",

--- a/packages/joint-vitest-plugin-mock-svg/package.json
+++ b/packages/joint-vitest-plugin-mock-svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/vitest-plugin-mock-svg",
   "title": "JointJS Mock SVG",
-  "version": "0.3.1-beta.1",
+  "version": "0.3.1",
   "description": "A Vitest plugin to mock SVG global constants required for JointJS testing.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
# CHANGELOG

## @joint/react
  * **new package** - idiomatic React components and hooks for JointJS, built directly on the core engine (c87d3453)

## @joint/core
  * **dia.Paper** - add `originX` and `originY` options to `getFitToContentArea()` (82f2e079)
  * **dia.Paper** - add typed `EventMap` for IDE autocomplete and type-checking on `on()` calls (bb2f01be)
  * **dia.Paper** - `resolveViewClass` factory now receives the resolved namespace view class as a second argument (88e5812a)
  * **dia.Paper** - add `getCellView()` method for strict view lookup (42ecbe42)
  * **dia.Paper** - add `setDragging()` and `isDragging()` methods for drag-state access (ec6eb331)
  * **dia.Paper** - auto-emit `resize` event when the host container is resized via CSS (adc8f522)
  * **dia.Paper** - fix stale cell views when cells become hidden during a batch update (2eff4f32)
  * **dia.Paper** - `elementView` / `linkView` factory options now receive the namespace view class as a second argument (fdbf8491)
  * **dia.GridLayerView** - read built-in grid patterns from the paper constructor's static field (79827c66)
  * **dia.CellView** - `getNodeBoundingRect()` and new `computeNodeBoundingRect()` support HTML elements (8ef72b69, 4b4bb52e)
  * **dia.Graph** - add `getCellNamespace()`, `setCellNamespace()`, `getTypeConstructor()`, `getTypeDefaults()`; deprecate `CellCollection.cellNamespace` setter (fea4bf33)
  * **dia.Graph** - add typed `EventMap` for IDE autocomplete and type-checking on `on()` calls (bb2f01be)
  * **dia.Graph** - add `port` and `magnet` options to `getConnectedLinks()` (906ddd59)
  * **dia.Cell** - support predicate function for `ignoreEmptyAttributes` option of `toJSON()` (6363f39a)
  * **dia.Cell** - add `Cell.JSON` and `Cell.JSONInit` types; deprecate `GenericAttributes` (5cbc52f3)
  * **anchors.midSide** - add `'top-bottom'`, `'bottom-top'`, `'left-right'`, `'right-left'` direction modes (67d83ba1)
  * **highlighters** - add HTML element support to the mask highlighter (dcd60ac2)
  * **routers.rightAngle** - fix anchor point excluded from clearance bounding-box union (2a1fec50)
  * **routers.rightAngle** - add `minPathMargin`, `sourceMargin`, and `targetMargin` options (858d0495)
  * **mvc.View** - add `classNamePrefix` instance property to override the `joint-` CSS class prefix (0a399774)
  * **config** - add `storeEmbeds` option to suppress the `embeds` attribute (de2357e2)
  * **Vectorizer** - fix `getRelativeTransformation()` when the screen CTM is non-invertible (66e68104)