### PR TITLE
chore: backfill changesets for PRs merged since v4.3.1/v4.3.2

### DIFF
--- a/.changeset/link-anchor-arrowhead.md
+++ b/.changeset/link-anchor-arrowhead.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+link routing - account for the arrowhead when a custom link anchor is used

--- a/.changeset/paper-guard-blank-pointerdown.md
+++ b/.changeset/paper-guard-blank-pointerdown.md
@@ -1,0 +1,5 @@
+---
+"@joint/core": patch
+---
+
+dia.Paper - the `guard` option can now veto blank pointerdowns; its `view` argument is `undefined` when the event did not hit a cell view

--- a/.changeset/paper-magnet-interactive-controls.md
+++ b/.changeset/paper-magnet-interactive-controls.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+<Paper /> - support interactive controls (buttons, inputs) nested inside magnets without the press starting a link drag or an element move

--- a/.changeset/use-cell-removed-mid-render.md
+++ b/.changeset/use-cell-removed-mid-render.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+useCell - tolerate a cell removed from the graph mid-render

--- a/.changeset/use-combined-ref-commit-assignment.md
+++ b/.changeset/use-combined-ref-commit-assignment.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+useCombinedRef - assign the forwarded ref during the commit phase

--- a/.changeset/use-markup-unrendered-view.md
+++ b/.changeset/use-markup-unrendered-view.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+useMarkup - tolerate a cell view whose markup has not been rendered yet (synchronous rendering in development)


### PR DESCRIPTION
Changesets for the releasable PRs merged after the v4.3.1 (core) / v4.3.2 (react) release but before the changesets tooling (#3448) landed - without them the next release's changelogs would miss these entries:

| PR | Package | Bump | Entry |
|---|---|---|---|
| #3446 | `@joint/core` | patch | dia.Paper - `guard` option can veto blank pointerdowns (`view` argument is `undefined` when no cell view was hit) |
| #3446 | `@joint/react` | patch | `<Paper />` - interactive controls nested inside magnets |
| #3453 | `@joint/react` | patch | link routing - account for the arrowhead with a custom link anchor |
| #3455 | `@joint/react` | patch | useCell - tolerate a cell removed mid-render |
| #3455 | `@joint/react` | patch | useCombinedRef - assign the forwarded ref during commit |
| #3458 | `@joint/react` | patch | useMarkup - tolerate a not-yet-rendered cell view |

CI/build-only PRs (sonar GHA, yarn bump, coverage configs, the changesets tooling itself) and the `@joint/eslint-config` chore (#3451) intentionally have no changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)