### PR TITLE
chore: apply package versions according to latest published on npm [prod]

### DIFF
--- a/packages/joint-decorators/package.json
+++ b/packages/joint-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/decorators",
   "title": "JointJS Decorators",
-  "version": "4.3.1",
+  "version": "0.4.0",
   "description": "Decorators module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-eslint-config/package.json
+++ b/packages/joint-eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/eslint-config",
   "title": "JointJS ESLintConfig",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "description": "ESLintConfig module for JointJS",
   "sideEffects": false,
   "type": "module",

--- a/packages/joint-layout-directed-graph/package.json
+++ b/packages/joint-layout-directed-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-directed-graph",
   "title": "JointJS LayoutDirectedGraph",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "description": "LayoutDirectedGraph module for JointJS",
   "main": "dist/DirectedGraph.js",
   "module": "./DirectedGraph.mjs",

--- a/packages/joint-layout-msagl/package.json
+++ b/packages/joint-layout-msagl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/layout-msagl",
   "title": "JointJS LayoutMSAGL",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "description": "LayoutMSAGL module for JointJS",
   "sideEffects": false,
   "main": "./dist/esm/index.mjs",

--- a/packages/joint-shapes-general-tools/package.json
+++ b/packages/joint-shapes-general-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general-tools",
   "title": "JointJS General Shapes Tools",
-  "version": "4.3.1",
+  "version": "0.1.0",
   "description": "General Shapes Tools module for JointJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/joint-shapes-general/package.json
+++ b/packages/joint-shapes-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joint/shapes-general",
   "title": "JointJS General Shapes",
-  "version": "4.3.1",
+  "version": "0.1.0",
   "description": "General Shapes module for JointJS",
   "main": "src/index.ts",
   "homepage": "https://jointjs.com",


### PR DESCRIPTION
## Description

Fixes a mistake from #3434 - packages which were published to NPM previously should not have their versions bumped in source code if we know we are not planning to release such a version on NPM yet.

