### PR TITLE
Release v4.3.1 (@joint/react)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+07-07-2026 (v4.3.1)
+
+  @joint/react
+  * useCreateFeature - fix duplicate paper feature registration under React 18 StrictMode causing interactions to fire twice (e.g. selection drag translating cells 2x)
+  * useCells - fix ghost cells reported after `resetCells()` (bulk reset emits no per-cell `remove` events)
+
 07-07-2026 (v4.3.0)
 
   @joint/react

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 07-07-2026 (v4.3.1)
 
   @joint/react
-  * useCreateFeature - fix duplicate paper feature registration under React 18 StrictMode causing interactions to fire twice (e.g. selection drag translating cells 2x)
-  * useCells - fix ghost cells reported after `resetCells()` (bulk reset emits no per-cell `remove` events)
+  * useCreateFeature - fix duplicate paper feature registration under React 18 StrictMode causing interactions to fire twice
+  * useCells - fix ghost cells reported after `resetCells()`
 
 07-07-2026 (v4.3.0)
 

--- a/packages/joint-react/package.json
+++ b/packages/joint-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/react",
   "title": "JointJS React",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "React bindings and hooks for JointJS to build interactive diagrams and graphs.",
   "type": "module",
   "sideEffects": [


### PR DESCRIPTION
# CHANGELOG

## @joint/react
  * **useCreateFeature** - fix duplicate paper feature registration under React 18 StrictMode causing interactions to fire twice (0a670d25)
  * **useCells** - fix ghost cells reported after `resetCells()` (0a670d25)