### PR TITLE
fix(joint-react): do not hide links connected to other links

### DIFF
--- a/.changeset/light-moons-wonder.md
+++ b/.changeset/light-moons-wonder.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+<Paper /> - fix links connected to other links staying permanently hidden (the link-end readiness check only looked the end up among the elements)

--- a/packages/joint-react/src/mvc/__tests__/paper-portal-selector.test.ts
+++ b/packages/joint-react/src/mvc/__tests__/paper-portal-selector.test.ts
@@ -148,6 +148,49 @@ describe('PaperView / portalSelector overrides', () => {
       expect(linkView).toBeDefined();
     });
 
+    it('does not keep a link-to-link connection hidden', () => {
+      const noPortalSelector: undefined = undefined;
+      paper = createPaper(noPortalSelector);
+
+      const a = new shapes.standard.Rectangle({ position: { x: 0, y: 0 }, size: { width: 50, height: 50 } });
+      const b = new shapes.standard.Rectangle({ position: { x: 200, y: 0 }, size: { width: 50, height: 50 } });
+      const flow = new shapes.standard.Link({ source: { id: a.id }, target: { id: b.id } });
+      const commentLink = new shapes.standard.Link({ source: { x: 100, y: 100 }, target: { id: flow.id } });
+      graphStore.graph.addCells([a, b, flow, commentLink]);
+
+      const commentLinkView = paper.findViewByModel(commentLink)!;
+      expect(commentLinkView.el.style.visibility).not.toBe('hidden');
+    });
+
+    it('does not hide a chain of link-to-link connections', () => {
+      const noPortalSelector: undefined = undefined;
+      paper = createPaper(noPortalSelector);
+
+      const a = new shapes.standard.Rectangle({ position: { x: 0, y: 0 }, size: { width: 50, height: 50 } });
+      const b = new shapes.standard.Rectangle({ position: { x: 200, y: 0 }, size: { width: 50, height: 50 } });
+      const flow = new shapes.standard.Link({ source: { id: a.id }, target: { id: b.id } });
+      const first = new shapes.standard.Link({ source: { x: 0, y: 100 }, target: { id: flow.id } });
+      const second = new shapes.standard.Link({ source: { x: 0, y: 200 }, target: { id: first.id } });
+      graphStore.graph.addCells([a, b, flow, first, second]);
+
+      const firstView = paper.findViewByModel(first)!;
+      const secondView = paper.findViewByModel(second)!;
+      expect(firstView.el.style.visibility).not.toBe('hidden');
+      expect(secondView.el.style.visibility).not.toBe('hidden');
+    });
+
+    it('does not hide links between portal-less elements', () => {
+      const noPortalSelector: undefined = undefined;
+      paper = createPaper(noPortalSelector);
+
+      const a = new shapes.standard.Rectangle({ position: { x: 0, y: 0 }, size: { width: 50, height: 50 } });
+      const link = new shapes.standard.Link({ source: { id: a.id }, target: { x: 200, y: 100 } });
+      graphStore.graph.addCells([a, link]);
+
+      const linkView = paper.findViewByModel(link)!;
+      expect(linkView.el.style.visibility).not.toBe('hidden');
+    });
+
     it('treats link end with no view as not ready (private isElementReady)', () => {
       const noPortalSelector: undefined = undefined;
       paper = createPaper(noPortalSelector);

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -128,11 +128,18 @@ export class PaperView extends Paper {
   /**
    * Check whether a link end can be rendered immediately.
    * @param end - The link end JSON descriptor.
-   * @returns True if the link end's target element is ready.
+   * @returns True if the link end's target cell is ready.
    */
   private isLinkEndReady(end: dia.Link.EndJSON): boolean {
-    if (!end.id) return true;
-    return this.isElementReady(end.id as CellId);
+    const endId = end.id as CellId | undefined;
+    if (!endId) return true;
+
+    // Only elements can render asynchronously (their React portal content
+    // mounts after the view) — a link end never needs to be waited for.
+    const cell = this.model.getCell(endId);
+    if (cell?.isLink()) return true;
+
+    return this.isElementReady(endId);
   }
 
   /**

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -131,7 +131,7 @@ export class PaperView extends Paper {
    * @returns True if the link end's target cell is ready.
    */
   private isLinkEndReady(end: dia.Link.EndJSON): boolean {
-    const endId = end.id as CellId | undefined;
+    const endId = end.id;
     if (!endId) return true;
 
     // Only elements can render asynchronously (their React portal content


### PR DESCRIPTION
## Problem

The react paper hides a freshly inserted link view (`visibility: hidden`) until its end views are "ready" — portal-rendered elements are empty until their React content mounts, so a link pointing at them would otherwise dangle in the void.

The readiness check (`isLinkEndReady → isElementReady → getElementView(id)`) only ever resolves the end id among **elements**. When a link's end is another **link** (e.g. a BPMN annotation attached to a flow), the end never becomes ready and the link stays hidden forever — `checkPendingLinks` re-checks with the same test on every element insert, so it never recovers.

## Fix

A link end never needs to be waited for — only elements render asynchronously. `isLinkEndReady` now returns `true` when the end cell is a link.

Elements without portals are unaffected (already handled per view by `isElementReady` — a view with no portal node is ready), so mixed portal/portal-less diagrams keep working.

## Tests

- link connected to another link is not hidden
- a chain of link-to-link connections is not hidden
- links between portal-less elements are not hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)