### PR TITLE
fix(joint-router-avoid): fire idle after incremental main-thread changes

### DIFF
--- a/.changeset/steady-idle-returns.md
+++ b/.changeset/steady-idle-returns.md
@@ -1,0 +1,5 @@
+---
+"@joint/router-avoid": patch
+---
+
+MainThreadProvider - fire `processed` (and so the RouterService `idle` event) after every incremental change, not only after a full sync, matching the Worker provider's behaviour

--- a/packages/joint-router-avoid/src/providers/MainThreadProvider.mts
+++ b/packages/joint-router-avoid/src/providers/MainThreadProvider.mts
@@ -63,6 +63,18 @@ export class MainThreadProvider extends Provider {
     }
 
     /**
+     * Runs a routing pass over the pending avoid changes and announces its
+     * completion. Every processing path must go through here - `processed`
+     * drives the `RouterService`'s `idle` event, and the Worker provider
+     * fires it after every batch, so the incremental main-thread paths
+     * (not just {@link sync}) have to fire it too for parity.
+     */
+    protected processTransaction(): void {
+        this.avoidRouter.processTransaction();
+        this.trigger('processed');
+    }
+
+    /**
      * Creates or updates the avoid shape for a JointJS element.
      *
      * @param shape - The shape to create or update.
@@ -81,7 +93,7 @@ export class MainThreadProvider extends Provider {
             // Only update the position and size of the shape.
             avoidRouter.moveShape(existingShapeRef, shapeRect);
             if (process) {
-                avoidRouter.processTransaction();
+                this.processTransaction();
             }
             return;
         }
@@ -103,7 +115,7 @@ export class MainThreadProvider extends Provider {
         });
 
         if (process) {
-            avoidRouter.processTransaction();
+            this.processTransaction();
         }
     }
 
@@ -121,7 +133,9 @@ export class MainThreadProvider extends Provider {
             connector.sourceId === undefined || connector.sourcePinId === undefined ||
             connector.targetId === undefined || connector.targetPinId === undefined
         ) {
-            this.deleteConnector(connector.id);
+            // Forward `process`: inside a batched sync() the deletion must not
+            // process (and announce) a transaction of its own mid-batch.
+            this.deleteConnector(connector.id, process);
             return;
         }
 
@@ -146,7 +160,7 @@ export class MainThreadProvider extends Provider {
         if (existingConnRef) {
             // It was already created, we just updated the endpoints.
             if (process) {
-                this.avoidRouter.processTransaction();
+                this.processTransaction();
             }
             return;
         }
@@ -161,7 +175,7 @@ export class MainThreadProvider extends Provider {
         connRef.setCallback(this.onAvoidConnectorChanged, connRef);
 
         if (process) {
-            this.avoidRouter.processTransaction();
+            this.processTransaction();
         }
 
         return;
@@ -180,7 +194,7 @@ export class MainThreadProvider extends Provider {
         delete this.shapeRefs[shapeId];
 
         if (process) {
-            this.avoidRouter.processTransaction();
+            this.processTransaction();
         }
     }
 
@@ -199,7 +213,7 @@ export class MainThreadProvider extends Provider {
         delete this.linksByPointer[connRef.g];
 
         if (process) {
-            this.avoidRouter.processTransaction();
+            this.processTransaction();
         }
     }
 
@@ -244,8 +258,7 @@ export class MainThreadProvider extends Provider {
         shapes.forEach((shape) => this.setShape(shape, false));
         connectors.forEach((connector) => this.setConnector(connector, false));
 
-        this.avoidRouter.processTransaction();
-        this.trigger('processed');
+        this.processTransaction();
     }
 
     /**

--- a/packages/joint-router-avoid/test/index.js
+++ b/packages/joint-router-avoid/test/index.js
@@ -654,3 +654,28 @@ QUnit.module('destroy()', () => {
         assert.deepEqual(cancelledLinks, []);
     });
 });
+
+QUnit.module('idle after incremental changes (main thread)', () => {
+    // `MainThreadProvider` routes synchronously, so `idle` (driven by the
+    // provider's `processed`) must fire during the originating graph change,
+    // not only after `start()`'s initial sync / `routeAll()`.
+    QUnit.test('an element move fires idle', async assert => {
+        const { routerService, source } = await initRouterWithLink({ x: 0, y: 0 }, { x: 300, y: 0 });
+
+        let idleCount = 0;
+        routerService.on('idle', () => idleCount++);
+
+        source.position(50, 50);
+        assert.equal(idleCount, 1, 'idle fired for the element move');
+    });
+
+    QUnit.test('a link removal fires idle', async assert => {
+        const { routerService, link } = await initRouterWithLink({ x: 0, y: 0 }, { x: 300, y: 0 });
+
+        let idleCount = 0;
+        routerService.on('idle', () => idleCount++);
+
+        link.remove();
+        assert.equal(idleCount, 1, 'idle fired for the link removal');
+    });
+});


### PR DESCRIPTION
## Description

`RouterService` emits `idle` when its provider triggers `processed` — but `MainThreadProvider` only triggered `processed` inside `sync()`. With `worker: false`, `idle` therefore fired after the initial sync / `routeAll()` and **never again** after ordinary graph changes (element moves, link edits). `WorkerProvider` posts `processed` after every debounce batch, so worker mode behaves as documented; the main-thread incremental paths now match it.

## Changes

- The incremental paths (`setShape` / `setConnector` / `deleteShape` / `deleteConnector`) run through a shared `processTransaction()` helper that runs the pass and triggers `processed`.
- `setConnector`'s loose-end deletion forwards the `process` flag — previously a batched `sync()` could run (and announce) a transaction mid-batch through that branch.

## Tests

TDD — both written first and watched fail: `an element move fires idle`, `a link removal fires idle` (main-thread provider, synchronous assertion). 30/30 passing; lint clean. Changeset: `@joint/router-avoid` patch.

Split out of #3488 (the `worker.createWorker` feature, against `dev`) — same source markdown issue, independent defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
