### PR TITLE
docs(joint-react): add link to Storybook to README

### DIFF
--- a/packages/joint-react/.storybook/main.ts
+++ b/packages/joint-react/.storybook/main.ts
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename);
 
 configureSort({
   storyOrder: {
+    introduction: null,
     tutorials: null,
     examples: null,
     components: null,

--- a/packages/joint-react/.storybook/preview.ts
+++ b/packages/joint-react/.storybook/preview.ts
@@ -16,11 +16,9 @@ const preview: Preview = {
         dark: { name: 'Dark', value: theme.appBg },
       },
     },
-    parameters: {
-      options: {
-        // @ts-expect-error its storybook multilevel sort
-        storySort: (a, b) => globalThis['storybook-multilevel-sort:storySort'](a, b),
-      },
+    options: {
+      // @ts-expect-error its storybook multilevel sort
+      storySort: (a, b) => globalThis['storybook-multilevel-sort:storySort'](a, b),
     },
     controls: {
       matchers: {

--- a/packages/joint-react/README.md
+++ b/packages/joint-react/README.md
@@ -106,7 +106,7 @@ Explore the [demos](https://www.jointjs.com/demos) to see them in action.
 - 📖 [Learn JointJS for React](https://docs.jointjs.com/react)
 - 🧾 [API reference](https://docs.jointjs.com/api-react)
 - 🖼️ [Examples](https://www.jointjs.com/demos)
-- 📚 [Storybook](https://react.jointjs.com/learn/?path=/docs/introduction--docs)
+- 📚 [Storybook](https://react.jointjs.com/learn/)
 - 🤖 [MCP server](#using-jointjs-for-react-with-ai-coding-agents)
 - 💬 [Ask a question or share feedback](https://github.com/clientIO/joint/discussions)
 

--- a/packages/joint-react/README.md
+++ b/packages/joint-react/README.md
@@ -106,6 +106,7 @@ Explore the [demos](https://www.jointjs.com/demos) to see them in action.
 - 📖 [Learn JointJS for React](https://docs.jointjs.com/react)
 - 🧾 [API reference](https://docs.jointjs.com/api-react)
 - 🖼️ [Examples](https://www.jointjs.com/demos)
+- 📚 [Storybook](https://react.jointjs.com/learn/?path=/docs/introduction--docs)
 - 🤖 [MCP server](#using-jointjs-for-react-with-ai-coding-agents)
 - 💬 [Ask a question or share feedback](https://github.com/clientIO/joint/discussions)
 


### PR DESCRIPTION
## Description

Adds a link to Storybook to joint-react's README file.

Also fixes Storybook to use the introduction page as the homepage (add as first entry in story ordering and fix config so the story ordering works.