### PR TITLE
fix(joint-react): tolerate a cell removed mid-render (useCell) and assign the forwarded ref during commit (useCombinedRef)

### DIFF
--- a/packages/joint-react/src/hooks/__tests__/use-cell-controlled-removal.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-cell-controlled-removal.test.tsx
@@ -1,0 +1,117 @@
+import { Component, type ReactNode } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { GraphProvider, Paper } from '../../components';
+import { useCell } from '../use-cell';
+import { ELEMENT_MODEL_TYPE } from '../../mvc/element-model';
+import type { CellRecord, Computed, ElementRecord } from '../../types/cell.types';
+
+// Surfaces an error thrown anywhere in its subtree so the test can assert on it
+// instead of the throw tearing down the whole test render.
+class CatchErrorBoundary extends Component<
+  Readonly<{ onCatch: (error: Error) => void; children: ReactNode }>,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error: Error) {
+    this.props.onCatch(error);
+  }
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+interface NodeData {
+  readonly label: string;
+}
+
+// Module-scope error capture so the JSX prop is a stable reference (avoids
+// react-perf's new-function-as-prop rule), mirroring use-cell.test.tsx.
+const caughtState: { error: Error | null } = { error: null };
+function captureError(error: Error) {
+  caughtState.error = error;
+}
+
+function buildCells(secondId: string): ReadonlyArray<CellRecord<NodeData>> {
+  return [
+    {
+      id: 'a',
+      type: ELEMENT_MODEL_TYPE,
+      position: { x: 0, y: 0 },
+      size: { width: 40, height: 40 },
+      data: { label: 'a' },
+    },
+    {
+      id: secondId,
+      type: ELEMENT_MODEL_TYPE,
+      position: { x: 80, y: 0 },
+      size: { width: 40, height: 40 },
+      data: { label: secondId },
+    },
+  ];
+}
+
+// Subscribes to its OWN cell via useCell — the ingredient the crash needs. This
+// is exactly what a content-sized node does through useMeasureElement, so the
+// scenario is reachable without a consumer ever naming useCell.
+function SubscribingNode() {
+  const label = useCell((cell: Computed<ElementRecord<NodeData>>) => cell.data.label);
+  return <text>{label}</text>;
+}
+const renderSubscribing = () => <SubscribingNode />;
+
+const PAPER_STYLE = { width: 200, height: 200 } as const;
+
+// Regression: removing a cell from a controlled `cells` array must not throw.
+// When a renderElement subtree subscribes to its own cell, the controlled
+// removal fires that cell's per-id listener synchronously (inside
+// GraphProvider's applyControlled layout effect) before <Paper> unmounts the
+// portal. The still-mounted subtree then re-selects against a cell that is
+// already gone. Before the fix, useCell's selector threw
+// `useCell(): no cell with id "b"`, unrecoverably taking the whole paper down.
+describe('useCell — controlled cell removal', () => {
+  // Restore the console.error spy even when an assertion throws mid-test, so
+  // the mock can never leak into other tests.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not throw when a subscribed cell is removed from a controlled cells array', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    caughtState.error = null;
+
+    const { rerender, container } = render(
+      <CatchErrorBoundary onCatch={captureError}>
+        <GraphProvider cells={buildCells('b')}>
+          <Paper style={PAPER_STYLE} id="usecell-removal-paper" renderElement={renderSubscribing} />
+        </GraphProvider>
+      </CatchErrorBoundary>
+    );
+
+    // Both element subtrees mounted and subscribed before we remove one.
+    await waitFor(() => {
+      expect(container.querySelectorAll('.joint-cell.joint-element')).toHaveLength(2);
+    });
+
+    // Rename the second cell id b -> c: a remove ('b') + add ('c') on the
+    // controlled array. Pre-fix this throws synchronously during the controlled
+    // apply, before Paper unmounts b's portal.
+    await act(async () => {
+      rerender(
+        <CatchErrorBoundary onCatch={captureError}>
+          <GraphProvider cells={buildCells('c')}>
+            <Paper style={PAPER_STYLE} id="usecell-removal-paper" renderElement={renderSubscribing} />
+          </GraphProvider>
+        </CatchErrorBoundary>
+      );
+    });
+
+    // Paper survives: the removal reconciles to the two surviving elements (a, c).
+    await waitFor(() => {
+      expect(container.querySelectorAll('.joint-cell.joint-element')).toHaveLength(2);
+    });
+    expect(caughtState.error).toBeNull();
+  });
+});

--- a/packages/joint-react/src/hooks/__tests__/use-combined-ref-timing.test.tsx
+++ b/packages/joint-react/src/hooks/__tests__/use-combined-ref-timing.test.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable @eslint-react/no-create-ref */
+/* eslint-disable react-perf/jsx-no-new-array-as-prop -- the recorder is per-test state */
+import { render, screen } from '@testing-library/react';
+import { createRef, useLayoutEffect, type ReactNode, type Ref } from 'react';
+import { useCombinedRef } from '../use-combined-ref';
+
+/**
+ * `useCombinedRef` must assign the forwarded ref DURING COMMIT — like any DOM ref —
+ * not in a passive effect, or a consumer that reads it in a layout effect sees `null`.
+ *
+ * React attaches refs during commit, before layout effects run, and consumers are
+ * entitled to rely on that. Assigning in a passive effect instead:
+ *
+ * ```ts
+ * useEffect(() => { setForwardRef(ref, innerRef.current); }, [ref]);
+ * ```
+ *
+ * means a parent that renders `<SVGText ref={myRef} />` and reads `myRef.current` in
+ * its own `useLayoutEffect` sees `null` — parent layout effects run before any passive
+ * effect.
+ *
+ * `useMeasureElement` is exactly that consumer. It reads `nodeRef.current` in a layout
+ * effect and returns early when the ref is empty, and its dependency list —
+ * `[nodeRef, graph, id, paper, setMeasuredNode]` — contains nothing that changes when
+ * the node is finally assigned, so it never registers the node with the size observer.
+ * The element then stays 0x0 permanently: no size, and no layout for anything that
+ * reads sizes.
+ *
+ * Two things hid this everywhere it would otherwise show up:
+ *
+ * 1. StrictMode remounts effects, so a second pass finds the ref already set by the
+ *    first pass. It is on for every story (`.storybook/preview.ts`) and for every test
+ *    (`configure({ reactStrictMode: true })` in `jest-setup.ts`) — which is why the
+ *    suite below has to opt out explicitly to see the bug.
+ * 2. None of the library's own examples pass a ref to `SVGText`. The flowchart,
+ *    svg-node and portal-selectors stories put a plain DOM ref on a native `<text>`,
+ *    and the `SVGText` story measures a `<g>` wrapper.
+ *
+ * Found in an app that measured `SVGText` directly: correct in development, every node
+ * rendered as a bare label with no shape and no layout once built for production,
+ * where effects run once.
+ */
+
+/** Records what the parent's layout effect saw, in order. */
+function Harness({ forwardedRef, seen }: Readonly<{
+  forwardedRef: Ref<HTMLDivElement>;
+  seen: Array<HTMLDivElement | null>;
+}>) {
+  const ref = forwardedRef as { current: HTMLDivElement | null };
+  useLayoutEffect(() => {
+    seen.push(ref.current);
+  }, [ref, seen]);
+  return <Child forwardedRef={forwardedRef} />;
+}
+
+function Child({ forwardedRef }: Readonly<{ forwardedRef: Ref<HTMLDivElement> }>): ReactNode {
+  // Stands in for `SVGText`, whose only relevant behaviour here is that it forwards its
+  // ref through `useCombinedRef`.
+  const combinedRef = useCombinedRef<HTMLDivElement>(forwardedRef);
+  return <div data-testid="el" ref={combinedRef} />;
+}
+
+describe('useCombinedRef ref-assignment timing', () => {
+  it('assigns the forwarded ref before a consumer layout effect runs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    // `reactStrictMode: false` is the whole point: effects run once, as they do in any
+    // production build. With the suite-wide StrictMode left on, the remount masks this.
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: false });
+
+    // The parent's layout effect must have seen the node, not null: the ref is assigned
+    // during commit, before layout effects run.
+    expect(seen).toEqual([screen.getByTestId('el')]);
+  });
+
+  it('is masked by StrictMode, which is why nothing caught it', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: true });
+
+    // The remount leaves a correct ref behind, so a consumer whose layout effect runs
+    // more than once recovers. Deliberately asserts only the final value: this holds
+    // both before and after a fix, so it is documentation rather than something that
+    // has to change when `useCombinedRef` is corrected.
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.at(-1)).toBe(screen.getByTestId('el'));
+  });
+
+  it('has assigned the ref by the time render returns, which is what the existing tests assert', () => {
+    const ref = createRef<HTMLDivElement>();
+    const seen: Array<HTMLDivElement | null> = [];
+
+    render(<Harness forwardedRef={ref} seen={seen} />, { reactStrictMode: false });
+
+    // Passing here is not evidence of correctness: passive effects have flushed by now.
+    // The defect is only visible from inside a layout effect.
+    expect(ref.current).toBe(screen.getByTestId('el'));
+  });
+});

--- a/packages/joint-react/src/hooks/use-cell.ts
+++ b/packages/joint-react/src/hooks/use-cell.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useRef } from 'react';
 import { CellIdContext } from '../context';
 import { useCells } from './use-cells';
 import type { AnyCellRecord, CellId, CellRecord, Computed } from '../types/cell.types';
@@ -124,16 +124,40 @@ export function useCell<Cell extends AnyCellRecord = CellRecord, Selected = Comp
     );
   }
 
+  // Remembers the last value this hook resolved and the id it belonged to, so the
+  // selector can tolerate the removed-mid-render window below. One ref mutated in
+  // place (never reassigned) — no per-render allocation on the hot path. Tagging
+  // by id means a changed id never returns a stale value from a different cell.
+  const lastResolvedRef = useRef<{
+    id: CellId | undefined;
+    value: Computed<Cell> | Selected | undefined;
+  }>({ id: undefined, value: undefined });
+
   // Always run through the (id, selector, isEqual?) form so React only sees
-  // one stable hook call shape across all overloads. The selector throws on
-  // missing cells; the identity case re-uses the cell record reference, so
-  // isEqual=Object.is bails out on data-only commits.
+  // one stable hook call shape across all overloads. The identity case re-uses
+  // the cell record reference, so isEqual=Object.is bails out on data-only commits.
   const selector = useMemo(() => {
     return (cell: Computed<Cell> | undefined): Computed<Cell> | Selected => {
+      const lastResolved = lastResolvedRef.current;
       if (cell === undefined) {
+        // The subscribed cell was removed while this subtree is still mounted: a
+        // controlled `cells` update fires the cell's per-id listener synchronously
+        // (inside GraphProvider's applyControlled commit) one step before <Paper>
+        // unmounts the portal, so the selector re-runs against a cell that is
+        // already gone. Return the last value resolved for THIS id — the doomed
+        // subtree renders once more with stale data (equal to the cached value, so
+        // it does not even re-render) and unmounts on the next commit, instead of
+        // throwing and taking the whole paper down. A cell that never resolved is
+        // genuine misuse (bad id / outside a render context) and still throws.
+        if (lastResolved.id === id) {
+          return lastResolved.value as Computed<Cell> | Selected;
+        }
         throw new Error(`useCell(): no cell with id "${String(id)}"`);
       }
-      return userSelector ? userSelector(cell) : cell;
+      const value = userSelector ? userSelector(cell) : cell;
+      lastResolved.id = id;
+      lastResolved.value = value;
+      return value;
     };
     // userSelector is captured by reference; React's referential equality on
     // the closure is enough here because `useCells` keeps its own selectorRef.

--- a/packages/joint-react/src/hooks/use-combined-ref.ts
+++ b/packages/joint-react/src/hooks/use-combined-ref.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type RefObject, type ForwardedRef } from 'react';
+import { useRef, useMemo, type RefObject, type ForwardedRef } from 'react';
 
 /**
  * Sets the value of a forwarded ref, handling both function refs and object refs.
@@ -28,11 +28,30 @@ export function setForwardRef<T>(ref: ForwardedRef<T> | undefined, value: T | nu
  * });
  */
 export function useCombinedRef<T>(ref?: ForwardedRef<T>): RefObject<T | null> {
-  const innerRef = useRef<T>(null);
+  // Explicitly nullable so `current` stays mutable under React 18's typings
+  // too — the proxy setter below assigns to it.
+  const innerRef = useRef<T | null>(null);
 
-  useEffect(() => {
-    setForwardRef(ref, innerRef.current);
-  }, [ref]);
-
-  return innerRef;
+  // Assign the forwarded ref DURING COMMIT — when React writes to this object's
+  // `current` — not in a passive effect. React attaches refs before layout effects
+  // run, and consumers rely on that: a parent that reads the forwarded ref in its own
+  // `useLayoutEffect` would see `null` if the assignment were deferred to a passive
+  // effect (parent layout effects run first). `useMeasureElement` is exactly such a
+  // consumer — it bails on a null node and never re-registers, leaving the element
+  // 0x0 in production (StrictMode's remount masks it in dev/tests). A proxy whose
+  // setter forwards keeps the `RefObject` read interface (`.current`) callers depend
+  // on, which a plain callback ref could not. Keyed on `ref` so a changed forwarded
+  // ref re-attaches and receives the current node.
+  return useMemo<RefObject<T | null>>(
+    () => ({
+      get current() {
+        return innerRef.current;
+      },
+      set current(value: T | null) {
+        innerRef.current = value;
+        setForwardRef(ref, value);
+      },
+    }),
+    [ref]
+  );
 }


### PR DESCRIPTION
Backport of #3447 (merged to `dev` as aebebf993) to `master` — both fixes are reachable in production builds of the released line.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run the joint-react test suite locally (`yarn test`: typecheck + lint + knip + jest on React 18 & 19)
* [x] There are new unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Two independent React-hook lifecycle fixes in `@joint/react`, each with a jest repro. Both are reachable through ordinary, documented usage and both are masked by StrictMode's effect remount, so they only surfaced in production builds.

### 1. `useCell` — tolerate a cell removed mid-render (fixes #3442)

`useCell()` threw `useCell(): no cell with id "X"` and took the whole paper down when a subscribed cell was removed from a controlled `cells` array (renaming a node id is a remove + add). A `renderElement` subtree that subscribes to its own cell — directly, or via `useMeasureElement` -> `useCell(selectElementSize)` for any content-sized node, i.e. the default `HTMLBox` / `SVGText` renderers — re-runs its selector against the already-removed cell before `<Paper>` reconciles the removal, because the controlled apply fires that cell's per-id listener synchronously in a layout effect.

The wrapper selector now keeps the last value it resolved for the current id (one in-place-mutated ref, no per-render allocation) and returns it during that removed-mid-render window: the doomed subtree renders once more with stale data (equal to the cached value, so it does not even re-render) and unmounts on the next commit, instead of throwing. A cell that never resolved (genuine bad-id misuse / outside a render context) still throws.

Repro: `use-cell-controlled-removal.test.tsx` — a real `Paper` + subscribing `renderElement` doing a controlled `b -> c` rename crashes to 0 elements before the fix, survives (2 elements, no error) after.

### 2. `useCombinedRef` — assign the forwarded ref during commit, not in a passive effect (fixes #3444)

`useCombinedRef` assigned the forwarded ref inside a passive `useEffect`, one phase too late. React attaches refs during commit, before layout effects; a parent that reads the forwarded ref in its own `useLayoutEffect` saw `null`. `useMeasureElement` is exactly that consumer — it reads `nodeRef.current` in a layout effect, bails on null, and its dependency list does not change when the node is finally assigned, so a measured element stayed 0x0 in production.

The hook now returns a proxy whose setter forwards during commit (`setForwardRef` runs when React writes `.current`), keeping the `RefObject` `.current` read interface consumers depend on — which a plain callback ref could not.

Repro: `use-combined-ref-timing.test.tsx` (rendered with `reactStrictMode: false`) — a parent layout effect sees `null` before the fix, the node after.

## Motivation and Context

The `useCell` crash came out of a Mermaid-to-JointJS renderer where every keystroke in a node id took the canvas down; the `useCombinedRef` one from an app measuring `SVGText` directly — correct under `vite dev`, every node a bare label with no shape or layout once built for production. StrictMode (on for every story and test) masks both, which is why the suite was blind to them.

Fixes #3442
Fixes #3444