### PR TITLE
chore: enable yarn deferred versioning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,11 @@ Thank you for submitting a pull request!
 
 Please verify that:
 * [ ] Code is up-to-date with the `master` branch
-* [ ] You've successfully run `grunt test` locally
+* [ ] You've successfully run `yarn test` locally
 * [ ] If applicable, there are new or updated unit tests validating the change
 * [ ] If applicable, there are new or updated @types
 * [ ] If applicable, documentation has been updated
+* [ ] You've declared a version bump with `yarn version-check` and committed the generated `.yarn/versions/*.yml` file (or the change needs no release)
 -->
 
 ## Description

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -62,6 +62,13 @@ jobs:
         id: install-dependencies
         run: yarn install --immutable
 
+      # Ensure every PR declares version bumps for the packages it changes
+      # (deferred versioning: entries live in .yarn/versions/*.yml)
+      - name: Check version bumps
+        id: version-check
+        if: ${{ github.event_name == 'pull_request' }}
+        run: yarn version check
+
       # Build the joint project
       - name: Prepare joint
         id: prepare-joint

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,74 @@
 compressionLevel: mixed
 
+# Deferred versioning (`yarn version check` / `yarn version apply`).
+# `changesetBaseRefs` is the git ref the change detection diffs against;
+# `changesetIgnorePatterns` are paths that never require a version bump.
+changesetBaseRefs:
+  - master
+  - origin/master
+  - upstream/master
+
+changesetIgnorePatterns:
+  # A change to a publishable package requires a version bump ONLY when it
+  # touches distributed source, types, an entry file, or its package.json.
+  # = For reference, the following paths that ARE allowed to trigger a bump:
+  #- "**/src/**"                # source (all packages)
+  #- "**/types/**"              # @joint/core public type tree
+  #- "**/*.d.ts"                # hand-written type decls (svg.d.ts, DirectedGraph.d.ts)
+  #- "**/package.json"          # dependencies / exports / manifest
+  #- "**/wrappers/**"           # @joint/core build-time bundle wrappers
+  #- "**/mocks/**"              # @joint/vitest-plugin-mock-svg shipped mocks
+  #- "**/index.js"              # @joint/core entry
+  #- "**/index.mjs"             # @joint/eslint-config entry
+  #- "**/joint.mjs"             # @joint/core ESM entry
+  #- "**/DirectedGraph.mjs"     # @joint/layout-directed-graph entry
+  #- "**/eslint.config.*.mjs"   # @joint/eslint-config product configs
+  # = Everything below is IGNORED (never triggers a bump)
+
+  # Tests, mocks, benchmarks, demos, stories (not shipped)
+  - "**/*.test.{js,ts,mjs}"
+  - "**/test/**"
+  - "**/__mocks__/**"
+  - "**/bench/**"
+  - "**/demo/**"
+  - "**/stories/**"
+  - "**/.storybook/**"
+
+  # Generated build output & caches (produced from src/, git-ignored anyway)
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/coverage/**"
+  - "**/coverage.json"
+  - "**/.tscache/**"
+
+  # Build & tooling scripts / config (do not change the published API)
+  - "**/scripts/**"
+  - "**/grunt/**"
+  - "**/Gruntfile.js"
+  - "**/Makefile"
+  - "**/rollup.config.*"
+  - "**/rollup.resources.mjs"
+  - "**/vite.config.*"
+  - "**/vitest.workspace.*"
+  - "**/jest.config.js"
+  - "**/jest.react18.config.mjs"
+  - "**/karma.conf.js"
+  - "**/tsconfig*.json"
+  - "**/dts-generator.config.js"
+  - "**/api-extractor.json"
+  - "**/knip.json"
+  - "**/typedoc.*"
+  - "**/.prettierrc*"
+  - "**/.gitignore"
+
+  # Per-package lint config only. @joint/eslint-config ships
+  # `eslint.config.<name>.mjs` files, which this exact pattern does NOT match.
+  - "**/eslint.config.mjs"
+
+  # Documentation & metadata
+  - "**/*.md"
+  - "**/LICENSE"
+
 enableGlobalCache: false
 
 logFilters:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,34 @@ Before submitting a PR, please verify:
 - [ ] If applicable, there are new or updated unit tests validating the change
 - [ ] If applicable, there are new or updated @types
 - [ ] If applicable, documentation has been updated
+- [ ] You've declared a version bump with `yarn version-check` and committed the generated `.yarn/versions/*.yml` file (or the change needs no release — e.g. tests/docs only)
+
+### Versioning Your Change
+
+We use [Yarn's deferred versioning](https://yarnpkg.com/features/release-workflow). Instead of
+editing `"version"` in `package.json`, you declare *what kind* of release your change is and let
+Yarn apply the actual bumps at release time.
+
+Before opening a PR, run from the repo root:
+
+```bash
+yarn version-check   # opens an interactive prompt (yarn version check --interactive)
+```
+
+Pick a bump for each changed package and commit the file Yarn writes under `.yarn/versions/`:
+
+- **patch** — a bug fix (`4.3.0` → `4.3.1`)
+- **minor** — a new backwards-compatible feature (`4.3.0` → `4.4.0`)
+- **major** — a breaking change (`4.3.0` → `5.0.0`)
+
+Your conventional-commit type is a good hint: `fix` → patch, `feat` → minor, a breaking change → major.
+When you bump a package, the prompt also lists the published packages that depend on it (e.g.
+bumping `@joint/core` lists `@joint/decorators`, `@joint/layout-*`, `@joint/shapes-*`,
+`@joint/react`, …); set those to the same bump so they track `@joint/core`, our ruling version.
+Yarn then rewrites their `workspace:` ranges for you at release. Private example apps under
+`examples/` have no version field and never appear. Changes to ignored paths (tests, docs,
+`examples/`) need no bump. CI runs
+`yarn version check` on every PR and will fail if a changed package is missing its version entry.
 
 ### Commit Message Format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,14 +92,9 @@ Pick a bump for each changed package and commit the file Yarn writes under `.yar
 - **minor** — a new backwards-compatible feature (`4.3.0` → `4.4.0`)
 - **major** — a breaking change (`4.3.0` → `5.0.0`)
 
-Your conventional-commit type is a good hint: `fix` → patch, `feat` → minor, a breaking change → major.
-When you bump a package, the prompt also lists the published packages that depend on it (e.g.
-bumping `@joint/core` lists `@joint/decorators`, `@joint/layout-*`, `@joint/shapes-*`,
-`@joint/react`, …); set those to the same bump so they track `@joint/core`, our ruling version.
-Yarn then rewrites their `workspace:` ranges for you at release. Private example apps under
-`examples/` have no version field and never appear. Changes to ignored paths (tests, docs,
-`examples/`) need no bump. CI runs
-`yarn version check` on every PR and will fail if a changed package is missing its version entry.
+Your conventional-commit type is a good hint: `fix` → patch, `feat` → minor, a breaking change → major. When you bump a package, the prompt lists its dependents and asks you to decide, for each, whether they should be bumped too. Even though Yarn flags them all, you should `decline` them when the new version of the modified package matches the published range. For example, patch bump in `@joint/core` needs no dependent bumps, while a minor bump in `@joint/core` needs none from `@joint/react` but does from the rest. Note that this is a one-way consideration — dependent packages (e.g. `@joint/react`) may be bumped independently of packages they depend on.
+
+Changes to ignored paths (tests, docs, `examples/`) need no bump. CI runs `yarn version check` on every PR and will fail if a changed package is missing its version entry.
 
 ### Commit Message Format
 

--- a/examples/absolute-port-layout-dynamic-port-sizes-js/package.json
+++ b/examples/absolute-port-layout-dynamic-port-sizes-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-absolute-port-layout-dynamic-port-sizes-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/activity-diagram-js/package.json
+++ b/examples/activity-diagram-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-activity-diagram-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/anchors-ts/package.json
+++ b/examples/anchors-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-anchors-ts",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/angular-element-view-ts/package.json
+++ b/examples/angular-element-view-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-angular-element-view-ts",
-  "version": "4.3.1",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/examples/animated-process-flow-diagram-js/package.json
+++ b/examples/animated-process-flow-diagram-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-animated-process-flow-diagram-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/bezier-js/package.json
+++ b/examples/bezier-js/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-bezier-js",
-  "version": "4.3.1",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/callouts-js/package.json
+++ b/examples/callouts-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-callouts-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/chatgpt-timeline-js/package.json
+++ b/examples/chatgpt-timeline-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-chatgpt-timeline-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/circular-layout-js/package.json
+++ b/examples/circular-layout-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-circular-layout-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/connection-points-ts/package.json
+++ b/examples/connection-points-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-connection-points-ts",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/connector-arrows-js/package.json
+++ b/examples/connector-arrows-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-connector-arrows-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/container/package.json
+++ b/examples/container/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-container",
-  "version": "4.3.1",
   "main": "dist/bundle.js",
   "author": {
     "name": "client IO",

--- a/examples/content-driven-shapes-js/package.json
+++ b/examples/content-driven-shapes-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-content-driven-shapes-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/control-tool-js/package.json
+++ b/examples/control-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-control-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/counters-js/package.json
+++ b/examples/counters-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-counters-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/curve-connector-js/package.json
+++ b/examples/curve-connector-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-curve-connector-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/decorators/package.json
+++ b/examples/decorators/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-decorators",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/different-views-of-the-same-graph-js/package.json
+++ b/examples/different-views-of-the-same-graph-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-different-views-of-the-same-graph-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/drop-image-as-shape-js/package.json
+++ b/examples/drop-image-as-shape-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-drop-image-as-shape-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/dwdm/package.json
+++ b/examples/dwdm/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-dwdm",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/dynamic-font-size-js/package.json
+++ b/examples/dynamic-font-size-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-dynamic-font-size-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/dynamic-status-icons-js/package.json
+++ b/examples/dynamic-status-icons-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-dynamic-status-icons-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/electric-generator-js/package.json
+++ b/examples/electric-generator-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-electric-generator-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-connect-tool-js/package.json
+++ b/examples/element-connect-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-element-connect-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-port-and-link-label-markup-js/package.json
+++ b/examples/element-port-and-link-label-markup-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-element-port-and-link-label-markup-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/element-tags-and-badges-js/package.json
+++ b/examples/element-tags-and-badges-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-element-tags-and-badges-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/external-svg-images-js/package.json
+++ b/examples/external-svg-images-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-external-svg-images-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fault-tree-analysis-js/package.json
+++ b/examples/fault-tree-analysis-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-fault-tree-analysis-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fills-js/package.json
+++ b/examples/fills-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-fills-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/find-all-cells-between-2-elements-js/package.json
+++ b/examples/find-all-cells-between-2-elements-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-find-all-cells-between-2-elements-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/foreign-object-magnet-js/package.json
+++ b/examples/foreign-object-magnet-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-foreign-object-magnet-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/fta-js/package.json
+++ b/examples/fta-js/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-fta-js",
-  "version": "4.3.1",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/genogram-ts/package.json
+++ b/examples/genogram-ts/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-genogram-directed-graph-ts",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hexagonal-grid-js/package.json
+++ b/examples/hexagonal-grid-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-hexagonal-grid-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hierarchical-diagrams-js/package.json
+++ b/examples/hierarchical-diagrams-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-hierarchical-diagrams-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/highlighterview-update-attribute-js/package.json
+++ b/examples/highlighterview-update-attribute-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-highlighterview-update-attribute-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hover-element-connect-tool-js/package.json
+++ b/examples/hover-element-connect-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-hover-element-connect-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/hover-link-connect-tool-js/package.json
+++ b/examples/hover-link-connect-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-hover-link-connect-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/isometric/package.json
+++ b/examples/isometric/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-isometric",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/layout-directed-graph/package.json
+++ b/examples/layout-directed-graph/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-layout-directed-graph",
-  "version": "4.3.1",
   "description": "JointJS - Directed Graph Layout Demo",
   "main": "./index.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-elk-ts/package.json
+++ b/examples/layout-elk-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-layout-elk-ts",
-  "version": "4.3.1",
   "description": "JointJS - ELK Layout Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/layout-msagl/package.json
+++ b/examples/layout-msagl/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-layout-msagl",
-  "version": "4.3.1",
   "description": "JointJS - MSAGL Demo",
   "main": "dist/bundle.js",
   "homepage": "https://jointjs.com",

--- a/examples/libavoid/package.json
+++ b/examples/libavoid/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-libavoid",
-  "version": "4.3.1",
   "main": "src/index.js",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/link-connect-tool-js/package.json
+++ b/examples/link-connect-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-link-connect-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/link-labels-ts/package.json
+++ b/examples/link-labels-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-link-labels-ts",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-list",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/microsoft-adaptive-cards-js/package.json
+++ b/examples/microsoft-adaptive-cards-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-microsoft-adaptive-cards-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/nodejs-milestones-timeline-js/package.json
+++ b/examples/nodejs-milestones-timeline-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-nodejs-milestones-timeline-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/offscreen-rendering/package.json
+++ b/examples/offscreen-rendering/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-offscreen-rendering",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/optional-ports-js/package.json
+++ b/examples/optional-ports-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-optional-ports-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/port-reordering-tool-js/package.json
+++ b/examples/port-reordering-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-port-reordering-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/preserve-spaces-in-text-wrap-js/package.json
+++ b/examples/preserve-spaces-in-text-wrap-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-preserve-spaces-in-text-wrap-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/rectangular-layout-js/package.json
+++ b/examples/rectangular-layout-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-rectangular-layout-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/resize-control-tool-js/package.json
+++ b/examples/resize-control-tool-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-resize-control-tool-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/right-angle-playground-js/package.json
+++ b/examples/right-angle-playground-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-right-angle-playground-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/roi-calculator-js/package.json
+++ b/examples/roi-calculator-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-roi-calculator-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/scale-option-for-tools-js/package.json
+++ b/examples/scale-option-for-tools-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-scale-option-for-tools-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/scale-svgmarker-js/package.json
+++ b/examples/scale-svgmarker-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-scale-svgmarker-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/serpentine-layout-js/package.json
+++ b/examples/serpentine-layout-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-serpentine-layout-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/shapes-drawing-js/package.json
+++ b/examples/shapes-drawing-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-shapes-drawing-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/shapes-general/package.json
+++ b/examples/shapes-general/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-shapes-general",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",
   "author": {

--- a/examples/snap-links-to-themselves-js/package.json
+++ b/examples/snap-links-to-themselves-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-snap-links-to-themselves-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/spreadsheet-shapes-with-handsontable-js/package.json
+++ b/examples/spreadsheet-shapes-with-handsontable-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-spreadsheet-shapes-with-handsontable-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/tree-of-life/package.json
+++ b/examples/tree-of-life/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-tree-of-life",
-  "version": "4.3.1",
   "main": "src/index.ts",
   "author": {
     "name": "client IO",

--- a/examples/tree-shake/package.json
+++ b/examples/tree-shake/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@joint/demo-tree-shake",
-  "version": "4.3.1",
   "description": "JointJS - Tree Shake Demo",
   "main": "index.html",
   "homepage": "https://jointjs.com",

--- a/examples/use-case-diagram-js/package.json
+++ b/examples/use-case-diagram-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-use-case-diagram-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/examples/working-with-ports-js/package.json
+++ b/examples/working-with-ports-js/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@joint/demo-working-with-ports-js",
     "private": true,
-    "version": "4.3.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "joint",
-  "version": "4.3.1",
   "sideEffects": false,
   "homepage": "https://jointjs.com",
   "author": {
@@ -24,6 +23,8 @@
     "test-e2e-all": "yarn workspaces foreach --all -tvv run test-e2e-all",
     "lint": "yarn workspaces foreach --all -tvv run lint",
     "lint-fix": "yarn workspaces foreach --all -tvv run lint-fix",
+    "version-check": "yarn version check --interactive",
+    "version-apply": "yarn version apply --all",
     "pack-all": "yarn workspaces foreach --all -tvv --include \"@joint/core\" --include \"@joint/layout-directed-graph\" --include \"@joint/layout-msagl\" pack --out %s-%v.tgz"
   },
   "workspaces": [


### PR DESCRIPTION
## Description

Adopt [Yarn's deferred versioning](https://yarnpkg.com/features/release-workflow) so the intended release type (patch / minor / major) for each publishable `@joint/*` package is declared **per pull request** instead of being hand-applied at release time.

Contributors run `yarn version-check` and commit a small `.yarn/versions/*.yml` file describing their bump; CI blocks PRs that change a publishable package without one. At release a maintainer runs `yarn version-apply` to apply all accumulated bumps at once (Yarn rewrites cross-package `workspace:` ranges automatically).

## Motivation and Context

Releases are currently fully manual: a maintainer hand-edits each `package.json` `version` and the `CHANGELOG`, then tags and publishes. Nothing records what kind of release a normal PR implies, so the bump decision is deferred to one person at the end and is easy to get wrong. Deferred versioning captures that intent at PR time, i.e. by the author with the most context, and makes the release step mechanical.