### PR TITLE
test(joint-react): add repro for useCombinedRef assigning the ref after layout effects

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-combined-ref-timing.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-combined-ref-timing.test.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable @eslint-react/no-create-ref */
+/* eslint-disable react-perf/jsx-no-new-array-as-prop -- the recorder is per-test state */
+import { render, screen } from '@testing-library/react';
+import { createRef, useLayoutEffect, type ReactNode, type Ref } from 'react';
+import { useCombinedRef } from '../use-combined-ref';
+
+/**
+ * `useCombinedRef` assigns the forwarded ref in a passive effect, one phase too
+ * late for any consumer that reads it in a layout effect.
+ *
+ * React attaches refs during commit, before layout effects run, and consumers
+ * are entitled to rely on that. `useCombinedRef` instead defers the assignment:
+ *
+ * ```ts
+ * useEffect(() => { setForwardRef(ref, innerRef.current); }, [ref]);
+ * ```
+ *
+ * So a parent that renders `<SVGText ref={myRef} />` and reads `myRef.current`
+ * in its own `useLayoutEffect` sees `null` — parent layout effects run before
+ * any passive effect.
+ *
+ * `useMeasureElement` is exactly that consumer. It reads `nodeRef.current` in a
+ * layout effect and returns early when the ref is empty, and its dependency
+ * list — `[nodeRef, graph, id, paper, setMeasuredNode]` — contains nothing that
+ * changes when the node is finally assigned, so it never registers the node with
+ * the size observer. The element then stays 0x0 permanently: no size, and no
+ * layout for anything that reads sizes.
+ *
+ * Two things hide this everywhere it would otherwise show up:
+ *
+ * 1. StrictMode remounts effects, so a second pass finds the ref already set by
+ *    the first pass. It is on for every story (`.storybook/preview.ts`) and for
+ *    every test (`configure({ reactStrictMode: true })` in `jest-setup.ts`) —
+ *    which is why the suite below has to opt out explicitly to see the bug.
+ * 2. None of the library's own examples pass a ref to `SVGText`. The flowchart,
+ *    svg-node and portal-selectors stories put a plain DOM ref on a native
+ *    `<text>`, and the `SVGText` story measures a `<g>` wrapper.
+ *
+ * Found in an app that measured `SVGText` directly: correct in development,
+ * every node rendered as a bare label with no shape and no layout once built
+ * for production, where effects run once.
+ *
+ * A callback ref in `useCombinedRef` — assigned during commit like any DOM ref —
+ * fixes it, and makes the first test below flip from failing to passing.
+ */
+
+/** Records what the parent's layout effect saw, in order. */
+function Harness({ forwardedRef, seen }: Readonly<{
+  forwardedRef: Ref<HTMLDivElement>;
+  seen: Array<HTMLDivElement | null>;
+}>) {
+  const ref = forwardedRef as { current: HTMLDivElement | null };
+  useLayoutEffect(() => {
+    seen.push(ref.current);
+  }, [ref, seen]);
+  return <Child forwardedRef={forwardedRef} />;
+}
+
+function Child({ forwardedRef }: Readonly<{ forwardedRef: Ref<HTMLDivElement> }>): ReactNode {
+  // Stands in for `SVGText`, whose only relevant behaviour here is that it
+  // forwards its ref through `useCombinedRef`.
+  const combinedRef = useCombinedRef<HTMLDivElement>(forwardedRef);
+  return <div data-testid="el" ref={combinedRef} />;
+}
+
+describe('useCombinedRef ref-assignment timing', () => {
+  /*
+   * Marked `failing` so it documents the defect without reddening CI: Jest
+   * reports it as passing while the body throws, and starts reporting a failure
+   * once `useCombinedRef` is fixed — at which point drop the `.failing`.
+   */
+  it.failing('assigns the forwarded ref before a consumer layout effect runs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    // `reactStrictMode: false` is the whole point: effects run once, as they do
+    // in any production build. With the suite-wide StrictMode left on, the
+    // remount masks this and the assertion passes.
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: false });
+
+    expect(seen).toEqual([screen.getByTestId('el')]);
+  });
+
+  it('is masked by StrictMode, which is why nothing caught it', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: true });
+
+    // The remount leaves a correct ref behind, so a consumer whose layout effect
+    // runs more than once recovers. Deliberately asserts only the final value:
+    // this holds both before and after a fix, so it is documentation rather than
+    // something that has to change when `useCombinedRef` is corrected.
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.at(-1)).toBe(screen.getByTestId('el'));
+  });
+
+  it('has assigned the ref by the time render returns, which is what the existing tests assert', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: false });
+
+    // Passing here is not evidence of correctness: passive effects have flushed
+    // by now. The defect is only visible from inside a layout effect.
+    expect(ref.current).toBe(screen.getByTestId('el'));
+  });
+});


### PR DESCRIPTION
Repro only — no production code touched. Adds `src/hooks/__tests__/use-combined-ref-timing.test.tsx`.

## The defect

`useCombinedRef` assigns the forwarded ref inside a **passive** effect:

```ts
export function useCombinedRef<T>(ref?: ForwardedRef<T>): RefObject<T | null> {
  const innerRef = useRef<T>(null);
  useEffect(() => {
    setForwardRef(ref, innerRef.current);
  }, [ref]);
  return innerRef;
}
```

React attaches refs during commit, before layout effects run, and consumers are entitled to rely on that. Deferring the assignment means a parent that renders `<SVGText ref={myRef} />` and reads `myRef.current` in its own `useLayoutEffect` sees `null`, because parent layout effects run before any passive effect.

`useMeasureElement` is exactly that consumer:

```ts
useLayoutEffect(() => {
  const element = nodeRef.current;
  if (!element) return;               // <- takes this branch on first commit
  ...
  const clean = setMeasuredNode({ id, node: nodeRef.current, transform });
  return () => { clean(); };
}, [nodeRef, graph, id, paper, setMeasuredNode]);
```

It returns before `setMeasuredNode`, and its dependency list contains nothing that changes when the node is finally assigned — so the node is never registered with the size observer and the element stays 0×0 permanently. No size, and no layout for anything that consumes sizes.

## Why nothing caught it

1. **StrictMode remounts effects**, so a second pass finds the ref already set by the first pass. It is on for every story (`.storybook/preview.ts`) and for every test (`configure({ reactStrictMode: true })` in `__mocks__/jest-setup.ts`). The suite is blind to this class of bug by default, which is why the new test has to pass `reactStrictMode: false` explicitly.
2. **No example passes a ref to `SVGText`.** The flowchart, svg-node and portal-selectors stories put a plain DOM ref on a native `<text>`; the `SVGText` story measures a `<g>` wrapper. The broken path is never exercised.

The existing `use-combined-ref.test.tsx` cases assert `ref.current` *after* `render()` returns, by which point passive effects have flushed — so they pass regardless. The new file keeps one such assertion, labelled, to make that explicit.

## How it was found

An app that measured `SVGText` directly: correct under `vite dev`, and in the production build every node rendered as a bare label with no shape behind it and no layout. Tracing `ResizeObserver` in the page showed dev observing all ten `text` nodes and the production build observing none.

## The tests

- `assigns the forwarded ref before a consumer layout effect runs` — marked `it.failing`, so it documents the defect without reddening CI and starts failing once the hook is fixed (drop the `.failing` then).
- `is masked by StrictMode, which is why nothing caught it` — asserts only the final value, so it holds before and after a fix.
- `has assigned the ref by the time render returns…` — shows why the current tests pass.

Verified in both directions: as it stands the first body throws (all three green); with `useCombinedRef` switched to assign during commit, **only** that test flips and the other two stay green. So it pins this defect specifically.

## Possible fix

Assign during commit rather than in an effect — a callback ref, or a proxy whose setter forwards:

```ts
const proxy = useMemo(() => ({
  get current() { return innerRef.current; },
  set current(value: T | null) { innerRef.current = value; setForwardRef(ref, value); },
}), [ref]);
```

Hardening `useMeasureElement` so a late ref is still picked up would be worth doing too, but the contract violation is in `useCombinedRef`. Happy to turn this into a fix PR if you'd like it in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)