### PR TITLE
docs(react): rewrite @see URLs as markdown links

### DIFF
--- a/packages/joint-react/src/components/graph/graph-provider.tsx
+++ b/packages/joint-react/src/components/graph/graph-provider.tsx
@@ -27,7 +27,7 @@ export interface GraphProviderProps<
   /**
    * Pre-existing JointJS graph instance to use. If omitted, GraphProvider
    * creates a fresh `new dia.Graph(...)`.
-   * @see https://docs.jointjs.com/api/dia/Graph
+   * @see [`dia.Graph`](https://docs.jointjs.com/api/dia/Graph)
    */
   readonly graph?: dia.Graph;
   /** React children rendered inside the provider, typically a `<Paper />`. */
@@ -43,7 +43,7 @@ export interface GraphProviderProps<
    * Base model class used for every cell the graph constructs from JSON. Maps to
    * the (deprecated) `cellModel` option of `dia.Graph`; prefer `cellNamespace`,
    * which registers shapes by `type` and supports per-type model classes.
-   * @see https://docs.jointjs.com/api/dia/Graph
+   * @see [`dia.Graph`](https://docs.jointjs.com/api/dia/Graph)
    */
   readonly cellModel?: typeof dia.Cell;
   /**

--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -379,7 +379,7 @@ export type RenderLink<LinkData = unknown> = (data: LinkData) => ReactNode;
  * re-subscription on render. For raw native event names or events without an
  * `on*` form (`render:done`, `cell:highlight`, …), use the {@link useOnPaperEvents}
  * hook.
- * @see https://docs.jointjs.com/api/dia/Paper
+ * @see [`dia.Paper`](https://docs.jointjs.com/api/dia/Paper)
  * @expand
  * @group Types
  */

--- a/packages/joint-react/src/hooks/use-paper.ts
+++ b/packages/joint-react/src/hooks/use-paper.ts
@@ -80,19 +80,19 @@ export interface PaperApi {
   /**
    * Trigger a render pass on the paper. Forwards to `paper.wakeUp()`.
    * No-op when the paper isn't resolved yet.
-   * @see https://docs.jointjs.com/api/dia/Paper#wakeUp
+   * @see [`paper.wakeUp()`](https://docs.jointjs.com/api/dia/Paper#wakeup)
    */
   readonly wakeUp: () => void;
   /**
    * Suspend view updates so edits don't repaint until {@link PaperApi.unfreeze}.
    * Forwards to `paper.freeze()`. No-op when the paper isn't resolved yet.
-   * @see https://docs.jointjs.com/api/dia/Paper#freeze
+   * @see [`paper.freeze()`](https://docs.jointjs.com/api/dia/Paper#freeze)
    */
   readonly freeze: () => void;
   /**
    * Resume view updates and flush everything queued while frozen. Forwards to
    * `paper.unfreeze()`. No-op when the paper isn't resolved yet.
-   * @see https://docs.jointjs.com/api/dia/Paper#unfreeze
+   * @see [`paper.unfreeze()`](https://docs.jointjs.com/api/dia/Paper#unfreeze)
    */
   readonly unfreeze: () => void;
 }
@@ -109,7 +109,7 @@ export interface PaperApi {
  * @param paperId - An explicit paper id, or omitted for the context/default paper.
  * @returns The {@link PaperApi}: the resolved `paper` (or `null`) plus `wakeUp`,
  *          `freeze`, and `unfreeze` actions.
- * @see https://docs.jointjs.com/learn/quickstart/paper
+ * @see [Paper quickstart](https://docs.jointjs.com/learn/quickstart/paper)
  * @group Hooks
  * @example
  * ```tsx


### PR DESCRIPTION
Bare `@see https://docs.jointjs.com/...` URLs in joint-react TSDoc render poorly in the generated API reference: the docs converter falls back to the URL path tail as link text (`Paper#wakeUp`), and the `#wakeUp` anchor doesn't match the lowercase Docusaurus slug, so the link lands nowhere.

Rewrites all 7 bare `@see` URLs as markdown links with code-styled, human-readable text (e.g. `[`paper.wakeUp()`](https://docs.jointjs.com/api/dia/Paper#wakeup)`) and fixes the anchor casing. The converter in joint-docs preserves author link text, so the API reference picks these up on the next regeneration (already verified end to end).

Touched: `use-paper.ts`, `paper.types.ts`, `graph-provider.tsx` — TSDoc comments only, no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)