### PR TITLE
feat(dia.Paper): add focus and blur events; expose them as @joint/react Paper props

### DIFF
--- a/.changeset/big-donkeys-refuse.md
+++ b/.changeset/big-donkeys-refuse.md
@@ -2,4 +2,4 @@
 "@joint/core": minor
 ---
 
-dia.Paper - add `focusin` and `focusout` events (`cell:`, `element:`, `link:` variants)
+dia.Paper - add `focus` and `blur` events (`cell:`, `element:`, `link:` variants), driven by the bubbling `focusin`/`focusout` DOM events

--- a/.changeset/big-donkeys-refuse.md
+++ b/.changeset/big-donkeys-refuse.md
@@ -2,4 +2,4 @@
 "@joint/core": minor
 ---
 
-dia.Paper - add `focusin` and `focusout` events (`cell:`, `element:`, `link:`, `blank:` variants)
+dia.Paper - add `focusin` and `focusout` events (`cell:`, `element:`, `link:` variants)

--- a/.changeset/big-donkeys-refuse.md
+++ b/.changeset/big-donkeys-refuse.md
@@ -1,0 +1,5 @@
+---
+"@joint/core": minor
+---
+
+dia.Paper - add `focusin` and `focusout` events (`cell:`, `element:`, `link:`, `blank:` variants)

--- a/.changeset/khaki-donkeys-agree.md
+++ b/.changeset/khaki-donkeys-agree.md
@@ -2,4 +2,4 @@
 "@joint/react": minor
 ---
 
-Paper - add `onElementFocus`, `onElementBlur`, `onLinkFocus` and `onLinkBlur` event props; `onCellFocus` / `onCellBlur` are now driven by the core `cell:focus` / `cell:blur` paper events
+Paper - add the `onCellFocus`, `onCellBlur`, `onElementFocus`, `onElementBlur`, `onLinkFocus` and `onLinkBlur` event props, driven by the core `cell:`/`element:`/`link:` `focus` and `blur` paper events

--- a/.changeset/khaki-donkeys-agree.md
+++ b/.changeset/khaki-donkeys-agree.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": minor
+---
+
+Paper - add `onElementFocus`, `onElementBlur`, `onLinkFocus` and `onLinkBlur` event props; `onCellFocus` / `onCellBlur` are now driven by the core `cell:focus` / `cell:blur` paper events

--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -1299,6 +1299,16 @@ export const CellView = View.extend({
         this.notify('cell:mouseout', evt);
     },
 
+    focusin: function(evt) {
+
+        this.notify('cell:focusin', evt);
+    },
+
+    focusout: function(evt) {
+
+        this.notify('cell:focusout', evt);
+    },
+
     mouseenter: function(evt) {
 
         this.notify('cell:mouseenter', evt);

--- a/packages/joint-core/src/dia/CellView.mjs
+++ b/packages/joint-core/src/dia/CellView.mjs
@@ -1301,12 +1301,12 @@ export const CellView = View.extend({
 
     focusin: function(evt) {
 
-        this.notify('cell:focusin', evt);
+        this.notify('cell:focus', evt);
     },
 
     focusout: function(evt) {
 
-        this.notify('cell:focusout', evt);
+        this.notify('cell:blur', evt);
     },
 
     mouseenter: function(evt) {

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -690,13 +690,13 @@ export const ElementView = CellView.extend({
     focusin: function(evt) {
 
         CellView.prototype.focusin.apply(this, arguments);
-        this.notify('element:focusin', evt);
+        this.notify('element:focus', evt);
     },
 
     focusout: function(evt) {
 
         CellView.prototype.focusout.apply(this, arguments);
-        this.notify('element:focusout', evt);
+        this.notify('element:blur', evt);
     },
 
     mouseenter: function(evt) {

--- a/packages/joint-core/src/dia/ElementView.mjs
+++ b/packages/joint-core/src/dia/ElementView.mjs
@@ -687,6 +687,18 @@ export const ElementView = CellView.extend({
         this.notify('element:mouseout', evt);
     },
 
+    focusin: function(evt) {
+
+        CellView.prototype.focusin.apply(this, arguments);
+        this.notify('element:focusin', evt);
+    },
+
+    focusout: function(evt) {
+
+        CellView.prototype.focusout.apply(this, arguments);
+        this.notify('element:focusout', evt);
+    },
+
     mouseenter: function(evt) {
 
         CellView.prototype.mouseenter.apply(this, arguments);

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1561,6 +1561,18 @@ export const LinkView = CellView.extend({
         this.notify('link:mouseout', evt);
     },
 
+    focusin: function(evt) {
+
+        CellView.prototype.focusin.apply(this, arguments);
+        this.notify('link:focusin', evt);
+    },
+
+    focusout: function(evt) {
+
+        CellView.prototype.focusout.apply(this, arguments);
+        this.notify('link:focusout', evt);
+    },
+
     mouseenter: function(evt) {
 
         CellView.prototype.mouseenter.apply(this, arguments);

--- a/packages/joint-core/src/dia/LinkView.mjs
+++ b/packages/joint-core/src/dia/LinkView.mjs
@@ -1564,13 +1564,13 @@ export const LinkView = CellView.extend({
     focusin: function(evt) {
 
         CellView.prototype.focusin.apply(this, arguments);
-        this.notify('link:focusin', evt);
+        this.notify('link:focus', evt);
     },
 
     focusout: function(evt) {
 
         CellView.prototype.focusout.apply(this, arguments);
-        this.notify('link:focusout', evt);
+        this.notify('link:blur', evt);
     },
 
     mouseenter: function(evt) {

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -549,6 +549,8 @@ export const Paper = View.extend({
         'touchstart': 'pointerdown',
         'mouseover': 'mouseover',
         'mouseout': 'mouseout',
+        'focusin': 'focusin',
+        'focusout': 'focusout',
         'mouseenter': 'mouseenter',
         'mouseleave': 'mouseleave',
         'wheel': 'mousewheel',
@@ -3671,6 +3673,34 @@ export const Paper = View.extend({
         } else {
             if (this.el === evt.target) return; // prevent border of paper from triggering this
             this.trigger('blank:mouseout', evt);
+        }
+    },
+
+    focusin: function(evt) {
+
+        var view = this.findView(evt.target);
+        if (this.guard(evt, view)) return;
+
+        if (view) {
+            view.focusin(evt);
+
+        } else {
+            if (this.el === evt.target) return; // prevent border of paper from triggering this
+            this.trigger('blank:focusin', evt);
+        }
+    },
+
+    focusout: function(evt) {
+
+        var view = this.findView(evt.target);
+        if (this.guard(evt, view)) return;
+
+        if (view) {
+            view.focusout(evt);
+
+        } else {
+            if (this.el === evt.target) return; // prevent border of paper from triggering this
+            this.trigger('blank:focusout', evt);
         }
     },
 

--- a/packages/joint-core/src/dia/Paper.mjs
+++ b/packages/joint-core/src/dia/Paper.mjs
@@ -3681,13 +3681,7 @@ export const Paper = View.extend({
         var view = this.findView(evt.target);
         if (this.guard(evt, view)) return;
 
-        if (view) {
-            view.focusin(evt);
-
-        } else {
-            if (this.el === evt.target) return; // prevent border of paper from triggering this
-            this.trigger('blank:focusin', evt);
-        }
+        if (view) view.focusin(evt);
     },
 
     focusout: function(evt) {
@@ -3695,13 +3689,7 @@ export const Paper = View.extend({
         var view = this.findView(evt.target);
         if (this.guard(evt, view)) return;
 
-        if (view) {
-            view.focusout(evt);
-
-        } else {
-            if (this.el === evt.target) return; // prevent border of paper from triggering this
-            this.trigger('blank:focusout', evt);
-        }
+        if (view) view.focusout(evt);
     },
 
     mouseenter: function(evt) {

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -355,6 +355,46 @@ QUnit.module('paper', function(hooks) {
         assert.ok(blankContextmenuCallback.called, 'blank:contextmenu triggered');
     });
 
+    QUnit.test('focusin & focusout', function(assert) {
+
+        var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
+        var r2 = new joint.shapes.standard.Rectangle({ position: { x: 150, y: 50 }, size: { width: 20, height: 20 }});
+        var l1 = new joint.shapes.standard.Link({ source: { id: r1.id }, target: { id: r2.id }});
+        this.graph.resetCells([r1, r2, l1]);
+
+        var events = [];
+        this.paper.on('all', function(name) {
+            if (name.indexOf('focus') > -1) events.push(name);
+        });
+
+        // The test `$.fn.trigger` does not dispatch bubbling events —
+        // dispatch native focus events instead.
+        var focus = function(el, type) {
+            el.dispatchEvent(new FocusEvent(type, { bubbles: true }));
+        };
+
+        var r1View = this.paper.findViewByModel(r1);
+        focus(r1View.el, 'focusin');
+        assert.deepEqual(events, ['cell:focusin', 'element:focusin'], 'cell:focusin precedes element:focusin');
+
+        events = [];
+        focus(r1View.el, 'focusout');
+        assert.deepEqual(events, ['cell:focusout', 'element:focusout'], 'cell:focusout precedes element:focusout');
+
+        events = [];
+        var l1View = this.paper.findViewByModel(l1);
+        focus(l1View.el, 'focusin');
+        assert.deepEqual(events, ['cell:focusin', 'link:focusin'], 'cell:focusin precedes link:focusin');
+
+        events = [];
+        focus(this.paper.svg, 'focusin');
+        assert.deepEqual(events, ['blank:focusin'], 'blank:focusin triggered');
+
+        events = [];
+        focus(this.paper.svg, 'focusout');
+        assert.deepEqual(events, ['blank:focusout'], 'blank:focusout triggered');
+    });
+
     QUnit.test('paper.getArea()', function(assert) {
 
         this.paper.translate(0, 0);

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -355,7 +355,7 @@ QUnit.module('paper', function(hooks) {
         assert.ok(blankContextmenuCallback.called, 'blank:contextmenu triggered');
     });
 
-    QUnit.test('focusin & focusout', function(assert) {
+    QUnit.test('focus & blur', function(assert) {
 
         var r1 = new joint.shapes.standard.Rectangle({ position: { x: 50, y: 50 }, size: { width: 20, height: 20 }});
         var r2 = new joint.shapes.standard.Rectangle({ position: { x: 150, y: 50 }, size: { width: 20, height: 20 }});
@@ -364,7 +364,7 @@ QUnit.module('paper', function(hooks) {
 
         var events = [];
         this.paper.on('all', function(name) {
-            if (name.indexOf('focus') > -1) events.push(name);
+            if (/focus|blur/.test(name)) events.push(name);
         });
 
         // The test `$.fn.trigger` does not dispatch bubbling events —
@@ -375,16 +375,16 @@ QUnit.module('paper', function(hooks) {
 
         var r1View = this.paper.findViewByModel(r1);
         focus(r1View.el, 'focusin');
-        assert.deepEqual(events, ['cell:focusin', 'element:focusin'], 'cell:focusin precedes element:focusin');
+        assert.deepEqual(events, ['cell:focus', 'element:focus'], 'cell:focus precedes element:focus');
 
         events = [];
         focus(r1View.el, 'focusout');
-        assert.deepEqual(events, ['cell:focusout', 'element:focusout'], 'cell:focusout precedes element:focusout');
+        assert.deepEqual(events, ['cell:blur', 'element:blur'], 'cell:blur precedes element:blur');
 
         events = [];
         var l1View = this.paper.findViewByModel(l1);
         focus(l1View.el, 'focusin');
-        assert.deepEqual(events, ['cell:focusin', 'link:focusin'], 'cell:focusin precedes link:focusin');
+        assert.deepEqual(events, ['cell:focus', 'link:focus'], 'cell:focus precedes link:focus');
 
         events = [];
         focus(this.paper.svg, 'focusin');

--- a/packages/joint-core/test/jointjs/paper.js
+++ b/packages/joint-core/test/jointjs/paper.js
@@ -388,11 +388,7 @@ QUnit.module('paper', function(hooks) {
 
         events = [];
         focus(this.paper.svg, 'focusin');
-        assert.deepEqual(events, ['blank:focusin'], 'blank:focusin triggered');
-
-        events = [];
-        focus(this.paper.svg, 'focusout');
-        assert.deepEqual(events, ['blank:focusout'], 'blank:focusout triggered');
+        assert.deepEqual(events, [], 'no event for a focusin outside of a cell view');
     });
 
     QUnit.test('paper.getArea()', function(assert) {

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1895,14 +1895,14 @@ export namespace Paper {
         'element:mouseout': (elementView: ElementView, evt: Event) => void;
         'link:mouseout': (linkView: LinkView, evt: Event) => void;
         'blank:mouseout': (evt: Event) => void;
-        // focusin
-        'cell:focusin': (cellView: CellView, evt: Event) => void;
-        'element:focusin': (elementView: ElementView, evt: Event) => void;
-        'link:focusin': (linkView: LinkView, evt: Event) => void;
-        // focusout
-        'cell:focusout': (cellView: CellView, evt: Event) => void;
-        'element:focusout': (elementView: ElementView, evt: Event) => void;
-        'link:focusout': (linkView: LinkView, evt: Event) => void;
+        // focus (driven by the bubbling focusin DOM event)
+        'cell:focus': (cellView: CellView, evt: Event) => void;
+        'element:focus': (elementView: ElementView, evt: Event) => void;
+        'link:focus': (linkView: LinkView, evt: Event) => void;
+        // blur (driven by the bubbling focusout DOM event)
+        'cell:blur': (cellView: CellView, evt: Event) => void;
+        'element:blur': (elementView: ElementView, evt: Event) => void;
+        'link:blur': (linkView: LinkView, evt: Event) => void;
         // mouseenter
         'cell:mouseenter': (cellView: CellView, evt: Event) => void;
         'element:mouseenter': (elementView: ElementView, evt: Event) => void;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1895,6 +1895,16 @@ export namespace Paper {
         'element:mouseout': (elementView: ElementView, evt: Event) => void;
         'link:mouseout': (linkView: LinkView, evt: Event) => void;
         'blank:mouseout': (evt: Event) => void;
+        // focusin
+        'cell:focusin': (cellView: CellView, evt: Event) => void;
+        'element:focusin': (elementView: ElementView, evt: Event) => void;
+        'link:focusin': (linkView: LinkView, evt: Event) => void;
+        'blank:focusin': (evt: Event) => void;
+        // focusout
+        'cell:focusout': (cellView: CellView, evt: Event) => void;
+        'element:focusout': (elementView: ElementView, evt: Event) => void;
+        'link:focusout': (linkView: LinkView, evt: Event) => void;
+        'blank:focusout': (evt: Event) => void;
         // mouseenter
         'cell:mouseenter': (cellView: CellView, evt: Event) => void;
         'element:mouseenter': (elementView: ElementView, evt: Event) => void;

--- a/packages/joint-core/types/dia.d.ts
+++ b/packages/joint-core/types/dia.d.ts
@@ -1899,12 +1899,10 @@ export namespace Paper {
         'cell:focusin': (cellView: CellView, evt: Event) => void;
         'element:focusin': (elementView: ElementView, evt: Event) => void;
         'link:focusin': (linkView: LinkView, evt: Event) => void;
-        'blank:focusin': (evt: Event) => void;
         // focusout
         'cell:focusout': (cellView: CellView, evt: Event) => void;
         'element:focusout': (elementView: ElementView, evt: Event) => void;
         'link:focusout': (linkView: LinkView, evt: Event) => void;
-        'blank:focusout': (evt: Event) => void;
         // mouseenter
         'cell:mouseenter': (cellView: CellView, evt: Event) => void;
         'element:mouseenter': (elementView: ElementView, evt: Event) => void;

--- a/packages/joint-react/src/components/paper/__tests__/paper-focus-events.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/paper-focus-events.test.tsx
@@ -4,11 +4,18 @@ import { Paper } from '../paper';
 import { GraphProvider } from '../../graph/graph-provider';
 import { useOnPaperEvents } from '../../../hooks/use-on-paper-events';
 import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { LINK_MODEL_TYPE } from '../../../mvc/link-model';
 import type { CellRecord } from '../../../types/cell.types';
 
 const CELLS = [
   { id: 'n1', type: ELEMENT_MODEL_TYPE, size: { width: 50, height: 50 } },
 ] satisfies readonly CellRecord[];
+
+const LINKED_CELLS = [
+  { id: 'n1', type: ELEMENT_MODEL_TYPE, size: { width: 50, height: 50 } },
+  { id: 'n2', type: ELEMENT_MODEL_TYPE, position: { x: 100, y: 0 }, size: { width: 50, height: 50 } },
+  { id: 'l1', type: LINK_MODEL_TYPE, source: { id: 'n1' }, target: { id: 'n2' } } as CellRecord,
+];
 
 const renderRect = () => <rect />;
 
@@ -42,6 +49,40 @@ describe('Paper focus events', () => {
     await waitFor(() => {
       expect(focus).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
       expect(blur).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
+    });
+  });
+
+  it('fires the element and link variants with the cell id', async () => {
+    const elementFocus = jest.fn();
+    const elementBlur = jest.fn();
+    const linkFocus = jest.fn();
+    const linkBlur = jest.fn();
+    const { container } = render(
+      <GraphProvider initialCells={LINKED_CELLS}>
+        <Paper
+          style={{ width: 200, height: 200 }}
+          renderElement={renderRect}
+          onElementFocus={elementFocus}
+          onElementBlur={elementBlur}
+          onLinkFocus={linkFocus}
+          onLinkBlur={linkBlur}
+        />
+      </GraphProvider>
+    );
+    await waitFor(() => expect(container.querySelector('.joint-link')).toBeTruthy());
+
+    fireEvent.focusIn(focusableInCell(container));
+    fireEvent.focusOut(focusableInCell(container));
+
+    const link = container.querySelector('.joint-link') as Element;
+    fireEvent.focusIn(link);
+    fireEvent.focusOut(link);
+
+    await waitFor(() => {
+      expect(elementFocus).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
+      expect(elementBlur).toHaveBeenCalledWith(expect.objectContaining({ id: 'n1' }));
+      expect(linkFocus).toHaveBeenCalledWith(expect.objectContaining({ id: 'l1' }));
+      expect(linkBlur).toHaveBeenCalledWith(expect.objectContaining({ id: 'l1' }));
     });
   });
 

--- a/packages/joint-react/src/presets/paper-events.ts
+++ b/packages/joint-react/src/presets/paper-events.ts
@@ -60,8 +60,12 @@ type PointerLinkEventParams = WithPointer<LinkEventParams>;
 /** Pointer-style blank-area payload — event + coords on empty paper area. */
 type PointerBlankEventParams = WithPointer<BaseContext>;
 
-/** Focus-style cell-level payload (focusin/focusout) — cell context + event. */
+/** Focus-style cell-level payload (focus/blur) — cell context + event. */
 type FocusCellEventParams = WithHover<CellEventParams>;
+/** Focus-style element-level payload. */
+type FocusElementEventParams = WithHover<ElementEventParams>;
+/** Focus-style link-level payload. */
+type FocusLinkEventParams = WithHover<LinkEventParams>;
 
 /** Hover-style cell-level payload (mouseenter/leave/over/out). */
 type HoverCellEventParams = WithHover<CellEventParams>;
@@ -183,14 +187,17 @@ const POINTER_CELL_MAP = {
 } as const;
 
 // Focus enters/leaves a cell when a focusable node inside it (e.g. a `tabindex`
-// element) gains/loses focus. `onCellFocus`/`onCellBlur` map to the paper's
-// `cell:focus` / `cell:blur` events, which are driven by the bubbling
-// `focusin`/`focusout` DOM events — plain `focus`/`blur` do not bubble and so
-// cannot be delegated to cells (the same reason React's own onFocus/onBlur use
-// focusin/focusout under the hood).
+// element) gains/loses focus. The paper's `cell:focus` / `cell:blur` events are
+// driven by the bubbling `focusin`/`focusout` DOM events — plain `focus`/`blur`
+// do not bubble and so cannot be delegated to cells (the same reason React's
+// own onFocus/onBlur use focusin/focusout under the hood).
 const FOCUS_CELL_MAP = {
   onCellFocus: 'cell:focus',
   onCellBlur: 'cell:blur',
+  onElementFocus: 'element:focus',
+  onElementBlur: 'element:blur',
+  onLinkFocus: 'link:focus',
+  onLinkBlur: 'link:blur',
 } as const;
 
 const HOVER_CELL_MAP = {
@@ -332,10 +339,14 @@ export interface PaperEventHandlers {
   readonly onCellPointerClick?: (params: PointerCellEventParams) => void;
   readonly onCellPointerDblClick?: (params: PointerCellEventParams) => void;
   readonly onCellContextMenu?: (params: PointerCellEventParams) => void;
-  // focus (cell — fires when a focusable node inside any cell gains/loses focus,
+  // focus (fires when a focusable node inside a cell gains/loses focus,
   // driven by the bubbling focusin/focusout DOM events).
   readonly onCellFocus?: (params: FocusCellEventParams) => void;
   readonly onCellBlur?: (params: FocusCellEventParams) => void;
+  readonly onElementFocus?: (params: FocusElementEventParams) => void;
+  readonly onElementBlur?: (params: FocusElementEventParams) => void;
+  readonly onLinkFocus?: (params: FocusLinkEventParams) => void;
+  readonly onLinkBlur?: (params: FocusLinkEventParams) => void;
   // pointer (element)
   readonly onElementPointerDown?: (params: PointerElementEventParams) => void;
   readonly onElementPointerMove?: (params: PointerElementEventParams) => void;

--- a/packages/joint-react/src/presets/paper.ts
+++ b/packages/joint-react/src/presets/paper.ts
@@ -194,37 +194,6 @@ export const Paper = dia.Paper.extend(
 
     documentEvents: POINTER_DOCUMENT_EVENTS,
 
-    // Cell focus tracking. `focusin`/`focusout` bubble (unlike `focus`/`blur`),
-    // so they delegate to `.joint-cell` and report which cell owns the focused
-    // node (e.g. a `tabindex` element) via the `cell:focus` / `cell:blur` paper
-    // events. The parent hash is spread first because a subclass `events` object
-    // replaces — rather than merges with — the inherited one.
-    events: {
-      ...dia.Paper.prototype.events,
-      'focusin .joint-cell': 'handleCellFocus',
-      'focusout .joint-cell': 'handleCellBlur',
-    },
-
-    /**
-     * Delegated `focusin` on a cell — emit `cell:focus` naming the cell that
-     * owns the newly focused node.
-     * @param event - The delegated focusin event; `event.target` is the node.
-     */
-    handleCellFocus(this: dia.Paper, event: dia.Event) {
-      const view = this.findView<dia.ElementView | dia.LinkView>(event.target);
-      if (view) view.notify('cell:focus', event);
-    },
-
-    /**
-     * Delegated `focusout` on a cell — emit `cell:blur` naming the cell that
-     * owned the just-blurred node.
-     * @param event - The delegated focusout event; `event.target` is the node.
-     */
-    handleCellBlur(this: dia.Paper, event: dia.Event) {
-      const view = this.findView<dia.ElementView | dia.LinkView>(event.target);
-      if (view) view.notify('cell:blur', event);
-    },
-
     /**
      * Add listeners that record the original pointerdown target into the
      * drag's `evt.data`, so `pointermove` can use it as a `setPointerCapture`


### PR DESCRIPTION
## Description

Adds `focus`/`blur` paper events with the `cell:` / `element:` / `link:` variants, following the `mouseover`/`mouseout` pattern (same guard, same `findView` resolution, `cell:*` fired before `element:*`/`link:*` via the view `notify` chain), and exposes them in `@joint/react` as Paper event props.

The paper events are driven by the bubbling `focusin`/`focusout` DOM events — plain `focus`/`blur` do not bubble and so cannot be delegated (the same reason React's own `onFocus`/`onBlur` use `focusin`/`focusout` under the hood). The event names describe what happened to the cell. `normalizeEvent` is not applied (nothing to normalize on focus events). No `blank:` variants — a focus event outside of a cell view carries no useful information.

## Motivation

Making cells keyboard-focusable (`tabindex` on the root via `attrs`) is a common accessibility approach; reacting to the focus currently requires a native DOM listener on `paper.el`. With this change:

```js
paper.on('element:focus', (elementView) => {
    // e.g. select the focused element
});
```

or in React:

```jsx
<Paper onElementFocus={({ id }) => setSelection(id)} />
```

## Changes

### `@joint/core`

- `dia/Paper.mjs` — `focusin`/`focusout` in the `events` hash + handlers
- `dia/CellView.mjs`, `dia/ElementView.mjs`, `dia/LinkView.mjs` — `focusin`/`focusout` methods notifying the `cell:`/`element:`/`link:` `focus`/`blur` events
- `types/dia.d.ts` — the 6 new event signatures
- `test/jointjs/paper.js` — event order + no event outside of cell views (native bubbling `FocusEvent`s; the test `$.fn.trigger` shim dispatches non-bubbling `CustomEvent`s)
- changeset (`@joint/core`: minor)

### `@joint/react`

- `presets/paper.ts` — the `ReactPaper` `focusin .joint-cell` delegation workaround is deleted; the core now emits `cell:focus`/`cell:blur` natively under the same names, so the existing `onCellFocus`/`onCellBlur` props keep working unchanged (no API break)
- `presets/paper-events.ts` — new `onElementFocus`, `onElementBlur`, `onLinkFocus` and `onLinkBlur` props for the `element:`/`link:` variants
- `paper-focus-events.test.tsx` — coverage for the element/link variants
- changeset (`@joint/react`: minor)
