### PR TITLE
docs(changeset): backfill changesets for unreleased dev changes

### DIFF
--- a/.changeset/swift-cells-commit.md
+++ b/.changeset/swift-cells-commit.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+<GraphProvider /> - rewrite the cells container as a lazy, memoised, Map-backed immutable snapshot: commits are O(change-set) instead of O(n), uncontrolled drags are ~2x faster and consumers receive stable array references

--- a/.changeset/wide-graphs-accept.md
+++ b/.changeset/wide-graphs-accept.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": minor
+---
+
+useGraph - `removeCells()` and `resetCells()` accept a JointJS cell collection (e.g. a selection's `collection`) directly, without `.toArray()`; adds the `CellCollection` and `CellRefList` types


### PR DESCRIPTION
## Description

Backfills the changesets for the changes on `dev` that are not in any published release — changesets were introduced after these commits landed, so the next release would otherwise ship them without changelog entries.

Most of the dev work turned out to be already released: it was cherry-picked to master (#3446, #3455, …) and covered by the changeset backfill there (#3467), shipping in v4.3.2–v4.3.5. The `packages/joint-core` source delta between `master` and `dev` is empty — no core changeset is needed at all.

What remains unreleased on `dev` (verified against the published npm artifacts):

| PR | Changeset |
|---|---|
| #3423 | `<GraphProvider />` — lazy Map-backed immutable cells container, O(change-set) commits, ~2× faster uncontrolled drags (patch) |
| #3427 | `useGraph` — `removeCells()` / `resetCells()` accept a cell collection; adds `CellCollection` / `CellRefList` types (**minor**) |

## Not covered

- The `onCellFocus`/`onCellBlur` part of #3427 — its changeset lives on the `feat/paper-focus-events` branch (#3481), where the feature is reworked on top of the new core `focus`/`blur` events.
- #3431 (Storybook design system) — stories and devDependencies only, no releasable code.
- #3438 / #3447 — released via master as #3446 / #3455 (changelog entries in v4.3.3–v4.3.4 and core v4.3.2).

`yarn changeset status`: `@joint/react` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
