### PR TITLE
fix(routers.rightAngle): allow zero-value margins and un-clamp minPathMargin

### DIFF
--- a/examples/right-angle-playground-js/index.html
+++ b/examples/right-angle-playground-js/index.html
@@ -4,12 +4,30 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A playground for the right-angle router with movable vertices, anchors, and a resize handle.">
+    <meta name="description" content="A playground for the right-angle router playground">
     <title>JointJS: Right Angle Router Playground</title>
 </head>
 
 <body id="app">
-    <div id="paper-container"></div>
+    <div class="toolbar">
+        <div class="control-group">
+            <label for="source-margin">sourceMargin</label>
+            <input type="range" id="source-margin" min="0" max="30" step="1" />
+            <output id="source-margin-val"></output>
+        </div>
+        <div class="control-group">
+            <label for="target-margin">targetMargin</label>
+            <input type="range" id="target-margin" min="0" max="30" step="1" />
+            <output id="target-margin-val"></output>
+        </div>
+        <div class="control-group">
+            <label for="min-path-margin">minPathMargin</label>
+            <input type="range" id="min-path-margin" min="0" max="30" step="1" />
+            <output id="min-path-margin-val"></output>
+        </div>
+    </div>
+
+    <div id="paper"></div>
     <!-- Application files: -->
     <script type="module" src="/src/main.js"></script>
 </body>

--- a/examples/right-angle-playground-js/index.html
+++ b/examples/right-angle-playground-js/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A playground for the right-angle router playground">
+    <meta name="description" content="Interactive playground for the right-angle router.">
     <title>JointJS: Right Angle Router Playground</title>
 </head>
 

--- a/examples/right-angle-playground-js/src/main.js
+++ b/examples/right-angle-playground-js/src/main.js
@@ -1,4 +1,5 @@
 import { dia, shapes, linkTools, elementTools } from '@joint/core';
+
 import './styles.css';
 
 class ResizeTool extends elementTools.Control {
@@ -20,78 +21,81 @@ class ResizeTool extends elementTools.Control {
 const graph = new dia.Graph({}, { cellNamespace: shapes });
 
 const paper = new dia.Paper({
-    el: document.getElementById('paper-container'),
-    width: '100%',
-    height: '100%',
-    gridSize: 10,
-    async: true,
-    frozen: true,
+    el: document.getElementById('paper'),
+    width: 800,
+    height: 800,
     model: graph,
     cellViewNamespace: shapes,
-    defaultRouter: { name: 'rightAngle', args: {
-        useVertices: true,
-        margin: 40,
-        minPathMargin: 10,
-        //sourceMargin: 40,
-        //targetMargin: 30
-    }},
-    defaultConnector: { name: 'rounded' },
-    background: {
-        color: '#151D29'
-    },
-    defaultLinkAnchor: {
-        name: 'connectionRatio',
-        args: {
-            ratio: 0.25
-        }
-    }
+    async: true,
+    frozen: true,
+    defaultAnchor: { name: 'midSide', args: { mode: 'right-left' } },
+    defaultConnector: { name: 'rounded', args: { radius: 8 } }
 });
 
-paper.setGrid({ name: 'dot'});
+// Router options, tuned live from the toolbar.
+const options = { sourceMargin: 20, targetMargin: 20, minPathMargin: 20 };
 
-const rect = new shapes.standard.Rectangle({
-    position: { x: 120, y: 120 },
-    size: { width: 220, height: 60 },
+// A rectangle with an extra rect behind the body that visualises its routing
+// margin: the band's stroke width is half the margin (margin = strokeWidth * 2).
+const MarginRectangle = shapes.standard.Rectangle.define('demo.MarginRectangle', {
     attrs: {
-        body: {
-            stroke: 'none',
-            fill: '#DF423D',
-            rx: 10,
-            ry: 10,
-        }
+        margin: {
+            x: 0,
+            y: 0,
+            width: 'calc(w)',
+            height: 'calc(h)',
+            rx: 8,
+            ry: 8,
+            fill: 'none',
+            stroke: '#226CE0',
+            strokeOpacity: 0.15,
+            pointerEvents: 'none'
+        },
+        body: { rx: 8, ry: 8, stroke: '#226CE0', fill: '#eef4ff' }
     }
+}, {
+    markup: [
+        { tagName: 'rect', selector: 'margin' },
+        { tagName: 'rect', selector: 'body' },
+        { tagName: 'text', selector: 'label' }
+    ]
 });
 
-const rect2 = rect.clone();
+const el1 = new MarginRectangle({
+    position: { x: 200, y: 50 },
+    size: { width: 110, height: 44 },
+    attrs: { label: { text: 'Source', fontSize: 12 } }
+});
 
-rect2.resize(60, 220);
-rect2.position(300, 250);
+const el2 = new MarginRectangle({
+    position: { x: 220, y: 120 },
+    size: { width: 110, height: 44 },
+    attrs: { label: { text: 'Target', fontSize: 12 } }
+});
 
 const link = new shapes.standard.Link({
+    source: { id: el1.id },
+    target: { id: el2.id },
+    // The rightAngle router is set explicitly on the link.
+    router: { name: 'rightAngle', args: { ...options } },
     attrs: {
         line: {
-            stroke: 'white'
+            stroke: '#f43f5e',
+            strokeWidth: 3,
+            targetMarker: { fill: '#f43f5e' }
+        },
+        // The wrapper band visualises the minPathMargin corridor.
+        wrapper: {
+            stroke: '#f43f5e',
+            strokeOpacity: 0.2,
+            strokeLinecap: 'none'
         }
     }
 });
 
-link.source({ id: rect.id, anchor: { name: 'top' }});
-link.target({ id: rect2.id, anchor: { name: 'right' }});
+graph.addCells([el1, el2, link]);
 
-graph.addCells([rect, rect2, link]);
-
-rect.findView(paper).addTools(
-    new dia.ToolsView({
-        tools: [
-            new ResizeTool({
-                selector: 'body',
-
-            })
-        ]
-    })
-);
-
-rect2.findView(paper).addTools(
+el1.findView(paper).addTools(
     new dia.ToolsView({
         tools: [
             new ResizeTool({
@@ -101,37 +105,58 @@ rect2.findView(paper).addTools(
     })
 );
 
-const linkToolsView = new dia.ToolsView({
-    tools: [
-        new linkTools.Vertices({
-            focusOpacity: 0.5,
-        }),
-        new linkTools.TargetAnchor({
-            focusOpacity: 0.5,
-            scale: 1.2
-        }),
-        new linkTools.SourceAnchor({
-            focusOpacity: 0.5,
-            scale: 1.2
-        }),
-    ]
-});
+el2.findView(paper).addTools(
+    new dia.ToolsView({
+        tools: [
+            new ResizeTool({
+                selector: 'body'
+            })
+        ]
+    })
+);
 
-link.findView(paper).addTools(linkToolsView);
+link.findView(paper).addTools(
+    new dia.ToolsView({
+        tools: [
+            new linkTools.Vertices({
+                focusOpacity: 0.5
+            }),
+            new linkTools.TargetAnchor({
+                focusOpacity: 0.5,
+                scale: 1.2
+            }),
+            new linkTools.SourceAnchor({
+                focusOpacity: 0.5,
+                scale: 1.2
+            })
+        ]
+    })
+);
 
-function scaleToFit() {
-    const graphBBox = graph.getBBox();
-    paper.transformToFitContent({
-        contentArea: graphBBox.clone().inflate(0, 100)
-    });
-    const { sy } = paper.scale();
-    const area = paper.getArea();
-    const yTop = area.height / 2 - graphBBox.y - graphBBox.height / 2;
-    const xLeft = area.width / 2 - graphBBox.x - graphBBox.width / 2;
-    paper.translate(xLeft * sy, yTop * sy);
+function render() {
+    // The band straddles the element edge, so a strokeWidth of margin * 2
+    // extends the margin distance outward on every side.
+    el1.attr('margin/strokeWidth', options.sourceMargin * 2);
+    el2.attr('margin/strokeWidth', options.targetMargin * 2);
+    link.attr('wrapper/strokeWidth', options.minPathMargin * 2);
+    link.router('rightAngle', { ...options });
 }
 
-window.addEventListener('resize', () => scaleToFit());
-scaleToFit();
+function bind(id, key) {
+    const input = document.getElementById(id);
+    const output = document.getElementById(`${id}-val`);
+    input.value = options[key];
+    output.textContent = options[key];
+    input.addEventListener('input', () => {
+        options[key] = Number(input.value);
+        output.textContent = options[key];
+        render();
+    });
+}
 
+bind('source-margin', 'sourceMargin');
+bind('target-margin', 'targetMargin');
+bind('min-path-margin', 'minPathMargin');
+
+render();
 paper.unfreeze();

--- a/examples/right-angle-playground-js/src/main.js
+++ b/examples/right-angle-playground-js/src/main.js
@@ -88,7 +88,7 @@ const link = new shapes.standard.Link({
         wrapper: {
             stroke: '#f43f5e',
             strokeOpacity: 0.2,
-            strokeLinecap: 'none'
+            strokeLinecap: 'butt'
         }
     }
 });

--- a/examples/right-angle-playground-js/src/styles.css
+++ b/examples/right-angle-playground-js/src/styles.css
@@ -10,7 +10,7 @@ body {
     height: 100vh;
 }
 
-#paper-container {
+#paper {
     position: absolute;
     inset: 0;
     overflow: hidden;

--- a/examples/right-angle-playground-js/src/styles.css
+++ b/examples/right-angle-playground-js/src/styles.css
@@ -5,7 +5,7 @@
 }
 
 body {
-    background-color: #151D29;
+    background-color: #f8fafc;
     width: 100%;
     height: 100vh;
 }
@@ -14,4 +14,37 @@ body {
     position: absolute;
     inset: 0;
     overflow: hidden;
+}
+
+.toolbar {
+    padding: 8px 12px;
+    border-bottom: 1px solid #ccc;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+}
+
+.control-group label {
+    font-family: monospace;
+    color: #226CE0;
+}
+
+.control-group output {
+    min-width: 18px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: #64748b;
+}
+
+input[type="range"] {
+    accent-color: #226CE0;
+    cursor: pointer;
 }

--- a/packages/joint-core/src/routers/rightAngle.mjs
+++ b/packages/joint-core/src/routers/rightAngle.mjs
@@ -488,8 +488,8 @@ function routeBetweenPoints(source, target, opt = {}) {
 
     const { targetInSourceBBox = false } = opt;
 
-    const minSourceMargin = opt.minPathMargin != null ? Math.min(opt.minPathMargin, sourceMargin) : sourceMargin;
-    const minTargetMargin = opt.minPathMargin != null ? Math.min(opt.minPathMargin, targetMargin) : targetMargin;
+    const minSourceMargin = opt.minPathMargin ?? sourceMargin;
+    const minTargetMargin = opt.minPathMargin ?? targetMargin;
 
     const tBoxX1 = tBoxX0 + targetWidth;
     const tBoxY1 = tBoxY0 + targetHeight;
@@ -1866,10 +1866,10 @@ function getLoopCoordinates(direction, angle, margin) {
 
 function rightAngleRouter(vertices, opt, linkView) {
     const { sourceDirection = Directions.AUTO, targetDirection = Directions.AUTO, minPathMargin = null } = opt;
-    const margin = opt.margin || 20;
+    const margin = opt.margin ?? 20;
 
-    const sourceMargin = opt.sourceMargin || margin;
-    const targetMargin = opt.targetMargin || margin;
+    const sourceMargin = opt.sourceMargin ?? margin;
+    const targetMargin = opt.targetMargin ?? margin;
 
     const useVertices = opt.useVertices || false;
 

--- a/packages/joint-core/test/jointjs/routers.js
+++ b/packages/joint-core/test/jointjs/routers.js
@@ -2625,98 +2625,147 @@ QUnit.module('routers', function(hooks) {
         assert.checkDataPath(d, 'M 25 0 L 25 -28 L 100 -28 L 100 150 L -28 150 L -28 175 L 0 175', 'Source above target with vertex inside the target element bbox');
     });
 
-    // minMargin tests
+    // minPathMargin tests
     // r1 at (0,0), r2 repositioned so their margin zones overlap.
-    // margin=28, minMargin=5 → minSourceMargin=minTargetMargin=5, used as tighter routing boundaries.
+    // margin=28, minPathMargin=5 → minSourceMargin=minTargetMargin=5, used as tighter routing boundaries.
 
-    QUnit.test('rightAngle routing - minMargin - source: bottom, target: top', function(assert) {
-        // r1 at (0,0), r2 at (60,20) — elements offset horizontally so their x-margin zones barely touch.
-        // source outside point: (25, 78);  target outside point: (85, -8)
-        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin, minMargin: 5 }});
-        r2.position(60, 20);
+    QUnit.test('rightAngle routing - minPathMargin - source: bottom, target: top', function(assert) {
+        // r1 at (0,0), r2 at (70,20) — a 20px gap between the elements: wider than
+        // 2 * minPathMargin (10), so the narrower minPathMargin zone no longer triggers
+        // the detour, but narrower than 2 * margin (56), so plain margin still does.
+        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin, minPathMargin: 5 }});
+        r2.position(70, 20);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 25 50 L 25 98 L 138 98 L 138 -8 L 85 -8 L 85 20', 'minMargin - source: bottom, target: top');
+        assert.checkDataPath(d, 'M 25 50 L 25 78 L 60 78 L 60 -8 L 95 -8 L 95 20', 'minPathMargin - source: bottom, target: top');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 25 50 L 25 98 L 138 98 L 138 -8 L 85 -8 L 85 20', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 25 50 L 25 98 L 148 98 L 148 -8 L 95 -8 L 95 20', 'Without minPathMargin, route detours around margin zones');
     });
 
-    QUnit.test('rightAngle routing - minMargin - source: top, target: bottom', function(assert) {
-        // r1 at (0,0), r2 at (60,20) — elements offset horizontally so their x-margin zones barely touch.
-        // source outside point: (25, -28);  target outside point: (85, 98)
-        const [, r2, l] = this.addTestSubjects('top', 'bottom', { name: 'rightAngle', args: { margin, minMargin: 5 }});
-        r2.position(60, 20);
+    QUnit.test('rightAngle routing - minPathMargin - source: top, target: bottom', function(assert) {
+        // r1 at (0,0), r2 at (70,20) — a 20px gap between the elements: wider than
+        // 2 * minPathMargin (10), so the narrower minPathMargin zone no longer triggers
+        // the detour, but narrower than 2 * margin (56), so plain margin still does.
+        const [, r2, l] = this.addTestSubjects('top', 'bottom', { name: 'rightAngle', args: { margin, minPathMargin: 5 }});
+        r2.position(70, 20);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 138 -28 L 138 98 L 85 98 L 85 70', 'minMargin - source: top, target: bottom');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 60 -28 L 60 98 L 95 98 L 95 70', 'minPathMargin - source: top, target: bottom');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 138 -28 L 138 98 L 85 98 L 85 70', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 25 0 L 25 -28 L 148 -28 L 148 98 L 95 98 L 95 70', 'Without minPathMargin, route detours around margin zones');
     });
 
-    QUnit.test('rightAngle routing - minMargin - source: right, target: left', function(assert) {
-        // r1 at (0,0), r2 at (20,60) — elements offset vertically so their y-margin zones barely touch.
-        // source outside point: (78, 25);  target outside point: (-8, 85)
-        const [, r2, l] = this.addTestSubjects('right', 'left', { name: 'rightAngle', args: { margin, minMargin: 5 }});
-        r2.position(20, 60);
+    QUnit.test('rightAngle routing - minPathMargin - source: right, target: left', function(assert) {
+        // r1 at (0,0), r2 at (20,70) — a 20px gap between the elements: wider than
+        // 2 * minPathMargin (10), so the narrower minPathMargin zone no longer triggers
+        // the detour, but narrower than 2 * margin (56), so plain margin still does.
+        const [, r2, l] = this.addTestSubjects('right', 'left', { name: 'rightAngle', args: { margin, minPathMargin: 5 }});
+        r2.position(20, 70);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 50 25 L 98 25 L 98 138 L -8 138 L -8 85 L 20 85', 'minMargin - source: right, target: left');
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 60 L -8 60 L -8 95 L 20 95', 'minPathMargin - source: right, target: left');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 50 25 L 98 25 L 98 138 L -8 138 L -8 85 L 20 85', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 50 25 L 98 25 L 98 148 L -8 148 L -8 95 L 20 95', 'Without minPathMargin, route detours around margin zones');
     });
 
-    QUnit.test('rightAngle routing - minMargin - source: left, target: right', function(assert) {
-        // r1 at (60,0), r2 at (0,60) — elements offset vertically so their y-margin zones barely touch.
-        // source outside point: (32, 25);  target outside point: (78, 85)
-        const [r1, r2, l] = this.addTestSubjects('left', 'right', { name: 'rightAngle', args: { margin, minMargin: 5 }});
+    QUnit.test('rightAngle routing - minPathMargin - source: left, target: right', function(assert) {
+        // r1 at (60,0), r2 at (0,70) — a 20px gap between the elements: wider than
+        // 2 * minPathMargin (10), so the narrower minPathMargin zone no longer triggers
+        // the detour, but narrower than 2 * margin (56), so plain margin still does.
+        const [r1, r2, l] = this.addTestSubjects('left', 'right', { name: 'rightAngle', args: { margin, minPathMargin: 5 }});
         r1.position(60, 0);
-        r2.position(0, 60);
+        r2.position(0, 70);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 60 25 L -28 25 L -28 138 L 78 138 L 78 85 L 50 85', 'minMargin - source: left, target: right');
+        assert.checkDataPath(d, 'M 60 25 L 32 25 L 32 60 L 78 60 L 78 95 L 50 95', 'minPathMargin - source: left, target: right');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 60 25 L -28 25 L -28 138 L 78 138 L 78 85 L 50 85', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 60 25 L -28 25 L -28 148 L 78 148 L 78 95 L 50 95', 'Without minPathMargin, route detours around margin zones');
     });
 
     // The facing-elements condition: source left anchor facing a target right anchor (and the reverse).
-    // Positions are chosen so the anchors' outside points land outside the inflated bboxes (no S-shape).
-    // r1 at (100,0), r2 at (0,60), minMargin=25: minSourceMargin=minTargetMargin=25.
+    // Positions are chosen so the anchors' outside points land outside the inflated bboxes (no S-shape),
+    // and the 52px vertical gap between the elements is wider than 2 * minPathMargin (50) - so the
+    // narrower minPathMargin zone no longer triggers the detour - but narrower than 2 * margin (56),
+    // so plain margin still does.
 
-    QUnit.test('rightAngle routing - minMargin facing - source: left, target: right', function(assert) {
-        // r1 at (100,0), r2 at (0,60) — anchors face each other with a 50px gap (tox−smx0=6=ignoreOverlappingMargin).
-        // source outside point: (72, 25);  target outside point: (78, 85)
-        const [r1, r2, l] = this.addTestSubjects('left', 'right', { name: 'rightAngle', args: { margin, minMargin: 25 }});
+    QUnit.test('rightAngle routing - minPathMargin facing - source: left, target: right', function(assert) {
+        const [r1, r2, l] = this.addTestSubjects('left', 'right', { name: 'rightAngle', args: { margin, minPathMargin: 25 }});
         r1.position(100, 0);
-        r2.position(0, 60);
+        r2.position(0, 102);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 100 25 L -28 25 L -28 138 L 78 138 L 78 85 L 50 85', 'minMargin facing - source: left, target: right');
+        assert.checkDataPath(d, 'M 100 25 L 72 25 L 72 76 L 78 76 L 78 127 L 50 127', 'minPathMargin facing - source: left, target: right');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 100 25 L -28 25 L -28 138 L 78 138 L 78 85 L 50 85', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 100 25 L -28 25 L -28 180 L 78 180 L 78 127 L 50 127', 'Without minPathMargin, route detours around margin zones');
     });
 
-    QUnit.test('rightAngle routing - minMargin facing - source: right, target: left', function(assert) {
-        // r1 at (0,0), r2 at (100,60) — anchors face each other with a 50px gap (smx1−tox=6=ignoreOverlappingMargin).
-        // source outside point: (78, 25);  target outside point: (72, 85)
-        const [, r2, l] = this.addTestSubjects('right', 'left', { name: 'rightAngle', args: { margin, minMargin: 25 }});
-        r2.position(100, 60);
+    QUnit.test('rightAngle routing - minPathMargin facing - source: right, target: left', function(assert) {
+        const [, r2, l] = this.addTestSubjects('right', 'left', { name: 'rightAngle', args: { margin, minPathMargin: 25 }});
+        r2.position(100, 102);
 
         let d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 50 25 L 178 25 L 178 138 L 72 138 L 72 85 L 100 85', 'minMargin facing - source: right, target: left');
+        assert.checkDataPath(d, 'M 50 25 L 78 25 L 78 76 L 72 76 L 72 127 L 100 127', 'minPathMargin facing - source: right, target: left');
 
         l.router({ name: 'rightAngle', args: { margin }});
         d = this.paper.findViewByModel(l).metrics.data;
-        assert.checkDataPath(d, 'M 50 25 L 178 25 L 178 138 L 72 138 L 72 85 L 100 85', 'Without minMargin, route detours around margin zones');
+        assert.checkDataPath(d, 'M 50 25 L 178 25 L 178 180 L 72 180 L 72 127 L 100 127', 'Without minPathMargin, route detours around margin zones');
+    });
+
+    // Zero-value margin tests
+    // r1 at (0,0), r2 at (60,20) — same offset used by the minPathMargin tests above.
+
+    QUnit.test('rightAngle routing - margin: 0', function(assert) {
+        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin: 0 }});
+        r2.position(60, 20);
+
+        const d = this.paper.findViewByModel(l).metrics.data;
+        assert.checkDataPath(d, 'M 25 50 L 25 50 L 55 50 L 55 20 L 85 20 L 85 20', 'margin: 0 - source: bottom, target: top');
+    });
+
+    // r1 at (0,0), r2 at (120,20) - far enough apart horizontally that the route
+    // takes the simple one-bend shape, so the first/last segments directly reflect
+    // each side's own margin instead of being masked by the other side's margin.
+
+    QUnit.test('rightAngle routing - sourceMargin: 0', function(assert) {
+        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin, sourceMargin: 0 }});
+        r2.position(120, 20);
+
+        const d = this.paper.findViewByModel(l).metrics.data;
+        assert.checkDataPath(d, 'M 25 50 L 25 50 L 85 50 L 85 -8 L 145 -8 L 145 20', 'sourceMargin: 0 - source: bottom, target: top');
+    });
+
+    QUnit.test('rightAngle routing - targetMargin: 0', function(assert) {
+        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin, targetMargin: 0 }});
+        r2.position(120, 20);
+
+        const d = this.paper.findViewByModel(l).metrics.data;
+        assert.checkDataPath(d, 'M 25 50 L 25 78 L 85 78 L 85 20 L 145 20 L 145 20', 'targetMargin: 0 - source: bottom, target: top');
+    });
+
+    QUnit.test('rightAngle routing - minPathMargin larger than margin', function(assert) {
+        // r1 at (0,0), r2 at (100,20) - with margin=5 the two elements are far enough
+        // apart that the route takes the simple one-bend shape. minPathMargin=50 widens
+        // the overlap-detection zone (independently of the 5px margin used for the route's
+        // own coordinates) enough that it now includes the bend, forcing a wider detour.
+        const [, r2, l] = this.addTestSubjects('bottom', 'top', { name: 'rightAngle', args: { margin: 5, minPathMargin: 50 }});
+        r2.position(100, 20);
+
+        let d = this.paper.findViewByModel(l).metrics.data;
+        assert.checkDataPath(d, 'M 25 50 L 25 75 L 155 75 L 155 15 L 125 15 L 125 20', 'minPathMargin larger than margin - source: bottom, target: top');
+
+        l.router({ name: 'rightAngle', args: { margin: 5 }});
+        d = this.paper.findViewByModel(l).metrics.data;
+        assert.checkDataPath(d, 'M 25 50 L 25 55 L 75 55 L 75 15 L 125 15 L 125 20', 'Without minPathMargin, the 5px margin does not force a detour');
     });
 
     QUnit.test('rightAngle routing with source anchor outside the element bbox', function(assert) {


### PR DESCRIPTION
## Summary
- `rightAngle` router used `||` for `margin`, `sourceMargin`, and `targetMargin`, so `0` was silently coerced back to the default (20/`margin`) instead of being honored.
- `minPathMargin` was clamped with `Math.min(opt.minPathMargin, sourceMargin/targetMargin)`, so it could only ever narrow the overlap-detection zone, never widen it beyond `margin`.
- Both are now resolved with `??`, so `0` is respected and `minPathMargin` can be set larger than `margin` to intentionally widen the detour-detection zone.
- Rewrote the `right-angle-playground-js` example into an interactive demo with live sliders for `sourceMargin`, `targetMargin`, and `minPathMargin`, visualizing each margin as a band around the elements/link.

## Test plan
- [x] Added tests covering `margin: 0`, `sourceMargin: 0`, and `targetMargin: 0`.
- [x] Added a test demonstrating `minPathMargin` larger than `margin` actually changes the route.
- [x] Renamed the pre-existing (mistyped) `minMargin` test option to `minPathMargin` and adjusted element positions so the "with"/"without" assertions in each of those tests actually diverge instead of asserting identical paths.
- [x] `grunt karma:joint` passes for `test/jointjs/routers.js` (66/66); full `joint` suite shows only 2 pre-existing, unrelated failures (`util.breakText ellipsis`, `port labels label attributes`).
- [x] `eslint` clean on the modified test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)