### PR TITLE
fix(joint-react): prevent stale layout:update entries from resurrecting removed cells

### DIFF
--- a/.changeset/eleven-moments-heal.md
+++ b/.changeset/eleven-moments-heal.md
@@ -2,4 +2,4 @@
 "@joint/react": patch
 ---
 
-Fixed a permanent render loss with externally-owned graphs: a `layout:update` entry naming a cell that had just been removed (paper view-mount re-broadcasts, layout pipelines applying async results) resurrected the removed cell's record in the cells container. The container then disagreed with the graph forever, and a later re-add of the byte-identical cell (CommandManager undo of a delete) merged into the stale record without any membership or version notification — `renderElement` was never called again and the restored links stayed `visibility: hidden`. Change entries are now gated on graph membership (with container repair when a stale record is found), `remove` entries only apply when the cell has actually left the graph (so paper view-unmount notifications can no longer delete live cells' records), an element removal now sweeps the container for orphaned link records in one pass per batch, and parked hidden links are rechecked after every React commit that mounts element portal content.
+<GraphProvider /> - fix removed cells' records being resurrected by stale `layout:update` batches, breaking undo of a delete

--- a/.changeset/eleven-moments-heal.md
+++ b/.changeset/eleven-moments-heal.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+Fixed a permanent render loss with externally-owned graphs: a `layout:update` entry naming a cell that had just been removed (paper view-mount re-broadcasts, layout pipelines applying async results) resurrected the removed cell's record in the cells container. The container then disagreed with the graph forever, and a later re-add of the byte-identical cell (CommandManager undo of a delete) merged into the stale record without any membership or version notification — `renderElement` was never called again and the restored links stayed `visibility: hidden`. Change entries are now gated on graph membership (with container repair when a stale record is found), `remove` entries only apply when the cell has actually left the graph (so paper view-unmount notifications can no longer delete live cells' records), an element removal now sweeps the container for orphaned link records in one pass per batch, and parked hidden links are rechecked after every React commit that mounts element portal content.

--- a/.changeset/lucky-parks-shine.md
+++ b/.changeset/lucky-parks-shine.md
@@ -1,0 +1,5 @@
+---
+"@joint/react": patch
+---
+
+<Paper /> - fix links parked with `visibility: hidden` staying invisible after their endpoint's React content mounts

--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -152,6 +152,39 @@ describe('external graph — undo of a delete (element with a link)', () => {
     projection.destroy();
   });
 
+  it('a data-less remove entry for an already-removed cell adds no phantom id to the delta', async () => {
+    // The paper's view-unmount notification for a deleted cell arrives in a
+    // later `layout:update` batch, after the graph removal already reported
+    // the id. Removing "again" must not re-report the id in whatever
+    // incremental delta flushes next — consumers mirroring an external store
+    // would receive stale removals in unrelated batches.
+    const graph = createExternalGraph();
+    const deltas: string[][] = [];
+    const projection = graphProjection({
+      graph,
+      onIncrementalCellsChange: ({ removed }) => deltas.push([...removed].map(String)),
+    });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0)]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    graph.getCell('e1').remove();
+    await act(async () => {});
+    expect(deltas.pop()).toContain('e1');
+
+    // View-unmount re-broadcast for the deleted cell (no data, inside batch),
+    // then an unrelated move that flushes the next delta.
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'remove' }]]),
+    });
+    (graph.getCell('e2') as dia.Element).position(120, 0);
+    await act(async () => {});
+
+    const flushed = deltas.flat();
+    expect(flushed).not.toContain('e1');
+    projection.destroy();
+  });
+
   it('a data-less remove entry for a LIVE cell (view unmount) keeps its record', async () => {
     // Paper view-unmount notifications re-broadcast through `layout:update`
     // carry `{ type: 'remove' }` with no cell reference — and can name a cell

--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -50,9 +50,9 @@ function createExternalGraph(): dia.Graph {
  * which is exactly what makes `mergeCellRecord` hit its identity fast-path
  * if a stale record survived the delete.
  */
-function undoDelete(graph: dia.Graph, cells: readonly dia.Cell.JSON[]): void {
+function undoDelete(graph: dia.Graph, cells: dia.Cell.JSON[]): void {
   graph.startBatch('undo');
-  graph.addCells(cells as dia.Cell.JSON[]);
+  graph.addCells(cells);
   graph.stopBatch('undo');
 }
 
@@ -120,6 +120,35 @@ describe('external graph — undo of a delete (element with a link)', () => {
     expect(projection.cells.has('e1')).toBe(false);
     expect(projection.cells.has('l1')).toBe(false);
     expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a delayed entry holding the OLD model cannot overwrite a re-added replacement', async () => {
+    // After undo installs a replacement model under the same id, a delayed
+    // `layout:update` entry may still reference the old detached model with
+    // stale attributes. The projection must snapshot the graph's CURRENT
+    // model, never the entry's reference.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0)]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    const oldModel = graph.getCell('e1');
+    oldModel.remove();
+    await act(async () => {});
+
+    // Undo-style re-add: a NEW model under the same id, moved elsewhere.
+    graph.addCell(elementJSON('e1', 300, 300));
+    await act(async () => {});
+
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'change', data: oldModel }]]),
+    });
+    await act(async () => {});
+
+    const record = projection.cells.get('e1') as { position?: { x: number; y: number } };
+    expect(record?.position).toEqual({ x: 300, y: 300 });
     projection.destroy();
   });
 

--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -1,0 +1,243 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { dia } from '@joint/core';
+import { GraphProvider, Paper } from '../..';
+import { useCell } from '../../../hooks/use-cell';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
+import { graphProjection } from '../../../store/graph-projection';
+import type { Computed, ElementRecord } from '../../../types/cell.types';
+
+const PAPER_STYLE = { width: 400, height: 400 } as const;
+
+/** Content mounts recorded per cell id — the "did renderElement paint" probe. */
+const mounts: string[] = [];
+
+function SubscribingNode() {
+  const label = useCell(
+    (cell: Computed<ElementRecord<{ readonly label: string }>>) => cell.data.label
+  );
+  mounts.push(label);
+  return <text>{label}</text>;
+}
+const renderSubscribing = () => <SubscribingNode />;
+
+function elementJSON(id: string, x = 0, y = 0): dia.Cell.JSON {
+  return {
+    id,
+    type: ELEMENT_MODEL_TYPE,
+    position: { x, y },
+    size: { width: 20, height: 20 },
+    data: { label: `label-${id}` },
+  };
+}
+
+function linkJSON(id: string, source: string, target: string): dia.Cell.JSON {
+  return {
+    id,
+    type: 'standard.Link',
+    source: { id: source },
+    target: { id: target },
+  };
+}
+
+function createExternalGraph(): dia.Graph {
+  return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+}
+
+/**
+ * CommandManager-style undo of a delete: re-add the removed cells from their
+ * stored JSON inside a plain batch — byte-identical to what was removed,
+ * which is exactly what makes `mergeCellRecord` hit its identity fast-path
+ * if a stale record survived the delete.
+ */
+function undoDelete(graph: dia.Graph, cells: readonly dia.Cell.JSON[]): void {
+  graph.startBatch('undo');
+  graph.addCells(cells as dia.Cell.JSON[]);
+  graph.stopBatch('undo');
+}
+
+// Customer scenario (externally-owned graph, imperative mutations, undo via
+// CommandManager): delete an element that has a link, then undo. The restored
+// element must render its React content again and the restored link must be
+// visible — not a positioned-but-empty ghost.
+describe('external graph — undo of a delete (element with a link)', () => {
+  beforeEach(() => {
+    mounts.length = 0;
+  });
+
+  it('projection prunes the removed element AND its link from the container', async () => {
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {}); // flush the scheduler microtask
+    projection.syncFromGraph();
+    expect(projection.cells.getSize()).toBe(3);
+
+    graph.getCell('e1').remove();
+    await act(async () => {});
+
+    // The graph holds one cell; the container must agree — a stale record
+    // here turns the undo's re-add into a no-op update.
+    expect(graph.getCells().length).toBe(1);
+    expect(projection.cells.has('e1')).toBe(false);
+    expect(projection.cells.has('l1')).toBe(false);
+    expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a layout:update naming a removed cell must not resurrect its record', async () => {
+    // The genesis of the customer's stale records: `layout:update` entries
+    // (emitted by `setPaperViews` re-broadcasting view mounts, and by app
+    // layout pipelines applying ELK results) are written to the container
+    // WITHOUT checking the cell still lives in the graph. A delete that lands
+    // between computing such a batch and applying it resurrects the record —
+    // and from then on every undo re-add is a "no-op update" that never
+    // notifies membership, so the cell never renders again.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    const elementCell = graph.getCell('e1');
+    const linkCell = graph.getCell('l1');
+    elementCell.remove();
+    await act(async () => {});
+    expect(projection.cells.getSize()).toBe(1);
+
+    // Apply a stale layout batch that still references the removed cells
+    // (their models are detached but alive — exactly what a pending
+    // view-mount notification or an in-flight ELK result holds).
+    graph.trigger('layout:update', {
+      changes: new Map([
+        ['e1', { type: 'change', data: elementCell }],
+        ['l1', { type: 'change', data: linkCell }],
+        ['e2', { type: 'change', data: graph.getCell('e2') }],
+      ]),
+    });
+    await act(async () => {});
+
+    expect(projection.cells.has('e1')).toBe(false);
+    expect(projection.cells.has('l1')).toBe(false);
+    expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a data-less remove entry for a LIVE cell (view unmount) keeps its record', async () => {
+    // Paper view-unmount notifications re-broadcast through `layout:update`
+    // carry `{ type: 'remove' }` with no cell reference — and can name a cell
+    // the paper merely unmounted (viewport culling) while the graph still
+    // holds it. That must never delete the live cell's record.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {});
+    projection.syncFromGraph();
+    expect(projection.cells.getSize()).toBe(3);
+
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'remove' }]]),
+    });
+    await act(async () => {});
+
+    expect(projection.cells.has('e1')).toBe(true);
+    expect(projection.cells.getSize()).toBe(3);
+    projection.destroy();
+  });
+
+  it('undo still paints after a stale layout:update raced the delete', async () => {
+    // Full customer symptom: stale record present → undo re-adds the
+    // byte-identical cell → mergeCellRecord identity fast-path → no version
+    // bump, no membership change → renderElement never called, link hidden.
+    const graph = createExternalGraph();
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="undo-race-paper" renderElement={renderSubscribing} />
+      </GraphProvider>
+    );
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+
+    const elementCell = graph.getCell('e1');
+    const linkCell = graph.getCell('l1');
+    const removedJSON = [elementCell.toJSON(), linkCell.toJSON()];
+
+    await act(async () => {
+      elementCell.remove();
+      // The race: a view-mount / layout notification for the removed cells
+      // flushes after the remove in the same microtask cascade.
+      graph.trigger('layout:update', {
+        changes: new Map([
+          ['e1', { type: 'change', data: elementCell }],
+          ['l1', { type: 'change', data: linkCell }],
+        ]),
+      });
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('label-e1');
+    });
+
+    mounts.length = 0;
+    await act(async () => {
+      undoDelete(graph, [removedJSON[0], removedJSON[1]]);
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+    expect(mounts).toContain('label-e1');
+
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+
+  it('re-renders the element and shows the link after delete + undo', async () => {
+    const graph = createExternalGraph();
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="undo-paper" renderElement={renderSubscribing} />
+      </GraphProvider>
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+      expect(container.textContent).toContain('label-e2');
+    });
+
+    // Delete the element — JointJS removes its connected link with it.
+    const removedJSON = [graph.getCell('e1').toJSON(), graph.getCell('l1').toJSON()];
+    await act(async () => {
+      graph.getCell('e1').remove();
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('label-e1');
+    });
+
+    // Undo: restore element first, then the link (CommandManager order).
+    mounts.length = 0;
+    await act(async () => {
+      undoDelete(graph, [removedJSON[0], removedJSON[1]]);
+    });
+
+    // The restored element paints again…
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+    expect(mounts).toContain('label-e1');
+
+    // …and the restored link is visible (not parked hidden forever).
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+});

--- a/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { dia } from '@joint/core';
+import { GraphProvider, Paper } from '../../..';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
+
+const PAPER_STYLE = { width: 400, height: 400 } as const;
+
+// Reveal setters captured per mounted node so the test can flip content
+// through CHILD-ONLY state updates — the parent portal hook must not
+// re-render for the link to become visible.
+const reveals: Array<(ready: boolean) => void> = [];
+
+function DelayedNode() {
+  const [ready, setReady] = useState(false);
+  reveals.push(setReady);
+  return ready ? <text>content</text> : null;
+}
+const renderDelayed = () => <DelayedNode />;
+
+function elementJSON(id: string, x: number): dia.Cell.JSON {
+  return {
+    id,
+    type: ELEMENT_MODEL_TYPE,
+    position: { x, y: 0 },
+    size: { width: 20, height: 20 },
+  };
+}
+
+// A link is parked with `visibility: hidden` while its endpoints' React
+// content has not painted. Content that arrives LATER through a child-only
+// update (local state, Suspense) mounts into the portal without re-rendering
+// the portal hook and without any joint render — the link must still be
+// revealed.
+describe('pending links — endpoint content mounting after a delay', () => {
+  it('reveals the link once delayed endpoint content paints', async () => {
+    reveals.length = 0;
+    const graph = new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+    graph.addCells([
+      elementJSON('e1', 0),
+      elementJSON('e2', 100),
+      { id: 'l1', type: 'standard.Link', source: { id: 'e1' }, target: { id: 'e2' } },
+    ]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="delayed-content-paper" renderElement={renderDelayed} />
+      </GraphProvider>
+    );
+
+    // Both endpoints render null → the link parks hidden.
+    await waitFor(() => {
+      expect(reveals.length).toBeGreaterThanOrEqual(2);
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).toBe('hidden');
+    });
+
+    // Child-only updates: only the node components re-render.
+    await act(async () => {
+      for (const reveal of reveals) reveal(true);
+    });
+
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+});

--- a/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { dia } from '@joint/core';
 import { GraphProvider, Paper } from '../../..';
 import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { PaperView } from '../../../mvc/paper';
 import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
 
 const PAPER_STYLE = { width: 400, height: 400 } as const;
@@ -66,5 +67,40 @@ describe('pending links — endpoint content mounting after a delay', () => {
       const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
       expect(linkNode!.style.visibility).not.toBe('hidden');
     });
+  });
+
+  it('parking many links stays linear in portal lookups', async () => {
+    // Regression guard for the O(N²) shape: observing endpoints must not
+    // re-walk every already-parked link (each walk pays portal lookups per
+    // link). With N chained links, linear bookkeeping needs a few lookups
+    // per link; the quadratic walk needs ~N²/2 and blows the budget.
+    reveals.length = 0;
+    const LINKS = 300;
+    const graph = new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+    const cells: dia.Cell.JSON[] = [];
+    for (let index = 0; index <= LINKS; index += 1) cells.push(elementJSON(`e${index}`, index * 30));
+    for (let index = 0; index < LINKS; index += 1) {
+      cells.push({
+        id: `l${index}`,
+        type: 'standard.Link',
+        source: { id: `e${index}` },
+        target: { id: `e${index + 1}` },
+      });
+    }
+    graph.addCells(cells);
+
+    const spy = jest.spyOn(PaperView.prototype, 'getCellViewPortalNode');
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="linear-park-paper" renderElement={renderDelayed} />
+      </GraphProvider>
+    );
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l0"]') as HTMLElement | null;
+      expect(linkNode!.style.visibility).toBe('hidden');
+    });
+
+    expect(spy.mock.calls.length).toBeLessThan(LINKS * 20);
+    spy.mockRestore();
   });
 });

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -508,17 +508,6 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
-  // Links parked hidden by `insertView` (endpoint content not painted yet)
-  // are only rechecked from `insertView` / joint's `afterRender` — a React
-  // commit that mounts portal content triggers neither, leaving such links
-  // hidden forever. Recheck after each element-portal commit; `elements`
-  // does not change on cell data/position updates (no drag-frame runs), and
-  // `checkPendingLinks` is O(1) while nothing is parked.
-  useEffect(() => {
-    const paper = paperStore?.paper;
-    if (paper instanceof PaperView) paper.checkPendingLinks();
-  }, [elements, paperStore]);
-
   const renderedLinks = useMemo(() => {
     if (!hasRenderLink || !renderLink) {
       return null;

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -508,21 +508,12 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
-  // A link whose endpoint's React content has not painted yet is parked in
-  // `pendingLinks` with `visibility: hidden` by `insertView`. The recheck used
-  // to run only from `insertView` and joint's `afterRender` — but an
-  // endpoint's PORTAL content mounts in a REACT commit, which triggers
-  // neither, so a link could stay hidden permanently once its endpoint
-  // painted (a fixed-size element never re-enters a joint render cycle).
-  //
-  // Recheck after every commit that (re)rendered the element portals:
-  // effects flush after portal children are in the DOM, so `isElementReady`
-  // sees them. `elements` is the precise dependency — it recomputes exactly
-  // when the portal set could have (re)mounted content (ids, paper version,
-  // measurement gate) and NOT on cell data/position changes, so this never
-  // runs on drag frames. When nothing is parked, `checkPendingLinks` returns
-  // on its first line (`pendingLinks.size === 0`), making the steady-state
-  // cost of this effect a single property read per portal commit.
+  // Links parked hidden by `insertView` (endpoint content not painted yet)
+  // are only rechecked from `insertView` / joint's `afterRender` — a React
+  // commit that mounts portal content triggers neither, leaving such links
+  // hidden forever. Recheck after each element-portal commit; `elements`
+  // does not change on cell data/position updates (no drag-frame runs), and
+  // `checkPendingLinks` is O(1) while nothing is parked.
   useEffect(() => {
     const paper = paperStore?.paper;
     if (paper instanceof PaperView) paper.checkPendingLinks();

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -508,6 +508,26 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
+  // A link whose endpoint's React content has not painted yet is parked in
+  // `pendingLinks` with `visibility: hidden` by `insertView`. The recheck used
+  // to run only from `insertView` and joint's `afterRender` — but an
+  // endpoint's PORTAL content mounts in a REACT commit, which triggers
+  // neither, so a link could stay hidden permanently once its endpoint
+  // painted (a fixed-size element never re-enters a joint render cycle).
+  //
+  // Recheck after every commit that (re)rendered the element portals:
+  // effects flush after portal children are in the DOM, so `isElementReady`
+  // sees them. `elements` is the precise dependency — it recomputes exactly
+  // when the portal set could have (re)mounted content (ids, paper version,
+  // measurement gate) and NOT on cell data/position changes, so this never
+  // runs on drag frames. When nothing is parked, `checkPendingLinks` returns
+  // on its first line (`pendingLinks.size === 0`), making the steady-state
+  // cost of this effect a single property read per portal commit.
+  useEffect(() => {
+    const paper = paperStore?.paper;
+    if (paper instanceof PaperView) paper.checkPendingLinks();
+  }, [elements, paperStore]);
+
   const renderedLinks = useMemo(() => {
     if (!hasRenderLink || !renderLink) {
       return null;

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -26,6 +26,11 @@ export class PaperView extends Paper {
   private readonly shouldPreserveHostElementOnRemove: boolean;
   private readonly portalSelector: PortalSelector | undefined;
   private pendingLinks: Set<CellId> = new Set();
+  // Portal nodes of parked links' not-ready endpoints. React mounts portal
+  // content outside joint's render cycle (child state, Suspense), so a DOM
+  // mutation is the only reliable "content painted" signal.
+  private portalObserver: MutationObserver | null = null;
+  private observedPortalNodes: Set<Node> = new Set();
 
   constructor(options: PaperViewOptions) {
     const { onViewMountChange, portalSelector, id, ...paperOptions } = options;
@@ -143,6 +148,33 @@ export class PaperView extends Paper {
   }
 
   /**
+   * Observe the portal nodes of every parked link's endpoints, so content
+   * mounted by a child-only React update still triggers a recheck.
+   */
+  private observePendingLinkEndpoints(): void {
+    for (const linkId of this.pendingLinks) {
+      const link = this.getLinkView(linkId)?.model;
+      if (!link) continue;
+      for (const end of [link.source(), link.target()]) {
+        const endId = end.id;
+        if (!endId) continue;
+        const elementView = this.getElementView(endId);
+        if (!elementView?.el) continue;
+        const portalNode = this.getCellViewPortalNode(elementView);
+        if (!portalNode || this.observedPortalNodes.has(portalNode)) continue;
+        this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
+        this.portalObserver.observe(portalNode, { childList: true });
+        this.observedPortalNodes.add(portalNode);
+      }
+    }
+  }
+
+  private disconnectPortalObserver(): void {
+    this.portalObserver?.disconnect();
+    this.observedPortalNodes.clear();
+  }
+
+  /**
    * Check pending links and show them if their source/target are ready.
    */
   public checkPendingLinks(): void {
@@ -170,6 +202,8 @@ export class PaperView extends Paper {
         linkView.el.style.visibility = '';
       }
     }
+
+    if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
   }
 
   public onViewMountChangeFlush() {
@@ -197,6 +231,7 @@ export class PaperView extends Paper {
 
     if (cell.isLink()) {
       this.pendingLinks.delete(cellId);
+      if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
       this.viewChanges.set(cellId, { type: 'remove' });
       this.onViewMountChangeFlush();
     }
@@ -216,6 +251,8 @@ export class PaperView extends Paper {
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
       this.onViewMountChangeFlush();
       this.checkPendingLinks();
+      // Links can park before this endpoint's view existed — observe now.
+      this.observePendingLinkEndpoints();
       return;
     }
 
@@ -228,6 +265,7 @@ export class PaperView extends Paper {
       if (!isSourceReady || !isTargetReady) {
         view.el.style.visibility = 'hidden';
         this.pendingLinks.add(cellId);
+        this.observePendingLinkEndpoints();
       }
 
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
@@ -246,6 +284,7 @@ export class PaperView extends Paper {
   }
 
   public remove() {
+    this.disconnectPortalObserver();
     // call CLEANUP_EVENT_NAME for any listeners that need to clean up before the paper is removed
     this.trigger(CLEANUP_EVENT_NAME);
     super.remove();

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -31,6 +31,10 @@ export class PaperView extends Paper {
   // mutation is the only reliable "content painted" signal.
   private portalObserver: MutationObserver | null = null;
   private observedPortalNodes: Set<Node> = new Set();
+  // Element id → number of parked links waiting on it. Lets a park and an
+  // element mount each do O(1) observation work instead of re-walking every
+  // pending link (which made a mount of N parked links O(N²)).
+  private pendingEndpointIds: Map<CellId, number> = new Map();
 
   constructor(options: PaperViewOptions) {
     const { onViewMountChange, portalSelector, id, ...paperOptions } = options;
@@ -147,31 +151,33 @@ export class PaperView extends Paper {
     return this.isElementReady(endId);
   }
 
+  private bumpPendingEndpoint(endId: CellId | undefined, delta: 1 | -1): void {
+    if (!endId) return;
+    const count = (this.pendingEndpointIds.get(endId) ?? 0) + delta;
+    if (count <= 0) this.pendingEndpointIds.delete(endId);
+    else this.pendingEndpointIds.set(endId, count);
+  }
+
   /**
-   * Observe the portal nodes of every parked link's endpoints, so content
-   * mounted by a child-only React update still triggers a recheck.
+   * Observe one parked endpoint's portal node, so content mounted by a
+   * child-only React update still triggers a recheck. O(1) per call — a
+   * park observes its own two endpoints, an element mount observes itself.
    */
-  private observePendingLinkEndpoints(): void {
-    for (const linkId of this.pendingLinks) {
-      const link = this.getLinkView(linkId)?.model;
-      if (!link) continue;
-      for (const end of [link.source(), link.target()]) {
-        const endId = end.id;
-        if (!endId) continue;
-        const elementView = this.getElementView(endId);
-        if (!elementView?.el) continue;
-        const portalNode = this.getCellViewPortalNode(elementView);
-        if (!portalNode || this.observedPortalNodes.has(portalNode)) continue;
-        this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
-        this.portalObserver.observe(portalNode, { childList: true });
-        this.observedPortalNodes.add(portalNode);
-      }
-    }
+  private observeEndpoint(endId: CellId | undefined): void {
+    if (!endId) return;
+    const elementView = this.getElementView(endId);
+    if (!elementView?.el) return;
+    const portalNode = this.getCellViewPortalNode(elementView);
+    if (!portalNode || this.observedPortalNodes.has(portalNode)) return;
+    this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
+    this.portalObserver.observe(portalNode, { childList: true });
+    this.observedPortalNodes.add(portalNode);
   }
 
   private disconnectPortalObserver(): void {
     this.portalObserver?.disconnect();
     this.observedPortalNodes.clear();
+    this.pendingEndpointIds.clear();
   }
 
   /**
@@ -201,6 +207,9 @@ export class PaperView extends Paper {
       if (linkView?.el) {
         linkView.el.style.visibility = '';
       }
+      const link = linkView?.model;
+      this.bumpPendingEndpoint(link?.source().id, -1);
+      this.bumpPendingEndpoint(link?.target().id, -1);
     }
 
     if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
@@ -230,8 +239,12 @@ export class PaperView extends Paper {
     }
 
     if (cell.isLink()) {
-      this.pendingLinks.delete(cellId);
-      if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
+      if (this.pendingLinks.delete(cellId)) {
+        const link = cell as dia.Link;
+        this.bumpPendingEndpoint(link.source().id, -1);
+        this.bumpPendingEndpoint(link.target().id, -1);
+        if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
+      }
       this.viewChanges.set(cellId, { type: 'remove' });
       this.onViewMountChangeFlush();
     }
@@ -250,9 +263,12 @@ export class PaperView extends Paper {
     if (view.model.isElement()) {
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
       this.onViewMountChangeFlush();
-      this.checkPendingLinks();
-      // Links can park before this endpoint's view existed — observe now.
-      this.observePendingLinkEndpoints();
+      // Only when parked links wait on THIS element (a link can park before
+      // its endpoint's view exists) — keeps unrelated element mounts O(1).
+      if (this.pendingEndpointIds.has(cellId)) {
+        this.checkPendingLinks();
+        if (this.pendingEndpointIds.has(cellId)) this.observeEndpoint(cellId);
+      }
       return;
     }
 
@@ -264,8 +280,15 @@ export class PaperView extends Paper {
 
       if (!isSourceReady || !isTargetReady) {
         view.el.style.visibility = 'hidden';
-        this.pendingLinks.add(cellId);
-        this.observePendingLinkEndpoints();
+        if (!this.pendingLinks.has(cellId)) {
+          this.pendingLinks.add(cellId);
+          const sourceId = link.source().id;
+          const targetId = link.target().id;
+          this.bumpPendingEndpoint(sourceId, 1);
+          this.bumpPendingEndpoint(targetId, 1);
+          this.observeEndpoint(sourceId);
+          this.observeEndpoint(targetId);
+        }
       }
 
       this.viewChanges.set(cellId, { type: 'add', data: view.model });

--- a/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
@@ -87,13 +87,17 @@ describe('graphProjection — incremental remove of element with connected links
     ]);
     await flush();
 
-    // Build a synthetic change-set carrying just the element 'a' as a
-    // remove. Because the graph still owns the link 'l1' at the moment
-    // the LAYOUT_UPDATE_EVENT fires, the for-of over getConnectedLinks
-    // walks the link removal branch (lines 221-223).
-    const elementA = graph.getCell('a') as dia.Element;
-    const layoutChanges = new Map([['a', { type: 'remove' as const, data: elementA }]]);
-    graph.trigger('layout:update', { changes: layoutChanges });
+    // Lose the link's own remove event (flagged `isUpdateFromReact`, which
+    // graph-changes skips) so its record lingers in the container — the
+    // "missed link removal" the element-remove sweep exists for. Removing
+    // the element afterwards must prune the stranded link record even
+    // though `getConnectedLinks` can no longer name it (both cells are out
+    // of the graph by then).
+    graph.getCell('l1').remove({ isUpdateFromReact: true } as dia.Cell.DisconnectableOptions);
+    await flush();
+    expect(view.cells.has('l1')).toBe(true);
+
+    (graph.getCell('a') as dia.Element).remove();
     await flush();
 
     expect(view.cells.has('a')).toBe(false);

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -65,41 +65,38 @@ export function graphProjection<
   const changed = trackChanges ? new Map<CellId, Element | Link>() : undefined;
   const removed = trackChanges ? new Set<CellId>() : undefined;
 
+  /** Drop a record and report it removed to the incremental delta. */
+  function removeRecord(id: CellId): void {
+    cells.delete(id);
+    if (trackChanges) removed!.add(id);
+  }
+
   const graphChangesController = graphChanges({
     graph,
     onElementsSizeChange,
     onChanges: ({ changes, isInsideBatch, deferCommit, isReset }) => {
-      // Elements removed in this batch — swept ONCE after the loop for link
-      // records they may have stranded (see `sweepOrphanedLinkRecords`).
+      // Elements removed in this batch — swept once after the loop for link
+      // records they may have stranded.
       let removedElementIds: Set<CellId> | undefined;
-
-      /** Drop a record and report it removed to the incremental delta. */
-      const removeRecord = (id: CellId): void => {
-        cells.delete(id);
-        if (trackChanges) removed!.add(id);
-      };
 
       for (const [id, change] of changes) {
         const { data, type } = change;
         switch (type) {
           case 'add':
           case 'change': {
-            // An entry can outlive its cell: `layout:update` batches (paper
-            // view-mount re-broadcasts, app layout pipelines applying async
-            // results) hold direct cell references, and a removal can land
-            // in between. Writing such an entry would RESURRECT the removed
-            // cell's record — the container would disagree with the graph
-            // forever, and a later re-add of the byte-identical cell
-            // (CommandManager undo) would merge into the stale record with
-            // no membership/version notification, leaving the cell
-            // unrendered. Gate on graph membership; repair the container
-            // when a stale record is present.
-            if (!graph.getCell(id)) {
+            // An entry can outlive its cell: `layout:update` batches hold
+            // direct cell references, and a removal (or a remove + re-add of
+            // the same id) can land before the entry processes. Writing the
+            // entry's detached model would resurrect or overwrite the record
+            // with stale state, so always snapshot the graph's CURRENT model
+            // — and repair a lingering record when the cell is gone.
+            const cell = graph.getCell(id);
+            if (!cell) {
               if (cells.has(id)) removeRecord(id);
               continue;
             }
             const isAdd = type === 'add';
-            const record = writeCellToContainer(cells, data);
+            const record = writeCellToContainer(cells, cell);
             if (trackChanges) {
               if (isAdd) added!.set(id, record);
               else changed!.set(id, record);
@@ -108,18 +105,17 @@ export function graphProjection<
             // moved or resized — its links' routes need re-snapshotting).
             // On `add`, the link gets its own change-set entry from JointJS
             // and will be written in this loop without re-ordering issues.
-            if (!isAdd && data.isElement()) {
-              for (const link of graph.getConnectedLinks(data)) {
+            if (!isAdd && cell.isElement()) {
+              for (const link of graph.getConnectedLinks(cell)) {
                 writeCellToContainer(cells, link);
               }
             }
             break;
           }
           case 'remove': {
-            // A `remove` entry is only a graph removal when the cell is
-            // actually gone — paper view-unmount notifications re-broadcast
-            // through `layout:update` (carrying no cell reference) can name
-            // a cell the paper merely unmounted, e.g. viewport culling.
+            // Only a graph removal when the cell is actually gone — a paper
+            // view-unmount notification (no cell reference) can name a cell
+            // the paper merely unmounted, e.g. viewport culling.
             if (graph.getCell(id)) continue;
             removeRecord(id);
             if (data?.isElement()) {
@@ -131,18 +127,14 @@ export function graphProjection<
         }
       }
 
-      // Connected links are removed by JointJS alongside their element and
-      // normally arrive as their own `remove` entries. The elements are
-      // already OUT of the graph by the time their entries process, so
-      // `graph.getConnectedLinks` can no longer name their links (it reads
-      // graph adjacency) — instead, sweep the container once per batch for
-      // link records that reference a removed element and whose link the
-      // graph no longer holds, so a missed link removal can never strand a
-      // record. The graph check also protects links legitimately re-added
-      // within the same batch.
+      // Connected links normally arrive as their own `remove` entries, but a
+      // missed one must not strand a record — the element is already out of
+      // the graph adjacency, so `getConnectedLinks` cannot name its links.
+      // One pass per removal batch; links the graph still holds are kept.
       if (removedElementIds !== undefined) {
+        const elementIds = removedElementIds;
         const referencesRemoved = (end: LinkJSONInit['source']): boolean =>
-          typeof end === 'object' && end?.id !== undefined && removedElementIds!.has(end.id);
+          typeof end === 'object' && end?.id !== undefined && elementIds.has(end.id);
         // Snapshot ids first — `cells.delete` swap-pops the live array, so
         // deleting while iterating `getAll()` would skip entries.
         const staleLinkIds: CellId[] = [];
@@ -167,10 +159,7 @@ export function graphProjection<
         for (const item of cells.getAll()) {
           if (item.id !== undefined && !survivingIds.has(item.id)) staleIds.push(item.id);
         }
-        for (const staleId of staleIds) {
-          cells.delete(staleId);
-          if (trackChanges) removed!.add(staleId);
-        }
+        for (const staleId of staleIds) removeRecord(staleId);
       }
 
       // Two commit modes, decided by `deferCommit` (see graph-changes):

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -65,8 +65,13 @@ export function graphProjection<
   const changed = trackChanges ? new Map<CellId, Element | Link>() : undefined;
   const removed = trackChanges ? new Set<CellId>() : undefined;
 
-  /** Drop a record and report it removed to the incremental delta. */
+  /**
+   * Drop a record and report it removed to the incremental delta. A cell with
+   * no record (already removed, or never written) reports nothing —
+   * re-reporting ids in later deltas would feed consumers stale removals.
+   */
   function removeRecord(id: CellId): void {
+    if (!cells.has(id)) return;
     cells.delete(id);
     if (trackChanges) removed!.add(id);
   }
@@ -92,7 +97,7 @@ export function graphProjection<
             // — and repair a lingering record when the cell is gone.
             const cell = graph.getCell(id);
             if (!cell) {
-              if (cells.has(id)) removeRecord(id);
+              removeRecord(id);
               continue;
             }
             const isAdd = type === 'add';
@@ -140,8 +145,11 @@ export function graphProjection<
         const staleLinkIds: CellId[] = [];
         for (const item of cells.getAll()) {
           const { id: linkId, source, target } = item as LinkJSONInit;
-          if (linkId === undefined || graph.getCell(linkId)) continue;
-          if (referencesRemoved(source) || referencesRemoved(target)) staleLinkIds.push(linkId);
+          if (linkId === undefined) continue;
+          // Cheap Set checks first — `getCell` only runs for real candidates.
+          if (!referencesRemoved(source) && !referencesRemoved(target)) continue;
+          if (graph.getCell(linkId)) continue;
+          staleLinkIds.push(linkId);
         }
         for (const linkId of staleLinkIds) removeRecord(linkId);
       }

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -69,11 +69,35 @@ export function graphProjection<
     graph,
     onElementsSizeChange,
     onChanges: ({ changes, isInsideBatch, deferCommit, isReset }) => {
+      // Elements removed in this batch — swept ONCE after the loop for link
+      // records they may have stranded (see `sweepOrphanedLinkRecords`).
+      let removedElementIds: Set<CellId> | undefined;
+
+      /** Drop a record and report it removed to the incremental delta. */
+      const removeRecord = (id: CellId): void => {
+        cells.delete(id);
+        if (trackChanges) removed!.add(id);
+      };
+
       for (const [id, change] of changes) {
         const { data, type } = change;
         switch (type) {
           case 'add':
           case 'change': {
+            // An entry can outlive its cell: `layout:update` batches (paper
+            // view-mount re-broadcasts, app layout pipelines applying async
+            // results) hold direct cell references, and a removal can land
+            // in between. Writing such an entry would RESURRECT the removed
+            // cell's record — the container would disagree with the graph
+            // forever, and a later re-add of the byte-identical cell
+            // (CommandManager undo) would merge into the stale record with
+            // no membership/version notification, leaving the cell
+            // unrendered. Gate on graph membership; repair the container
+            // when a stale record is present.
+            if (!graph.getCell(id)) {
+              if (cells.has(id)) removeRecord(id);
+              continue;
+            }
             const isAdd = type === 'add';
             const record = writeCellToContainer(cells, data);
             if (trackChanges) {
@@ -92,20 +116,42 @@ export function graphProjection<
             break;
           }
           case 'remove': {
-            if (!data) continue;
-            cells.delete(id);
-            if (trackChanges) removed!.add(id);
-            if (data.isElement()) {
-              // Connected links are also removed by JointJS — mirror that.
-              for (const link of graph.getConnectedLinks(data)) {
-                const linkId = link.id;
-                cells.delete(linkId);
-                if (trackChanges) removed!.add(linkId);
-              }
+            // A `remove` entry is only a graph removal when the cell is
+            // actually gone — paper view-unmount notifications re-broadcast
+            // through `layout:update` (carrying no cell reference) can name
+            // a cell the paper merely unmounted, e.g. viewport culling.
+            if (graph.getCell(id)) continue;
+            removeRecord(id);
+            if (data?.isElement()) {
+              removedElementIds ??= new Set();
+              removedElementIds.add(id);
             }
             break;
           }
         }
+      }
+
+      // Connected links are removed by JointJS alongside their element and
+      // normally arrive as their own `remove` entries. The elements are
+      // already OUT of the graph by the time their entries process, so
+      // `graph.getConnectedLinks` can no longer name their links (it reads
+      // graph adjacency) — instead, sweep the container once per batch for
+      // link records that reference a removed element and whose link the
+      // graph no longer holds, so a missed link removal can never strand a
+      // record. The graph check also protects links legitimately re-added
+      // within the same batch.
+      if (removedElementIds !== undefined) {
+        const referencesRemoved = (end: LinkJSONInit['source']): boolean =>
+          typeof end === 'object' && end?.id !== undefined && removedElementIds!.has(end.id);
+        // Snapshot ids first — `cells.delete` swap-pops the live array, so
+        // deleting while iterating `getAll()` would skip entries.
+        const staleLinkIds: CellId[] = [];
+        for (const item of cells.getAll()) {
+          const { id: linkId, source, target } = item as LinkJSONInit;
+          if (linkId === undefined || graph.getCell(linkId)) continue;
+          if (referencesRemoved(source) || referencesRemoved(target)) staleLinkIds.push(linkId);
+        }
+        for (const linkId of staleLinkIds) removeRecord(linkId);
       }
 
       // A bulk `reset` sends only `add`s for the surviving cells and no per-cell


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Fixes a permanent render loss with externally-owned graphs (`<GraphProvider graph={graph}>` +
imperative mutations + CommandManager undo): after deleting an element that has a link and
undoing, the restored element came back positioned and sized but empty — `renderElement` was
never called for it again — and the restored link stayed `visibility: hidden`.

Mechanism: `layout:update` change batches hold direct cell references and are produced
asynchronously (paper view-mount re-broadcasts via `setPaperViews`, app layout pipelines
applying async results such as ELK). When a removal landed between producing and processing
such a batch, the projection wrote the entry into the cells container without checking that
the cell was still in the graph — resurrecting the removed cell's record. From then on the
container permanently disagreed with the graph: the undo's re-add of the byte-identical cell
merged into the stale record (`mergeCellRecord` identity fast path → `isStrictEqual` early
return), so no version bump and no membership notification ever fired, `useContainerKeys`
kept its cached ids, and the cell never rendered again.

Changes in `graph-projection.ts`:

- `add`/`change` entries are gated on graph membership; a stale entry now also repairs the
  container by deleting a lingering record.
- `remove` entries only apply when the cell has actually left the graph, so a paper
  view-unmount notification (which can name a still-mounted cell, e.g. viewport culling)
  can no longer delete a live cell's record.
- On element removal, the container is swept once per batch for orphaned link records
  (`graph.getConnectedLinks` cannot name them at that point — the cells are already out of
  the graph adjacency). The sweep skips links the graph still holds, so links re-added
  within the same batch survive.

Change in `use-create-portal-paper.tsx`:

- Links parked hidden in `pendingLinks` (endpoint's React content not painted yet) were only
  rechecked from `insertView` and joint's `afterRender`; portal content mounting in a React
  commit triggers neither, so a link could stay hidden permanently once its endpoint painted.
  A `useEffect` now rechecks after every commit that (re)rendered the element portals. The
  effect is O(1) in steady state (`pendingLinks.size === 0` early return) and its dependency
  does not change on cell data/position updates, so it never runs on drag frames.

Tests: new `external-graph-undo.test.tsx` covers the delete+undo scenario end to end
(projection pruning, stale-entry resurrection, live-cell view-unmount safety, undo repaint
with link visibility). The `graph-projection-edge-cases` sweep test was updated to exercise
the sweep through a genuinely missed link removal instead of a synthetic remove entry for a
cell still in the graph (which is exactly the unsafe input this fix rejects).

## Motivation and Context

Reported against 4.3.5 by a customer running an externally-owned `dia.Graph` subclass with
imperative mutations (`fromJSON`, stencil drops, layout) and CommandManager undo/redo:
delete an element with a link, press Ctrl+Z, and the shape returns empty with its link
hidden, unrecoverably. Their measurement (graph at 2 cells while the projection held 4,
including the deleted element and its link) matches the resurrection mechanism above.

### Screenshots (if appropriate):