### PR TITLE
chore: fix sonar GHA, bump actions versions in all

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +70,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-joint-react-docs.yml
+++ b/.github/workflows/publish-joint-react-docs.yml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       # Checkout the repo contents
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Set up Node.js version for building
       - name: Use Node.js 22.14.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.14.0'
 
       # Cache Yarn packages to speed up CI
       - name: Cache Yarn
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .yarn/cache
@@ -87,7 +87,7 @@ jobs:
 
       # Upload the built docs as an artifact for GitHub Pages deployment
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./packages/joint-react/docs
 
@@ -103,9 +103,9 @@ jobs:
     steps:
       # Setup GitHub Pages deployment environment
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       # Deploy the uploaded artifact to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,21 +29,36 @@ jobs:
       # Checkout contents of joint repo
       - name: Checkout code
         id: checkout-joint
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      # Install environment packages
+      # Fonts - util.breakText - international characters
+      - name: Install environment packages
+        id: install-environment-packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: |
+            fonts-arphic-ukai \
+            fonts-arphic-uming \
+            fonts-ipafont-mincho \
+            fonts-ipafont-gothic \
+            fonts-unfonts-core \
+            fonts-noto-core
+          version: 1.0
 
       # Set up Node.js version for building
       - name: Setup Node.js v22
         id: setup-node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.14.0
 
       # Cache Yarn packages to speed up CI
       - name: Cache Yarn
         id: cache-yarn
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .yarn/cache

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v11
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Please remove stale label or comment or this will be closed in 14 days.'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -22,7 +22,7 @@ jobs:
       # Checkout contents of joint repo
       - name: Checkout joint
         id: checkout-joint
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -44,14 +44,14 @@ jobs:
       # Set up Node.js version for building
       - name: Setup Node.js v22
         id: setup-node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.14.0
 
       # Cache Yarn packages to speed up CI
       - name: Cache Yarn
         id: cache-yarn
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .yarn/cache


### PR DESCRIPTION
## Description

Fixes `sonar.yml` GitHub Action to import missing fonts (which made the `yarn run test-coverage` command fail, in contrast to `test-pr.yml` which worked well).

Bumps the version of all used GitHub Actions to most recent major versions to resolve warning/error annotations.