### PR TITLE
chore(core): promote alg.rightAnglePath and rightAngle's useModelGeometry to public API

### DIFF
--- a/.changeset/publish-right-angle-path.md
+++ b/.changeset/publish-right-angle-path.md
@@ -1,0 +1,5 @@
+---
+"@joint/core": minor
+---
+
+alg - add `rightAnglePath()`, the `rightAngle` router's path-finding algorithm, as a public utility

--- a/.changeset/publish-use-model-geometry.md
+++ b/.changeset/publish-use-model-geometry.md
@@ -1,0 +1,5 @@
+---
+"@joint/core": minor
+---
+
+routers.rightAngle - add `useModelGeometry` option to read the source/target geometry from the models instead of the rendered views


### PR DESCRIPTION
Two changesets promoting API introduced (as `@internal`) by #3457 to the public API in the **next minor release**:

- `alg.rightAnglePath()` - the `rightAngle` router's path-finding algorithm as a public utility
- `useModelGeometry` option on the `rightAngle` router

## Before merging

- [ ] #3457 is merged and released
- [ ] Remove the `@internal` tag (and the "not part of the public API yet" wording) from `rightAnglePath`/`RightAnglePathOptions` in `packages/joint-core/types/alg.d.ts`
- [ ] Remove the `@internal` tag from `useModelGeometry` in `packages/joint-core/types/routers.d.ts`
- [ ] Resolve the `targetInSourceBBox` option first - it is flagged in the code as a temporary `rightAngle` router internal to be removed (deduced inside the algorithm) before the API is frozen

Merge as part of the next **minor** release train - the changesets bump `@joint/core` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)