### PR TITLE
feat(joint-react): cell focus/blur events, reactive grid, collection setters

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper-focus-events.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-focus-events.test.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { Paper } from '../paper';
+import { GraphProvider } from '../../graph/graph-provider';
+import { useOnPaperEvents } from '../../../hooks/use-on-paper-events';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import type { CellRecord } from '../../../types/cell.types';
+
+const CELLS = [
+  { id: 'n1', type: ELEMENT_MODEL_TYPE, size: { width: 50, height: 50 } },
+] satisfies readonly CellRecord[];
+
+const renderRect = () => <rect />;
+
+/** The cell's portal group carries a `tabindex`, i.e. a focusable node. */
+function focusableInCell(container: HTMLElement): Element {
+  const node = container.querySelector('.joint-cell [tabindex]');
+  if (!node) throw new Error('expected a focusable node inside the cell');
+  return node;
+}
+
+describe('Paper focus events', () => {
+  it('fires onCellFocus / onCellBlur with the cell id', async () => {
+    const focus = jest.fn();
+    const blur = jest.fn();
+    const { container } = render(
+      <GraphProvider initialCells={CELLS}>
+        <Paper
+          style={{ width: 200, height: 200 }}
+          renderElement={renderRect}
+          onCellFocus={focus}
+          onCellBlur={blur}
+        />
+      </GraphProvider>
+    );
+    await waitFor(() => expect(container.querySelector('.joint-cell')).toBeTruthy());
+    const node = focusableInCell(container);
+
+    fireEvent.focusIn(node);
+    fireEvent.focusOut(node);
+
+    await waitFor(() => {
+      expect(focus).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
+      expect(blur).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
+    });
+  });
+
+  it('is exposed through the paper events API (useOnPaperEvents)', async () => {
+    const focus = jest.fn();
+    function FocusLogger() {
+      useOnPaperEvents({ onCellFocus: focus });
+      return null;
+    }
+    const { container } = render(
+      <GraphProvider initialCells={CELLS}>
+        <Paper style={{ width: 200, height: 200 }} renderElement={renderRect} />
+        <FocusLogger />
+      </GraphProvider>
+    );
+    await waitFor(() => expect(container.querySelector('.joint-cell')).toBeTruthy());
+
+    fireEvent.focusIn(focusableInCell(container));
+
+    await waitFor(() =>
+      expect(focus).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }))
+    );
+  });
+});

--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -119,4 +119,66 @@ describe('Paper', () => {
     ).toThrow(/cellVisibility.*escape hatch/);
     spy.mockRestore();
   });
+
+  it('keeps inline style authoritative over className (same as an HTML div)', async () => {
+    // Report: `<Paper style={{ width: 1000 }} className="w-10" />` should let the
+    // inline width win over the class, like any HTML element. The host div IS
+    // `paper.el`; the inline `style` must land on it (present in the `style`
+    // attribute) so the CSS cascade — inline beats class, there is no
+    // `!important` in paper.css — resolves in the user's favour. `_setDimensions`
+    // (which runs with width/height forced to `undefined`) must not wipe it.
+    const { container } = render(
+      <GraphProvider initialCells={CELLS}>
+        <Paper
+          style={{ width: 1000, height: 500 }}
+          className="w-10"
+          renderElement={renderRectElement}
+        />
+      </GraphProvider>
+    );
+    await waitFor(() => expect(container.querySelector('svg')).toBeTruthy());
+    const host = container.querySelector('.jj-paper');
+    if (!(host instanceof HTMLElement)) throw new Error('paper host div not found');
+    // Inline style survived on paper.el → wins over the class in a real browser.
+    expect(host.style.width).toBe('1000px');
+    expect(host.style.height).toBe('500px');
+    // The class is applied too (alongside the framework's jj-paper).
+    expect(host.classList.contains('w-10')).toBe(true);
+    expect(host.classList.contains('jj-paper')).toBe(true);
+  });
+
+  it('redraws the visual grid when drawGridSize changes reactively', async () => {
+    // Regression: the visual grid only redrew via the top-level `drawGrid`
+    // prop; `drawGridSize` changes updated snapping (gridSize) but left the
+    // rendered grid pattern stale.
+    const refHolder: { current: dia.Paper | null } = { current: null };
+    function App({ drawGridSize }: Readonly<{ drawGridSize: number }>) {
+      const ref = useRef<dia.Paper | null>(null);
+      useEffect(() => {
+        if (ref.current) refHolder.current = ref.current;
+      });
+      return (
+        <GraphProvider initialCells={CELLS}>
+          <Paper
+            ref={ref}
+            renderElement={renderRectElement}
+            style={{ width: 300, height: 200 }}
+            gridSize={10}
+            drawGridSize={drawGridSize}
+          />
+        </GraphProvider>
+      );
+    }
+    const patternWidth = () =>
+      refHolder.current?.el.querySelector('pattern')?.getAttribute('width') ?? null;
+
+    const { rerender } = render(<App drawGridSize={20} />);
+    await waitFor(() => {
+      rerender(<App drawGridSize={20} />);
+      expect(patternWidth()).toBe('20');
+    });
+
+    rerender(<App drawGridSize={60} />);
+    await waitFor(() => expect(patternWidth()).toBe('60'));
+  });
 });

--- a/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-setters.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { shapes, type dia } from '@joint/core';
+import { shapes, mvc, type dia } from '@joint/core';
 import { graphProviderWrapper } from '../../utils/test-wrappers';
 import {
   useSetCell,
@@ -328,6 +328,24 @@ describe('use-cell-setters', () => {
       expect(result.current.store.graph.getCell('a')).toBeUndefined();
       expect(result.current.store.graph.getCell('b')).toBeUndefined();
     });
+
+    it('removes cells passed as a JointJS collection (no toArray needed)', async () => {
+      const { result } = renderHook(
+        () => ({ removeCells: useRemoveCells(), store: useGraphStore() }),
+        { wrapper }
+      );
+      await waitFor(() => expect(result.current).toBeDefined());
+      const cellA = result.current.store.graph.getCell('a');
+      const cellB = result.current.store.graph.getCell('b');
+      if (!cellA || !cellB) throw new Error('expected cells a and b to exist');
+      const collection = new mvc.Collection<dia.Cell>([cellA, cellB]);
+      await act(async () => {
+        result.current.removeCells(collection);
+        await flush();
+      });
+      expect(result.current.store.graph.getCell('a')).toBeUndefined();
+      expect(result.current.store.graph.getCell('b')).toBeUndefined();
+    });
   });
 
   describe('useResetCells', () => {
@@ -364,6 +382,23 @@ describe('use-cell-setters', () => {
       });
       expect(result.current.store.graph.getCell('a')).toBeUndefined();
       expect(result.current.store.graph.getCell('b')).toBeDefined();
+    });
+
+    it('accepts a JointJS collection as the next cell set', async () => {
+      const { result } = renderHook(
+        () => ({ resetCells: useResetCells(), store: useGraphStore() }),
+        { wrapper }
+      );
+      await waitFor(() => expect(result.current).toBeDefined());
+      const cellB = result.current.store.graph.getCell('b');
+      if (!cellB) throw new Error('expected cell b to exist');
+      const collection = new mvc.Collection<dia.Cell>([cellB]);
+      await act(async () => {
+        result.current.resetCells(collection);
+        await flush();
+      });
+      expect(result.current.store.graph.getCell('b')).toBeDefined();
+      expect(result.current.store.graph.getCell('a')).toBeUndefined();
     });
   });
 

--- a/packages/joint-react/src/hooks/use-cell-setters.ts
+++ b/packages/joint-react/src/hooks/use-cell-setters.ts
@@ -8,6 +8,8 @@ import type {
   CellId,
   CellInput,
   CellRef,
+  CellCollection,
+  CellRefList,
 } from '../types/cell.types';
 import { type ArrayUpdate } from '../store/state-container';
 import { cellInputToRecord, cellInputToModel } from '../utils/normalize-cell-input';
@@ -227,15 +229,17 @@ export function useRemoveCell() {
 
 /**
  * Returns a function that removes multiple cells by id or dia.Cell reference.
- * A nullish array warns in dev and no-ops; references that resolve to no cell
- * are silently skipped.
+ * Accepts a readonly array or a JointJS cell collection (both are iterated the
+ * same way, so a selection's `collection` can be passed directly). A nullish
+ * input warns in dev and no-ops; references that resolve to no cell are silently
+ * skipped.
  * @returns memoized removeCells setter
  */
 export function useRemoveCells() {
   const store = useGraphStore();
   const { graph } = store;
   return useCallback(
-    (cellRefs?: readonly CellRef[] | null, metadata?: Record<string, unknown>) => {
+    (cellRefs?: CellRefList | null, metadata?: Record<string, unknown>) => {
       if (cellRefs === undefined || cellRefs === null) {
         warnMissingSetterCell('removeCells', cellRefs);
         return;
@@ -254,9 +258,9 @@ export function useRemoveCells() {
 
 /**
  * Returns a function that atomically replaces all cells.
- * Accepts either a new array or an updater receiving the current snapshot.
- * Both records and dia.Cell instances are accepted, dia.Cell instances
- * are normalized to records before mapping.
+ * Accepts a new array, a JointJS cell collection, or an updater receiving the
+ * current snapshot. Both records and dia.Cell instances are accepted, dia.Cell
+ * instances are normalized to records before mapping.
  * Maps the next cells through `mapCellToAttributes` and calls
  * `graph.resetCells` directly, equivalent to JointJS' bulk-reset semantics.
  * @template Element - element record shape
@@ -271,12 +275,14 @@ export function useResetCells<
   const { graph } = store;
   return useCallback(
     (
-      input: ArrayUpdate<Element | Link, CellInput<Element, Link>>,
+      input: ArrayUpdate<Element | Link, CellInput<Element, Link>> | CellCollection,
       metadata?: Record<string, unknown>
     ) => {
       const current = store.graphProjection.cells.getAll();
       const next = typeof input === 'function' ? input(current) : input;
-      const models = next.map((cell) => cellInputToModel<Element, Link>(cell, graph));
+      // `next` may be a readonly array or a JointJS collection (both iterable);
+      // Array.from normalizes either into the mapped model array in one pass.
+      const models = Array.from(next, (cell) => cellInputToModel<Element, Link>(cell, graph));
       graph.resetCells(models, metadata);
     },
     [graph, store]

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable @typescript-eslint/no-shadow */
-import { dia } from '@joint/core';
+import { dia, util } from '@joint/core';
 import {
   useDeferredValue,
   useEffect,
@@ -257,6 +257,12 @@ export function useCreatePortalPaper(
 
   const paperRef = useRef<PaperView | null>(null);
   const isReadyNotifiedRef = useRef(false);
+  // Last grid options pushed to the paper, so the visual grid is redrawn only
+  // when one of them actually changes (see the grid block in the update effect).
+  const gridSignatureRef = useRef<Pick<
+    dia.Paper.Options,
+    'drawGrid' | 'drawGridSize' | 'gridSize'
+  > | null>(null);
 
   const [HTMLRendererContainer, setHTMLRendererContainer] = useState<HTMLElement | null>(null);
 
@@ -402,16 +408,26 @@ export function useCreatePortalPaper(
       ...escapeHatchOptions,
     });
 
-    const { drawGrid, gridSize } = paperOptions;
-
     paper.setInteractivity(interactiveValue);
 
-    if (drawGrid !== undefined) {
-      paper.setGrid(drawGrid);
+    // Redraw the visual grid whenever any grid-affecting option changes.
+    // `assignOptions` above already wrote drawGrid / drawGridSize / gridSize
+    // onto `paper.options`, and `setGrid` re-reads them (`drawGridSize ||
+    // gridSize`), so a single call keeps the rendered grid in sync for both the
+    // snap size and the visual spacing/style. This covers `drawGridSize` (which
+    // `paper.setGridSize` deliberately skips) and grid options set through the
+    // `options` escape hatch — the previous per-prop calls missed both. The
+    // equality guard keeps the grid from re-rendering on unrelated re-renders.
+    const nextGrid = {
+      drawGrid: paper.options.drawGrid,
+      drawGridSize: paper.options.drawGridSize,
+      gridSize: paper.options.gridSize,
+    };
+    if (!util.isEqual(gridSignatureRef.current, nextGrid)) {
+      gridSignatureRef.current = nextGrid;
+      paper.setGrid(paper.options.drawGrid);
     }
-    if (gridSize !== undefined) {
-      paper.setGridSize(gridSize);
-    }
+
     if (transform !== undefined) {
       paper.matrix(toSVGMatrix(transform));
     }

--- a/packages/joint-react/src/hooks/use-graph.ts
+++ b/packages/joint-react/src/hooks/use-graph.ts
@@ -13,7 +13,14 @@ import {
   type SetCellData,
 } from './use-cell-setters';
 import type { ArrayUpdate } from '../store/state-container';
-import type { ElementJSONInit, LinkJSONInit, CellInput, CellRef } from '../types/cell.types';
+import type {
+  ElementJSONInit,
+  LinkJSONInit,
+  CellInput,
+  CellRef,
+  CellCollection,
+  CellRefList,
+} from '../types/cell.types';
 
 /**
  * The shape of the graph's JSON export, as produced by `graph.toJSON()`.
@@ -87,20 +94,24 @@ export interface GraphApi<
    */
   readonly removeCell: (cellRef?: CellRef | null, metadata?: Record<string, unknown>) => void;
   /**
-   * Remove multiple cells by id or dia.Cell reference. A nullish array warns in
-   * dev and no-ops; references that resolve to no cell are silently skipped. The
-   * optional `metadata` is forwarded as the `graph.removeCells` event opt.
+   * Remove multiple cells by id or dia.Cell reference. Accepts a readonly array
+   * or a JointJS cell collection (e.g. a selection's `collection`) directly. A
+   * nullish input warns in dev and no-ops; references that resolve to no cell
+   * are silently skipped. The optional `metadata` is forwarded as the
+   * `graph.removeCells` event opt.
    */
   readonly removeCells: (
-    cellRefs?: readonly CellRef[] | null,
+    cellRefs?: CellRefList | null,
     metadata?: Record<string, unknown>
   ) => void;
   /**
-   * Atomically replace the cell set. Accepts dia.Cell instances alongside
-   * records. The optional `metadata` is forwarded as the `graph.resetCells` opt.
+   * Atomically replace the cell set. Accepts an array (dia.Cell instances
+   * alongside records), a JointJS cell collection, or an updater receiving the
+   * current snapshot. The optional `metadata` is forwarded as the
+   * `graph.resetCells` opt.
    */
   readonly resetCells: (
-    input: ArrayUpdate<Element | Link, CellInput<Element, Link>>,
+    input: ArrayUpdate<Element | Link, CellInput<Element, Link>> | CellCollection,
     metadata?: Record<string, unknown>
   ) => void;
   /**

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { usePaper } from './use-paper';
 import { useCellId } from './use-cell-id';
-import type { dia } from '@joint/core';
 import { PORTAL_SELECTOR } from '../mvc/element-model';
 
 /**
@@ -77,16 +76,25 @@ export function useMarkup(): MarkupApi {
   const id = useCellId();
   const applySelector = useCallback(
     (node: Element | null, selector: string) => {
-      const elementView = paper?.getCellView(id) as dia.ElementView | null;
-      if (!elementView) return;
+      // The view can exist but not yet have rendered its markup — its `selectors`
+      // map (the selector -> node dictionary) is then `undefined`: joint-core only
+      // assigns it during render and never re-nulls it. This happens during a
+      // visibility/teardown churn, e.g. hiding a cell when its group collapses. A
+      // ref-cleanup would otherwise do `delete undefined[selector]` and throw
+      // "Cannot convert undefined or null to object". Guard the map, not just the
+      // view. `selectors` isn't part of the public ElementView type, hence the cast
+      // to a deletable dictionary.
+      const elementView = paper?.getCellView(id) as {
+        selectors?: Record<string, Element | undefined>;
+      } | null;
+      const selectors = elementView?.selectors;
+      if (!selectors) return;
       if (node) {
         node.setAttribute('joint-selector', selector);
-        // @ts-expect-error - selector is dynamic key on selectors object
-        elementView.selectors[selector] = node;
+        selectors[selector] = node;
       } else {
-        // @ts-expect-error - selector is dynamic key on selectors object
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete elementView.selectors[selector];
+        delete selectors[selector];
       }
     },
     [paper, id]

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -207,6 +207,8 @@ export type {
   CellId,
   CellInput,
   CellRef,
+  CellRefList,
+  CellCollection,
   CellRecord,
   AnyCellRecord,
   Computed,

--- a/packages/joint-react/src/presets/paper-events.ts
+++ b/packages/joint-react/src/presets/paper-events.ts
@@ -60,6 +60,9 @@ type PointerLinkEventParams = WithPointer<LinkEventParams>;
 /** Pointer-style blank-area payload — event + coords on empty paper area. */
 type PointerBlankEventParams = WithPointer<BaseContext>;
 
+/** Focus-style cell-level payload (focusin/focusout) — cell context + event. */
+type FocusCellEventParams = WithHover<CellEventParams>;
+
 /** Hover-style cell-level payload (mouseenter/leave/over/out). */
 type HoverCellEventParams = WithHover<CellEventParams>;
 /** Hover-style element-level payload. */
@@ -179,6 +182,17 @@ const POINTER_CELL_MAP = {
   onLinkContextMenu: 'link:contextmenu',
 } as const;
 
+// Focus enters/leaves a cell when a focusable node inside it (e.g. a `tabindex`
+// element) gains/loses focus. `onCellFocus`/`onCellBlur` map to the paper's
+// `cell:focus` / `cell:blur` events, which are driven by the bubbling
+// `focusin`/`focusout` DOM events — plain `focus`/`blur` do not bubble and so
+// cannot be delegated to cells (the same reason React's own onFocus/onBlur use
+// focusin/focusout under the hood).
+const FOCUS_CELL_MAP = {
+  onCellFocus: 'cell:focus',
+  onCellBlur: 'cell:blur',
+} as const;
+
 const HOVER_CELL_MAP = {
   onCellMouseEnter: 'cell:mouseenter',
   onCellMouseLeave: 'cell:mouseleave',
@@ -280,6 +294,7 @@ const TRANSFORM_MAP = {
 
 const PAPER_EVENT_KEYS = new Set<string>([
   ...Object.keys(POINTER_CELL_MAP),
+  ...Object.keys(FOCUS_CELL_MAP),
   ...Object.keys(HOVER_CELL_MAP),
   ...Object.keys(WHEEL_CELL_MAP),
   ...Object.keys(MAGNET_MAP),
@@ -317,6 +332,10 @@ export interface PaperEventHandlers {
   readonly onCellPointerClick?: (params: PointerCellEventParams) => void;
   readonly onCellPointerDblClick?: (params: PointerCellEventParams) => void;
   readonly onCellContextMenu?: (params: PointerCellEventParams) => void;
+  // focus (cell — fires when a focusable node inside any cell gains/loses focus,
+  // driven by the bubbling focusin/focusout DOM events).
+  readonly onCellFocus?: (params: FocusCellEventParams) => void;
+  readonly onCellBlur?: (params: FocusCellEventParams) => void;
   // pointer (element)
   readonly onElementPointerDown?: (params: PointerElementEventParams) => void;
   readonly onElementPointerMove?: (params: PointerElementEventParams) => void;
@@ -498,6 +517,14 @@ export function addPaperEventListeners(paper: dia.Paper, handlers: PaperEventMap
       x,
       y,
     })
+  );
+
+  subscribeGroup(
+    controller,
+    paper,
+    eventMap,
+    FOCUS_CELL_MAP,
+    (view: dia.CellView, event: dia.Event) => ({ ...baseContext, ...makeCellContext(view), event })
   );
 
   subscribeGroup(

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -135,6 +135,37 @@ export const Paper = dia.Paper.extend(
 
     documentEvents: POINTER_DOCUMENT_EVENTS,
 
+    // Cell focus tracking. `focusin`/`focusout` bubble (unlike `focus`/`blur`),
+    // so they delegate to `.joint-cell` and report which cell owns the focused
+    // node (e.g. a `tabindex` element) via the `cell:focus` / `cell:blur` paper
+    // events. The parent hash is spread first because a subclass `events` object
+    // replaces — rather than merges with — the inherited one.
+    events: {
+      ...dia.Paper.prototype.events,
+      'focusin .joint-cell': 'handleCellFocus',
+      'focusout .joint-cell': 'handleCellBlur',
+    },
+
+    /**
+     * Delegated `focusin` on a cell — emit `cell:focus` naming the cell that
+     * owns the newly focused node.
+     * @param event - The delegated focusin event; `event.target` is the node.
+     */
+    handleCellFocus(this: dia.Paper, event: dia.Event) {
+      const view = this.findView<dia.ElementView | dia.LinkView>(event.target);
+      if (view) view.notify('cell:focus', event);
+    },
+
+    /**
+     * Delegated `focusout` on a cell — emit `cell:blur` naming the cell that
+     * owned the just-blurred node.
+     * @param event - The delegated focusout event; `event.target` is the node.
+     */
+    handleCellBlur(this: dia.Paper, event: dia.Event) {
+      const view = this.findView<dia.ElementView | dia.LinkView>(event.target);
+      if (view) view.notify('cell:blur', event);
+    },
+
     /**
      * Add listeners that record the original pointerdown target into the
      * drag's `evt.data`, so `pointermove` can use it as a `setPointerCapture`

--- a/packages/joint-react/src/types/cell.types.ts
+++ b/packages/joint-react/src/types/cell.types.ts
@@ -6,6 +6,7 @@ import type {
   Point as DiaPoint,
   Size as DiaSize,
 } from '@joint/core/types/dia';
+import type { Collection as MvcCollection } from '@joint/core/types/mvc';
 import type { ELEMENT_MODEL_TYPE } from '../mvc/element-model';
 import type { LINK_MODEL_TYPE } from '../mvc/link-model';
 import type { LinkPresetAttributes } from '../presets/link-attributes';
@@ -269,3 +270,19 @@ export type CellInput<
  * @group Types
  */
 export type CellRef = DiaGraph.CellRef;
+
+/**
+ * A JointJS cell collection (e.g. the `collection` from a selection). Iterable —
+ * it yields its `dia.Cell` models — so it can be passed directly to the bulk
+ * cell setters instead of `collection.toArray()`.
+ * @group Types
+ */
+export type CellCollection = MvcCollection<DiaCell>;
+
+/**
+ * A list of cell references accepted by `removeCells`: either a readonly array
+ * of {@link CellRef}s (ids and/or `dia.Cell` instances) or a {@link CellCollection}.
+ * Both are iterated the same way.
+ * @group Types
+ */
+export type CellRefList = readonly CellRef[] | CellCollection;


### PR DESCRIPTION
## Description

Several `@joint/react` `<Paper>` / graph-API fixes and additions reported 

- **`onCellFocus` / `onCellBlur` events** — `<Paper>` now emits `cell:focus` / `cell:blur` when a focusable node (e.g. a `tabindex` element) inside a cell gains/loses focus. Available both as `<Paper>` props and via `useOnPaperEvents`. Implemented by delegating the bubbling `focusin` / `focusout` DOM events to `.joint-cell` (plain `focus` / `blur` do not bubble — the same reason React's own `onFocus` / `onBlur` use `focusin` / `focusout`).

  ```tsx
  <Paper onCellFocus={({ id }) => selectCell([id])} />
  ```

- **Reactive visual grid** — changing `drawGridSize` (and grid options set via the `options` escape hatch) now redraws the grid. Previously only `drawGrid` / `gridSize` triggered a redraw, so `drawGridSize` updated snapping but left the rendered grid stale.

- **`removeCells()` / `resetCells()` accept a collection** — a JointJS cell collection (e.g. a selection's `collection`) can be passed directly, without `.toArray()`. Adds `CellCollection` / `CellRefList` types.

  ```ts
  const { removeCells } = useGraph();
  const { collection } = useSelection();
  removeCells(collection); // previously required collection.toArray()
  ```

- **`<Paper>` `style` vs `className`** — verified inline `style` correctly wins over `className`, same as a plain HTML `div`. It already behaved correctly; added a regression test to lock it in.

## Motivation and Context

Fixes:
- https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=210316690
- https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=210954116
- https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=210956012
- https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=210957778

All checks pass locally: typecheck, lint, knip, and Jest (React 19 — 1032 tests, React 18 — 1028 tests). New/updated unit tests cover each change.
