### PR TITLE
chore: improve coverage and duplications reporting in sonar GHA

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,8 @@ sonar.scm.provider=git
 
 # SOURCES
 
+sonar.typescript.file.suffixes=.ts,.tsx,.mts,.cts
+
 sonar.sources=.
 sonar.exclusions=**/build/**,\
     **/coverage/**,\
@@ -36,18 +38,44 @@ sonar.test.inclusions=**/test/**/*,\
 
 # Each workspace writes its reports into its own `coverage/` directory
 # NOTE: Coverage report paths must be listed one by one here
-# NOTE: All source paths inside them must be relative to repo root!
+# NOTE: All source paths inside coverage reports must be relative to repo root!
 sonar.javascript.lcov.reportPaths=packages/joint-core/coverage/geometry/lcov.info,\
     packages/joint-core/coverage/vectorizer/lcov.info,\
     packages/joint-core/coverage/joint/lcov.info,\
     packages/joint-layout-directed-graph/coverage/lcov.info,\
     packages/joint-layout-msagl/coverage/lcov.info,\
     packages/joint-react/coverage/lcov.info
-# Packages that report no coverage statistics must be explicitly excluded here
-# (Otherwise, SonarQube would report them as 0% and fail "Coverage on new code")
+# Code that reports no coverage statistics should be excluded here:
+# - Packages which measure no coverage at all
+# - Configuration (config, rollup)
+# - Build tooling (grunt, scripts)
+# - Build bundle entry points (`index.js`, `joint.mjs`)
 sonar.coverage.exclusions=packages/joint-cli/**,\
     packages/joint-decorators/**,\
     packages/joint-eslint-config/**,\
     packages/joint-shapes-general/**,\
     packages/joint-shapes-general-tools/**,\
-    packages/joint-vitest-plugin-mock-svg/**
+    packages/joint-vitest-plugin-mock-svg/**,\
+    **/*.config.js,\
+    **/*.config.mjs,\
+    **/*.config.ts,\
+    **/*.conf.js,\
+    packages/joint-core/rollup.resources.mjs,\
+    packages/joint-core/Gruntfile.js,\
+    packages/joint-core/grunt/**,\
+    packages/joint-core/scripts/**,\
+    packages/joint-react/scripts/**,\
+    packages/joint-core/index.js,\
+    packages/joint-core/joint.mjs
+
+# DUPLICATION
+
+# Duplication is measured for everything except tests and types by default
+# Code that may have duplications should be excluded here:
+# - Configuration (config, rollup)
+# NOTE: Procedural build code (grunt, scripts) should not be excluded
+sonar.cpd.exclusions=**/*.config.js,\
+    **/*.config.mjs,\
+    **/*.config.ts,\
+    **/*.conf.js,\
+    packages/joint-core/rollup.resources.mjs


### PR DESCRIPTION
## Description

Improves sonar reporting by:
- Excluding all non-source-code files from coverage reporting
- Excluding config files from duplicate-code reporting