### PR TITLE
types(geometry): Segment.getSegment code never returns null

### DIFF
--- a/packages/joint-core/types/geometry.d.ts
+++ b/packages/joint-core/types/geometry.d.ts
@@ -395,7 +395,7 @@ export class Path {
 
     equals(p: Path): boolean;
 
-    getSegment(index: number): Segment | null;
+    getSegment(index: number): Segment;
 
     getSegmentSubdivisions(opt?: PrecisionOpt): Curve[][];
 


### PR DESCRIPTION
## Description

Corrects the return type of `Segment.getSegment()` - its source code never returns null.

## Motivation and Context

This is relevant for `strict` TS consumers and prevents unnecessary non-null assertions.