### PR TITLE
docs(react): fix generated API reference TSDoc

### DIFF
--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -184,8 +184,7 @@ function GraphBase(props: Readonly<GraphProviderBaseInternalProps>): React.React
  * `initialCells` to let JointJS own the graph after mount (uncontrolled), pass
  * `cells` + `onCellsChange` to drive the graph from React state (controlled), or
  * pass `onIncrementalCellsChange` to forward deltas to an external store.
- * @example
- * @title Uncontrolled — seed once, JointJS owns the graph
+ * @example Uncontrolled — seed once, JointJS owns the graph
  * ```tsx
  * import { GraphProvider, Paper } from '@joint/react';
  *
@@ -198,8 +197,7 @@ function GraphBase(props: Readonly<GraphProviderBaseInternalProps>): React.React
  *   <Paper renderElement={(data) => <rect width={80} height={40} rx={4} fill="#4763ff" />} />
  * </GraphProvider>
  * ```
- * @example
- * @title Controlled — React state owns the cells
+ * @example Controlled — React state owns the cells
  * ```tsx
  * import { useState } from 'react';
  * import { GraphProvider, Paper, type CellRecord } from '@joint/react';
@@ -209,8 +207,7 @@ function GraphBase(props: Readonly<GraphProviderBaseInternalProps>): React.React
  *   <Paper />
  * </GraphProvider>
  * ```
- * @example
- * @title Incremental — forward deltas to an external store
+ * @example Incremental — forward deltas to an external store
  * ```tsx
  * import { GraphProvider, Paper } from '@joint/react';
  *

--- a/packages/joint-react/src/components/html-host.tsx
+++ b/packages/joint-react/src/components/html-host.tsx
@@ -57,6 +57,19 @@ function HTMLFrame({ nodeRef, width, height, style, ...rest }: Readonly<HTMLFram
   );
 }
 
+function HTMLHostComponent(
+  props: Readonly<HTMLHostProps>,
+  ref: ForwardedRef<HTMLDivElement>
+): ReactNode {
+  const { useModelGeometry = false, ...rest } = props;
+
+  return useModelGeometry ? (
+    <StaticHTMLFrame hostRef={ref} {...rest} />
+  ) : (
+    <MeasuredHTMLFrame hostRef={ref} {...rest} />
+  );
+}
+
 /**
  * Renders a graph element as an unstyled HTML node you fully control. Reach for
  * this inside `<Paper renderElement={...}>` when you want plain DOM (a `<div>`,
@@ -82,19 +95,6 @@ function HTMLFrame({ nodeRef, width, height, style, ...rest }: Readonly<HTMLFram
  * ```
  * @group Components
  */
-function HTMLHostComponent(
-  props: Readonly<HTMLHostProps>,
-  ref: ForwardedRef<HTMLDivElement>
-): ReactNode {
-  const { useModelGeometry = false, ...rest } = props;
-
-  return useModelGeometry ? (
-    <StaticHTMLFrame hostRef={ref} {...rest} />
-  ) : (
-    <MeasuredHTMLFrame hostRef={ref} {...rest} />
-  );
-}
-
 export const HTMLHost = forwardRef(HTMLHostComponent);
 
 /**

--- a/packages/joint-react/src/components/svg-text/svg-text.tsx
+++ b/packages/joint-react/src/components/svg-text/svg-text.tsx
@@ -244,16 +244,14 @@ function Component(props: SVGTextProps, ref: React.ForwardedRef<SVGTextElement>)
  * `textWrap` runs `util.breakText` so long strings wrap to the element's width.
  * See {@link SVGTextProps} for every supported option.
  * @group Components
- * @example
- * @title Basic label
+ * @example Basic label
  * ```tsx
  * import { Paper, SVGText } from '@joint/react';
  *
  * // Label each element with a static caption.
  * <Paper renderElement={() => <SVGText x={10} y={20}>Hello World</SVGText>} />
  * ```
- * @example
- * @title Wrap text to a fixed width
+ * @example Wrap text to a fixed width
  * ```tsx
  * import { Paper, SVGText } from '@joint/react';
  *
@@ -266,8 +264,7 @@ function Component(props: SVGTextProps, ref: React.ForwardedRef<SVGTextElement>)
  *   )}
  * />
  * ```
- * @example
- * @title Vertical anchor, line height, and line breaks
+ * @example Vertical anchor, line height, and line breaks
  * ```tsx
  * import { Paper, SVGText } from '@joint/react';
  *

--- a/packages/joint-react/src/hooks/use-measure-element.tsx
+++ b/packages/joint-react/src/hooks/use-measure-element.tsx
@@ -62,8 +62,7 @@ const EMPTY_OBJECT: MeasureElementOptions = {};
  * @throws If used outside a `renderElement` context, or if the current cell is a
  *   link rather than an element.
  * @group Hooks
- * @example
- * @title Basic usage
+ * @example Basic usage
  * ```tsx
  * import { useMeasureElement } from '@joint/react';
  * import { useRef } from 'react';
@@ -81,8 +80,7 @@ const EMPTY_OBJECT: MeasureElementOptions = {};
  *   );
  * }
  * ```
- * @example
- * @title Use the returned size
+ * @example Use the returned size
  * ```tsx
  * import { useMeasureElement } from '@joint/react';
  * import { useRef } from 'react';
@@ -106,8 +104,7 @@ const EMPTY_OBJECT: MeasureElementOptions = {};
  *   );
  * }
  * ```
- * @example
- * @title Adjust size with a transform
+ * @example Adjust size with a transform
  * ```tsx
  * import { useMeasureElement, type TransformElementLayout } from '@joint/react';
  * import { useRef, useCallback } from 'react';


### PR DESCRIPTION
## Summary

Two TSDoc-only fixes so the generated `@joint/react` API reference renders correctly. No runtime changes.

The React API reference (`joint-docs/docs/api-react`) is generated from this package's TSDoc via typedoc. Two defects in the source produced broken pages; the sibling `@joint/react-plus` already uses the correct conventions.

## Changes

- **Inline example captions** — `@title` placed on the line *after* `@example` made typedoc emit a stray `## Title` heading plus an empty code fence, breaking the `GraphProvider`, `SVGText`, and `useMeasureElement` pages. Merged each caption onto its `@example` line (the form react-plus uses). Overload-label `@title` tags are untouched.
- **Document `HTMLHost` on its export** — the TSDoc block sat on the inner `HTMLHostComponent` while the exported `HTMLHost` had none, so its docs page was an empty stub. Moved the block (description + example + `@group`) onto the export, mirroring `svg-text.tsx`.

## Notes

- The generic-ize selectors change (position/size/angle leaking `InternalElementRecord`) was intentionally left out of this PR.
- Verification via `docs:typedoc-md` was not run locally (dependency sync issue); the edits are TSDoc-only and confirmed no `@example`→`@title` pairs remain in `src`.