### PR TITLE
chore(joint-eslint-config): remove duplicate property from abbrev whitelist

### DIFF
--- a/packages/joint-eslint-config/eslint.config.react.mjs
+++ b/packages/joint-eslint-config/eslint.config.react.mjs
@@ -191,7 +191,6 @@ export const reactTsConfig = defineConfig([
                         db: false,
                         cb: false,
                         refs: false,
-                        utils: false,
                         util: false,
                         utils: false
                     },


### PR DESCRIPTION
## Description

Removes a duplicate property from a list of abbreviations allowed in react.