### PR TITLE
fix(joint-react): account for the arrowhead on a custom link anchor

### DIFF
--- a/packages/joint-react/src/presets/__tests__/link-routing.test.ts
+++ b/packages/joint-react/src/presets/__tests__/link-routing.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { g } from '@joint/core';
+import type { LinkRouting } from '../link-routing';
 import {
   linkRoutingStraight,
   linkRoutingOrthogonal,
@@ -72,7 +75,9 @@ describe('presets / link-routing / linkRoutingSmooth', () => {
   it('returns plain variant when straightWhenDisconnected is false', () => {
     const routing = linkRoutingSmooth({ straightWhenDisconnected: false });
     expect(routing.defaultRouter).toEqual({ name: 'normal' });
-    expect(routing.defaultConnectionPoint).toEqual({ name: 'anchor' });
+    // The anchor connection point, wrapped so an end with its own anchor still
+    // gets the arrowhead accounted for.
+    expect(typeof routing.defaultConnectionPoint).toBe('function');
     expect(routing.defaultAnchor).toBeDefined();
     expect(routing.defaultConnector).toBeDefined();
   });
@@ -80,5 +85,79 @@ describe('presets / link-routing / linkRoutingSmooth', () => {
   it('respects custom offsets', () => {
     const routing = linkRoutingSmooth({ sourceOffset: 3, targetOffset: 7 });
     expect(routing.defaultConnectionPoint).toBeDefined();
+  });
+});
+
+const MARKER_LENGTH = 9;
+
+/** A link end, with an anchor of its own when one is given. */
+function makeEnd(anchor?: object) {
+  return anchor ? { id: 'e', anchor } : { id: 'e' };
+}
+
+function makeLinkView(targetAnchor?: object) {
+  const model = {
+    getSourceCell: () => ({ id: 's' }),
+    getTargetCell: () => ({ id: 't' }),
+    source: () => makeEnd(),
+    target: () => makeEnd(targetAnchor),
+    attributes: { attrs: { line: { targetMarker: { length: MARKER_LENGTH }}}},
+  };
+  return { model, metrics: {} } as any;
+}
+
+/** The last segment of a route arriving at (100, 260) from directly above. */
+function makeEndSegment() {
+  return { start: new g.Point(100, 100), end: new g.Point(100, 260) } as any;
+}
+
+/** With no port on the link, the element's own node doubles as the magnet. */
+function makeEndView() {
+  const element = {} as SVGElement;
+  return [{ el: element } as any, element] as const;
+}
+
+function targetPointY(routing: LinkRouting, targetAnchor?: object) {
+  const [endView, magnet] = makeEndView();
+  return (routing.defaultConnectionPoint as any)(
+    makeEndSegment(),
+    endView,
+    magnet,
+    {},
+    'target',
+    makeLinkView(targetAnchor)
+  ).y;
+}
+
+const CUSTOM_ANCHOR = { name: 'modelCenter', args: { dx: 0, dy: -20 }};
+
+describe('presets / link-routing / arrowhead inset', () => {
+  it('accounts for the arrowhead on an end that carries its own anchor', () => {
+    // The preset's anchor never ran for this end, so the connection point is
+    // what keeps the arrowhead off the element.
+    expect(targetPointY(linkRoutingOrthogonal(), CUSTOM_ANCHOR)).toBe(260 - MARKER_LENGTH);
+    expect(
+      targetPointY(linkRoutingOrthogonal({ straightWhenDisconnected: false }), CUSTOM_ANCHOR)
+    ).toBe(260 - MARKER_LENGTH);
+  });
+
+  it('adds the per-end offset to the arrowhead', () => {
+    const routing = linkRoutingOrthogonal({ targetOffset: 6 });
+    expect(targetPointY(routing, CUSTOM_ANCHOR)).toBe(260 - MARKER_LENGTH - 6);
+  });
+
+  it('leaves an end taking the preset anchor untouched', () => {
+    // `midSideAnchor` accounted for both there, so doing it again would count
+    // them twice.
+    expect(targetPointY(linkRoutingOrthogonal())).toBe(260);
+    expect(targetPointY(linkRoutingOrthogonal({ targetOffset: 6 }))).toBe(260);
+    expect(targetPointY(linkRoutingOrthogonal({ straightWhenDisconnected: false }))).toBe(260);
+  });
+
+  it('applies to the smooth preset as well', () => {
+    expect(targetPointY(linkRoutingSmooth(), CUSTOM_ANCHOR)).toBe(260 - MARKER_LENGTH);
+    expect(targetPointY(linkRoutingSmooth({ straightWhenDisconnected: false }), CUSTOM_ANCHOR))
+      .toBe(260 - MARKER_LENGTH);
+    expect(targetPointY(linkRoutingSmooth())).toBe(260);
   });
 });

--- a/packages/joint-react/src/presets/__tests__/wrappers.test.ts
+++ b/packages/joint-react/src/presets/__tests__/wrappers.test.ts
@@ -3,6 +3,7 @@ import {
   straightRouterUntilConnected,
   straightConnectorUntilConnected,
   anchorWhenConnected,
+  connectionPointWhenAnchorIsDefault,
   connectionPointWhenConnected,
 } from '../wrappers';
 
@@ -151,5 +152,59 @@ describe('presets / wrappers / connectionPointWhenConnected', () => {
     );
     expect(result).toBe('C');
     expect(disconnected).not.toHaveBeenCalled();
+  });
+});
+
+function makeLinkViewWithEnds(sourceEnd?: unknown, targetEnd?: unknown) {
+  const model = {
+    getSourceCell: jest.fn(() => ({ id: 's' })),
+    getTargetCell: jest.fn(() => ({ id: 't' })),
+    source: jest.fn(() => sourceEnd),
+    target: jest.fn(() => targetEnd),
+  };
+  return { model } as any;
+}
+
+describe('presets / wrappers / connectionPointWhenAnchorIsDefault', () => {
+  it('uses the preset connection point when the end takes the default anchor', () => {
+    const presetAnchor = jest.fn(() => 'P');
+    const customAnchor = jest.fn(() => 'C');
+    const wrapped = connectionPointWhenAnchorIsDefault(presetAnchor as any, customAnchor as any);
+    const linkView = makeLinkViewWithEnds({ id: 's' }, { id: 't' });
+    const result = wrapped({} as any, {} as any, {} as any, {}, 'target', linkView);
+    expect(result).toBe('P');
+    expect(customAnchor).not.toHaveBeenCalled();
+  });
+
+  it('uses the custom connection point when the end declares its own anchor', () => {
+    const presetAnchor = jest.fn(() => 'P');
+    const customAnchor = jest.fn(() => 'C');
+    const wrapped = connectionPointWhenAnchorIsDefault(presetAnchor as any, customAnchor as any);
+    const linkView = makeLinkViewWithEnds(
+      { id: 's' },
+      { id: 't', anchor: { name: 'modelCenter', args: { dx: 0, dy: -20 }}}
+    );
+    const result = wrapped({} as any, {} as any, {} as any, {}, 'target', linkView);
+    expect(result).toBe('C');
+    expect(presetAnchor).not.toHaveBeenCalled();
+  });
+
+  it('decides per end, so one custom anchor does not affect the other end', () => {
+    const presetAnchor = jest.fn(() => 'P');
+    const customAnchor = jest.fn(() => 'C');
+    const wrapped = connectionPointWhenAnchorIsDefault(presetAnchor as any, customAnchor as any);
+    const linkView = makeLinkViewWithEnds({ id: 's', anchor: { name: 'center' }}, { id: 't' });
+    expect(wrapped({} as any, {} as any, {} as any, {}, 'source', linkView)).toBe('C');
+    expect(wrapped({} as any, {} as any, {} as any, {}, 'target', linkView)).toBe('P');
+  });
+
+  it('treats an end with no definition as taking the default anchor', () => {
+    const presetAnchor = jest.fn(() => 'P');
+    const customAnchor = jest.fn(() => 'C');
+    const wrapped = connectionPointWhenAnchorIsDefault(presetAnchor as any, customAnchor as any);
+    const linkView = makeLinkViewWithEnds();
+    const result = wrapped({} as any, {} as any, {} as any, {}, 'source', linkView);
+    expect(result).toBe('P');
+    expect(customAnchor).not.toHaveBeenCalled();
   });
 });

--- a/packages/joint-react/src/presets/link-routing.ts
+++ b/packages/joint-react/src/presets/link-routing.ts
@@ -8,6 +8,7 @@ import {
   straightRouterUntilConnected,
   straightConnectorUntilConnected,
   anchorWhenConnected,
+  connectionPointWhenAnchorIsDefault,
   connectionPointWhenConnected,
 } from './wrappers';
 
@@ -39,6 +40,31 @@ interface BaseLinkOptions {
   readonly straightWhenDisconnected?: boolean;
   /** The attrs selector that holds the marker definitions. @default 'line' */
   readonly markerSelector?: string;
+}
+
+/**
+ * The connection point for a preset whose anchor already accounts for the arrowhead.
+ *
+ * `midSideAnchor` sits where the arrowhead's tail belongs — the arrowhead length plus
+ * the per-end offset — so an end that takes it needs its anchor returned untouched.
+ * An end carrying its own anchor never runs it, so the same two are applied here for
+ * those ends instead, leaving the position the anchor chose otherwise intact. Applied
+ * in one place or the other, never both.
+ * @param presetPoint - the point used for ends taking the preset's own anchor
+ * @param sourceOffset
+ * @param targetOffset
+ * @param markerSelector
+ */
+function withCustomAnchorOffsets(
+  presetPoint: connectionPoints.ConnectionPoint,
+  sourceOffset: number,
+  targetOffset: number,
+  markerSelector?: string
+): connectionPoints.ConnectionPoint {
+  return connectionPointWhenAnchorIsDefault(
+    presetPoint,
+    withOffsets(presetPoint, sourceOffset, targetOffset, markerSelector)
+  );
 }
 
 /**
@@ -156,7 +182,7 @@ export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}
         centerAnchor
       ),
       defaultConnectionPoint: connectionPointWhenConnected(
-        anchorPoint,
+        withCustomAnchorOffsets(anchorPoint, sourceOffset, targetOffset, markerSelector),
         withOffsets(boundaryPoint, sourceOffset, targetOffset, markerSelector)
       ),
     };
@@ -169,7 +195,12 @@ export function linkRoutingOrthogonal(options: LinkRoutingOrthogonalOptions = {}
       args: { cornerType, cornerRadius, cornerPreserveAspectRatio: true },
     },
     defaultAnchor: midSideAnchor(mode, sourceOffset, targetOffset, markerSelector),
-    defaultConnectionPoint: anchorPoint,
+    defaultConnectionPoint: withCustomAnchorOffsets(
+      anchorPoint,
+      sourceOffset,
+      targetOffset,
+      markerSelector
+    ),
   };
 }
 
@@ -213,7 +244,12 @@ export function linkRoutingSmooth(options: LinkRoutingSmoothOptions = {}): LinkR
         centerAnchor
       ),
       defaultConnectionPoint: connectionPointWhenConnected(
-        connectionPoints.anchor as connectionPoints.ConnectionPoint,
+        withCustomAnchorOffsets(
+          connectionPoints.anchor as connectionPoints.ConnectionPoint,
+          sourceOffset,
+          targetOffset,
+          markerSelector
+        ),
         withOffsets(boundaryPoint, sourceOffset, targetOffset, markerSelector)
       ),
     };
@@ -223,6 +259,11 @@ export function linkRoutingSmooth(options: LinkRoutingSmoothOptions = {}): LinkR
     defaultRouter: { name: 'normal' },
     defaultConnector: outwardsCurveConnector,
     defaultAnchor: midSideAnchor(mode, sourceOffset, targetOffset, markerSelector),
-    defaultConnectionPoint: { name: 'anchor' },
+    defaultConnectionPoint: withCustomAnchorOffsets(
+      connectionPoints.anchor as connectionPoints.ConnectionPoint,
+      sourceOffset,
+      targetOffset,
+      markerSelector
+    ),
   };
 }

--- a/packages/joint-react/src/presets/wrappers.ts
+++ b/packages/joint-react/src/presets/wrappers.ts
@@ -49,6 +49,26 @@ export function anchorWhenConnected(connected: anchors.Anchor, disconnected: anc
 }
 
 /**
+ * Wraps a connection point, uses `presetAnchor` when the link end takes the paper's
+ * default anchor, `customAnchor` when the end carries an anchor of its own.
+ *
+ * A preset whose anchor already accounts for the arrowhead (as `midSideAnchor` does)
+ * pairs it with a connection point that returns the anchor untouched. An end with its
+ * own `anchor` never runs that anchor, so a preset can use this to treat those ends
+ * differently without the two ever both being applied.
+ * @param presetAnchor - used when the end has no anchor of its own
+ * @param customAnchor - used when the end declares its own anchor
+ */
+export function connectionPointWhenAnchorIsDefault(presetAnchor: connectionPoints.ConnectionPoint, customAnchor: connectionPoints.ConnectionPoint): connectionPoints.ConnectionPoint {
+  return (endPathSegmentLine, endView, endMagnet, opt, endType, linkView) => {
+    const link = linkView.model;
+    const end = endType === 'source' ? link.source() : link.target();
+    const connectionPoint = end?.anchor ? customAnchor : presetAnchor;
+    return connectionPoint(endPathSegmentLine, endView, endMagnet, opt, endType, linkView);
+  };
+}
+
+/**
  * Wraps a connection point, uses `connected` when both ends are attached, `disconnected` otherwise.
  * @param connected
  * @param disconnected

--- a/packages/joint-react/stories/examples/fixed-connection-points/code.tsx
+++ b/packages/joint-react/stories/examples/fixed-connection-points/code.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-perf/jsx-no-new-function-as-prop */
 import { useEffect, useRef } from 'react';
 import type { CellRecord, LinkStyle } from '@joint/react';
-import { GraphProvider, useCell, jsx, Paper, resolveLinkMarker, selectElementSize, linkRoutingOrthogonal } from '@joint/react';
+import { GraphProvider, useCell, jsx, Paper, selectElementSize, linkRoutingOrthogonal } from '@joint/react';
 import { PAPER_CLASSNAME, PAPER_STYLE, BG, PRIMARY, TEXT, LIGHT } from 'storybook-config/theme';
 import { dia, elementTools, linkTools, highlighters, g } from '@joint/core';
 
@@ -12,9 +12,6 @@ const ORTHOGONAL_LINKS = linkRoutingOrthogonal({
   cornerRadius: 5,
   margin: 40,
 });
-
-/** Distance (px) to shift the dropped link-end away from the shape edge. */
-const ANCHOR_MARGIN = resolveLinkMarker('arrow')?.length ?? 0;
 
 const DEFAULT_LINK_STYLE: LinkStyle = { color: LIGHT, width: 2, targetMarker: 'arrow' };
 const DEFAULT_LINK = { style: DEFAULT_LINK_STYLE };
@@ -140,7 +137,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
     source: { id: 'square1', anchor: { name: 'modelCenter', args: { dx: 40, dy: -20 } } },
     target: {
       id: 'square2',
-      anchor: { name: 'modelCenter', args: { dx: -40 - ANCHOR_MARGIN, dy: -20 } },
+      anchor: { name: 'modelCenter', args: { dx: -40, dy: -20 } },
     },
     ...DEFAULT_LINK,
   },
@@ -148,7 +145,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
     id: 'link2',
     type: 'link',
     source: { id: 'ellipse1', anchor: { name: 'modelCenter', args: { dx: -40, dy: 0 } } },
-    target: { id: 'rectangle1', anchor: { name: 'modelCenter', args: { dx: -100, dy: -30 } } },
+    target: { id: 'rectangle1', anchor: { name: 'modelCenter', args: { dx: -100, dy: -20 } } },
     ...DEFAULT_LINK,
   },
   {
@@ -157,7 +154,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
     source: { id: 'rectangle1', anchor: { name: 'modelCenter', args: { dx: 100, dy: -20 } } },
     target: {
       id: 'ellipse1',
-      anchor: { name: 'modelCenter', args: { dx: 40 + ANCHOR_MARGIN, dy: 0 } },
+      anchor: { name: 'modelCenter', args: { dx: 40, dy: 0 } },
     },
     ...DEFAULT_LINK,
   },
@@ -167,7 +164,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
     source: { id: 'square2', anchor: { name: 'modelCenter', args: { dx: -40, dy: 20 } } },
     target: {
       id: 'ellipse1',
-      anchor: { name: 'modelCenter', args: { dx: 0, dy: -40 - ANCHOR_MARGIN } },
+      anchor: { name: 'modelCenter', args: { dx: 0, dy: -40 } },
     },
     ...DEFAULT_LINK,
   },
@@ -177,7 +174,7 @@ const initialCells: ReadonlyArray<CellRecord<ShapeData>> = [
     source: { id: 'square2', anchor: { name: 'modelCenter', args: { dx: -40, dy: 0 } } },
     target: {
       id: 'square1',
-      anchor: { name: 'modelCenter', args: { dx: 40 + ANCHOR_MARGIN, dy: 0 } },
+      anchor: { name: 'modelCenter', args: { dx: 40, dy: 0 } },
     },
     ...DEFAULT_LINK,
   },
@@ -403,12 +400,11 @@ function Main() {
       linkPinning={false}
       linkRouting={ORTHOGONAL_LINKS}
       // Connection strategy - find closest anchor point
-      connectionStrategy={({ end, model, dropPoint, endType }) => {
+      connectionStrategy={({ end, model, dropPoint }) => {
         const element = model as dia.Element;
         const { width, height } = element.size();
         const shapeType = element.prop('data/shapeType') as ShapeType;
-        const margin = endType === 'target' ? ANCHOR_MARGIN : 0;
-        const anchors = getAnchors(shapeType, width, height, margin);
+        const anchors = getAnchors(shapeType, width, height);
         const relativePoint = element.getRelativePointFromAbsolute(dropPoint);
         const anchor = findClosestAnchor(anchors, relativePoint);
         return {


### PR DESCRIPTION
## Description

`linkRoutingOrthogonal()` and `linkRoutingSmooth()` apply the arrowhead length and the per-end offset **inside the anchor** (`midSideAnchor`), so they pair it with a connection point that returns the anchor untouched:

```ts
// anchors.ts → midSideAnchor
const padding = userOffset + markerLength;
// link-routing.ts
defaultAnchor: anchorWhenConnected(midSideAnchor(mode, sourceOffset, targetOffset, markerSelector), centerAnchor),
defaultConnectionPoint: connectionPointWhenConnected(anchorPoint, withOffsets(boundaryPoint, …)),
```

A link end carrying its own `anchor` never runs `midSideAnchor`, so neither the arrowhead nor the offset was accounted for: the line reached the element and the marker was drawn over the shape, or hidden under the port it pointed at.

`connectionPointWhenAnchorIsDefault` splits the two cases, so the connection point applies both for the ends the preset's anchor did not place. They can never be counted twice — the fallback runs exactly when `midSideAnchor` did not.

Callers were left to discover this themselves. `stories/examples/fixed-connection-points` added `resolveLinkMarker('arrow')?.length` to every target anchor it computed, in `initialCells` and again in its `connectionStrategy`; the second commit removes that, since the preset handles it now.

`linkRoutingStraight()` was already correct — it applies the offsets in the connection point (`withOffsets(boundaryPoint, …)`), so a custom anchor keeps them there.

## Motivation and Context

Found while porting the [Libavoid standalone link routing demo](https://github.com/clientIO/joint-demos/tree/main/libavoid-standalone-link-routing/react) to `@joint/react-plus`. The router runs in a Web Worker and writes `modelCenter` + `dx`/`dy` anchors from Libavoid's own endpoints — anchors that know nothing about markers — and every arrowhead in the diagram disappeared under its port. The demo works around it by borrowing one field from the other preset, which this makes unnecessary:

```ts
const LINK_ROUTING = {
    ...linkRoutingOrthogonal({ cornerRadius: 4, margin: 12 }),
    defaultConnectionPoint: linkRoutingStraight().defaultConnectionPoint,
};
```

Any router or layout writing its own anchors lands in the same place, and nothing in the API signals that overriding the anchor also switches off marker handling.

## Verification

Two elements above each other, target's top edge at `y = 260`, marker `length` 9. One link with default anchors, one with `modelCenter` + `dx`/`dy` anchors:

| link | before | after |
|---|---|---|
| default anchors | `L 100 251` | `L 100 251` |
| custom anchors | `L 360 260` | `L 360 251` |

`Examples/Fixed Connection Points`, target endpoints, before this PR vs after (its hand-made margin removed in the same PR):

| link | before | after |
|---|---|---|
| link1 | (331, 120) | (331, 120) |
| link2 | (160, 490) | (160, 491) |
| link3 | (309, 340) | (309, 340) |
| link4 | (260, 291) | (260, 291) |
| link5 | (189, 140) | (189, 140) |

`link2` is the one anchor that moves: its target sat 10px above the rectangle, which is not where any of its handles are, so it now names the edge like the others and the arrowhead's 9px separates it. Source ends are untouched throughout — no source marker, so the offset is zero. `Examples/Link Routing` is unchanged (no custom anchors there, so the wrapper is a pass-through).

Both measured in a browser, against a local `yarn build` and the Storybook dev server, not only in unit tests.

- 9 new unit tests: 4 for `connectionPointWhenAnchorIsDefault`, 5 for the resulting geometry (the arrowhead on a custom anchor, the per-end offset added to it, preset-anchor ends left alone, the smooth preset, the `straightWhenDisconnected: false` branch).
- One existing assertion updated: `linkRoutingSmooth({ straightWhenDisconnected: false }).defaultConnectionPoint` was the literal `{ name: 'anchor' }` and is now that connection point wrapped.
- `yarn test` in `packages/joint-react` passes: typecheck, lint, knip, React 19 + React 18 — 1037 tests.

## Notes

### Related: markers with no `length`

`getMarkerLength` reads `attrs[selector].targetMarker.length`. A marker authored as raw SVG (`d` + `markerWidth`, no `length`) reports `0`, so it gets no room under any preset and tucks under the shape — same symptom, no custom anchor involved. Not addressed here; happy to follow up if you want `length` derived from the marker geometry, or documented as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)