### PR TITLE
fix(joint-react): stop guarding events targeting paper container itself

### DIFF
--- a/.changeset/lucky-pans-listen.md
+++ b/.changeset/lucky-pans-listen.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+<Paper /> - fix events dispatched at the paper container itself being guarded as portaled content

--- a/packages/joint-react/src/components/paper/__tests__/paper-html-content-events.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-html-content-events.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-perf/jsx-no-new-object-as-prop */
 import { useCallback } from 'react';
+import type { dia } from '@joint/core';
 import { render, waitFor } from '@testing-library/react';
 import { GraphProvider, Paper } from '../../../components';
 import { usePaper } from '../../../hooks/use-paper';
@@ -57,6 +58,12 @@ function OverlayProbe({ onButtonMouseDown }: Readonly<OverlayProbeProps>) {
 }
 
 const renderElement = () => <rect width={50} height={50} />;
+
+/** The guard pair, reachable from a test: both are `protected` on `dia.Paper`. */
+interface GuardProbe {
+  readonly guard: (event: dia.Event, view?: dia.CellView) => boolean;
+  readonly guardExplicit: (event: dia.Event, view?: dia.CellView) => boolean | undefined;
+}
 
 const readPaper = (): PaperView | null => capturedPaper;
 const readButton = (): HTMLButtonElement | null => capturedButton;
@@ -123,5 +130,33 @@ describe('HTML content inside the paper container', () => {
 
     expect(blankPointerdown).toHaveBeenCalledTimes(1);
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+
+  // `paper.el` is the container the portaled content lives in, not portaled content
+  // itself. joint-core documents it as part of the paper's event surface (`guard()`:
+  // `if (this.el === target || …) return false`), which is what makes replaying a
+  // synthetic event onto it a way to reach the paper's pipeline. `guardExplicit` must
+  // stay undecided there — `Node.contains()` is true for the node itself, so the
+  // portaled-content check would otherwise claim it and drop the event.
+  it('does not guard an event targeting the paper container itself', async () => {
+    const paper = await renderPaperWithOverlay(() => {});
+    // `guardExplicit` is protected on `dia.Paper`; the contract it implements is public.
+    const { guard, guardExplicit } = paper as unknown as GuardProbe;
+    const event = { type: 'wheel', target: paper.el } as unknown as dia.Event;
+
+    expect(guardExplicit.call(paper, event)).toBeUndefined();
+    expect(guard.call(paper, event)).toBe(false);
+  });
+
+  it('pans the paper for a wheel replayed onto the paper container', async () => {
+    const paper = await renderPaperWithOverlay(() => {});
+    const pan = jest.fn();
+    paper.on('paper:pan', pan);
+
+    paper.el.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true })
+    );
+
+    expect(pan).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -266,6 +266,12 @@ export const Paper = dia.Paper.extend(
      * joint-core leaves such a press alone for backwards compatibility, deciding it only
      * from `guardExplicit`. Rejecting it here — after the caller's own `options.guard` —
      * is what lets overlay content use plain React events with no interception of its own.
+     *
+     * `paper.el` itself is not portaled content: joint-core's `guard()` documents the root
+     * element as part of the paper's event surface (`this.el === target` returns `false`
+     * there), and code replays synthetic events onto it precisely to reach the paper's
+     * pipeline. `Node.contains()` is true for the node itself, so it needs excluding
+     * explicitly — otherwise those events are silently dropped.
      * @param event - Event delivered to the paper's dispatch.
      * @param view - View resolved from the event target, if any.
      * @returns `true` to guard, `false` to allow, `undefined` to leave it undecided.
@@ -275,7 +281,10 @@ export const Paper = dia.Paper.extend(
       if (guarded !== undefined) return guarded;
       const { target } = event;
       const isPortaledContent =
-        target instanceof Node && !this.svg.contains(target) && this.el.contains(target);
+        target instanceof Node &&
+        target !== this.el &&
+        !this.svg.contains(target) &&
+        this.el.contains(target);
       // Anything else stays undecided, so the paper goes on to judge the target itself.
       return isPortaledContent ? true : undefined;
     },


### PR DESCRIPTION
## Description

Fixes the paper preset's `guardExplicit` override treating `paper.el` itself as portaled content (because `Node.contains()` is true for the node itself, so the check meant for descendants also caught the root element, guarding it before joint-core's guard() could reach its `this.el === target` exemption).

Adds regression tests for the boundary; real portaled content stays guarded.

## Motivation and Context

This fixes a failing test in joint-react-plus.
