### PR TITLE
chore: GHA permissions hardening

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '37 5 * * 2'
 
+# Reset permissions and grant them explicitly per job.
+permissions: {}
+
 jobs:
   analyze:
     if: ${{ github.repository == 'clientIO/joint' }}
@@ -29,7 +32,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -38,38 +40,40 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-joint-react-docs.yml
+++ b/.github/workflows/publish-joint-react-docs.yml
@@ -13,11 +13,8 @@ on:
       - '.github/workflows/**'              # (optional) include changes to the workflow itself
   workflow_call:
 
-# Permissions needed to write to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Reset permissions and grant them explicitly per job.
+permissions: {}
 
 # Prevent concurrent runs of this workflow
 concurrency:
@@ -29,10 +26,11 @@ jobs:
   build-joint-react-docs:
     if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # the built docs leave as an artifact
     defaults:
       run:
         working-directory: ./packages/joint-react
-
     outputs:
       # Save the docs output path for the next job
       pages_path: ${{ steps.prepare.outputs.pages_path }}
@@ -40,6 +38,8 @@ jobs:
     steps:
       # Checkout the repo contents
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # Set up Node.js version for building
       - name: Use Node.js 22.14.0
@@ -96,6 +96,9 @@ jobs:
     needs: build-joint-react-docs
     if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
+    permissions:
+      pages: write # publish the artifact to GitHub Pages
+      id-token: write # OIDC token the Pages deployment is verified with
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
       contents: read
     outputs:
       mode: ${{ steps.select-mode.outputs.mode }}
+
     steps:
       - name: Checkout joint
         id: checkout-joint
@@ -80,6 +81,7 @@ jobs:
     permissions:
       contents: write # commit the version bumps
       pull-requests: write # open the release PR
+
     steps:
       - name: Checkout joint
         id: checkout-joint
@@ -117,10 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push git tags and create GitHub Releases
+
     steps:
       - name: Checkout joint
         id: checkout-joint
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js v22
         id: setup-node

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,11 +7,16 @@ on:
       - master
   workflow_dispatch: {} # Also allow manual triggering
 
+# Reset permissions and grant them explicitly per job.
+permissions: {}
+
 jobs:
   sonarqube:
     if: ${{ github.repository == 'clientIO/joint' }} # Skip for forks
     name: SonarQube Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout only - results go to SonarQube, not to GitHub
 
     steps:
       # Echo run information
@@ -31,7 +36,9 @@ jobs:
         id: checkout-joint
         uses: actions/checkout@v7
         with:
+          # Full history for SonarQube blame/SCM attribution (read from the local clone)
           fetch-depth: 0
+          persist-credentials: false
 
       # Install environment packages
       # Fonts - util.breakText - international characters

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,10 @@ name: Mark stale issues/PR
 on:
   workflow_dispatch:
   schedule:
-  - cron: '0 0 * * *'
+    - cron: '0 0 * * *'
+
+# Reset permissions and grant them explicitly per job.
+permissions: {}
 
 jobs:
   stale:
@@ -19,15 +22,15 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v11
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Please remove stale label or comment or this will be closed in 14 days.'
-        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Please remove stale label or comment or this will be closed in 14 days.'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
-        days-before-stale: 60
-        days-before-close: 14
-        exempt-issue-labels: 'bug,candidate feature,enhancement,technical debt'
-        exempt-draft-pr: true
-        operations-per-run: 999
+      - uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Please remove stale label or comment or this will be closed in 14 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Please remove stale label or comment or this will be closed in 14 days.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: 'bug,candidate feature,enhancement,technical debt'
+          exempt-draft-pr: true
+          operations-per-run: 999

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+# Reset permissions and grant them explicitly per job.
+permissions: {}
+
 # Cancel in-progress runs on new commits
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +21,9 @@ jobs:
   test:
     if: ${{ github.repository == 'clientIO/joint' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout only - nothing here writes back
+
     steps:
       # Checkout contents of joint repo
       - name: Checkout joint
@@ -25,6 +31,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Nothing here pushes; the `master` fetch below is anonymous (public repo)
+          persist-credentials: false
 
       # Install environment packages
       # Fonts - util.breakText - international characters

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # Nothing here pushes; the `master` fetch below is anonymous (public repo)
           persist-credentials: false
 
       # Install environment packages
@@ -78,6 +77,8 @@ jobs:
         # Release PR is skipped - it consumes all changesets instead
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
         # Compare PR to current committed master
+        # NOTE: the checkout sets `persist-credentials: false`, so this fetch is
+        # unauthenticated - it only works while the repository stays public
         run: |
           git fetch --no-tags origin '+refs/heads/master:refs/remotes/origin/master'
           yarn changeset status --since=origin/master


### PR DESCRIPTION
## Description

Implements two security hardening fixes on GHA workflows:
- Sets `permissions: {}` at the start of every workflow and grants scopes per job.
- Sets `persist-credentials: false` as part of all `actions/checkout` configs. By default, this action writes the run's `GITHUB_TOKEN` into `.git/config` as an auth header, where it stays readable by anything that runs later in the same job, but that is not necessary unless an action need to do something (e.g. a push) while relying on those credentials. Changing the default keeps the token out of reach of build and test code, which prevents some attack vectors. Writing to the repository is still allowed if an action supplies its own credentials (like what `changeset-release/master` does in `release.yml`).