### PR TITLE
fix(joint-react): guard pointerdown interactions on overlays and form controls

### DIFF
--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3476,9 +3476,16 @@ export const Paper = View.extend({
         const view = this.findView(target);
         const isContextMenu = (button === 2);
 
-        if (view) {
+        // Guard before any interaction starts, on blank areas too. Every other pointer
+        // handler (`pointerclick`, `pointerdblclick`, `contextMenuTrigger`, `mouseover`, …)
+        // guards unconditionally; guarding only the `view` branch let a press on non-SVG
+        // content inside `el` (an HTML overlay, a popup, a toolbar) start a blank
+        // interaction even though `guard()` rejects that target — and the matching
+        // `blank:pointerclick` was then guarded, so the events came out asymmetric.
+        // `contextmenu` stays exempt: `contextMenuTrigger()` runs its own guard.
+        if (!isContextMenu && this.guard(evt, view)) return;
 
-            if (!isContextMenu && this.guard(evt, view)) return;
+        if (view) {
 
             const isTargetFormNode = this.FORM_CONTROL_TAG_NAMES.includes(target.tagName);
 

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -1240,6 +1240,79 @@ QUnit.module('paper', function(hooks) {
         assert.ok(diffX < 5 && diffY < 5, 'element should not have been moved');
     });
 
+    QUnit.test('pointerdown is guarded on blank areas too', function(assert) {
+
+        // A press on non-SVG content inside `paper.el` (an HTML overlay, popup or
+        // toolbar) must not start a blank interaction: `guard()` rejects such a target,
+        // and every other pointer handler honours that. `pointerdown` used to consult
+        // `guard()` only when a cell view was found, so `blank:pointerdown` fired for
+        // overlay content while the matching `blank:pointerclick` stayed guarded.
+        const overlayEl = document.createElement('div');
+        this.paper.el.appendChild(overlayEl);
+
+        assert.equal(this.paper.guard({ type: 'mousedown', button: 0, target: overlayEl }), true,
+            'guard() rejects an HTML overlay target');
+
+        let blankPointerdownCount = 0;
+        this.paper.on('blank:pointerdown', function() {
+            blankPointerdownCount += 1;
+        });
+
+        simulate.mousedown({ el: overlayEl, clientX: 10, clientY: 10 });
+        simulate.mouseup({ el: overlayEl, clientX: 10, clientY: 10 });
+
+        assert.equal(blankPointerdownCount, 0,
+            'no blank:pointerdown for a press on HTML content inside the paper');
+
+        // A genuine blank press (on the SVG) must still work.
+        simulate.mousedown({ el: this.paper.svg, clientX: 10, clientY: 10 });
+        simulate.mouseup({ el: this.paper.svg, clientX: 10, clientY: 10 });
+
+        assert.equal(blankPointerdownCount, 1, 'blank:pointerdown still fires on the SVG');
+
+        overlayEl.remove();
+    });
+
+    QUnit.test('a press on a form control does not drag the element', function(assert) {
+
+        // FORM_CONTROL_TAG_NAMES marks a press on a <button>/<input>/<select>/<textarea>/
+        // <option> as default-interaction-prevented, so neither an element move
+        // (`ElementView#dragStart`) nor a link drag (`ElementView#dragMagnetStart`) begins
+        // from one. That is what lets a clickable control live inside a draggable element.
+        const element = new joint.shapes.standard.Rectangle({
+            position: { x: 100, y: 100 },
+            size: { width: 100, height: 100 },
+            markup: joint.util.svg`
+                <foreignObject @selector="fo" width="100" height="100">
+                    <button @selector="button" type="button">click me</button>
+                </foreignObject>
+            `
+        });
+        this.graph.addCell(element);
+
+        const elementView = this.paper.findViewByModel(element);
+        const buttonEl = elementView.findNode('button');
+        assert.ok(buttonEl, 'the button is rendered');
+
+        const positionBefore = element.position();
+
+        simulate.mousedown({ el: buttonEl, clientX: 150, clientY: 150 });
+        simulate.mousemove({ el: buttonEl, clientX: 250, clientY: 250 });
+        simulate.mouseup({ el: buttonEl, clientX: 250, clientY: 250 });
+
+        assert.deepEqual(element.position(), positionBefore,
+            'the element did not move when dragging from a <button>');
+
+        // Control: the same gesture on the element body DOES move it, so the assertion
+        // above reflects the form-control gate and not an inert drag simulation.
+        simulate.mousedown({ el: elementView.el, clientX: 150, clientY: 150 });
+        simulate.mousemove({ el: elementView.el, clientX: 250, clientY: 250 });
+        simulate.mouseup({ el: elementView.el, clientX: 250, clientY: 250 });
+
+        assert.notDeepEqual(element.position(), positionBefore,
+            'the element moved when dragging from its body');
+    });
+
     QUnit.test('getContentArea()', function(assert) {
 
         assert.checkBboxApproximately(2/* +- */, this.paper.getContentArea(), {

--- a/packages/joint-react/src/components/paper/__tests__/paper-html-content-events.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-html-content-events.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable react-perf/jsx-no-new-object-as-prop */
+import { useCallback } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { GraphProvider, Paper } from '../../../components';
+import { usePaper } from '../../../hooks/use-paper';
+import type { PaperView } from '../../../mvc/paper';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import type { CellRecord } from '../../../types/cell.types';
+
+// `<Paper>` children are portaled into `paper.el`, so an overlay, popup or toolbar
+// rendered there is a DOM sibling of the paper's SVG. The paper's `guard()` rejects such
+// a target, so pressing it must not start a blank interaction — and, because it never
+// has to be intercepted, React events on that content keep working normally.
+//
+// This used to be wrong in two compounding ways:
+//  1. `dia.Paper#pointerdown` consulted `guard()` only when the press hit a cell view, so
+//     overlay content fell through to `blank:pointerdown` (while the matching
+//     `blank:pointerclick` stayed guarded — the events came out asymmetric).
+//  2. Guarding it from React was impossible: React attaches its delegated listeners to
+//     the portal container, which here IS `paper.el` — the very node the paper delegates
+//     on, and the paper got there first. So a React `onMouseDown` runs AFTER the paper
+//     has already reacted, and `stopPropagation()` is too late.
+// Overlays therefore needed native `mousedown` / `touchstart` listeners, which in turn
+// broke React `onMouseDown` on the overlay content.
+
+const initialCells: readonly CellRecord[] = [
+  {
+    id: 'cell-1',
+    type: ELEMENT_MODEL_TYPE,
+    position: { x: 0, y: 0 },
+    size: { width: 50, height: 50 },
+  } as CellRecord,
+];
+
+let capturedPaper: PaperView | null = null;
+let capturedButton: HTMLButtonElement | null = null;
+
+function Capture() {
+  capturedPaper = usePaper().paper;
+  return null;
+}
+
+interface OverlayProbeProps {
+  readonly onButtonMouseDown: () => void;
+}
+
+function OverlayProbe({ onButtonMouseDown }: Readonly<OverlayProbeProps>) {
+  const buttonRef = useCallback((node: HTMLButtonElement | null) => {
+    capturedButton = node;
+  }, []);
+  return (
+    <div>
+      <button type="button" ref={buttonRef} onMouseDown={onButtonMouseDown}>
+        overlay button
+      </button>
+    </div>
+  );
+}
+
+const renderElement = () => <rect width={50} height={50} />;
+
+const readPaper = (): PaperView | null => capturedPaper;
+const readButton = (): HTMLButtonElement | null => capturedButton;
+
+/**
+ * Mount a paper with overlay content portaled into `paper.el`.
+ * @param onButtonMouseDown - Spy for the overlay button's React `onMouseDown`.
+ * @returns The mounted paper view.
+ */
+async function renderPaperWithOverlay(onButtonMouseDown: () => void): Promise<PaperView> {
+  capturedPaper = null;
+  capturedButton = null;
+  render(
+    <GraphProvider initialCells={initialCells}>
+      <Paper style={{ width: 100, height: 100 }} id="html-content-paper" renderElement={renderElement}>
+        <OverlayProbe onButtonMouseDown={onButtonMouseDown} />
+        <Capture />
+      </Paper>
+    </GraphProvider>
+  );
+  await waitFor(() => {
+    expect(capturedPaper).not.toBeNull();
+    expect(capturedButton).not.toBeNull();
+  });
+  const paper = readPaper();
+  if (!paper) throw new Error('paper not mounted');
+  return paper;
+}
+
+describe('HTML content inside the paper container', () => {
+  it('does not start a blank interaction when pressed', async () => {
+    const paper = await renderPaperWithOverlay(() => {});
+    const blankPointerdown = jest.fn();
+    paper.on('blank:pointerdown', blankPointerdown);
+
+    readButton()?.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true })
+    );
+
+    expect(blankPointerdown).not.toHaveBeenCalled();
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+
+  it('still lets React events on that content fire', async () => {
+    const onButtonMouseDown = jest.fn();
+    await renderPaperWithOverlay(onButtonMouseDown);
+
+    readButton()?.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true })
+    );
+
+    expect(onButtonMouseDown).toHaveBeenCalledTimes(1);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+
+  it('still starts a blank interaction when the SVG itself is pressed', async () => {
+    const paper = await renderPaperWithOverlay(() => {});
+    const blankPointerdown = jest.fn();
+    paper.on('blank:pointerdown', blankPointerdown);
+
+    paper.svg.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true })
+    );
+
+    expect(blankPointerdown).toHaveBeenCalledTimes(1);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+});

--- a/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-markup.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { useCallback, useEffect, useRef } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { GraphProvider, Paper } from '../../components';
@@ -161,7 +162,8 @@ describe('useMarkup', () => {
     cleanupUtilities = undefined;
     render(
       <GraphProvider initialCells={initialCells}>
-        <Paper style={{ width: 100, height: 100 }}
+        <Paper
+          style={{ width: 100, height: 100 }}
           id="markup-cleanup-paper"
           renderElement={renderCleanupProbe}
         />
@@ -177,7 +179,8 @@ describe('useMarkup', () => {
     reservedUtilities = undefined;
     render(
       <GraphProvider initialCells={initialCells}>
-        <Paper style={{ width: 100, height: 100 }}
+        <Paper
+          style={{ width: 100, height: 100 }}
           id="markup-reserved-paper"
           renderElement={renderReservedProbe}
         />
@@ -198,7 +201,8 @@ describe('useMarkup', () => {
     emptyCaptured = undefined;
     render(
       <GraphProvider initialCells={initialCells}>
-        <Paper style={{ width: 100, height: 100 }}
+        <Paper
+          style={{ width: 100, height: 100 }}
           id="markup-empty-paper"
           renderElement={renderEmptyMarkupProbe}
         />

--- a/packages/joint-react/src/hooks/use-markup.ts
+++ b/packages/joint-react/src/hooks/use-markup.ts
@@ -48,6 +48,33 @@ export interface MarkupApi {
  * Register SVG sub-elements as JointJS selectors (and optionally magnets) on
  * the current element view, so links and tools can target named parts of a
  * React-rendered element. Must be used inside `renderElement`.
+ * Interactive controls inside a magnet work with plain React events.
+ *
+ * To keep a press from reaching the paper, so it starts no link drag and no element
+ * move, stop the React event. `onClick` is a separate native event and still fires:
+ *
+ * ```tsx
+ * <g ref={magnetRef('row-0')}>
+ *   <foreignObject width={80} height={24}>
+ *     <button onMouseDown={(event) => event.stopPropagation()} onClick={toggle}>NN</button>
+ *   </foreignObject>
+ * </g>
+ * ```
+ *
+ * Stop `onMouseDown` (and `onTouchStart` for touch) — those are the events the paper
+ * listens to. Stopping `onPointerDown` does NOT work on its own: `pointerdown` is a
+ * separate event, so the `mousedown` that drives the paper still gets through. If a
+ * handler already owns the pointer (`setPointerCapture`), calling `preventDefault()` on
+ * `pointerdown` also works, because canceling it suppresses the compatibility
+ * `mousedown` altogether.
+ *
+ * Keeping a control clickable while the rest of the element stays draggable usually
+ * needs no wiring at all: JointJS refuses to start a link drag or an element move from a
+ * form control (`<button>`, `<input>`, `<select>`, `<textarea>`, `<option>`), so a press
+ * on one is always a click. For a non-form control that must both click and
+ * drag-to-connect, set `magnetThreshold="onleave"` on the `<Paper>`: the link forms only
+ * once the pointer leaves the magnet, so a drag releases away from the control and the
+ * browser fires no click on it, while a press-and-release in place still clicks.
  * @group Hooks
  * @returns The {@link MarkupApi}: a `selectorRef` factory that tags an SVG node
  * under a named selector so links and tools can target it, and a `magnetRef`


### PR DESCRIPTION
Guard pointerdown interactions on overlays and form controls to prevent unintended actions when interacting with non-SVG content. This change ensures that pressing on HTML overlays or form controls does not trigger blank interactions or element movements, enhancing the user experience and maintaining expected behavior in the interface.

