### PR TITLE
fix(joint-react): reactive visual grid + inline-style precedence

### DIFF
--- a/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper.test.tsx
@@ -119,4 +119,66 @@ describe('Paper', () => {
     ).toThrow(/cellVisibility.*escape hatch/);
     spy.mockRestore();
   });
+
+  it('keeps inline style authoritative over className (same as an HTML div)', async () => {
+    // Report: `<Paper style={{ width: 1000 }} className="w-10" />` should let the
+    // inline width win over the class, like any HTML element. The host div IS
+    // `paper.el`; the inline `style` must land on it (present in the `style`
+    // attribute) so the CSS cascade — inline beats class, there is no
+    // `!important` in paper.css — resolves in the user's favour. `_setDimensions`
+    // (which runs with width/height forced to `undefined`) must not wipe it.
+    const { container } = render(
+      <GraphProvider initialCells={CELLS}>
+        <Paper
+          style={{ width: 1000, height: 500 }}
+          className="w-10"
+          renderElement={renderRectElement}
+        />
+      </GraphProvider>
+    );
+    await waitFor(() => expect(container.querySelector('svg')).toBeTruthy());
+    const host = container.querySelector('.jj-paper');
+    if (!(host instanceof HTMLElement)) throw new Error('paper host div not found');
+    // Inline style survived on paper.el → wins over the class in a real browser.
+    expect(host.style.width).toBe('1000px');
+    expect(host.style.height).toBe('500px');
+    // The class is applied too (alongside the framework's jj-paper).
+    expect(host.classList.contains('w-10')).toBe(true);
+    expect(host.classList.contains('jj-paper')).toBe(true);
+  });
+
+  it('redraws the visual grid when drawGridSize changes reactively', async () => {
+    // Regression: the visual grid only redrew via the top-level `drawGrid`
+    // prop; `drawGridSize` changes updated snapping (gridSize) but left the
+    // rendered grid pattern stale.
+    const refHolder: { current: dia.Paper | null } = { current: null };
+    function App({ drawGridSize }: Readonly<{ drawGridSize: number }>) {
+      const ref = useRef<dia.Paper | null>(null);
+      useEffect(() => {
+        if (ref.current) refHolder.current = ref.current;
+      });
+      return (
+        <GraphProvider initialCells={CELLS}>
+          <Paper
+            ref={ref}
+            renderElement={renderRectElement}
+            style={{ width: 300, height: 200 }}
+            gridSize={10}
+            drawGridSize={drawGridSize}
+          />
+        </GraphProvider>
+      );
+    }
+    const patternWidth = () =>
+      refHolder.current?.el.querySelector('pattern')?.getAttribute('width') ?? null;
+
+    const { rerender } = render(<App drawGridSize={20} />);
+    await waitFor(() => {
+      rerender(<App drawGridSize={20} />);
+      expect(patternWidth()).toBe('20');
+    });
+
+    rerender(<App drawGridSize={60} />);
+    await waitFor(() => expect(patternWidth()).toBe('60'));
+  });
 });

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable @typescript-eslint/no-shadow */
-import { dia } from '@joint/core';
+import { dia, util } from '@joint/core';
 import {
   useDeferredValue,
   useEffect,
@@ -257,6 +257,12 @@ export function useCreatePortalPaper(
 
   const paperRef = useRef<PaperView | null>(null);
   const isReadyNotifiedRef = useRef(false);
+  // Last grid options pushed to the paper, so the visual grid is redrawn only
+  // when one of them actually changes (see the grid block in the update effect).
+  const gridSignatureRef = useRef<Pick<
+    dia.Paper.Options,
+    'drawGrid' | 'drawGridSize' | 'gridSize'
+  > | null>(null);
 
   const [HTMLRendererContainer, setHTMLRendererContainer] = useState<HTMLElement | null>(null);
 
@@ -402,16 +408,26 @@ export function useCreatePortalPaper(
       ...escapeHatchOptions,
     });
 
-    const { drawGrid, gridSize } = paperOptions;
-
     paper.setInteractivity(interactiveValue);
 
-    if (drawGrid !== undefined) {
-      paper.setGrid(drawGrid);
+    // Redraw the visual grid whenever any grid-affecting option changes.
+    // `assignOptions` above already wrote drawGrid / drawGridSize / gridSize
+    // onto `paper.options`, and `setGrid` re-reads them (`drawGridSize ||
+    // gridSize`), so a single call keeps the rendered grid in sync for both the
+    // snap size and the visual spacing/style. This covers `drawGridSize` (which
+    // `paper.setGridSize` deliberately skips) and grid options set through the
+    // `options` escape hatch — the previous per-prop calls missed both. The
+    // equality guard keeps the grid from re-rendering on unrelated re-renders.
+    const nextGrid = {
+      drawGrid: paper.options.drawGrid,
+      drawGridSize: paper.options.drawGridSize,
+      gridSize: paper.options.gridSize,
+    };
+    if (!util.isEqual(gridSignatureRef.current, nextGrid)) {
+      gridSignatureRef.current = nextGrid;
+      paper.setGrid(paper.options.drawGrid);
     }
-    if (gridSize !== undefined) {
-      paper.setGridSize(gridSize);
-    }
+
     if (transform !== undefined) {
       paper.matrix(toSVGMatrix(transform));
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Two `<Paper/>` bug fixes, split out of #3428 so they can ship ahead of the larger feature work in that PR.

### 1. Visual grid is not reactive (`fix`)

`useCreatePortalPaper` only pushed grid changes to the paper with per-prop `setGrid` / `setGridSize` calls. As a result:

- `drawGridSize` changes updated snapping (`gridSize`) but left the **rendered** grid pattern stale — `setGridSize` deliberately skips the visual grid.
- Grid options set through the `options` escape hatch were ignored entirely.

The fix recomputes the grid from `paper.options` (`drawGrid` / `drawGridSize` / `gridSize`) and re-runs `setGrid` whenever any of them actually changes, guarded by an equality check so unrelated re-renders don't trigger a redraw.

### 2. Inline `style` vs `className` precedence (regression test)

`<Paper style={{ width: 1000 }} className="w-10" />` should let the inline width win over the class, exactly like a plain HTML element. This already resolves correctly on `master` (the inline `style` lands on the `.jj-paper` host element and the cascade favours it — there is no `!important` in `paper.css`), so this PR adds a **regression test** to lock the behaviour and guard against `_setDimensions` wiping the inline style.

## Motivation and Context

These are triaged `<Paper/>` bugs (grid reactivity — Medium; style/className order — High) that users hit directly. They were developed alongside unrelated feature work in #3428; pulling them into their own PR lets the fixes be reviewed and released on their own timeline while the features continue separately. The changes remain in #3428 as well.

**Verification:** `yarn test` passes — typecheck, lint, knip, jest 93 suites / 1028 tests (React 19) and 92 / 1024 (React 18), including the two new regression tests.

### Screenshots (if appropriate):
