### PR TITLE
chore: custom changeset changelog format

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,40 @@
+// Changelog line format: `- <summary> (<short sha>)`.
+//
+// This replaces the default `@changesets/cli/changelog`, which renders the same
+// information as a `<short sha>: ` prefix instead. `changeset.commit` is the
+// full SHA of the commit that added the changeset file, resolved by Changesets
+// from local git history - no GitHub token or API request is involved. It is
+// `undefined` when the changeset file has not been committed yet (a local
+// `changeset version` run), in which case the suffix is omitted.
+//
+// `getDependencyReleaseLine` is a verbatim port of the default implementation,
+// so "Updated dependencies" blocks are unchanged.
+const SHA_LENGTH = 7;
+
+module.exports = {
+    getReleaseLine: async (changeset) => {
+        const [firstLine, ...continuationLines] = changeset.summary
+            .split('\n')
+            .map((line) => line.trimEnd());
+        const sha = changeset.commit
+            ? ` (${changeset.commit.slice(0, SHA_LENGTH)})`
+            : '';
+        let releaseLine = `- ${firstLine}${sha}`;
+        if (continuationLines.length > 0) {
+            releaseLine += `\n${continuationLines.map((line) => `  ${line}`).join('\n')}`;
+        }
+        return releaseLine;
+    },
+
+    getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
+        if (dependenciesUpdated.length === 0) return '';
+        const changesetLinks = changesets.map(
+            (changeset) =>
+                `- Updated dependencies${changeset.commit ? ` [${changeset.commit.slice(0, SHA_LENGTH)}]` : ''}`
+        );
+        const updatedDependenciesList = dependenciesUpdated.map(
+            (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
+        );
+        return [...changesetLinks, ...updatedDependenciesList].join('\n');
+    },
+};

--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -7,8 +7,10 @@
 // `undefined` when the changeset file has not been committed yet (a local
 // `changeset version` run), in which case the suffix is omitted.
 //
-// `getDependencyReleaseLine` is a verbatim port of the default implementation,
-// so "Updated dependencies" blocks are unchanged.
+// "Updated dependencies" blocks follow the same `(<short sha>)` convention. The
+// default implementation emits one `- Updated dependencies [<short sha>]` line
+// per changeset, which repeats the line when several changesets share a commit;
+// this one emits a single line listing every contributing commit instead.
 const SHA_LENGTH = 7;
 
 module.exports = {
@@ -38,7 +40,7 @@ module.exports = {
                     .map((changeset) => changeset.commit.slice(0, SHA_LENGTH))
             ),
         ];
-        const suffix = shas.length > 0 ? ` (${shas.join(', ')})` : '';
+        const suffix = shas.length > 0 ? ` [${shas.join(', ')}]` : '';
         return [
             `- Updated dependencies${suffix}`,
             ...dependenciesUpdated.map(

--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,4 +1,4 @@
-const SHA_LENGTH = 7;
+const SHA_LENGTH = 8;
 
 // NOTE: Returns `null` if the changeset has no commit yet (e.g. local)
 const shortSha = (changeset) => {

--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,46 +1,48 @@
-// Changelog line format: `- <summary> (<short sha>)`.
-//
-// This replaces the default `@changesets/cli/changelog`, which renders the same
-// information as a `<short sha>: ` prefix instead. `changeset.commit` is the
-// full SHA of the commit that added the changeset file, resolved by Changesets
-// from local git history - no GitHub token or API request is involved. It is
-// `undefined` when the changeset file has not been committed yet (a local
-// `changeset version` run), in which case the suffix is omitted.
-//
-// "Updated dependencies" blocks follow the same `(<short sha>)` convention. The
-// default implementation emits one `- Updated dependencies [<short sha>]` line
-// per changeset, which repeats the line when several changesets share a commit;
-// this one emits a single line listing every contributing commit instead.
 const SHA_LENGTH = 7;
 
+// NOTE: Returns `null` if the changeset has no commit yet (e.g. local)
+const shortSha = (changeset) => {
+    return ((changeset.commit) ? changeset.commit.slice(0, SHA_LENGTH) : null);
+}
+
 module.exports = {
+    // Changelog line format:
+    // - <first line of summary> (<short SHA>)
+    //   <continuation lines of summary>
+    //   ...
     getReleaseLine: async (changeset) => {
-        const [firstLine, ...continuationLines] = changeset.summary
-            .split('\n')
-            .map((line) => line.trimEnd());
-        const sha = changeset.commit
-            ? ` (${changeset.commit.slice(0, SHA_LENGTH)})`
-            : '';
-        let releaseLine = `- ${firstLine}${sha}`;
+        const summaryLines = changeset.summary.split('\n');
+        const trimmedLines = summaryLines.map((line) => line.trimEnd());
+        const [firstLine, ...continuationLines] = trimmedLines;
+
+        // Omit SHA suffix if the changeset has no commit (`null`)
+        const sha = shortSha(changeset);
+        const suffix = ((sha !== null) ? ` (${sha})` : '');
+
+        // SHA suffix is added only to first line of summary
+        let releaseLine = `- ${firstLine}${suffix}`;
         if (continuationLines.length > 0) {
             releaseLine += `\n${continuationLines.map((line) => `  ${line}`).join('\n')}`;
         }
         return releaseLine;
     },
 
+    // Changelog dependency bump format:
+    // - Updated dependencies [<short SHA>, ...]
+    //   - <dependency@version>
+    //   - <...>
     getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
         if (dependenciesUpdated.length === 0) return '';
-        // One line for all contributing commits, not one line per changeset.
-        // Changesets that are not committed yet contribute no SHA, and a single
-        // commit adding several changesets is only listed once.
-        const shas = [
-            ...new Set(
-                changesets
-                    .filter((changeset) => changeset.commit)
-                    .map((changeset) => changeset.commit.slice(0, SHA_LENGTH))
-            ),
-        ];
-        const suffix = shas.length > 0 ? ` [${shas.join(', ')}]` : '';
+
+        // Get one SHA per changeset
+        const changesetShas = changesets.map((changeset) => shortSha(changeset));
+        // Skip changesets with no commit (`null`)
+        const filteredShas = changesetShas.filter((sha) => (sha !== null));
+        // List each commit at most once
+        const shas = [...new Set(filteredShas)];
+        // Omit SHA suffix if there are no commits left after the above logic
+        const suffix = ((shas.length) > 0 ? ` [${shas.join(', ')}]` : '');
+
         return [
             `- Updated dependencies${suffix}`,
             ...dependenciesUpdated.map(

--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -28,13 +28,22 @@ module.exports = {
 
     getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
         if (dependenciesUpdated.length === 0) return '';
-        const changesetLinks = changesets.map(
-            (changeset) =>
-                `- Updated dependencies${changeset.commit ? ` [${changeset.commit.slice(0, SHA_LENGTH)}]` : ''}`
-        );
-        const updatedDependenciesList = dependenciesUpdated.map(
-            (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
-        );
-        return [...changesetLinks, ...updatedDependenciesList].join('\n');
+        // One line for all contributing commits, not one line per changeset.
+        // Changesets that are not committed yet contribute no SHA, and a single
+        // commit adding several changesets is only listed once.
+        const shas = [
+            ...new Set(
+                changesets
+                    .filter((changeset) => changeset.commit)
+                    .map((changeset) => changeset.commit.slice(0, SHA_LENGTH))
+            ),
+        ];
+        const suffix = shas.length > 0 ? ` (${shas.join(', ')})` : '';
+        return [
+            `- Updated dependencies${suffix}`,
+            ...dependenciesUpdated.map(
+                (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
+            ),
+        ].join('\n');
     },
 };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "baseBranch": "master",
   "access": "public",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "ignore": [],
   "fixed": [],


### PR DESCRIPTION
## Description

Instead of adding commit reference at the beginning of a changelog line (`- abcdef1: <summary>`), applies it at the end (`- <summary> (aabbccdd)`).

Also consolidates "Updated dependencies" lines to a single line that lists all commits, instead of having them listed separately. For example...
```
- Updated dependencies [aaaaaaa, bbbbbbb, ccccccc]
  - @joint/core@4.2.0
  ```
 ...instead of:
 ```
 - Updated dependencies [aaaaaaa]
- Updated dependencies [aaaaaaa]
- Updated dependencies [bbbbbbb]
- Updated dependencies [ccccccc]
  - @joint/core@4.2.0
 ```