### PR TITLE
feat(joint-router-avoid): worker.createWorker option and /worker subpath export

### DIFF
--- a/.changeset/plain-workers-spawn.md
+++ b/.changeset/plain-workers-spawn.md
@@ -1,0 +1,5 @@
+---
+"@joint/router-avoid": minor
+---
+
+initAvoidRouter - add the `worker.createWorker` option and the `@joint/router-avoid/worker` subpath export, so bundlers that do not transform Worker spawns inside dependencies (e.g. the Angular CLI esbuild builder) can spawn the routing Worker from application code

--- a/packages/joint-router-avoid/package.json
+++ b/packages/joint-router-avoid/package.json
@@ -45,6 +45,11 @@
       "types": "./dist/esm/index.d.mts",
       "import": "./dist/esm/index.mjs",
       "default": "./dist/esm/index.mjs"
+    },
+    "./worker": {
+      "types": "./dist/esm/providers/Worker.d.mts",
+      "import": "./dist/esm/providers/Worker.mjs",
+      "default": "./dist/esm/providers/Worker.mjs"
     }
   },
   "files": [

--- a/packages/joint-router-avoid/src/init.mts
+++ b/packages/joint-router-avoid/src/init.mts
@@ -38,6 +38,32 @@ export interface WorkerOptions {
      * pass. Set to `0` to apply every change immediately. Defaults to `100`.
      */
     debounceTime?: number;
+    /**
+     * Overrides how the routing Worker is created. Required with bundlers
+     * that do not transform `new Worker(new URL(...))` spawns inside
+     * dependencies (e.g. the Angular CLI esbuild builder).
+     *
+     * Add a worker-entry file to your application's sources whose only
+     * content is a side-effect import of the routing Worker's runtime:
+     *
+     * ```ts
+     * // src/my-avoid.worker.ts
+     * import '@joint/router-avoid/worker';
+     * ```
+     *
+     * Then spawn that file - the `new Worker(new URL(...))` call now sits
+     * in your own sources, where the bundler's Worker handling applies:
+     *
+     * ```ts
+     * // src/diagram.ts
+     * initAvoidRouter(graph, {
+     *     worker: {
+     *         createWorker: () => new Worker(new URL('./my-avoid.worker', import.meta.url), { type: 'module' })
+     *     }
+     * });
+     * ```
+     */
+    createWorker?: () => Worker;
 }
 
 /** Options used to configure {@link initAvoidRouter}. */
@@ -98,7 +124,8 @@ export async function initAvoidRouter(graph: dia.Graph, options: InitAvoidOption
             shapeBufferDistance: shapeBufferDistance,
             idealNudgingDistance: idealNudgingDistance,
             updateDebounceTime: updateDebounceTime,
-            libavoidFilePath: options.libavoidFilePath
+            libavoidFilePath: options.libavoidFilePath,
+            createWorker: workerOptions.createWorker
         });
     } else {
         await provider.init({

--- a/packages/joint-router-avoid/src/providers/WorkerProvider.mts
+++ b/packages/joint-router-avoid/src/providers/WorkerProvider.mts
@@ -15,6 +15,13 @@ export interface WorkerProviderOptions extends ProviderOptions {
     updateDebounceTime?: number;
     /** Path to the avoid WASM binary, forwarded to `AvoidLib.load()` inside the Worker. */
     libavoidFilePath?: string;
+    /**
+     * Overrides how the routing Worker is created. Required with bundlers
+     * that do not transform `new Worker(new URL(...))` spawns inside
+     * dependencies (e.g. the Angular CLI esbuild builder) - spawn the
+     * `@joint/router-avoid/worker` entry from application code instead.
+     */
+    createWorker?: () => Worker;
 }
 
 /**
@@ -54,7 +61,10 @@ export class WorkerProvider extends Provider {
      * @param options - Configuration for the avoid router instance, forwarded to the Worker.
      */
     override async init(options: WorkerProviderOptions): Promise<void> {
-        const worker = new Worker(new URL('./Worker.mjs', import.meta.url), { type: 'module' });
+        const { createWorker, ...workerInitOptions } = options;
+        const worker = createWorker
+            ? createWorker()
+            : new Worker(new URL('./Worker.mjs', import.meta.url), { type: 'module' });
         this.worker = worker;
 
         const ready = new Promise<void>((resolve, reject) => {
@@ -95,7 +105,9 @@ export class WorkerProvider extends Provider {
             };
         });
 
-        this.postMessage({ type: 'init', options });
+        // `createWorker` is stripped: a function cannot be structured-cloned
+        // into the Worker (and the Worker has no use for it).
+        this.postMessage({ type: 'init', options: workerInitOptions });
 
         await ready;
     }

--- a/packages/joint-router-avoid/test/index.js
+++ b/packages/joint-router-avoid/test/index.js
@@ -654,3 +654,44 @@ QUnit.module('destroy()', () => {
         assert.deepEqual(cancelledLinks, []);
     });
 });
+
+QUnit.module('worker.createWorker', () => {
+    // A stand-in for the routing Worker: answers `init` with `ready` so the
+    // provider's handshake completes without loading any script.
+    function createFakeWorker(messages) {
+        return {
+            onmessage: null,
+            onerror: null,
+            onmessageerror: null,
+            postMessage(message) {
+                messages.push(message);
+                if (message.type === 'init') {
+                    Promise.resolve().then(() => this.onmessage({ data: { type: 'ready' }}));
+                }
+            },
+            terminate() {}
+        };
+    }
+
+    QUnit.test('overrides how the routing Worker is spawned', async assert => {
+        const graph = new joint.dia.Graph();
+        const messages = [];
+        let created = 0;
+
+        const routerService = await joint.routers.avoid.initAvoidRouter(graph, {
+            worker: {
+                createWorker: () => {
+                    created++;
+                    return createFakeWorker(messages);
+                }
+            }
+        });
+
+        assert.equal(created, 1, 'the factory was used to spawn the Worker');
+        assert.equal(messages.length, 1, 'the provider talked to the factory-created Worker');
+        assert.equal(messages[0].type, 'init', 'the first message initializes the Worker');
+        assert.equal(typeof messages[0].options.updateDebounceTime, 'number', 'worker options are forwarded');
+
+        routerService.destroy();
+    });
+});


### PR DESCRIPTION
## Description

`WorkerProvider` spawns its Web Worker with a hardcoded `new Worker(new URL('./Worker.mjs', import.meta.url), { type: 'module' })`. That only works when the consumer's bundler transforms this pattern **inside `node_modules`** (Vite, webpack 5). The Angular CLI esbuild builder transforms it only in application TS sources — at runtime the URL resolves against the main bundle (`/Worker.mjs` → 404), and hand-copying the file cannot work either, since it contains bare `@joint/core` / `libavoid-js` specifiers. The worker script URL was not configurable at all.

## Changes

### 1. `worker.createWorker` option

```ts
initAvoidRouter(graph, {
    worker: {
        createWorker: () => new Worker(new URL('./my-avoid.worker', import.meta.url), { type: 'module' })
    }
});
```

The factory is stripped from the options posted to the Worker (a function cannot be structured-cloned). Default path unchanged — Vite/webpack consumers are unaffected.

### 2. `@joint/router-avoid/worker` subpath export

Public worker entry so the application-side worker file is one line — `import '@joint/router-avoid/worker';` — and never references the private `dist/` layout. Same pattern as `pdfjs-dist` and the Monaco editor workers.

## Tests

TDD — written first and watched fail on `dev`: `worker.createWorker overrides how the routing Worker is spawned` (factory called once, provider talks to the factory-created Worker through the `init`/`ready` handshake, worker options forwarded). 29/29 passing; lint clean. Changeset: `@joint/router-avoid` minor.

The `MainThreadProvider` `idle` fix that briefly lived on this branch was split out to #3489 (patch, against `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
