### PR TITLE
feat(joint-react): out-of-the-box touch support (pinch-to-zoom, two-finger pan)

### DIFF
--- a/packages/joint-react/src/components/paper/paper.types.ts
+++ b/packages/joint-react/src/components/paper/paper.types.ts
@@ -17,6 +17,7 @@ import type { CellVisibility } from '../../presets/cell-visibility';
 import type { CellInteractivity } from '../../presets/cell-interactivity';
 import type { LinkRouting } from '../../presets/link-routing';
 import type { PaperEventHandlers } from '../../presets/paper-events';
+import type { PinchZoomBounds } from '../../hooks/use-pinch-zoom';
 
 /**
  * Viewport transform accepted by the `<Paper>` `transform` prop: either a CSS
@@ -473,6 +474,24 @@ export interface PaperProps extends PaperSupportedOptions, PropsWithChildren, Pa
    * ```
    */
   readonly transform?: PaperTransform;
+
+  /**
+   * Built-in pinch-to-zoom: two-finger touch pinches and touchpad
+   * (`Ctrl`/`Cmd`+wheel) pinches zoom the canvas around the gesture point,
+   * and two-finger touch pans move it. Pass `{ min, max }` to tune the zoom
+   * bounds, or `false` to turn the behavior off (e.g. when the viewport is
+   * driven through the `transform` prop).
+   *
+   * Subscribing your own `onPaperPinch` / `onPaperPan` handler takes
+   * precedence — the built-in behavior yields automatically, no need to also
+   * pass `false`.
+   * @default true
+   * @example
+   * ```tsx
+   * <Paper zoomOnPinch={{ min: 0.5, max: 2 }} />
+   * ```
+   */
+  readonly zoomOnPinch?: boolean | PinchZoomBounds;
 
   /**
    * Maximum pointer travel (in px) still treated as a click rather than a drag.

--- a/packages/joint-react/src/hooks/__tests__/use-pinch-zoom.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-pinch-zoom.test.tsx
@@ -1,0 +1,146 @@
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+import { render, act, waitFor } from '@testing-library/react';
+import type { dia } from '@joint/core';
+import { GraphProvider } from '../../components';
+import { Paper } from '../../components/paper/paper';
+import type { PaperProps } from '../../components/paper/paper.types';
+import type { CellRecord } from '../../types/cell.types';
+
+const EMPTY_CELLS: readonly CellRecord[] = [];
+
+function touchPanEvent(): dia.Event {
+  return { type: 'touchmove' } as unknown as dia.Event;
+}
+
+function wheelPanEvent(): dia.Event {
+  return { type: 'wheel' } as unknown as dia.Event;
+}
+
+// jsdom's mocked SVG matrix degenerates real transform math (all-zero CTM), so
+// the paper's transform API is stubbed and the assertions target what the hook
+// owns: clamping, yielding, and event filtering.
+function stubPaperTransforms(paper: dia.Paper) {
+  const state = { scale: 1, tx: 0, ty: 0 };
+  // The getter/setter overloads defeat direct mock typing — cast the whole
+  // implementation to the method type instead.
+  jest
+    .spyOn(paper, 'scale')
+    .mockImplementation(
+      (() => ({ sx: state.scale, sy: state.scale })) as unknown as dia.Paper['scale']
+    );
+  const scaleUniformAtPoint = jest
+    .spyOn(paper, 'scaleUniformAtPoint')
+    .mockImplementation((nextScale: number) => {
+      state.scale = nextScale;
+      return paper;
+    });
+  const translate = jest.spyOn(paper, 'translate').mockImplementation(
+    ((tx?: number, ty?: number) => {
+      if (tx === undefined || ty === undefined) return { tx: state.tx, ty: state.ty };
+      state.tx = tx;
+      state.ty = ty;
+      return paper;
+    }) as unknown as dia.Paper['translate']
+  );
+  return { state, scaleUniformAtPoint, translate };
+}
+
+async function renderPaper(props: Partial<PaperProps> = {}) {
+  const paperRef: { current: dia.Paper | null } = { current: null };
+  render(
+    <GraphProvider initialCells={EMPTY_CELLS}>
+      <Paper
+        ref={(paper: dia.Paper | null) => {
+          paperRef.current = paper;
+        }}
+        {...props}
+      />
+    </GraphProvider>
+  );
+  await waitFor(() => expect(paperRef.current).toBeTruthy());
+  const paper = paperRef.current;
+  if (!paper) throw new Error('Paper was not created.');
+  return { paper, ...stubPaperTransforms(paper) };
+}
+
+describe('usePinchZoom (Paper zoomOnPinch)', () => {
+  it('applies pinch samples as a clamped uniform scale by default', async () => {
+    const { paper, state, scaleUniformAtPoint } = await renderPaper();
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 20, 2));
+    expect(scaleUniformAtPoint).toHaveBeenCalledWith(2, { x: 10, y: 20 });
+    expect(state.scale).toBe(2);
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 20, 2));
+    expect(state.scale).toBe(4);
+
+    // 4 × 2 = 8 exceeds the default upper bound of 5.
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 20, 2));
+    expect(state.scale).toBe(5);
+  });
+
+  it('respects custom bounds', async () => {
+    const { paper, state } = await renderPaper({ zoomOnPinch: { min: 0.5, max: 2 } });
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 0, 0, 4));
+    expect(state.scale).toBe(2);
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 0, 0, 0.1));
+    expect(state.scale).toBe(0.5);
+  });
+
+  it('is disabled with zoomOnPinch={false}', async () => {
+    const { paper, scaleUniformAtPoint } = await renderPaper({ zoomOnPinch: false });
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 10, 2));
+    expect(scaleUniformAtPoint).not.toHaveBeenCalled();
+  });
+
+  it('yields to an external paper:pinch subscriber', async () => {
+    const { paper, state, scaleUniformAtPoint } = await renderPaper();
+    const external = jest.fn();
+    paper.on('paper:pinch', external);
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 10, 2));
+    expect(external).toHaveBeenCalledTimes(1);
+    expect(scaleUniformAtPoint).not.toHaveBeenCalled(); // the external handler owns zooming
+
+    // Once the external subscriber is gone, the built-in takes over again.
+    paper.off('paper:pinch', external);
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 10, 2));
+    expect(state.scale).toBe(2);
+  });
+
+  it('yields to the onPaperPinch prop', async () => {
+    const onPaperPinch = jest.fn();
+    const { paper, scaleUniformAtPoint } = await renderPaper({ onPaperPinch });
+
+    act(() => paper.trigger('paper:pinch', touchPanEvent(), 10, 10, 2));
+    expect(onPaperPinch).toHaveBeenCalledTimes(1);
+    expect(scaleUniformAtPoint).not.toHaveBeenCalled();
+  });
+
+  it('applies touch-sourced pan samples as a translation', async () => {
+    const { paper, state } = await renderPaper();
+
+    act(() => paper.trigger('paper:pan', touchPanEvent(), 10, 20));
+    expect(state).toMatchObject({ tx: -10, ty: -20 });
+  });
+
+  it('ignores wheel-sourced pan events', async () => {
+    const { paper, translate } = await renderPaper();
+
+    act(() => paper.trigger('paper:pan', wheelPanEvent(), 10, 20));
+    expect(translate).not.toHaveBeenCalled();
+  });
+
+  it('yields to an external paper:pan subscriber', async () => {
+    const { paper, translate } = await renderPaper();
+    const external = jest.fn();
+    paper.on('paper:pan', external);
+
+    act(() => paper.trigger('paper:pan', touchPanEvent(), 10, 20));
+    expect(external).toHaveBeenCalledTimes(1);
+    expect(translate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -48,6 +48,7 @@ import { useAreElementsMeasured } from './use-are-elements-measured';
 import { LINK_MODEL_TYPE } from '../mvc/link-model';
 import { subscribeToPaperEvents } from './use-on-paper-events';
 import { useOnEvents } from './use-on-events';
+import { usePinchZoom } from './use-pinch-zoom';
 import type { CellId } from '../types/cell.types';
 import { extractEventsFromPaperProps } from '../presets/paper-events';
 
@@ -193,6 +194,7 @@ export function useCreatePortalPaper(
     transform,
     portalSelector,
     linkRouting,
+    zoomOnPinch,
     options: escapeHatchOptions,
     // These are React host props and must not be forwarded to dia.Paper options.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -310,6 +312,7 @@ export function useCreatePortalPaper(
 
   const eventHandlers = useMemo(() => extractEventsFromPaperProps(paperOptions), [paperOptions]);
   useOnEvents(paperStore, eventHandlers, subscribeToPaperEvents);
+  usePinchZoom(paperStore, zoomOnPinch);
 
   useLayoutEffect(() => {
     const hostElementForCreation = nodeRef?.current;

--- a/packages/joint-react/src/hooks/use-pinch-zoom.ts
+++ b/packages/joint-react/src/hooks/use-pinch-zoom.ts
@@ -1,0 +1,88 @@
+import { mvc, type dia } from '@joint/core';
+import { useEffect } from 'react';
+import type { PaperStore } from '../store/paper-store';
+
+/**
+ * Zoom limits for the built-in pinch-zoom behavior of `<Paper>`.
+ * @group Types
+ */
+export interface PinchZoomBounds {
+  /**
+   * Lower zoom bound.
+   * @default 0.2
+   */
+  readonly min?: number;
+  /**
+   * Upper zoom bound.
+   * @default 5
+   */
+  readonly max?: number;
+}
+
+const DEFAULT_MIN_ZOOM = 0.2;
+const DEFAULT_MAX_ZOOM = 5;
+
+/**
+ * Count subscribers of a paper event — the same internal `_events`
+ * introspection joint-core uses to gate its ctrl+wheel pinch handling.
+ * @param paper - The paper whose subscriptions are inspected.
+ * @param eventName - Paper event name.
+ * @returns Number of handlers currently subscribed.
+ */
+function countSubscribers(paper: dia.Paper, eventName: string): number {
+  const events = (paper as unknown as { _events?: Record<string, readonly unknown[]> })._events;
+  return events?.[eventName]?.length ?? 0;
+}
+
+function isTouchSourced(event: dia.Event): boolean {
+  const type = (event as { type?: string }).type ?? '';
+  return type.startsWith('touch');
+}
+
+/**
+ * Built-in pinch-zoom behavior for `<Paper>`: applies `paper:pinch` samples as
+ * a clamped `scaleUniformAtPoint` around the gesture point, and touch-sourced
+ * `paper:pan` samples as a translation — so pinch-to-zoom and two-finger pan
+ * work out of the box on a touchscreen and a touchpad (ctrl+wheel).
+ *
+ * Self-yielding: whenever any other subscriber listens to the same event (an
+ * `onPaperPinch` / `onPaperPan` prop, a scroller's interactions), that
+ * subscriber owns the gesture and the built-in does nothing. Checked per
+ * event, so handlers subscribed at any time are honored.
+ * @param paperStore - Store owning the paper, or nullish before creation.
+ * @param zoomOnPinch - The `zoomOnPinch` prop: `false` disables, an object tunes the bounds.
+ * @internal
+ */
+export function usePinchZoom(
+  paperStore: PaperStore | null | undefined,
+  zoomOnPinch: boolean | PinchZoomBounds | undefined
+): void {
+  const isEnabled = zoomOnPinch !== false;
+  const bounds = typeof zoomOnPinch === 'object' ? zoomOnPinch : undefined;
+  const minZoom = bounds?.min ?? DEFAULT_MIN_ZOOM;
+  const maxZoom = bounds?.max ?? DEFAULT_MAX_ZOOM;
+  const paper = paperStore?.paper;
+
+  useEffect(() => {
+    if (!paper || !isEnabled) return;
+    const onPinch = (_event: dia.Event, x: number, y: number, scale: number) => {
+      if (countSubscribers(paper, 'paper:pinch') > 1) return;
+      const currentScale = paper.scale().sx;
+      const nextScale = Math.min(maxZoom, Math.max(minZoom, currentScale * scale));
+      if (nextScale === currentScale) return;
+      paper.scaleUniformAtPoint(nextScale, { x, y });
+    };
+    const onPan = (event: dia.Event, deltaX: number, deltaY: number) => {
+      // Touch gestures only: wheel emits `paper:pan` for every plain scroll,
+      // and out-of-the-box wheel panning is not part of this behavior.
+      if (!isTouchSourced(event)) return;
+      if (countSubscribers(paper, 'paper:pan') > 1) return;
+      const { tx, ty } = paper.translate();
+      paper.translate(tx - deltaX, ty - deltaY);
+    };
+    const controller = new mvc.Listener();
+    controller.listenTo(paper, 'paper:pinch', onPinch);
+    controller.listenTo(paper, 'paper:pan', onPan);
+    return () => controller.stopListening();
+  }, [paper, isEnabled, minZoom, maxZoom]);
+}

--- a/packages/joint-react/src/index.ts
+++ b/packages/joint-react/src/index.ts
@@ -32,6 +32,8 @@ export type {
   DefaultLinkParams,
 } from './components/paper/paper.types';
 /** @group Types */
+export type { PinchZoomBounds } from './hooks/use-pinch-zoom';
+/** @group Types */
 export type { PortalHostCell, PortalSelector, PortalSelectorParams } from './mvc/paper.types';
 /** @group Types */
 export type {

--- a/packages/joint-react/src/internal.ts
+++ b/packages/joint-react/src/internal.ts
@@ -67,6 +67,7 @@ export { assignOptions, pickValues, makeOptions } from './utils/object-utilities
 export { resolvePaper, resolvePaperId, isPaperTarget } from './utils/resolve-paper-target';
 export { isRecord } from './utils/is';
 export { wheelGuard, SCROLLABLE_ATTRIBUTE } from './utils/wheel-guard';
+export { isMultiTouchEvent } from './utils/touch-gestures';
 
 // Constants
 export { ELEMENT_MODEL_TYPE, PORTAL_SELECTOR } from './mvc/element-model';

--- a/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
+++ b/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
@@ -176,19 +176,53 @@ describe('paper preset touch gestures', () => {
     ]);
 
     // Drag moves arrive as pointer events under this preset. The first one is
-    // caught by the pointermove leg of the detector and ends the drag — at
-    // most one garbled move leaks (same as the official demo).
+    // caught by the preset's `pointermove` override and ends the drag before
+    // it processes — no garbled move ever reaches consumers.
     const pointerMove = new Event('pointermove', { bubbles: true });
     Object.assign(pointerMove, { pointerType: 'touch', clientX: 60, clientY: 60 });
     document.dispatchEvent(pointerMove);
-    expect(onCellPointerMove).toHaveBeenCalledTimes(1);
+    expect(onCellPointerMove).not.toHaveBeenCalled();
     expect(onCellPointerUp).toHaveBeenCalledTimes(1);
     // The neutralizing pointerup must not synthesize a click.
     expect(onCellPointerClick).not.toHaveBeenCalled();
 
     // The drag is gone — further moves reach nothing.
     document.dispatchEvent(pointerMove);
-    expect(onCellPointerMove).toHaveBeenCalledTimes(1);
+    expect(onCellPointerMove).not.toHaveBeenCalled();
+  });
+
+  it('neutralizes a magnet press too (magnet drags bypass the cell events)', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onMagnetPointerDown = jest.fn();
+    const onCellPointerClick = jest.fn();
+    paper.on('element:magnet:pointerdown', onMagnetPointerDown);
+    paper.on('cell:pointerclick', onCellPointerClick);
+    paper.on('paper:pinch', jest.fn());
+
+    // Make a node inside the cell a connectable magnet — a press on it routes
+    // through `onmagnet` / `dragMagnetStart`, which stops propagation and
+    // never fires the cell:pointer* events.
+    const magnetNode = document.createElement('div');
+    magnetNode.setAttribute('magnet', 'true');
+    cellNode.append(magnetNode);
+
+    dispatchTouch(magnetNode, 'touchstart', [{ x: 50, y: 50 }]);
+    expect(onMagnetPointerDown).toHaveBeenCalledTimes(1);
+
+    // Finger 2 lands on the magnet: the magnet leg of the detector prevents
+    // the magnet/link drag from arming and ends the single-pointer sequence.
+    dispatchTouch(magnetNode, 'touchstart', [
+      { x: 50, y: 50 },
+      { x: 150, y: 50 },
+    ]);
+    expect(onMagnetPointerDown).toHaveBeenCalledTimes(2);
+
+    // The pinch owns the sequence: moves start no link and click nothing.
+    const pointerMove = new Event('pointermove', { bubbles: true });
+    Object.assign(pointerMove, { pointerType: 'touch', clientX: 80, clientY: 60 });
+    document.dispatchEvent(pointerMove);
+    expect(paper.model.getLinks()).toHaveLength(0);
+    expect(onCellPointerClick).not.toHaveBeenCalled();
   });
 
   it('keeps single-finger touches on core untouched', async () => {

--- a/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
+++ b/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
@@ -40,16 +40,22 @@ interface TouchStub {
   readonly target?: Element;
 }
 
-function dispatchTouch(target: Element, type: string, touches: readonly TouchStub[]): Event {
+function dispatchTouch(
+  target: Element,
+  type: string,
+  touches: readonly TouchStub[],
+  changedTouches?: readonly TouchStub[]
+): Event {
   const event = new Event(type, { bubbles: true, cancelable: true });
-  const touchList = touches.map((touch) => ({
+  const toTouch = (touch: TouchStub) => ({
     clientX: touch.x,
     clientY: touch.y,
     target: touch.target ?? target,
-  }));
+  });
+  const touchList = touches.map(toTouch);
   Object.assign(event, {
     touches: touchList,
-    changedTouches: touchList,
+    changedTouches: changedTouches ? changedTouches.map(toTouch) : touchList,
     clientX: touches[0]?.x ?? 0,
     clientY: touches[0]?.y ?? 0,
   });
@@ -258,6 +264,70 @@ describe('paper preset touch gestures', () => {
     ]);
     expect(onPinch).not.toHaveBeenCalled();
     expect(start.defaultPrevented).toBe(false); // the region keeps native scrolling
+  });
+
+  it('leaves touch ends of unrelated page UI alone while a gesture is active', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    paper.on('paper:pinch', jest.fn());
+
+    // Two fingers pinch on the paper; a third finger taps a button OUTSIDE it.
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+    ]);
+    const outsideButton = document.createElement('button');
+    document.body.append(outsideButton);
+    // The outside tap lifts: the two paper fingers remain in `touches`, only
+    // the outside finger is in `changedTouches`. Its touchend reaches the
+    // document-level listener but must NOT be prevented — that would kill the
+    // button's click.
+    const outsideEnd = dispatchTouch(
+      outsideButton,
+      'touchend',
+      [
+        { x: 100, y: 100, target: cellNode },
+        { x: 200, y: 100, target: cellNode },
+      ],
+      [{ x: 400, y: 400, target: outsideButton }]
+    );
+    expect(outsideEnd.defaultPrevented).toBe(false);
+
+    // The gesture itself is untouched: its own end event is still processed.
+    const gestureEnd = dispatchTouch(cellNode, 'touchend', [{ x: 100, y: 100 }]);
+    expect(gestureEnd.defaultPrevented).toBe(true);
+    outsideButton.remove();
+  });
+
+  it('still ends the gesture when the touch target was removed from the DOM', async () => {
+    const { paper, cellNode, container } = await renderTouchPaper();
+    const onBlankPointerDown = jest.fn();
+    paper.on('blank:pointerdown', onBlankPointerDown);
+    paper.on('paper:pinch', jest.fn());
+
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+    ]);
+    // The pinched cell unmounts mid-gesture (view disposal / re-render). The
+    // fingers lift, but their touch events now target a detached node — they
+    // only reach the document-level listener, which must still process them.
+    cellNode.remove();
+    const detachedEnd = new Event('touchend', { bubbles: true, cancelable: true });
+    Object.assign(detachedEnd, {
+      touches: [],
+      changedTouches: [
+        { clientX: 100, clientY: 100, target: cellNode },
+        { clientX: 200, clientY: 100, target: cellNode },
+      ],
+    });
+    document.dispatchEvent(detachedEnd);
+
+    // Gesture over — a fresh single-finger touch flows to core again.
+    const svg = container.querySelector('svg');
+    if (!svg) throw new Error('Paper svg not rendered.');
+    const fresh = dispatchTouch(svg, 'touchstart', [{ x: 50, y: 50 }]);
+    expect(fresh.defaultPrevented).toBe(false); // recognizer is idle, not consuming
+    expect(onBlankPointerDown).toHaveBeenCalled();
   });
 
   it('drains the remaining finger after the gesture ends (no phantom interactions)', async () => {

--- a/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
+++ b/packages/joint-react/src/presets/__tests__/paper-touch.test.tsx
@@ -1,0 +1,255 @@
+/* eslint-disable react-perf/jsx-no-new-function-as-prop */
+import { render, waitFor } from '@testing-library/react';
+import type { CSSProperties } from 'react';
+import type { dia } from '@joint/core';
+import { GraphProvider } from '../../components';
+import { Paper } from '../../components/paper/paper';
+import type { CellRecord } from '../../types/cell.types';
+
+const PAPER_STYLE: CSSProperties = { width: 400, height: 400 };
+
+// Integration coverage for the touch-gesture layer wired in presets/paper.ts:
+// real DOM dispatches on a rendered <Paper>, asserting the emitted
+// `paper:pinch` / `paper:pan` events and the drag-cancel behavior. Geometry
+// going through the mocked SVG CTM degenerates in jsdom, so local x/y args are
+// not asserted — the scale ratio and pan deltas are pure client-space math.
+
+beforeEach(() => {
+  // jsdom does not implement elementFromPoint; core's `getEventTarget` calls
+  // it for captured-pointer / touch events. `null` = nothing under the point.
+  Object.defineProperty(document, 'elementFromPoint', {
+    value: () => null,
+    writable: true,
+    configurable: true,
+  });
+});
+
+const initialCells: readonly CellRecord[] = [
+  {
+    id: 'n1',
+    type: 'element',
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    data: {},
+  },
+];
+
+interface TouchStub {
+  readonly x: number;
+  readonly y: number;
+  readonly target?: Element;
+}
+
+function dispatchTouch(target: Element, type: string, touches: readonly TouchStub[]): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const touchList = touches.map((touch) => ({
+    clientX: touch.x,
+    clientY: touch.y,
+    target: touch.target ?? target,
+  }));
+  Object.assign(event, {
+    touches: touchList,
+    changedTouches: touchList,
+    clientX: touches[0]?.x ?? 0,
+    clientY: touches[0]?.y ?? 0,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+async function renderTouchPaper() {
+  const paperRef: { current: dia.Paper | null } = { current: null };
+  const { container, unmount } = render(
+    <GraphProvider initialCells={initialCells}>
+      <Paper
+        ref={(paper: dia.Paper | null) => {
+          paperRef.current = paper;
+        }}
+        style={PAPER_STYLE}
+      />
+    </GraphProvider>
+  );
+  await waitFor(() => expect(container.querySelector('.joint-cell')).toBeTruthy());
+  const paper = paperRef.current;
+  if (!paper) throw new Error('Paper was not created.');
+  const cellNode = container.querySelector('.joint-cell');
+  if (!cellNode) throw new Error('Cell node not rendered.');
+  return { paper, cellNode, container, unmount };
+}
+
+describe('paper preset touch gestures', () => {
+  it('emits paper:pinch with the relative scale ratio for a two-finger pinch', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onPinch = jest.fn();
+    paper.on('paper:pinch', onPinch);
+
+    const start = dispatchTouch(cellNode, 'touchstart', [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+    ]);
+    // Gesture start is announced immediately with a scale-1 pinch and the
+    // second finger's touchstart is consumed (no browser pinch-zoom).
+    expect(onPinch).toHaveBeenCalledTimes(1);
+    expect(onPinch.mock.calls[0][3]).toBe(1);
+    expect(start.defaultPrevented).toBe(true);
+
+    // Fingers spread 100 → 200 apart: relative scale ratio 2 after the
+    // animation-frame flush.
+    dispatchTouch(cellNode, 'touchmove', [
+      { x: 50, y: 100 },
+      { x: 250, y: 100 },
+    ]);
+    await waitFor(() => expect(onPinch).toHaveBeenCalledTimes(2));
+    expect(onPinch.mock.calls[1][3]).toBe(2);
+  });
+
+  it('emits paper:pan with wheel-convention deltas for a two-finger pan', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onPan = jest.fn();
+    paper.on('paper:pan', onPan);
+    // Subscribe pinch too so the built-in zoom yields (not under test here).
+    paper.on('paper:pinch', jest.fn());
+
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+    ]);
+    // Both fingers move right by 30 and down by 10 — content follows the
+    // fingers, which in wheel convention is a negative delta.
+    dispatchTouch(cellNode, 'touchmove', [
+      { x: 130, y: 110 },
+      { x: 230, y: 110 },
+    ]);
+    await waitFor(() => expect(onPan).toHaveBeenCalledTimes(1));
+    expect(onPan.mock.calls[0][1]).toBe(-30);
+    expect(onPan.mock.calls[0][2]).toBe(-10);
+  });
+
+  it('stops an in-flight single-finger drag when the second finger lands, without a click', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onCellPointerDown = jest.fn();
+    const onBlankPointerUp = jest.fn();
+    const onCellPointerClick = jest.fn();
+    const onBlankPointerClick = jest.fn();
+    paper.on('cell:pointerdown', onCellPointerDown);
+    paper.on('blank:pointerup', onBlankPointerUp);
+    paper.on('cell:pointerclick', onCellPointerClick);
+    paper.on('blank:pointerclick', onBlankPointerClick);
+    paper.on('paper:pinch', jest.fn());
+
+    // Finger 1 starts a regular cell drag through core's touchstart pipeline.
+    dispatchTouch(cellNode, 'touchstart', [{ x: 50, y: 50 }]);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(1);
+
+    // Finger 2 promotes the sequence to a pinch. Core still processes its
+    // touchstart (official pattern), and the gesture detector neutralizes it:
+    // `preventDefaultInteraction` stops the new cell drag from starting and
+    // `paper.pointerup` ends the single-pointer interaction (the finger-1
+    // drag's document events undelegate).
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 50, y: 50 },
+      { x: 150, y: 50 },
+    ]);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(2); // official: finger 2 is seen, then neutralized
+    expect(onBlankPointerUp).toHaveBeenCalledTimes(1); // the neutralizing pointerup
+    // A two-finger press must not click / select the pressed cell.
+    expect(onCellPointerClick).not.toHaveBeenCalled();
+    expect(onBlankPointerClick).not.toHaveBeenCalled();
+  });
+
+  it('neutralizes the re-delegated drag on the first touch-driven pointermove', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onCellPointerMove = jest.fn();
+    const onCellPointerUp = jest.fn();
+    const onCellPointerClick = jest.fn();
+    paper.on('cell:pointermove', onCellPointerMove);
+    paper.on('cell:pointerup', onCellPointerUp);
+    paper.on('cell:pointerclick', onCellPointerClick);
+    paper.on('paper:pinch', jest.fn());
+
+    dispatchTouch(cellNode, 'touchstart', [{ x: 50, y: 50 }]);
+    // Finger 2: core re-delegates drag events after the neutralization (it
+    // runs inside `pointerdown`, before `delegateDragEvents`).
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 50, y: 50 },
+      { x: 150, y: 50 },
+    ]);
+
+    // Drag moves arrive as pointer events under this preset. The first one is
+    // caught by the pointermove leg of the detector and ends the drag — at
+    // most one garbled move leaks (same as the official demo).
+    const pointerMove = new Event('pointermove', { bubbles: true });
+    Object.assign(pointerMove, { pointerType: 'touch', clientX: 60, clientY: 60 });
+    document.dispatchEvent(pointerMove);
+    expect(onCellPointerMove).toHaveBeenCalledTimes(1);
+    expect(onCellPointerUp).toHaveBeenCalledTimes(1);
+    // The neutralizing pointerup must not synthesize a click.
+    expect(onCellPointerClick).not.toHaveBeenCalled();
+
+    // The drag is gone — further moves reach nothing.
+    document.dispatchEvent(pointerMove);
+    expect(onCellPointerMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps single-finger touches on core untouched', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onCellPointerDown = jest.fn();
+    const onPinch = jest.fn();
+    paper.on('cell:pointerdown', onCellPointerDown);
+    paper.on('paper:pinch', onPinch);
+
+    const start = dispatchTouch(cellNode, 'touchstart', [{ x: 50, y: 50 }]);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(1);
+    expect(onPinch).not.toHaveBeenCalled();
+    // Core's own preventDefault policy applies — the gesture layer didn't veto
+    // propagation (the event reached core's delegated handler at all).
+    expect(start.defaultPrevented).toBe(true); // preventDefaultViewAction default
+  });
+
+  it('leaves gestures on scrollable regions to the region', async () => {
+    const { paper } = await renderTouchPaper();
+    const onPinch = jest.fn();
+    paper.on('paper:pinch', onPinch);
+
+    // A scrollable list inside the paper (same opt-out the wheel guard uses).
+    const scrollable = document.createElement('div');
+    scrollable.dataset.jjScrollable = '';
+    Object.defineProperty(scrollable, 'scrollHeight', { value: 500 });
+    Object.defineProperty(scrollable, 'clientHeight', { value: 100 });
+    paper.el.append(scrollable);
+
+    const start = dispatchTouch(scrollable, 'touchstart', [
+      { x: 10, y: 10 },
+      { x: 40, y: 40 },
+    ]);
+    expect(onPinch).not.toHaveBeenCalled();
+    expect(start.defaultPrevented).toBe(false); // the region keeps native scrolling
+  });
+
+  it('drains the remaining finger after the gesture ends (no phantom interactions)', async () => {
+    const { paper, cellNode } = await renderTouchPaper();
+    const onCellPointerDown = jest.fn();
+    paper.on('cell:pointerdown', onCellPointerDown);
+    paper.on('paper:pinch', jest.fn());
+
+    // Both fingers land in a single touchstart: core sees one pointerdown
+    // (official pattern) which the detector immediately neutralizes.
+    dispatchTouch(cellNode, 'touchstart', [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+    ]);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(1);
+
+    // One finger lifts — the gesture ends, the leftover finger drains: its
+    // moves stay browser-prevented and start nothing on the paper.
+    dispatchTouch(cellNode, 'touchend', [{ x: 100, y: 100 }]);
+    const drainMove = dispatchTouch(cellNode, 'touchmove', [{ x: 120, y: 120 }]);
+    expect(drainMove.defaultPrevented).toBe(true);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(1);
+
+    // All fingers up — the next single-finger touch flows to core again.
+    dispatchTouch(cellNode, 'touchend', []);
+    dispatchTouch(cellNode, 'touchstart', [{ x: 50, y: 50 }]);
+    expect(onCellPointerDown).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/joint-react/src/presets/paper.css
+++ b/packages/joint-react/src/presets/paper.css
@@ -26,6 +26,11 @@
 .jj-paper {
     background-color: var(--jj-paper-color);
     height: stretch;
+    /* Disable the browser's double-tap zoom so fast taps stay app gestures
+       (`dbltap`). Pan / pinch suppression is handled selectively in JS (see
+       utils/touch-gestures) so `[data-jj-scrollable]` regions keep native
+       touch scrolling — `touch-action: none` here would take it from them. */
+    touch-action: manipulation;
 }
 
 /* ── Paper Interactions ─────────────────────────────────────────────────────── */

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -3,7 +3,8 @@ import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
 import { MagnetHighlighter, MAGNET_HIGHLIGHTER_NAME } from './magnet-highlighter';
-import { wheelGuard } from '../utils/wheel-guard';
+import { isInsideScrollableRegion, wheelGuard } from '../utils/wheel-guard';
+import { isMultiTouchEvent, TouchGestureRecognizer } from '../utils/touch-gestures';
 
 // ---------------------------------------------------------------------------
 // PointerEvents migration
@@ -23,6 +24,7 @@ type ProtectedPaperPrototype = {
   readonly pointerup: (event: dia.Event) => void;
   readonly startListening: () => void;
   readonly guard: (event: dia.Event, view: dia.CellView) => boolean;
+  readonly onRemove: () => void;
 };
 
 const protectedProto = dia.Paper.prototype as unknown as ProtectedPaperPrototype;
@@ -44,6 +46,143 @@ function getPointerId(event: dia.Event): number | null {
 const DEFAULT_CLICK_THRESHOLD = 5;
 const DEFAULT_GRID_SIZE = 10;
 const DEFAULT_SNAP_RADIUS = 15;
+
+// ---------------------------------------------------------------------------
+// Touch gestures (pinch-to-zoom / two-finger pan)
+// ---------------------------------------------------------------------------
+// Joint-core models multi-touch nowhere: a second `touchstart` re-enters
+// `pointerdown` and garbles the drag, and `paper:pinch` fires only from the
+// touchpad's ctrl+wheel. This layer follows the structure of the official
+// JointJS+ touch demo: single-pointer interactions are neutralized via the
+// sanctioned APIs when a second finger lands (`preventDefaultInteraction` +
+// `paper.pointerup`, see `stopInteractionIfGestureDetected`), and an
+// in-library recognizer (the demo uses interact.js) turns the two-finger
+// stream into the very same `paper:pinch` / `paper:pan` events core fires for
+// touchpad gestures — so wheel and touch share one consumer pipeline.
+
+/** Per-paper touch-gesture teardown, run from `onRemove`. */
+const touchGestureCleanup = new WeakMap<dia.Paper, () => void>();
+
+/** Access to the paper's own `pointerup` dispatch (not part of the public typings). */
+type PaperPointerHandlers = { readonly pointerup: (event: dia.Event) => void };
+
+/**
+ * The official JointJS touch pattern (mirrors the JointJS+ touch demo): when a
+ * second finger lands during a single-pointer interaction, the interaction is
+ * neutralized through the sanctioned APIs — `cellView.preventDefaultInteraction`
+ * keeps a cell drag from starting, and `paper.pointerup` ends whatever
+ * single-pointer interaction had already started (drag document events
+ * undelegate, pointer capture releases). Wired to `pointerdown` AND
+ * `pointermove` because the paper re-delegates drag events on every
+ * `pointerdown` — the first drag move after that re-delegation is caught here.
+ * @param paper - The paper whose interaction should stop.
+ * @param recognizer - The gesture recognizer (its phase identifies touch-driven pointer moves).
+ * @param cellView - The view under the pointer, or `null` for a blank interaction.
+ * @param event - The paper-delivered event.
+ */
+function stopInteractionIfGestureDetected(
+  paper: dia.Paper,
+  recognizer: TouchGestureRecognizer,
+  cellView: dia.CellView | null,
+  event: dia.Event
+): void {
+  // With this preset's PointerEvents `documentEvents`, drag moves arrive as
+  // `pointermove` events that carry no `touches` list — the recognizer's
+  // active phase stands in for the official `touches.length` check there.
+  const isTouchDrivenPointerMove =
+    event.type === 'pointermove' &&
+    (event.originalEvent as Partial<PointerEvent> | undefined)?.pointerType === 'touch' &&
+    recognizer.isActive();
+  if (!isMultiTouchEvent(event) && !isTouchDrivenPointerMove) return;
+  if (cellView) cellView.preventDefaultInteraction(event);
+  // The neutralizing pointerup must not synthesize a `pointerclick` for the
+  // second finger — `pointerup` skips the click for propagation-stopped events.
+  event.stopPropagation();
+  (paper as unknown as PaperPointerHandlers).pointerup(event);
+}
+
+/**
+ * Safari's proprietary gesture pipeline — prevented as belt-and-braces next to
+ * the touch-level preventDefault (a no-op everywhere else).
+ * @param event - The `gesturestart` event.
+ */
+const preventNativeGesture = (event: Event) => event.preventDefault();
+
+/**
+ * Attach the two-finger gesture layer to a paper, following the official
+ * JointJS touch demo structure: (1) `stopInteractionIfGestureDetected`
+ * subscribed to the cell / blank `pointerdown` + `pointermove` events, and
+ * (2) a gesture recognizer on `paper.el` (the in-library replacement for the
+ * demo's interact.js `gesturable`) that re-emits two-finger pinch / pan as the
+ * very same `paper:pinch` / `paper:pan` events core fires for touchpad
+ * (ctrl+wheel) gestures. Listeners are capture-phase and `passive: false` so
+ * `preventDefault` reliably stops the browser's own pinch-zoom / scroll.
+ * Gestures starting on a natively scrollable region (`[data-jj-scrollable]` /
+ * `<textarea>` with overflow) are left alone — the same opt-out the wheel
+ * guard honors.
+ * @param paper - The paper to attach the gesture layer to.
+ */
+function attachTouchGestures(paper: dia.Paper): void {
+  const host = paper.el;
+  const recognizer = new TouchGestureRecognizer({
+    isEligibleTouch: (touchPoint) =>
+      touchPoint.target instanceof Node && host.contains(touchPoint.target),
+    shouldSkipGesture: (touches) =>
+      touches.some((touchPoint) => isInsideScrollableRegion(touchPoint.target)),
+    onGestureStart: (event, midpoint) => {
+      const local = paper.clientToLocalPoint(midpoint.x, midpoint.y);
+      // A scale-1 pinch announces the gesture immediately, so consumers (e.g.
+      // a paper scroller) can stop a pan the first finger may have started.
+      paper.trigger('paper:pinch', event, local.x, local.y, 1);
+    },
+    onGestureUpdate: ({ event, clientX, clientY, scale, deltaX, deltaY }) => {
+      if (deltaX !== 0 || deltaY !== 0) {
+        paper.trigger('paper:pan', event, deltaX, deltaY);
+      }
+      if (scale !== 1) {
+        const local = paper.clientToLocalPoint(clientX, clientY);
+        paper.trigger('paper:pinch', event, local.x, local.y, scale);
+      }
+    },
+  });
+  paper.on('cell:pointerdown', (cellView: dia.CellView, event: dia.Event) =>
+    stopInteractionIfGestureDetected(paper, recognizer, cellView, event)
+  );
+  paper.on('cell:pointermove', (cellView: dia.CellView, event: dia.Event) =>
+    stopInteractionIfGestureDetected(paper, recognizer, cellView, event)
+  );
+  paper.on('blank:pointerdown', (event: dia.Event) =>
+    stopInteractionIfGestureDetected(paper, recognizer, null, event)
+  );
+  paper.on('blank:pointermove', (event: dia.Event) =>
+    stopInteractionIfGestureDetected(paper, recognizer, null, event)
+  );
+  // Real touch events always carry `touches`; the guard skips synthetic
+  // `Event('touch*')` dispatches that lack a touch payload.
+  const handleTouchStart = (event: TouchEvent) => {
+    if (event.touches) recognizer.handleTouchStart(event);
+  };
+  const handleTouchMove = (event: TouchEvent) => {
+    if (event.touches) recognizer.handleTouchMove(event);
+  };
+  const handleTouchEnd = (event: TouchEvent) => {
+    if (event.touches) recognizer.handleTouchEnd(event);
+  };
+  const listenerOptions: AddEventListenerOptions = { capture: true, passive: false };
+  host.addEventListener('touchstart', handleTouchStart, listenerOptions);
+  host.addEventListener('touchmove', handleTouchMove, listenerOptions);
+  host.addEventListener('touchend', handleTouchEnd, listenerOptions);
+  host.addEventListener('touchcancel', handleTouchEnd, listenerOptions);
+  host.addEventListener('gesturestart', preventNativeGesture, listenerOptions);
+  touchGestureCleanup.set(paper, () => {
+    recognizer.dispose();
+    host.removeEventListener('touchstart', handleTouchStart, listenerOptions);
+    host.removeEventListener('touchmove', handleTouchMove, listenerOptions);
+    host.removeEventListener('touchend', handleTouchEnd, listenerOptions);
+    host.removeEventListener('touchcancel', handleTouchEnd, listenerOptions);
+    host.removeEventListener('gesturestart', preventNativeGesture, listenerOptions);
+  });
+}
 
 /** Applied to magnets highlighted as available link targets. */
 const MAGNET_AVAILABLE_CLASS_NAME = 'jj-is-magnet-available';
@@ -185,6 +324,16 @@ export const Paper = dia.Paper.extend(
         'cell:pointerdown': storePointerTarget,
         'element:magnet:pointerdown': storePointerTarget,
       });
+      attachTouchGestures(this);
+    },
+
+    /**
+     * Detach the touch-gesture listeners, then run the upstream teardown.
+     */
+    onRemove(this: dia.Paper) {
+      touchGestureCleanup.get(this)?.();
+      touchGestureCleanup.delete(this);
+      protectedProto.onRemove.call(this);
     },
 
     /**

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -1,10 +1,14 @@
-import { dia, highlighters, util } from '@joint/core';
+import { dia, highlighters, mvc, util } from '@joint/core';
 import { measureNode } from './measure-node';
 import { linkRoutingStraight } from './link-routing';
 import { LinkView } from './link-view';
 import { MagnetHighlighter, MAGNET_HIGHLIGHTER_NAME } from './magnet-highlighter';
 import { isInsideScrollableRegion, wheelGuard } from '../utils/wheel-guard';
-import { isMultiTouchEvent, TouchGestureRecognizer } from '../utils/touch-gestures';
+import {
+  isMultiTouchEvent,
+  TouchGestureRecognizer,
+  type TouchGestureEvent,
+} from '../utils/touch-gestures';
 
 // ---------------------------------------------------------------------------
 // PointerEvents migration
@@ -122,6 +126,9 @@ const DEFAULT_SNAP_RADIUS = 15;
 /** Per-paper touch-gesture teardown, run from `onRemove`. */
 const touchGestureCleanup = new WeakMap<dia.Paper, () => void>();
 
+/** Per-paper recognizer, consulted by the `pointermove` override during drags. */
+const touchGestureRecognizers = new WeakMap<dia.Paper, TouchGestureRecognizer>();
+
 /** Access to the paper's own `pointerup` dispatch (not part of the public typings). */
 type PaperPointerHandlers = { readonly pointerup: (event: dia.Event) => void };
 
@@ -129,30 +136,25 @@ type PaperPointerHandlers = { readonly pointerup: (event: dia.Event) => void };
  * The official JointJS touch pattern (mirrors the JointJS+ touch demo): when a
  * second finger lands during a single-pointer interaction, the interaction is
  * neutralized through the sanctioned APIs — `cellView.preventDefaultInteraction`
- * keeps a cell drag from starting, and `paper.pointerup` ends whatever
- * single-pointer interaction had already started (drag document events
- * undelegate, pointer capture releases). Wired to `pointerdown` AND
- * `pointermove` because the paper re-delegates drag events on every
- * `pointerdown` — the first drag move after that re-delegation is caught here.
+ * keeps a cell (or magnet/link) drag from starting, and `paper.pointerup` ends
+ * whatever single-pointer interaction had already started (drag document
+ * events undelegate, pointer capture releases). Wired to every drag-start
+ * notification: `cell:pointerdown`, `blank:pointerdown`, and
+ * `element:magnet:pointerdown` (a magnet press stops propagation inside
+ * `dragMagnetStart`, so the cell events never fire for it — the magnet
+ * notification precedes that and its drag honors `preventDefaultInteraction`).
+ * Drag MOVES are neutralized in the preset's `pointermove` override instead,
+ * which runs for every drag action.
  * @param paper - The paper whose interaction should stop.
- * @param recognizer - The gesture recognizer (its phase identifies touch-driven pointer moves).
  * @param cellView - The view under the pointer, or `null` for a blank interaction.
  * @param event - The paper-delivered event.
  */
 function stopInteractionIfGestureDetected(
   paper: dia.Paper,
-  recognizer: TouchGestureRecognizer,
   cellView: dia.CellView | null,
   event: dia.Event
 ): void {
-  // With this preset's PointerEvents `documentEvents`, drag moves arrive as
-  // `pointermove` events that carry no `touches` list — the recognizer's
-  // active phase stands in for the official `touches.length` check there.
-  const isTouchDrivenPointerMove =
-    event.type === 'pointermove' &&
-    (event.originalEvent as Partial<PointerEvent> | undefined)?.pointerType === 'touch' &&
-    recognizer.isActive();
-  if (!isMultiTouchEvent(event) && !isTouchDrivenPointerMove) return;
+  if (!isMultiTouchEvent(event)) return;
   if (cellView) cellView.preventDefaultInteraction(event);
   // The neutralizing pointerup must not synthesize a `pointerclick` for the
   // second finger — `pointerup` skips the click for propagation-stopped events.
@@ -183,6 +185,15 @@ const preventNativeGesture = (event: Event) => event.preventDefault();
  */
 function attachTouchGestures(paper: dia.Paper): void {
   const host = paper.el;
+  // Emissions must honor the `dia.Event` contract of `paper:pinch` /
+  // `paper:pan` (core always passes a normalized wrapper with `originalEvent`,
+  // `data`, `isPropagationStopped()`, …) — wrap the raw TouchEvent exactly as
+  // core's own dispatch would.
+  // `mvc.$` is exported at runtime (mvc/index.mjs) but missing from the type
+  // declarations — cast to reach the wrapper constructor.
+  const DomEvent = (mvc as unknown as { $: { Event: new (event: Event) => dia.Event } }).$.Event;
+  const toPaperEvent = (event: TouchGestureEvent): dia.Event =>
+    util.normalizeEvent(new DomEvent(event as unknown as Event)) as dia.Event;
   const recognizer = new TouchGestureRecognizer({
     isEligibleTouch: (touchPoint) =>
       touchPoint.target instanceof Node && host.contains(touchPoint.target),
@@ -192,29 +203,28 @@ function attachTouchGestures(paper: dia.Paper): void {
       const local = paper.clientToLocalPoint(midpoint.x, midpoint.y);
       // A scale-1 pinch announces the gesture immediately, so consumers (e.g.
       // a paper scroller) can stop a pan the first finger may have started.
-      paper.trigger('paper:pinch', event, local.x, local.y, 1);
+      paper.trigger('paper:pinch', toPaperEvent(event), local.x, local.y, 1);
     },
     onGestureUpdate: ({ event, clientX, clientY, scale, deltaX, deltaY }) => {
+      const paperEvent = toPaperEvent(event);
       if (deltaX !== 0 || deltaY !== 0) {
-        paper.trigger('paper:pan', event, deltaX, deltaY);
+        paper.trigger('paper:pan', paperEvent, deltaX, deltaY);
       }
       if (scale !== 1) {
         const local = paper.clientToLocalPoint(clientX, clientY);
-        paper.trigger('paper:pinch', event, local.x, local.y, scale);
+        paper.trigger('paper:pinch', paperEvent, local.x, local.y, scale);
       }
     },
   });
+  touchGestureRecognizers.set(paper, recognizer);
   paper.on('cell:pointerdown', (cellView: dia.CellView, event: dia.Event) =>
-    stopInteractionIfGestureDetected(paper, recognizer, cellView, event)
+    stopInteractionIfGestureDetected(paper, cellView, event)
   );
-  paper.on('cell:pointermove', (cellView: dia.CellView, event: dia.Event) =>
-    stopInteractionIfGestureDetected(paper, recognizer, cellView, event)
+  paper.on('element:magnet:pointerdown', (cellView: dia.CellView, event: dia.Event) =>
+    stopInteractionIfGestureDetected(paper, cellView, event)
   );
   paper.on('blank:pointerdown', (event: dia.Event) =>
-    stopInteractionIfGestureDetected(paper, recognizer, null, event)
-  );
-  paper.on('blank:pointermove', (event: dia.Event) =>
-    stopInteractionIfGestureDetected(paper, recognizer, null, event)
+    stopInteractionIfGestureDetected(paper, null, event)
   );
   // Real touch events always carry `touches`; the guard skips synthetic
   // `Event('touch*')` dispatches that lack a touch payload.
@@ -230,15 +240,22 @@ function attachTouchGestures(paper: dia.Paper): void {
   const listenerOptions: AddEventListenerOptions = { capture: true, passive: false };
   host.addEventListener('touchstart', handleTouchStart, listenerOptions);
   host.addEventListener('touchmove', handleTouchMove, listenerOptions);
-  host.addEventListener('touchend', handleTouchEnd, listenerOptions);
-  host.addEventListener('touchcancel', handleTouchEnd, listenerOptions);
+  // End events live on `document`: a touch's events dispatch to the target
+  // captured at touchstart, and if that node left the DOM (view disposal,
+  // re-render) they never bubble through `paper.el` — the gesture would stay
+  // active forever. Eligibility still scopes them to this paper's touches; the
+  // recognizer's staleness watchdog covers browsers that stop delivering
+  // events for detached targets altogether.
+  document.addEventListener('touchend', handleTouchEnd, listenerOptions);
+  document.addEventListener('touchcancel', handleTouchEnd, listenerOptions);
   host.addEventListener('gesturestart', preventNativeGesture, listenerOptions);
   touchGestureCleanup.set(paper, () => {
     recognizer.dispose();
+    touchGestureRecognizers.delete(paper);
     host.removeEventListener('touchstart', handleTouchStart, listenerOptions);
     host.removeEventListener('touchmove', handleTouchMove, listenerOptions);
-    host.removeEventListener('touchend', handleTouchEnd, listenerOptions);
-    host.removeEventListener('touchcancel', handleTouchEnd, listenerOptions);
+    document.removeEventListener('touchend', handleTouchEnd, listenerOptions);
+    document.removeEventListener('touchcancel', handleTouchEnd, listenerOptions);
     host.removeEventListener('gesturestart', preventNativeGesture, listenerOptions);
   });
 }
@@ -403,6 +420,21 @@ export const Paper = dia.Paper.extend(
      * @param event - The pointermove event from document delegation.
      */
     pointermove(this: dia.Paper, event: dia.Event) {
+      // Drag moves during an active two-finger gesture: the paper re-delegates
+      // drag events on every `pointerdown`, so the first move after a
+      // neutralization lands here — for EVERY drag action (element, blank,
+      // magnet/link), before it processes. End it the official way instead.
+      const recognizer = touchGestureRecognizers.get(this);
+      if (
+        recognizer?.isActive() &&
+        (event.originalEvent as Partial<PointerEvent> | undefined)?.pointerType === 'touch'
+      ) {
+        // No `pointerclick` from the neutralizing pointerup (see
+        // stopInteractionIfGestureDetected).
+        event.stopPropagation();
+        (this as unknown as PaperPointerHandlers).pointerup(event);
+        return;
+      }
       protectedProto.pointermove.call(this, event);
       const data = this.eventData(event);
       if (data.captureTarget) return;

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -234,8 +234,24 @@ function attachTouchGestures(paper: dia.Paper): void {
   const handleTouchMove = (event: TouchEvent) => {
     if (event.touches) recognizer.handleTouchMove(event);
   };
+  // The end listeners live on `document` (see below), so they also see touches
+  // that never belonged to this paper — e.g. a toolbar tap outside the canvas
+  // while a finger still rests on it. Those must not be processed (the
+  // recognizer would `preventDefault` them, killing their click). An end event
+  // is the gesture's own when a changed touch sits inside the host, or when
+  // its target is detached — the view-disposal case the document listeners
+  // exist for in the first place.
+  const isGestureRelatedEnd = (event: TouchEvent): boolean => {
+    const changed = event.changedTouches;
+    if (!changed) return true; // no payload to scope by — err on processing
+    // eslint-disable-next-line unicorn/prefer-spread
+    return Array.from(changed).some(({ target }) => {
+      if (!(target instanceof Node)) return true;
+      return !target.isConnected || host.contains(target);
+    });
+  };
   const handleTouchEnd = (event: TouchEvent) => {
-    if (event.touches) recognizer.handleTouchEnd(event);
+    if (event.touches && isGestureRelatedEnd(event)) recognizer.handleTouchEnd(event);
   };
   const listenerOptions: AddEventListenerOptions = { capture: true, passive: false };
   host.addEventListener('touchstart', handleTouchStart, listenerOptions);

--- a/packages/joint-react/src/utils/__tests__/touch-gestures.test.ts
+++ b/packages/joint-react/src/utils/__tests__/touch-gestures.test.ts
@@ -15,10 +15,15 @@ interface MockTouchEvent extends TouchGestureEvent {
   readonly preventDefault: jest.Mock;
 }
 
-function touchEvent(type: string, touches: readonly TouchPointLike[]): MockTouchEvent {
+function touchEvent(
+  type: string,
+  touches: readonly TouchPointLike[],
+  changedTouches?: readonly TouchPointLike[]
+): MockTouchEvent {
   return {
     type,
     touches,
+    changedTouches,
     preventDefault: jest.fn(),
   };
 }
@@ -43,15 +48,13 @@ function createRecognizer(overrides: Partial<TouchGestureOptions> = {}) {
   const scheduler = createManualScheduler();
   const onGestureStart = jest.fn();
   const onGestureUpdate = jest.fn();
-  const onGestureEnd = jest.fn();
   const recognizer = new TouchGestureRecognizer({
     onGestureStart,
     onGestureUpdate,
-    onGestureEnd,
     schedule: scheduler.schedule,
     ...overrides,
   });
-  return { recognizer, scheduler, onGestureStart, onGestureUpdate, onGestureEnd };
+  return { recognizer, scheduler, onGestureStart, onGestureUpdate };
 }
 
 function lastUpdate(onGestureUpdate: jest.Mock): TouchGestureUpdate {
@@ -178,16 +181,15 @@ describe('TouchGestureRecognizer', () => {
   });
 
   it('flushes pending sample and ends the gesture when dropping below two fingers', () => {
-    const { recognizer, scheduler, onGestureUpdate, onGestureEnd } = createRecognizer();
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
     recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
     recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(300, 0)]));
     const end = touchEvent('touchend', [touch(0, 0)]);
     recognizer.handleTouchEnd(end);
 
-    // Pending sample delivered synchronously on gesture end, before onGestureEnd.
+    // Pending sample delivered synchronously on gesture end.
     expect(onGestureUpdate).toHaveBeenCalledTimes(1);
     expect(lastUpdate(onGestureUpdate).scale).toBe(3);
-    expect(onGestureEnd).toHaveBeenCalledTimes(1);
     expect(end.preventDefault).toHaveBeenCalled();
     // The already-scheduled flush later becomes a no-op.
     expect(() => scheduler.runNext()).not.toThrow();
@@ -195,10 +197,10 @@ describe('TouchGestureRecognizer', () => {
   });
 
   it('drains the leftover finger: consumes its events without emitting', () => {
-    const { recognizer, onGestureUpdate, onGestureEnd } = createRecognizer();
+    const { recognizer, onGestureUpdate } = createRecognizer();
     recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
     recognizer.handleTouchEnd(touchEvent('touchend', [touch(0, 0)]));
-    expect(onGestureEnd).toHaveBeenCalledTimes(1);
+    expect(recognizer.isActive()).toBe(true); // draining still owns the sequence
 
     const drainMove = touchEvent('touchmove', [touch(30, 30)]);
     recognizer.handleTouchMove(drainMove);
@@ -207,16 +209,17 @@ describe('TouchGestureRecognizer', () => {
 
     // Last finger lifts → idle again; a fresh gesture can start.
     recognizer.handleTouchEnd(touchEvent('touchend', []));
+    expect(recognizer.isActive()).toBe(false);
     const restart = touchEvent('touchstart', [touch(0, 0), touch(50, 0)]);
     recognizer.handleTouchStart(restart);
     expect(restart.preventDefault).toHaveBeenCalled();
   });
 
   it('returns to idle directly when both fingers lift at once', () => {
-    const { recognizer, onGestureEnd } = createRecognizer();
+    const { recognizer } = createRecognizer();
     recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
     recognizer.handleTouchEnd(touchEvent('touchcancel', []));
-    expect(onGestureEnd).toHaveBeenCalledTimes(1);
+    expect(recognizer.isActive()).toBe(false);
 
     // Next single-finger touch flows through untouched — recognizer is idle.
     const single = touchEvent('touchstart', [touch(5, 5)]);
@@ -225,20 +228,46 @@ describe('TouchGestureRecognizer', () => {
   });
 
   it('swallows a third finger and re-baselines when it lifts', () => {
-    const { recognizer, scheduler, onGestureUpdate, onGestureEnd } = createRecognizer();
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
     recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
     const third = touchEvent('touchstart', [touch(0, 0), touch(100, 0), touch(500, 500)]);
     recognizer.handleTouchStart(third);
     expect(third.preventDefault).toHaveBeenCalled();
 
-    // The third finger lifts — tracked pair unchanged, no jump emitted.
+    // The third finger lifts — tracked pair unchanged, gesture stays active.
     recognizer.handleTouchEnd(touchEvent('touchend', [touch(0, 0), touch(100, 0)]));
-    expect(onGestureEnd).not.toHaveBeenCalled();
+    expect(recognizer.isActive()).toBe(true);
 
     // Gesture continues from the re-baselined pair.
     recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(150, 0)]));
     scheduler.runNext();
     expect(lastUpdate(onGestureUpdate).scale).toBe(1.5);
+  });
+
+  it('resets a stale sequence when a fresh touchstart proves every old finger left unseen', () => {
+    const { recognizer, onGestureStart } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    expect(recognizer.isActive()).toBe(true);
+
+    // Both fingers lift while their targets are detached — the recognizer
+    // never sees a touchend and would stay active forever. The next fresh
+    // touchstart reports all-new touches (touches === changedTouches) and
+    // resets the state machine before processing.
+    const fresh = touchEvent('touchstart', [touch(10, 10)], [touch(10, 10)]);
+    recognizer.handleTouchStart(fresh);
+    expect(recognizer.isActive()).toBe(false); // idle again — single touch flows to the paper
+    expect(fresh.preventDefault).not.toHaveBeenCalled();
+
+    // And a fresh two-finger start after a stale sequence begins a new gesture.
+    const freshPinch = touchEvent(
+      'touchstart',
+      [touch(0, 0), touch(80, 0)],
+      [touch(0, 0), touch(80, 0)]
+    );
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchStart(freshPinch);
+    expect(recognizer.isActive()).toBe(true);
+    expect(onGestureStart).toHaveBeenCalledTimes(3);
   });
 
   it('dispose cancels a scheduled flush', () => {

--- a/packages/joint-react/src/utils/__tests__/touch-gestures.test.ts
+++ b/packages/joint-react/src/utils/__tests__/touch-gestures.test.ts
@@ -1,0 +1,291 @@
+import {
+  isMultiTouchEvent,
+  TouchGestureRecognizer,
+  type TouchGestureEvent,
+  type TouchGestureOptions,
+  type TouchGestureUpdate,
+  type TouchPointLike,
+} from '../touch-gestures';
+
+function touch(clientX: number, clientY: number, target: EventTarget | null = null): TouchPointLike {
+  return { clientX, clientY, target };
+}
+
+interface MockTouchEvent extends TouchGestureEvent {
+  readonly preventDefault: jest.Mock;
+}
+
+function touchEvent(type: string, touches: readonly TouchPointLike[]): MockTouchEvent {
+  return {
+    type,
+    touches,
+    preventDefault: jest.fn(),
+  };
+}
+
+/** Deterministic scheduler: flushes run only when the test invokes them. */
+function createManualScheduler() {
+  const queue: Array<() => void> = [];
+  const cancel = jest.fn();
+  const schedule = jest.fn((flush: () => void) => {
+    queue.push(flush);
+    return cancel;
+  });
+  const runNext = () => {
+    const flush = queue.shift();
+    if (!flush) throw new Error('No scheduled flush to run.');
+    flush();
+  };
+  return { schedule, runNext, cancel, queue };
+}
+
+function createRecognizer(overrides: Partial<TouchGestureOptions> = {}) {
+  const scheduler = createManualScheduler();
+  const onGestureStart = jest.fn();
+  const onGestureUpdate = jest.fn();
+  const onGestureEnd = jest.fn();
+  const recognizer = new TouchGestureRecognizer({
+    onGestureStart,
+    onGestureUpdate,
+    onGestureEnd,
+    schedule: scheduler.schedule,
+    ...overrides,
+  });
+  return { recognizer, scheduler, onGestureStart, onGestureUpdate, onGestureEnd };
+}
+
+function lastUpdate(onGestureUpdate: jest.Mock): TouchGestureUpdate {
+  return onGestureUpdate.mock.calls.at(-1)![0] as TouchGestureUpdate;
+}
+
+describe('TouchGestureRecognizer', () => {
+  it('starts a gesture on the second finger and consumes the event', () => {
+    const { recognizer, onGestureStart } = createRecognizer();
+    const start = touchEvent('touchstart', [touch(0, 0), touch(100, 0)]);
+    recognizer.handleTouchStart(start);
+
+    expect(onGestureStart).toHaveBeenCalledTimes(1);
+    expect(onGestureStart).toHaveBeenCalledWith(start, { x: 50, y: 0 });
+    expect(start.preventDefault).toHaveBeenCalled();
+  });
+
+  it('ignores single-finger touches entirely', () => {
+    const { recognizer, onGestureStart, onGestureUpdate } = createRecognizer();
+    const start = touchEvent('touchstart', [touch(0, 0)]);
+    recognizer.handleTouchStart(start);
+    const move = touchEvent('touchmove', [touch(10, 10)]);
+    recognizer.handleTouchMove(move);
+
+    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(onGestureUpdate).not.toHaveBeenCalled();
+    expect(start.preventDefault).not.toHaveBeenCalled();
+    expect(move.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('respects the shouldSkipGesture veto without consuming the event', () => {
+    const shouldSkipGesture = jest.fn(() => true);
+    const { recognizer, onGestureStart } = createRecognizer({ shouldSkipGesture });
+    const touches = [touch(0, 0), touch(100, 0)];
+    const start = touchEvent('touchstart', touches);
+    recognizer.handleTouchStart(start);
+
+    expect(shouldSkipGesture).toHaveBeenCalledWith(touches);
+    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(start.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('counts only eligible touches', () => {
+    const outside = document.createElement('div');
+    const { recognizer, onGestureStart } = createRecognizer({
+      isEligibleTouch: (point) => point.target !== outside,
+    });
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0, outside)]));
+
+    expect(onGestureStart).not.toHaveBeenCalled();
+  });
+
+  it('emits a coalesced pinch sample with relative scale and midpoint', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    const move = touchEvent('touchmove', [touch(0, 0), touch(200, 0)]);
+    recognizer.handleTouchMove(move);
+
+    expect(onGestureUpdate).not.toHaveBeenCalled(); // coalesced until the frame flush
+    scheduler.runNext();
+
+    expect(onGestureUpdate).toHaveBeenCalledTimes(1);
+    expect(lastUpdate(onGestureUpdate)).toEqual({
+      event: move,
+      // Distance grew 100 → 200, midpoint moved (50,0) → (100,0).
+      scale: 2,
+      clientX: 100,
+      clientY: 0,
+      deltaX: -50,
+      deltaY: 0,
+    });
+    expect(move.preventDefault).toHaveBeenCalled();
+  });
+
+  it('folds multiple moves into a single sample per flush', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(200, 0)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(10, 0), touch(110, 0)]));
+    scheduler.runNext();
+
+    expect(onGestureUpdate).toHaveBeenCalledTimes(1);
+    const update = lastUpdate(onGestureUpdate);
+    // Ratios multiply: (200/100) * (100/200) = 1; midpoint 50 → 100 → 60.
+    expect(update.scale).toBe(1);
+    expect(update.deltaX).toBe(-10);
+    expect(update.clientX).toBe(60);
+    // Only one flush was scheduled for both moves.
+    expect(scheduler.schedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits pan-only samples with wheel sign convention', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    // Both fingers move down-right by (10, 20): content follows the fingers,
+    // which in wheel convention is a negative delta.
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(10, 20), touch(110, 20)]));
+    scheduler.runNext();
+
+    const update = lastUpdate(onGestureUpdate);
+    expect(update.scale).toBe(1);
+    expect(update.deltaX).toBe(-10);
+    expect(update.deltaY).toBe(-20);
+  });
+
+  it('does not emit when nothing changed', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(100, 0)]));
+    scheduler.runNext();
+
+    expect(onGestureUpdate).not.toHaveBeenCalled();
+  });
+
+  it('guards against a zero-distance baseline', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(50, 50), touch(50, 50)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(100, 0)]));
+    scheduler.runNext();
+
+    const update = lastUpdate(onGestureUpdate);
+    expect(update.scale).toBe(1); // no ratio from a 0 baseline — not Infinity
+    expect(Number.isFinite(update.deltaX)).toBe(true);
+  });
+
+  it('flushes pending sample and ends the gesture when dropping below two fingers', () => {
+    const { recognizer, scheduler, onGestureUpdate, onGestureEnd } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(300, 0)]));
+    const end = touchEvent('touchend', [touch(0, 0)]);
+    recognizer.handleTouchEnd(end);
+
+    // Pending sample delivered synchronously on gesture end, before onGestureEnd.
+    expect(onGestureUpdate).toHaveBeenCalledTimes(1);
+    expect(lastUpdate(onGestureUpdate).scale).toBe(3);
+    expect(onGestureEnd).toHaveBeenCalledTimes(1);
+    expect(end.preventDefault).toHaveBeenCalled();
+    // The already-scheduled flush later becomes a no-op.
+    expect(() => scheduler.runNext()).not.toThrow();
+    expect(onGestureUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains the leftover finger: consumes its events without emitting', () => {
+    const { recognizer, onGestureUpdate, onGestureEnd } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchEnd(touchEvent('touchend', [touch(0, 0)]));
+    expect(onGestureEnd).toHaveBeenCalledTimes(1);
+
+    const drainMove = touchEvent('touchmove', [touch(30, 30)]);
+    recognizer.handleTouchMove(drainMove);
+    expect(drainMove.preventDefault).toHaveBeenCalled();
+    expect(onGestureUpdate).not.toHaveBeenCalled();
+
+    // Last finger lifts → idle again; a fresh gesture can start.
+    recognizer.handleTouchEnd(touchEvent('touchend', []));
+    const restart = touchEvent('touchstart', [touch(0, 0), touch(50, 0)]);
+    recognizer.handleTouchStart(restart);
+    expect(restart.preventDefault).toHaveBeenCalled();
+  });
+
+  it('returns to idle directly when both fingers lift at once', () => {
+    const { recognizer, onGestureEnd } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchEnd(touchEvent('touchcancel', []));
+    expect(onGestureEnd).toHaveBeenCalledTimes(1);
+
+    // Next single-finger touch flows through untouched — recognizer is idle.
+    const single = touchEvent('touchstart', [touch(5, 5)]);
+    recognizer.handleTouchStart(single);
+    expect(single.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('swallows a third finger and re-baselines when it lifts', () => {
+    const { recognizer, scheduler, onGestureUpdate, onGestureEnd } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    const third = touchEvent('touchstart', [touch(0, 0), touch(100, 0), touch(500, 500)]);
+    recognizer.handleTouchStart(third);
+    expect(third.preventDefault).toHaveBeenCalled();
+
+    // The third finger lifts — tracked pair unchanged, no jump emitted.
+    recognizer.handleTouchEnd(touchEvent('touchend', [touch(0, 0), touch(100, 0)]));
+    expect(onGestureEnd).not.toHaveBeenCalled();
+
+    // Gesture continues from the re-baselined pair.
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(150, 0)]));
+    scheduler.runNext();
+    expect(lastUpdate(onGestureUpdate).scale).toBe(1.5);
+  });
+
+  it('dispose cancels a scheduled flush', () => {
+    const { recognizer, scheduler, onGestureUpdate } = createRecognizer();
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    recognizer.handleTouchMove(touchEvent('touchmove', [touch(0, 0), touch(200, 0)]));
+    recognizer.dispose();
+
+    expect(scheduler.cancel).toHaveBeenCalled();
+    scheduler.runNext(); // the stale flush delivers nothing
+    expect(onGestureUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('isMultiTouchEvent', () => {
+  it('detects multi-touch touchstart / touchmove via the native touches list', () => {
+    expect(isMultiTouchEvent({ type: 'touchstart', originalEvent: { touches: [1, 2] } })).toBe(
+      true
+    );
+    expect(isMultiTouchEvent({ type: 'touchmove', originalEvent: { touches: [1, 2, 3] } })).toBe(
+      true
+    );
+  });
+
+  it('rejects single-touch and non-touch events', () => {
+    expect(isMultiTouchEvent({ type: 'touchstart', originalEvent: { touches: [1] } })).toBe(false);
+    expect(isMultiTouchEvent({ type: 'pointermove', originalEvent: { touches: [1, 2] } })).toBe(
+      false
+    );
+    expect(isMultiTouchEvent({ type: 'touchmove' })).toBe(false);
+  });
+});
+
+describe('TouchGestureRecognizer.isActive', () => {
+  it('covers the whole gesture including the draining phase', () => {
+    const scheduler = createManualScheduler();
+    const recognizer = new TouchGestureRecognizer({
+      onGestureStart: jest.fn(),
+      onGestureUpdate: jest.fn(),
+      schedule: scheduler.schedule,
+    });
+    expect(recognizer.isActive()).toBe(false);
+    recognizer.handleTouchStart(touchEvent('touchstart', [touch(0, 0), touch(100, 0)]));
+    expect(recognizer.isActive()).toBe(true);
+    recognizer.handleTouchEnd(touchEvent('touchend', [touch(0, 0)]));
+    expect(recognizer.isActive()).toBe(true); // draining still owns the sequence
+    recognizer.handleTouchEnd(touchEvent('touchend', []));
+    expect(recognizer.isActive()).toBe(false);
+  });
+});

--- a/packages/joint-react/src/utils/touch-gestures.ts
+++ b/packages/joint-react/src/utils/touch-gestures.ts
@@ -1,0 +1,261 @@
+// Two-finger touch-gesture recognition for `dia.Paper` — turns real
+// touchscreen pinch / two-finger-pan sequences into the same relative
+// scale / wheel-convention pan values joint-core emits for touchpad
+// (`ctrl`+wheel) gestures.
+//
+// Pure logic: no DOM listener wiring and no joint imports. The paper preset
+// owns attaching it (capture-phase, non-passive listeners) and translating
+// updates into `paper:pinch` / `paper:pan` events; this module owns the state
+// machine and the math, so it is fully unit-testable in jsdom (which cannot
+// construct real `TouchEvent`s).
+
+/** Minimal structural view of a DOM `Touch` point. */
+export interface TouchPointLike {
+  readonly clientX: number;
+  readonly clientY: number;
+  readonly target: EventTarget | null;
+}
+
+/** Minimal structural view of a DOM `TouchEvent` as the recognizer consumes it. */
+export interface TouchGestureEvent {
+  readonly type: string;
+  /** All touches currently on the screen (`TouchEvent.touches`). */
+  readonly touches: Iterable<TouchPointLike>;
+  readonly preventDefault: () => void;
+}
+
+/**
+ * The official JointJS multi-touch predicate (as used by the JointJS+ touch
+ * demo): a `touchstart` / `touchmove` whose native event reports more than one
+ * active touch. Works on paper-delivered `dia.Event`s (which wrap the native
+ * event as `originalEvent`).
+ * @param event - A paper event (or any event-shaped object).
+ * @param event.type - The DOM event type.
+ * @param event.originalEvent - The wrapped native event, if any.
+ * @returns `true` when the event belongs to a multi-touch sequence.
+ * @group Utils
+ */
+export function isMultiTouchEvent(event: {
+  readonly type?: string;
+  readonly originalEvent?: unknown;
+}): boolean {
+  if (event.type !== 'touchstart' && event.type !== 'touchmove') return false;
+  const touches = (event.originalEvent as { touches?: ArrayLike<unknown> } | undefined)?.touches;
+  return !!touches && touches.length > 1;
+}
+
+/** One coalesced two-finger gesture sample (at most one per scheduled frame). */
+export interface TouchGestureUpdate {
+  /** The most recent raw touch event folded into this sample. */
+  readonly event: TouchGestureEvent;
+  /** Current gesture midpoint, client coordinates. */
+  readonly clientX: number;
+  /** Current gesture midpoint, client coordinates. */
+  readonly clientY: number;
+  /** Relative pinch ratio since the previous sample (`1` = no pinch). */
+  readonly scale: number;
+  /** Horizontal pan since the previous sample, wheel sign convention. */
+  readonly deltaX: number;
+  /** Vertical pan since the previous sample, wheel sign convention. */
+  readonly deltaY: number;
+}
+
+/** Configuration for {@link TouchGestureRecognizer}. */
+export interface TouchGestureOptions {
+  /**
+   * A two-finger gesture became active (fired once per gesture). Receives the
+   * gesture midpoint in client coordinates alongside the raw event.
+   */
+  readonly onGestureStart: (event: TouchGestureEvent, midpoint: { x: number; y: number }) => void;
+  /** A coalesced pinch / pan sample is ready. */
+  readonly onGestureUpdate: (update: TouchGestureUpdate) => void;
+  /** The gesture dropped below two fingers (fired once per gesture). */
+  readonly onGestureEnd?: () => void;
+  /**
+   * Restrict which touches belong to the gesture — e.g. only touches whose
+   * target sits inside the paper host. Defaults to accepting every touch.
+   */
+  readonly isEligibleTouch?: (touch: TouchPointLike) => boolean;
+  /**
+   * Veto a gesture before it starts — e.g. when a touch rests on a natively
+   * scrollable region that should keep owning its touch input.
+   */
+  readonly shouldSkipGesture?: (touches: readonly TouchPointLike[]) => boolean;
+  /**
+   * Frame scheduler used to coalesce samples; returns a cancel function.
+   * `requestAnimationFrame` by default, injectable for deterministic tests.
+   */
+  readonly schedule?: (flush: () => void) => () => void;
+}
+
+type GesturePhase = 'idle' | 'pinching' | 'draining';
+
+interface PendingSample {
+  scale: number;
+  deltaX: number;
+  deltaY: number;
+  event: TouchGestureEvent;
+}
+
+function defaultSchedule(flush: () => void): () => void {
+  const frameId = requestAnimationFrame(flush);
+  return () => cancelAnimationFrame(frameId);
+}
+
+function getMidpoint(a: TouchPointLike, b: TouchPointLike): { x: number; y: number } {
+  return { x: (a.clientX + b.clientX) / 2, y: (a.clientY + b.clientY) / 2 };
+}
+
+function getDistance(a: TouchPointLike, b: TouchPointLike): number {
+  return Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY);
+}
+
+/**
+ * Recognizes two-finger pinch / pan gestures from a raw touch-event stream.
+ *
+ * State machine: `idle` → `pinching` (a second eligible finger lands) →
+ * `draining` (below two fingers, leftover touches keep being prevented) →
+ * `idle` (all fingers lifted). While not idle every touch event is
+ * `preventDefault`ed so the browser never runs its own page pinch-zoom /
+ * scroll — the recognizer's replacement for the `touch-action: none`
+ * interact.js applies in the official JointJS touch demo (kept selective here
+ * so `[data-jj-scrollable]` regions retain native touch scrolling). Events are
+ * never stopped from propagating: the paper sees the full stream and
+ * neutralizes its own single-pointer interactions the official way (see
+ * `stopInteractionIfGestureDetected` in the paper preset).
+ *
+ * Samples are coalesced per scheduled frame: pinch ratios multiply and pan
+ * deltas add up between flushes, so consumers do at most one (potentially
+ * layout-heavy) transform per frame even on 120 Hz touch screens.
+ * @internal
+ */
+export class TouchGestureRecognizer {
+  private phase: GesturePhase = 'idle';
+  private previousMidpoint = { x: 0, y: 0 };
+  private previousDistance = 0;
+  private pending: PendingSample | null = null;
+  private cancelScheduledFlush: (() => void) | null = null;
+  private readonly options: TouchGestureOptions;
+
+  constructor(options: TouchGestureOptions) {
+    this.options = options;
+  }
+
+  /** Feed a `touchstart`. Consumed (and possibly starts a gesture) unless idle single-touch. */
+  handleTouchStart(event: TouchGestureEvent): void {
+    if (this.phase !== 'idle') {
+      // An extra finger joined mid-gesture (or while draining): swallow it so
+      // the paper never starts a competing drag; keep tracking the first two.
+      this.consume(event);
+      return;
+    }
+    const touches = this.eligibleTouches(event);
+    if (touches.length < 2) return;
+    if (this.options.shouldSkipGesture?.(touches)) return;
+    // Consume before anything else — preventing the second finger's
+    // `touchstart` is what stops Safari from starting its page pinch-zoom.
+    this.consume(event);
+    this.phase = 'pinching';
+    this.rebaseline(touches);
+    this.options.onGestureStart(event, { ...this.previousMidpoint });
+  }
+
+  /** Feed a `touchmove`. Accumulates a sample while pinching; swallowed while draining. */
+  handleTouchMove(event: TouchGestureEvent): void {
+    if (this.phase === 'idle') return;
+    this.consume(event);
+    if (this.phase !== 'pinching') return;
+    const touches = this.eligibleTouches(event);
+    if (touches.length < 2) return; // stale move racing a touchend
+    const [first, second] = touches;
+    const midpoint = getMidpoint(first, second);
+    const distance = getDistance(first, second);
+    // Guard against a zero baseline (both fingers on the same point).
+    const ratio = this.previousDistance > 0 ? distance / this.previousDistance : 1;
+    const pending = this.pending ?? { scale: 1, deltaX: 0, deltaY: 0, event };
+    pending.scale *= ratio;
+    pending.deltaX += this.previousMidpoint.x - midpoint.x;
+    pending.deltaY += this.previousMidpoint.y - midpoint.y;
+    pending.event = event;
+    this.pending = pending;
+    this.previousMidpoint = midpoint;
+    this.previousDistance = distance;
+    this.scheduleFlush();
+  }
+
+  /** Feed a `touchend` or `touchcancel`. Ends / drains the gesture as fingers lift. */
+  handleTouchEnd(event: TouchGestureEvent): void {
+    if (this.phase === 'idle') return;
+    this.consume(event);
+    const touches = this.eligibleTouches(event);
+    if (this.phase === 'pinching') {
+      if (touches.length >= 2) {
+        // A non-tracked (third) finger lifted — re-baseline so the next move
+        // doesn't read a distance jump between different finger pairs.
+        this.rebaseline(touches);
+        return;
+      }
+      this.flush();
+      this.options.onGestureEnd?.();
+      this.phase = touches.length > 0 ? 'draining' : 'idle';
+      return;
+    }
+    if (touches.length === 0) this.phase = 'idle';
+  }
+
+  /** Whether a two-finger gesture is in progress (pinching or draining). */
+  isActive(): boolean {
+    return this.phase !== 'idle';
+  }
+
+  /** Cancel any scheduled flush and reset to idle. */
+  dispose(): void {
+    this.cancelScheduledFlush?.();
+    this.cancelScheduledFlush = null;
+    this.pending = null;
+    this.phase = 'idle';
+  }
+
+  private consume(event: TouchGestureEvent): void {
+    event.preventDefault();
+  }
+
+  private eligibleTouches(event: TouchGestureEvent): TouchPointLike[] {
+    const touches = [...event.touches];
+    const { isEligibleTouch } = this.options;
+    return isEligibleTouch ? touches.filter((touch) => isEligibleTouch(touch)) : touches;
+  }
+
+  private rebaseline(touches: readonly TouchPointLike[]): void {
+    const [first, second] = touches;
+    this.previousMidpoint = getMidpoint(first, second);
+    this.previousDistance = getDistance(first, second);
+  }
+
+  private scheduleFlush(): void {
+    if (this.cancelScheduledFlush) return;
+    const schedule = this.options.schedule ?? defaultSchedule;
+    this.cancelScheduledFlush = schedule(() => {
+      this.cancelScheduledFlush = null;
+      this.flush();
+    });
+  }
+
+  private flush(): void {
+    this.cancelScheduledFlush?.();
+    this.cancelScheduledFlush = null;
+    const sample = this.pending;
+    this.pending = null;
+    if (!sample) return;
+    const { scale, deltaX, deltaY, event } = sample;
+    if (scale === 1 && deltaX === 0 && deltaY === 0) return;
+    this.options.onGestureUpdate({
+      event,
+      clientX: this.previousMidpoint.x,
+      clientY: this.previousMidpoint.y,
+      scale,
+      deltaX,
+      deltaY,
+    });
+  }
+}

--- a/packages/joint-react/src/utils/touch-gestures.ts
+++ b/packages/joint-react/src/utils/touch-gestures.ts
@@ -20,7 +20,7 @@ export interface TouchPointLike {
 export interface TouchGestureEvent {
   readonly type: string;
   /** All touches currently on the screen (`TouchEvent.touches`). */
-  readonly touches: Iterable<TouchPointLike>;
+  readonly touches: ArrayLike<TouchPointLike> | Iterable<TouchPointLike>;
   readonly preventDefault: () => void;
 }
 
@@ -221,7 +221,10 @@ export class TouchGestureRecognizer {
   }
 
   private eligibleTouches(event: TouchGestureEvent): TouchPointLike[] {
-    const touches = [...event.touches];
+    // `TouchList` is only array-like in some environments — `Array.from`
+    // handles both array-likes and iterables, a spread would need the latter.
+    // eslint-disable-next-line unicorn/prefer-spread
+    const touches = Array.from(event.touches);
     const { isEligibleTouch } = this.options;
     return isEligibleTouch ? touches.filter((touch) => isEligibleTouch(touch)) : touches;
   }

--- a/packages/joint-react/src/utils/touch-gestures.ts
+++ b/packages/joint-react/src/utils/touch-gestures.ts
@@ -21,6 +21,8 @@ export interface TouchGestureEvent {
   readonly type: string;
   /** All touches currently on the screen (`TouchEvent.touches`). */
   readonly touches: ArrayLike<TouchPointLike> | Iterable<TouchPointLike>;
+  /** Touches that changed in this event (`TouchEvent.changedTouches`). */
+  readonly changedTouches?: ArrayLike<TouchPointLike> | Iterable<TouchPointLike>;
   readonly preventDefault: () => void;
 }
 
@@ -69,8 +71,6 @@ export interface TouchGestureOptions {
   readonly onGestureStart: (event: TouchGestureEvent, midpoint: { x: number; y: number }) => void;
   /** A coalesced pinch / pan sample is ready. */
   readonly onGestureUpdate: (update: TouchGestureUpdate) => void;
-  /** The gesture dropped below two fingers (fired once per gesture). */
-  readonly onGestureEnd?: () => void;
   /**
    * Restrict which touches belong to the gesture — e.g. only touches whose
    * target sits inside the paper host. Defaults to accepting every touch.
@@ -144,10 +144,20 @@ export class TouchGestureRecognizer {
   /** Feed a `touchstart`. Consumed (and possibly starts a gesture) unless idle single-touch. */
   handleTouchStart(event: TouchGestureEvent): void {
     if (this.phase !== 'idle') {
-      // An extra finger joined mid-gesture (or while draining): swallow it so
-      // the paper never starts a competing drag; keep tracking the first two.
-      this.consume(event);
-      return;
+      // Staleness watchdog: browsers stop delivering touch events once the
+      // original target leaves the DOM (see the touchmove note in core's
+      // LinkView), so a gesture whose targets were disposed mid-pinch never
+      // sees its touchend. When a new touchstart reports that EVERY current
+      // screen touch is brand new, every previous finger must have lifted
+      // unseen — reset and process the event as a fresh sequence.
+      if (this.isStaleSequence(event)) {
+        this.dispose();
+      } else {
+        // An extra finger joined mid-gesture (or while draining): consume it
+        // and keep tracking the first two.
+        this.consume(event);
+        return;
+      }
     }
     const touches = this.eligibleTouches(event);
     if (touches.length < 2) return;
@@ -196,7 +206,6 @@ export class TouchGestureRecognizer {
         return;
       }
       this.flush();
-      this.options.onGestureEnd?.();
       this.phase = touches.length > 0 ? 'draining' : 'idle';
       return;
     }
@@ -218,6 +227,16 @@ export class TouchGestureRecognizer {
 
   private consume(event: TouchGestureEvent): void {
     event.preventDefault();
+  }
+
+  /** Every current screen touch is new in this event — no tracked finger survived. */
+  private isStaleSequence(event: TouchGestureEvent): boolean {
+    if (!event.changedTouches) return false;
+    // eslint-disable-next-line unicorn/prefer-spread
+    const total = Array.from(event.touches).length;
+    // eslint-disable-next-line unicorn/prefer-spread
+    const changed = Array.from(event.changedTouches).length;
+    return total > 0 && total === changed;
   }
 
   private eligibleTouches(event: TouchGestureEvent): TouchPointLike[] {

--- a/packages/joint-react/src/utils/wheel-guard.ts
+++ b/packages/joint-react/src/utils/wheel-guard.ts
@@ -25,6 +25,27 @@ function overflows(element: Element): boolean {
 }
 
 /**
+ * Whether `target` sits inside a natively scrollable region (a `<textarea>` or
+ * an element carrying {@link SCROLLABLE_ATTRIBUTE} — both with actual
+ * overflow). Shared by the wheel guard and the touch-gesture guard so both
+ * input kinds honor the same opt-out.
+ * @param target - event target to test
+ * @returns `true` when a scrollable region owns the input
+ * @group Utils
+ */
+export function isInsideScrollableRegion(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  for (
+    let element: Element | null = target.closest(SCROLLABLE_SELECTOR);
+    element;
+    element = element.parentElement?.closest(SCROLLABLE_SELECTOR) ?? null
+  ) {
+    if (overflows(element)) return true;
+  }
+  return false;
+}
+
+/**
  * Predicate for `dia.Paper.options.guard`. Returns `true` when a wheel event
  * targets a scrollable region (native `<textarea>` or an element carrying
  * {@link SCROLLABLE_ATTRIBUTE} — both with actual overflow), so the paper
@@ -37,13 +58,5 @@ function overflows(element: Element): boolean {
 export function wheelGuard(event: GuardEvent): boolean {
   if (!/wheel/i.test(event.type)) return false;
   if (event.ctrlKey || event.metaKey) return false;
-  if (!(event.target instanceof Element)) return false;
-  for (
-    let element: Element | null = event.target.closest(SCROLLABLE_SELECTOR);
-    element;
-    element = element.parentElement?.closest(SCROLLABLE_SELECTOR) ?? null
-  ) {
-    if (overflows(element)) return true;
-  }
-  return false;
+  return isInsideScrollableRegion(event.target);
 }

--- a/packages/joint-react/src/utils/wheel-guard.ts
+++ b/packages/joint-react/src/utils/wheel-guard.ts
@@ -31,7 +31,6 @@ function overflows(element: Element): boolean {
  * input kinds honor the same opt-out.
  * @param target - event target to test
  * @returns `true` when a scrollable region owns the input
- * @group Utils
  */
 export function isInsideScrollableRegion(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;

--- a/packages/joint-react/stories/examples/touch-pan-zoom/code.tsx
+++ b/packages/joint-react/stories/examples/touch-pan-zoom/code.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react';
+import type { dia } from '@joint/core';
+import {
+  type CellRecord,
+  GraphProvider,
+  HTMLBox,
+  Paper,
+  type RenderElement,
+} from '@joint/react';
+
+interface NodeData {
+  readonly label: string;
+}
+
+const SIZE = { width: 140, height: 50 };
+const LINK_COLOR = '#8697A6';
+const LINK_STYLE = { color: LINK_COLOR, targetMarker: 'arrow' } as const;
+
+const initialCells: ReadonlyArray<CellRecord<NodeData>> = [
+  { id: 'a', type: 'element', data: { label: 'Pinch' }, position: { x: 60, y: 40 }, size: SIZE },
+  { id: 'b', type: 'element', data: { label: 'to' }, position: { x: 300, y: 140 }, size: SIZE },
+  { id: 'c', type: 'element', data: { label: 'zoom' }, position: { x: 540, y: 40 }, size: SIZE },
+  { id: 'a→b', type: 'link', source: { id: 'a' }, target: { id: 'b' }, style: LINK_STYLE },
+  { id: 'b→c', type: 'link', source: { id: 'b' }, target: { id: 'c' }, style: LINK_STYLE },
+];
+
+const renderElement: RenderElement<NodeData> = (data) => (
+  <HTMLBox className="jj-node">{data.label}</HTMLBox>
+);
+
+function Main() {
+  const paperRef = useRef<dia.Paper | null>(null);
+  const [zoom, setZoom] = useState(1);
+
+  const resetView = useCallback(() => {
+    const paper = paperRef.current;
+    if (!paper) return;
+    paper.scale(1, 1);
+    paper.translate(0, 0);
+  }, []);
+
+  const handleScale = useCallback(
+    (params: { readonly scaleX: number }) => setZoom(params.scaleX),
+    []
+  );
+
+  return (
+    <div className="flex size-full flex-col">
+      <div className="jj-controls m-3">
+        <span className="jj-chip">{Math.round(zoom * 100)}%</span>
+        <button type="button" className="jj-btn jj-btn--primary" onClick={resetView}>
+          Reset view
+        </button>
+        <span className="jj-label">
+          Pinch to zoom &amp; two-finger drag to pan on a touchscreen — or Ctrl/Cmd + wheel on a
+          touchpad. Built in, no props needed.
+        </span>
+      </div>
+      <Paper
+        ref={paperRef}
+        className="min-h-0 flex-1"
+        renderElement={renderElement}
+        onScale={handleScale}
+      />
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <GraphProvider initialCells={initialCells}>
+      <Main />
+    </GraphProvider>
+  );
+}

--- a/packages/joint-react/stories/examples/touch-pan-zoom/story.tsx
+++ b/packages/joint-react/stories/examples/touch-pan-zoom/story.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { getAPILink } from '../../utils/get-api-documentation-link';
+import Code from './code';
+import codeRaw from './code?raw';
+
+const meta = {
+  title: 'Examples/Touch Pan & Zoom',
+  component: Code,
+  tags: ['example'],
+  parameters: {
+    showcase: {
+      description:
+        'Out-of-the-box pinch-to-zoom and two-finger pan: touchscreen pinches and touchpad (Ctrl/Cmd + wheel) pinches zoom the canvas around the gesture point. Tune the limits with the zoomOnPinch prop, or take over entirely with onPaperPinch / onPaperPan.',
+      apiUrl: getAPILink('Paper'),
+      code: codeRaw,
+    },
+  },
+} satisfies Meta<typeof Code>;
+
+export default meta;
+
+export type Story = StoryObj<typeof Code>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [x] You've successfully run the joint-react test suite locally (`yarn test`: typecheck + lint + knip + jest on React 18 & 19)
* [x] There are new unit tests validating the change
* [x] If applicable, there are new or updated @types
* [x] If applicable, documentation has been updated
-->

## Description

Proper touch support for `<Paper>`, out of the box: on a touchscreen, pinching zooms the canvas around the gesture point (instead of the browser zooming the page), two-finger drags pan it, and a second finger landing mid-drag cleanly stops the single-pointer interaction. On a touchpad, the existing Ctrl/Cmd+wheel pinch now also zooms with zero configuration.

**Structure follows the official JointJS+ touch demo:**
- `stopInteractionIfGestureDetected` subscribed to `cell:`/`blank:pointerdown` + `pointermove`, neutralizing single-pointer interactions via the sanctioned APIs — `cellView.preventDefaultInteraction(evt)` and `paper.pointerup(evt)` (the official `touches.length > 1` predicate is exported as `isMultiTouchEvent`). Two deliberate hardenings over the demo: the neutralizing pointerup is propagation-stopped so it never synthesizes a `pointerclick` (a two-finger press must not select the pressed cell), and a `pointermove` leg keyed on the recognizer phase — this preset's `documentEvents` are PointerEvents, which carry no `touches` list.
- A dependency-free two-finger recognizer (`utils/touch-gestures.ts`) replaces the demo's interact.js: it re-emits gestures as the very same `paper:pinch` (evt, x, y, scale) / `paper:pan` (evt, deltaX, deltaY) events joint-core fires for touchpad pinches — one consumer pipeline for wheel and touch (`onPaperPinch` / `onPaperPan` props work unchanged). Samples are rAF-coalesced (one transform per frame on 120 Hz screens). Browser page pinch-zoom/scroll is suppressed with selective non-passive `preventDefault` + `touch-action: manipulation` instead of interact.js's blanket `touch-action: none`, so `[data-jj-scrollable]` regions (and `<textarea>`s) inside nodes keep native touch scrolling — the same opt-out the wheel guard honors.
- **New `zoomOnPinch` prop** (default `true`, `{ min, max }` bounds 0.2–5, `false` to disable): applies pinches as a clamped `scaleUniformAtPoint` and touch pans as a translation. Self-yielding — any external `paper:pinch`/`paper:pan` subscriber (an `onPaperPinch` prop, a paper scroller's interactions) takes over automatically, so it never double-applies.

New story: `Examples/Touch Pan & Zoom`. Tests: recognizer unit tests, `<Paper>` integration tests (real DOM touch dispatches: pinch/pan emission, drag neutralization without a click, scrollable opt-out, leftover-finger draining), `zoomOnPinch` behavior tests. Verified in Chrome with real CDP touch input: pinch scales exactly, pan deltas exact, `visualViewport` untouched — both standalone and through a JointJS+ PaperScroller (which consumes the events with no changes to its pipeline).

Ticket: https://github.com/orgs/clientIO/projects/6/views/13?pane=issue&itemId=226891385

## Motivation and Context

On mobile, pinching over any JointJS app zoomed the browser page while the paper panned garbled underneath — multi-touch was unmodelled anywhere in the stack (`normalizeEvent` collapses to `changedTouches[0]`, a second `touchstart` re-enters `pointerdown` and resets the drag, and `paper:pinch` only ever fired from ctrl+wheel). This makes the canvas own the gesture, as a patch in joint-react with no core changes, following the pattern of the official touch demo.