### PR TITLE
chore: fix changelogs according to new custom logic

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -28,7 +28,7 @@ module.exports = {
     },
 
     // Changelog dependency bump format:
-    // - Updated dependencies [<short SHA>, ...]
+    // - Updated dependencies (<short SHA>, ...)
     //   - <dependency@version>
     //   - <...>
     getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
@@ -41,7 +41,7 @@ module.exports = {
         // List each commit at most once
         const shas = [...new Set(filteredShas)];
         // Omit SHA suffix if there are no commits left after the above logic
-        const suffix = ((shas.length) > 0 ? ` [${shas.join(', ')}]` : '');
+        const suffix = ((shas.length) > 0 ? ` (${shas.join(', ')})` : '');
 
         return [
             `- Updated dependencies${suffix}`,

--- a/packages/joint-core/CHANGELOG.md
+++ b/packages/joint-core/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Patch Changes
 
-- 0a2991b: alg.rightAnglePath: refactor to consolidate duplicate code into helpers
-- 68a4758: dia.Paper - the `guard` option can now veto blank pointerdowns; its `view` argument is `undefined` when the event did not hit a cell view
-- 54d9800: routers.rightAngle - refactor the path-finding algorithm into a separate utility
+- routers.rightAngle - refactor to consolidate duplicate code into helpers (0a2991b6)
+- dia.Paper - the `guard` option can now veto blank pointerdowns; its `view` argument is `undefined` when the event did not hit a cell view (68a47586)
+- routers.rightAngle - refactor the path-finding algorithm into a separate utility (54d98005)
 
 ## 4.3.1
 

--- a/packages/joint-react/CHANGELOG.md
+++ b/packages/joint-react/CHANGELOG.md
@@ -4,27 +4,25 @@
 
 ### Patch Changes
 
-- 22422ef: <Paper /> - fix links connected to other links staying permanently hidden (the link-end readiness check only looked the end up among the elements)
+- <Paper /> - fix links connected to other links staying permanently hidden (the link-end readiness check only looked the end up among the elements) (22422ef3)
 
 ## 4.3.4
 
 ### Patch Changes
 
-- 20aa3e2: <Paper /> - fix events dispatched at the paper container itself being guarded as portaled content
+- <Paper /> - fix events dispatched at the paper container itself being guarded as portaled content (20aa3e23)
 
 ## 4.3.3
 
 ### Patch Changes
 
-- 634fb9f: fix stale cell keys when a single commit swaps ids without changing the count (membership changes now notify key-list subscribers, and large-graph rendering no longer defers id updates)
-- 68a4758: link routing - account for the arrowhead when a custom link anchor is used
-- 68a4758: <Paper /> - support interactive controls (buttons, inputs) nested inside magnets without the press starting a link drag or an element move
-- 68a4758: useCell - tolerate a cell removed from the graph mid-render
-- 68a4758: useCombinedRef - assign the forwarded ref during the commit phase
-- 68a4758: useMarkup - tolerate a cell view whose markup has not been rendered yet (synchronous rendering in development)
-- Updated dependencies [0a2991b]
-- Updated dependencies [68a4758]
-- Updated dependencies [54d9800]
+- fix stale cell keys when a single commit swaps ids without changing the count (membership changes now notify key-list subscribers, and large-graph rendering no longer defers id updates) (634fb9f1)
+- link routing - account for the arrowhead when a custom link anchor is used (68a47586)
+- <Paper /> - support interactive controls (buttons, inputs) nested inside magnets without the press starting a link drag or an element move (68a47586)
+- useCell - tolerate a cell removed from the graph mid-render (68a47586)
+- useCombinedRef - assign the forwarded ref during the commit phase (68a47586)
+- useMarkup - tolerate a cell view whose markup has not been rendered yet (synchronous rendering in development) (68a47586)
+- Updated dependencies [0a2991b6, 68a47586, 54d98005]
   - @joint/core@4.3.2
 
 ## 4.3.2

--- a/packages/joint-react/CHANGELOG.md
+++ b/packages/joint-react/CHANGELOG.md
@@ -22,7 +22,7 @@
 - useCell - tolerate a cell removed from the graph mid-render (68a47586)
 - useCombinedRef - assign the forwarded ref during the commit phase (68a47586)
 - useMarkup - tolerate a cell view whose markup has not been rendered yet (synchronous rendering in development) (68a47586)
-- Updated dependencies [0a2991b6, 68a47586, 54d98005]
+- Updated dependencies (0a2991b6, 68a47586, 54d98005)
   - @joint/core@4.3.2
 
 ## 4.3.2

--- a/packages/joint-router-avoid/CHANGELOG.md
+++ b/packages/joint-router-avoid/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Patch Changes
 
-- 54d9800: Initial release - automatic obstacle-avoiding orthogonal link routing via libavoid (WASM), with main-thread and Web Worker providers
-- Updated dependencies [0a2991b]
-- Updated dependencies [68a4758]
-- Updated dependencies [54d9800]
+- Initial release - automatic obstacle-avoiding orthogonal link routing via libavoid (WASM), with main-thread and Web Worker providers (54d98005)
+- Updated dependencies [0a2991b6, 68a47586, 54d98005]
   - @joint/core@4.3.2

--- a/packages/joint-router-avoid/CHANGELOG.md
+++ b/packages/joint-router-avoid/CHANGELOG.md
@@ -5,5 +5,5 @@
 ### Patch Changes
 
 - Initial release - automatic obstacle-avoiding orthogonal link routing via libavoid (WASM), with main-thread and Web Worker providers (54d98005)
-- Updated dependencies [0a2991b6, 68a47586, 54d98005]
+- Updated dependencies (0a2991b6, 68a47586, 54d98005)
   - @joint/core@4.3.2


### PR DESCRIPTION
## Description

Modifies the custom changelog logic introduced in PR #3469 to also have parentheses around "Updated dependencies" SHA references.

Fixes previously-written changelog entries according to the new logic.
