### PR TITLE
fix(mvc.Collection): id lookups can return the wrong model when a user id collides with a cid

### DIFF
--- a/.changeset/tidy-models-resolve.md
+++ b/.changeset/tidy-models-resolve.md
@@ -1,0 +1,5 @@
+---
+"@joint/core": patch
+---
+
+mvc.Collection - store cids in a map separate from ids, so a model id in the cid namespace (e.g. `'c12'`) is never shadowed by another model's auto-generated cid — previously `graph.getCell()` could return the wrong cell or a newly added cell could be silently merged away as a duplicate

--- a/packages/joint-core/src/mvc/Collection.mjs
+++ b/packages/joint-core/src/mvc/Collection.mjs
@@ -255,11 +255,15 @@ assign(Collection.prototype, Events, {
 
     // Get a model from the set by id, cid, model object with id or cid
     // properties, or an attributes object that is transformed through modelId.
+    // Ids and cids live in separate maps so that a model id in the cid
+    // namespace (e.g. 'c12') can never be shadowed by another model's cid;
+    // a real id always wins the string lookup.
     get: function(obj) {
         if (obj == null) return void 0;
         return this._byId.get(obj) ||
             this._byId.get(this.modelId(this._isModel(obj) ? obj.attributes : obj, obj.idAttribute)) ||
-            obj.cid && this._byId.get(obj.cid);
+            obj.cid && this._byCid.get(obj.cid) ||
+            this._byCid.get(obj);
     },
 
     // Returns `true` if the model is in the collection.
@@ -376,6 +380,7 @@ assign(Collection.prototype, Events, {
         this.length = 0;
         this.models = [];
         this._byId  = new Map();
+        this._byCid = new Map();
     },
 
     // Prepare a hash of attributes (or other model) to be added to this
@@ -414,7 +419,7 @@ assign(Collection.prototype, Events, {
 
             // Remove references before triggering 'remove' event to prevent an
             // infinite loop. #3693
-            this._byId.delete(model.cid);
+            this._byCid.delete(model.cid);
             var id = this.modelId(model.attributes, model.idAttribute);
             if (id != null)this._byId.delete(id);
 
@@ -438,7 +443,7 @@ assign(Collection.prototype, Events, {
 
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
-        this._byId.set(model.cid, model);
+        this._byCid.set(model.cid, model);
         var id = this.modelId(model.attributes, model.idAttribute);
         if (id != null) this._byId.set(id, model);
         model.on('all', this._onModelEvent, this);
@@ -446,7 +451,7 @@ assign(Collection.prototype, Events, {
 
     // Internal method to sever a model's ties to a collection.
     _removeReference: function(model, options) {
-        this._byId.delete(model.cid);
+        this._byCid.delete(model.cid);
         var id = this.modelId(model.attributes, model.idAttribute);
         if (id != null) this._byId.delete(id);
         if (!options.dry && this === model.collection) delete model.collection;

--- a/packages/joint-core/test/jointjs/mvc.collection.js
+++ b/packages/joint-core/test/jointjs/mvc.collection.js
@@ -71,6 +71,20 @@ QUnit.module('joint.mvc.Collection', function(hooks) {
         assert.equal(col.get(col.first().cid), col.first());
     });
 
+    QUnit.test('get: a model id colliding with another model\'s cid', function(assert) {
+        assert.expect(5);
+        var a = new joint.mvc.Model();
+        var b = new joint.mvc.Model();
+        a.set('id', b.cid);
+        var collection = new joint.mvc.Collection([a, b]);
+        assert.equal(collection.get(a.id), a, 'the model with the real id wins the string lookup');
+        assert.equal(collection.get(a), a, 'the id-holder is reachable by model reference');
+        assert.equal(collection.get(b), b, 'the cid-colliding model is reachable by model reference');
+        collection.remove(a);
+        assert.equal(collection.get(b.cid), b, 'with the id-holder gone, the cid string lookup finds the other model');
+        assert.equal(collection.get(b), b, 'removing the id-holder does not sever the other model');
+    });
+
     QUnit.test('get with non-default ids', function(assert) {
         assert.expect(5);
         var MongoModel = joint.mvc.Model.extend({ idAttribute: '_id' });
@@ -1045,7 +1059,7 @@ QUnit.module('joint.mvc.Collection', function(hooks) {
                 joint.mvc.Collection.prototype._addReference.apply(this, arguments);
                 calls.add++;
                 assert.equal(model, this._byId.get(model.id));
-                assert.equal(model, this._byId.get(model.cid));
+                assert.equal(model, this._byCid.get(model.cid));
                 assert.equal(model._events.all.length, 1);
             },
 
@@ -1053,7 +1067,7 @@ QUnit.module('joint.mvc.Collection', function(hooks) {
                 joint.mvc.Collection.prototype._removeReference.apply(this, arguments);
                 calls.remove++;
                 assert.equal(this._byId.get(model.id), void 0);
-                assert.equal(this._byId.get(model.cid), void 0);
+                assert.equal(this._byCid.get(model.cid), void 0);
                 assert.equal(model.collection, void 0);
             }
 


### PR DESCRIPTION
## Description

`mvc.Collection` stored models in a single `_byId` map under **both** their model id and their internal client id (cid). cids are generated as `c<counter>` with a counter global to the JS realm that never resets — so a **user-supplied id matching `/^c\d+$/`** (e.g. `"c856"`) is clobbered as soon as the session has created that many models and some other model's auto-generated cid collides with it.

Two silent failure modes:

- `graph.getCell('c856')` returns the wrong cell — and everything downstream of it: link end resolution, `findViewByModel`, etc.
- worse, `set()`/`add()` dedup runs through `get()`, so a genuinely new model whose cid collides with an existing model's id is **silently merged away as a duplicate** and never added.

Both are timing/volume dependent — a graph loads fine on a fresh page and breaks after enough models have been created in the session — which makes them look like heisenbugs.

Observed in the wild: `demos/libavoid-standalone-link-routing` `example-2.json` had an element with id `"c856"`; after loading a second large diagram, a link's cid collided, `@joint/router-avoid`'s `validateEnds()` resolved the link's end to another link and permanently fallback-routed it.

## Fix

Ids and cids now live in separate maps (`_byId` / `_byCid`):

- `get()` checks real ids first — a real id always wins the string lookup;
- cid string lookup (`collection.get('c12')`, Backbone compatibility) still works whenever no real id claims the string;
- removing the id-holder no longer severs the other model's cid entry (the shared-map design also corrupted removal).

Inherited from Backbone's design; any graph with generated short ids is exposed.

## Tests

- New: `get: a model id colliding with another model's cid` — pins winning lookup, both models reachable, removal of the id-holder restores the cid string lookup. Fails on `master` (the colliding model is merged away as a duplicate).
- Updated: the legacy `_addReference binds all collection events & adds to the lookup hashes` test asserts against `_byCid` for the cid entry (it inspects the internal maps directly).
- Full client suite: 2113/2113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
