### PR TITLE
fix(joint-react): prevent stale layout:update entries from resurrecting removed cells (dev)

### DIFF
--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -152,6 +152,39 @@ describe('external graph — undo of a delete (element with a link)', () => {
     projection.destroy();
   });
 
+  it('a data-less remove entry for an already-removed cell adds no phantom id to the delta', async () => {
+    // The paper's view-unmount notification for a deleted cell arrives in a
+    // later `layout:update` batch, after the graph removal already reported
+    // the id. Removing "again" must not re-report the id in whatever
+    // incremental delta flushes next — consumers mirroring an external store
+    // would receive stale removals in unrelated batches.
+    const graph = createExternalGraph();
+    const deltas: string[][] = [];
+    const projection = graphProjection({
+      graph,
+      onIncrementalCellsChange: ({ removed }) => deltas.push([...removed].map(String)),
+    });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0)]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    graph.getCell('e1').remove();
+    await act(async () => {});
+    expect(deltas.pop()).toContain('e1');
+
+    // View-unmount re-broadcast for the deleted cell (no data, inside batch),
+    // then an unrelated move that flushes the next delta.
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'remove' }]]),
+    });
+    (graph.getCell('e2') as dia.Element).position(120, 0);
+    await act(async () => {});
+
+    const flushed = deltas.flat();
+    expect(flushed).not.toContain('e1');
+    projection.destroy();
+  });
+
   it('a data-less remove entry for a LIVE cell (view unmount) keeps its record', async () => {
     // Paper view-unmount notifications re-broadcast through `layout:update`
     // carry `{ type: 'remove' }` with no cell reference — and can name a cell

--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -50,9 +50,9 @@ function createExternalGraph(): dia.Graph {
  * which is exactly what makes `mergeCellRecord` hit its identity fast-path
  * if a stale record survived the delete.
  */
-function undoDelete(graph: dia.Graph, cells: readonly dia.Cell.JSON[]): void {
+function undoDelete(graph: dia.Graph, cells: dia.Cell.JSON[]): void {
   graph.startBatch('undo');
-  graph.addCells(cells as dia.Cell.JSON[]);
+  graph.addCells(cells);
   graph.stopBatch('undo');
 }
 
@@ -120,6 +120,35 @@ describe('external graph — undo of a delete (element with a link)', () => {
     expect(projection.cells.has('e1')).toBe(false);
     expect(projection.cells.has('l1')).toBe(false);
     expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a delayed entry holding the OLD model cannot overwrite a re-added replacement', async () => {
+    // After undo installs a replacement model under the same id, a delayed
+    // `layout:update` entry may still reference the old detached model with
+    // stale attributes. The projection must snapshot the graph's CURRENT
+    // model, never the entry's reference.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0)]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    const oldModel = graph.getCell('e1');
+    oldModel.remove();
+    await act(async () => {});
+
+    // Undo-style re-add: a NEW model under the same id, moved elsewhere.
+    graph.addCell(elementJSON('e1', 300, 300));
+    await act(async () => {});
+
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'change', data: oldModel }]]),
+    });
+    await act(async () => {});
+
+    const record = projection.cells.get('e1') as { position?: { x: number; y: number } };
+    expect(record?.position).toEqual({ x: 300, y: 300 });
     projection.destroy();
   });
 

--- a/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
+++ b/packages/joint-react/src/components/graph/__tests__/external-graph-undo.test.tsx
@@ -1,0 +1,243 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { dia } from '@joint/core';
+import { GraphProvider, Paper } from '../..';
+import { useCell } from '../../../hooks/use-cell';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
+import { graphProjection } from '../../../store/graph-projection';
+import type { Computed, ElementRecord } from '../../../types/cell.types';
+
+const PAPER_STYLE = { width: 400, height: 400 } as const;
+
+/** Content mounts recorded per cell id — the "did renderElement paint" probe. */
+const mounts: string[] = [];
+
+function SubscribingNode() {
+  const label = useCell(
+    (cell: Computed<ElementRecord<{ readonly label: string }>>) => cell.data.label
+  );
+  mounts.push(label);
+  return <text>{label}</text>;
+}
+const renderSubscribing = () => <SubscribingNode />;
+
+function elementJSON(id: string, x = 0, y = 0): dia.Cell.JSON {
+  return {
+    id,
+    type: ELEMENT_MODEL_TYPE,
+    position: { x, y },
+    size: { width: 20, height: 20 },
+    data: { label: `label-${id}` },
+  };
+}
+
+function linkJSON(id: string, source: string, target: string): dia.Cell.JSON {
+  return {
+    id,
+    type: 'standard.Link',
+    source: { id: source },
+    target: { id: target },
+  };
+}
+
+function createExternalGraph(): dia.Graph {
+  return new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+}
+
+/**
+ * CommandManager-style undo of a delete: re-add the removed cells from their
+ * stored JSON inside a plain batch — byte-identical to what was removed,
+ * which is exactly what makes `mergeCellRecord` hit its identity fast-path
+ * if a stale record survived the delete.
+ */
+function undoDelete(graph: dia.Graph, cells: readonly dia.Cell.JSON[]): void {
+  graph.startBatch('undo');
+  graph.addCells(cells as dia.Cell.JSON[]);
+  graph.stopBatch('undo');
+}
+
+// Customer scenario (externally-owned graph, imperative mutations, undo via
+// CommandManager): delete an element that has a link, then undo. The restored
+// element must render its React content again and the restored link must be
+// visible — not a positioned-but-empty ghost.
+describe('external graph — undo of a delete (element with a link)', () => {
+  beforeEach(() => {
+    mounts.length = 0;
+  });
+
+  it('projection prunes the removed element AND its link from the container', async () => {
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {}); // flush the scheduler microtask
+    projection.syncFromGraph();
+    expect(projection.cells.getSize()).toBe(3);
+
+    graph.getCell('e1').remove();
+    await act(async () => {});
+
+    // The graph holds one cell; the container must agree — a stale record
+    // here turns the undo's re-add into a no-op update.
+    expect(graph.getCells().length).toBe(1);
+    expect(projection.cells.has('e1')).toBe(false);
+    expect(projection.cells.has('l1')).toBe(false);
+    expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a layout:update naming a removed cell must not resurrect its record', async () => {
+    // The genesis of the customer's stale records: `layout:update` entries
+    // (emitted by `setPaperViews` re-broadcasting view mounts, and by app
+    // layout pipelines applying ELK results) are written to the container
+    // WITHOUT checking the cell still lives in the graph. A delete that lands
+    // between computing such a batch and applying it resurrects the record —
+    // and from then on every undo re-add is a "no-op update" that never
+    // notifies membership, so the cell never renders again.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {});
+    projection.syncFromGraph();
+
+    const elementCell = graph.getCell('e1');
+    const linkCell = graph.getCell('l1');
+    elementCell.remove();
+    await act(async () => {});
+    expect(projection.cells.getSize()).toBe(1);
+
+    // Apply a stale layout batch that still references the removed cells
+    // (their models are detached but alive — exactly what a pending
+    // view-mount notification or an in-flight ELK result holds).
+    graph.trigger('layout:update', {
+      changes: new Map([
+        ['e1', { type: 'change', data: elementCell }],
+        ['l1', { type: 'change', data: linkCell }],
+        ['e2', { type: 'change', data: graph.getCell('e2') }],
+      ]),
+    });
+    await act(async () => {});
+
+    expect(projection.cells.has('e1')).toBe(false);
+    expect(projection.cells.has('l1')).toBe(false);
+    expect(projection.cells.getSize()).toBe(1);
+    projection.destroy();
+  });
+
+  it('a data-less remove entry for a LIVE cell (view unmount) keeps its record', async () => {
+    // Paper view-unmount notifications re-broadcast through `layout:update`
+    // carry `{ type: 'remove' }` with no cell reference — and can name a cell
+    // the paper merely unmounted (viewport culling) while the graph still
+    // holds it. That must never delete the live cell's record.
+    const graph = createExternalGraph();
+    const projection = graphProjection({ graph });
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+    await act(async () => {});
+    projection.syncFromGraph();
+    expect(projection.cells.getSize()).toBe(3);
+
+    graph.trigger('layout:update', {
+      changes: new Map([['e1', { type: 'remove' }]]),
+    });
+    await act(async () => {});
+
+    expect(projection.cells.has('e1')).toBe(true);
+    expect(projection.cells.getSize()).toBe(3);
+    projection.destroy();
+  });
+
+  it('undo still paints after a stale layout:update raced the delete', async () => {
+    // Full customer symptom: stale record present → undo re-adds the
+    // byte-identical cell → mergeCellRecord identity fast-path → no version
+    // bump, no membership change → renderElement never called, link hidden.
+    const graph = createExternalGraph();
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="undo-race-paper" renderElement={renderSubscribing} />
+      </GraphProvider>
+    );
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+
+    const elementCell = graph.getCell('e1');
+    const linkCell = graph.getCell('l1');
+    const removedJSON = [elementCell.toJSON(), linkCell.toJSON()];
+
+    await act(async () => {
+      elementCell.remove();
+      // The race: a view-mount / layout notification for the removed cells
+      // flushes after the remove in the same microtask cascade.
+      graph.trigger('layout:update', {
+        changes: new Map([
+          ['e1', { type: 'change', data: elementCell }],
+          ['l1', { type: 'change', data: linkCell }],
+        ]),
+      });
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('label-e1');
+    });
+
+    mounts.length = 0;
+    await act(async () => {
+      undoDelete(graph, [removedJSON[0], removedJSON[1]]);
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+    expect(mounts).toContain('label-e1');
+
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+
+  it('re-renders the element and shows the link after delete + undo', async () => {
+    const graph = createExternalGraph();
+    graph.addCells([elementJSON('e1'), elementJSON('e2', 100, 0), linkJSON('l1', 'e1', 'e2')]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="undo-paper" renderElement={renderSubscribing} />
+      </GraphProvider>
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+      expect(container.textContent).toContain('label-e2');
+    });
+
+    // Delete the element — JointJS removes its connected link with it.
+    const removedJSON = [graph.getCell('e1').toJSON(), graph.getCell('l1').toJSON()];
+    await act(async () => {
+      graph.getCell('e1').remove();
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('label-e1');
+    });
+
+    // Undo: restore element first, then the link (CommandManager order).
+    mounts.length = 0;
+    await act(async () => {
+      undoDelete(graph, [removedJSON[0], removedJSON[1]]);
+    });
+
+    // The restored element paints again…
+    await waitFor(() => {
+      expect(container.textContent).toContain('label-e1');
+    });
+    expect(mounts).toContain('label-e1');
+
+    // …and the restored link is visible (not parked hidden forever).
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+});

--- a/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { dia } from '@joint/core';
+import { GraphProvider, Paper } from '../../..';
+import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
+
+const PAPER_STYLE = { width: 400, height: 400 } as const;
+
+// Reveal setters captured per mounted node so the test can flip content
+// through CHILD-ONLY state updates — the parent portal hook must not
+// re-render for the link to become visible.
+const reveals: Array<(ready: boolean) => void> = [];
+
+function DelayedNode() {
+  const [ready, setReady] = useState(false);
+  reveals.push(setReady);
+  return ready ? <text>content</text> : null;
+}
+const renderDelayed = () => <DelayedNode />;
+
+function elementJSON(id: string, x: number): dia.Cell.JSON {
+  return {
+    id,
+    type: ELEMENT_MODEL_TYPE,
+    position: { x, y: 0 },
+    size: { width: 20, height: 20 },
+  };
+}
+
+// A link is parked with `visibility: hidden` while its endpoints' React
+// content has not painted. Content that arrives LATER through a child-only
+// update (local state, Suspense) mounts into the portal without re-rendering
+// the portal hook and without any joint render — the link must still be
+// revealed.
+describe('pending links — endpoint content mounting after a delay', () => {
+  it('reveals the link once delayed endpoint content paints', async () => {
+    reveals.length = 0;
+    const graph = new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+    graph.addCells([
+      elementJSON('e1', 0),
+      elementJSON('e2', 100),
+      { id: 'l1', type: 'standard.Link', source: { id: 'e1' }, target: { id: 'e2' } },
+    ]);
+
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="delayed-content-paper" renderElement={renderDelayed} />
+      </GraphProvider>
+    );
+
+    // Both endpoints render null → the link parks hidden.
+    await waitFor(() => {
+      expect(reveals.length).toBeGreaterThanOrEqual(2);
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode).not.toBeNull();
+      expect(linkNode!.style.visibility).toBe('hidden');
+    });
+
+    // Child-only updates: only the node components re-render.
+    await act(async () => {
+      for (const reveal of reveals) reveal(true);
+    });
+
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
+      expect(linkNode!.style.visibility).not.toBe('hidden');
+    });
+  });
+});

--- a/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
+++ b/packages/joint-react/src/components/paper/__tests__/pending-links-delayed-content.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { dia } from '@joint/core';
 import { GraphProvider, Paper } from '../../..';
 import { ELEMENT_MODEL_TYPE } from '../../../mvc/element-model';
+import { PaperView } from '../../../mvc/paper';
 import { DEFAULT_CELL_NAMESPACE } from '../../../store/graph-store';
 
 const PAPER_STYLE = { width: 400, height: 400 } as const;
@@ -66,5 +67,40 @@ describe('pending links — endpoint content mounting after a delay', () => {
       const linkNode = container.querySelector('[model-id="l1"]') as HTMLElement | null;
       expect(linkNode!.style.visibility).not.toBe('hidden');
     });
+  });
+
+  it('parking many links stays linear in portal lookups', async () => {
+    // Regression guard for the O(N²) shape: observing endpoints must not
+    // re-walk every already-parked link (each walk pays portal lookups per
+    // link). With N chained links, linear bookkeeping needs a few lookups
+    // per link; the quadratic walk needs ~N²/2 and blows the budget.
+    reveals.length = 0;
+    const LINKS = 300;
+    const graph = new dia.Graph({}, { cellNamespace: DEFAULT_CELL_NAMESPACE });
+    const cells: dia.Cell.JSON[] = [];
+    for (let index = 0; index <= LINKS; index += 1) cells.push(elementJSON(`e${index}`, index * 30));
+    for (let index = 0; index < LINKS; index += 1) {
+      cells.push({
+        id: `l${index}`,
+        type: 'standard.Link',
+        source: { id: `e${index}` },
+        target: { id: `e${index + 1}` },
+      });
+    }
+    graph.addCells(cells);
+
+    const spy = jest.spyOn(PaperView.prototype, 'getCellViewPortalNode');
+    const { container } = render(
+      <GraphProvider graph={graph}>
+        <Paper style={PAPER_STYLE} id="linear-park-paper" renderElement={renderDelayed} />
+      </GraphProvider>
+    );
+    await waitFor(() => {
+      const linkNode = container.querySelector('[model-id="l0"]') as HTMLElement | null;
+      expect(linkNode!.style.visibility).toBe('hidden');
+    });
+
+    expect(spy.mock.calls.length).toBeLessThan(LINKS * 20);
+    spy.mockRestore();
   });
 });

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -500,21 +500,12 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
-  // A link whose endpoint's React content has not painted yet is parked in
-  // `pendingLinks` with `visibility: hidden` by `insertView`. The recheck used
-  // to run only from `insertView` and joint's `afterRender` — but an
-  // endpoint's PORTAL content mounts in a REACT commit, which triggers
-  // neither, so a link could stay hidden permanently once its endpoint
-  // painted (a fixed-size element never re-enters a joint render cycle).
-  //
-  // Recheck after every commit that (re)rendered the element portals:
-  // effects flush after portal children are in the DOM, so `isElementReady`
-  // sees them. `elements` is the precise dependency — it recomputes exactly
-  // when the portal set could have (re)mounted content (ids, paper version,
-  // measurement gate) and NOT on cell data/position changes, so this never
-  // runs on drag frames. When nothing is parked, `checkPendingLinks` returns
-  // on its first line (`pendingLinks.size === 0`), making the steady-state
-  // cost of this effect a single property read per portal commit.
+  // Links parked hidden by `insertView` (endpoint content not painted yet)
+  // are only rechecked from `insertView` / joint's `afterRender` — a React
+  // commit that mounts portal content triggers neither, leaving such links
+  // hidden forever. Recheck after each element-portal commit; `elements`
+  // does not change on cell data/position updates (no drag-frame runs), and
+  // `checkPendingLinks` is O(1) while nothing is parked.
   useEffect(() => {
     const paper = paperStore?.paper;
     if (paper instanceof PaperView) paper.checkPendingLinks();

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -500,6 +500,26 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
+  // A link whose endpoint's React content has not painted yet is parked in
+  // `pendingLinks` with `visibility: hidden` by `insertView`. The recheck used
+  // to run only from `insertView` and joint's `afterRender` — but an
+  // endpoint's PORTAL content mounts in a REACT commit, which triggers
+  // neither, so a link could stay hidden permanently once its endpoint
+  // painted (a fixed-size element never re-enters a joint render cycle).
+  //
+  // Recheck after every commit that (re)rendered the element portals:
+  // effects flush after portal children are in the DOM, so `isElementReady`
+  // sees them. `elements` is the precise dependency — it recomputes exactly
+  // when the portal set could have (re)mounted content (ids, paper version,
+  // measurement gate) and NOT on cell data/position changes, so this never
+  // runs on drag frames. When nothing is parked, `checkPendingLinks` returns
+  // on its first line (`pendingLinks.size === 0`), making the steady-state
+  // cost of this effect a single property read per portal commit.
+  useEffect(() => {
+    const paper = paperStore?.paper;
+    if (paper instanceof PaperView) paper.checkPendingLinks();
+  }, [elements, paperStore]);
+
   const renderedLinks = useMemo(() => {
     if (!hasRenderLink || !renderLink) {
       return null;

--- a/packages/joint-react/src/hooks/use-create-portal-paper.tsx
+++ b/packages/joint-react/src/hooks/use-create-portal-paper.tsx
@@ -500,17 +500,6 @@ export function useCreatePortalPaper(
     useHTMLOverlay,
   ]);
 
-  // Links parked hidden by `insertView` (endpoint content not painted yet)
-  // are only rechecked from `insertView` / joint's `afterRender` — a React
-  // commit that mounts portal content triggers neither, leaving such links
-  // hidden forever. Recheck after each element-portal commit; `elements`
-  // does not change on cell data/position updates (no drag-frame runs), and
-  // `checkPendingLinks` is O(1) while nothing is parked.
-  useEffect(() => {
-    const paper = paperStore?.paper;
-    if (paper instanceof PaperView) paper.checkPendingLinks();
-  }, [elements, paperStore]);
-
   const renderedLinks = useMemo(() => {
     if (!hasRenderLink || !renderLink) {
       return null;

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -26,6 +26,11 @@ export class PaperView extends Paper {
   private readonly shouldPreserveHostElementOnRemove: boolean;
   private readonly portalSelector: PortalSelector | undefined;
   private pendingLinks: Set<CellId> = new Set();
+  // Portal nodes of parked links' not-ready endpoints. React mounts portal
+  // content outside joint's render cycle (child state, Suspense), so a DOM
+  // mutation is the only reliable "content painted" signal.
+  private portalObserver: MutationObserver | null = null;
+  private observedPortalNodes: Set<Node> = new Set();
 
   constructor(options: PaperViewOptions) {
     const { onViewMountChange, portalSelector, id, ...paperOptions } = options;
@@ -143,6 +148,33 @@ export class PaperView extends Paper {
   }
 
   /**
+   * Observe the portal nodes of every parked link's endpoints, so content
+   * mounted by a child-only React update still triggers a recheck.
+   */
+  private observePendingLinkEndpoints(): void {
+    for (const linkId of this.pendingLinks) {
+      const link = this.getLinkView(linkId)?.model;
+      if (!link) continue;
+      for (const end of [link.source(), link.target()]) {
+        const endId = end.id;
+        if (!endId) continue;
+        const elementView = this.getElementView(endId);
+        if (!elementView?.el) continue;
+        const portalNode = this.getCellViewPortalNode(elementView);
+        if (!portalNode || this.observedPortalNodes.has(portalNode)) continue;
+        this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
+        this.portalObserver.observe(portalNode, { childList: true });
+        this.observedPortalNodes.add(portalNode);
+      }
+    }
+  }
+
+  private disconnectPortalObserver(): void {
+    this.portalObserver?.disconnect();
+    this.observedPortalNodes.clear();
+  }
+
+  /**
    * Check pending links and show them if their source/target are ready.
    */
   public checkPendingLinks(): void {
@@ -170,6 +202,8 @@ export class PaperView extends Paper {
         linkView.el.style.visibility = '';
       }
     }
+
+    if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
   }
 
   public onViewMountChangeFlush() {
@@ -197,6 +231,7 @@ export class PaperView extends Paper {
 
     if (cell.isLink()) {
       this.pendingLinks.delete(cellId);
+      if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
       this.viewChanges.set(cellId, { type: 'remove' });
       this.onViewMountChangeFlush();
     }
@@ -216,6 +251,8 @@ export class PaperView extends Paper {
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
       this.onViewMountChangeFlush();
       this.checkPendingLinks();
+      // Links can park before this endpoint's view existed — observe now.
+      this.observePendingLinkEndpoints();
       return;
     }
 
@@ -228,6 +265,7 @@ export class PaperView extends Paper {
       if (!isSourceReady || !isTargetReady) {
         view.el.style.visibility = 'hidden';
         this.pendingLinks.add(cellId);
+        this.observePendingLinkEndpoints();
       }
 
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
@@ -246,6 +284,7 @@ export class PaperView extends Paper {
   }
 
   public remove() {
+    this.disconnectPortalObserver();
     // call CLEANUP_EVENT_NAME for any listeners that need to clean up before the paper is removed
     this.trigger(CLEANUP_EVENT_NAME);
     super.remove();

--- a/packages/joint-react/src/mvc/paper.ts
+++ b/packages/joint-react/src/mvc/paper.ts
@@ -31,6 +31,10 @@ export class PaperView extends Paper {
   // mutation is the only reliable "content painted" signal.
   private portalObserver: MutationObserver | null = null;
   private observedPortalNodes: Set<Node> = new Set();
+  // Element id → number of parked links waiting on it. Lets a park and an
+  // element mount each do O(1) observation work instead of re-walking every
+  // pending link (which made a mount of N parked links O(N²)).
+  private pendingEndpointIds: Map<CellId, number> = new Map();
 
   constructor(options: PaperViewOptions) {
     const { onViewMountChange, portalSelector, id, ...paperOptions } = options;
@@ -147,31 +151,33 @@ export class PaperView extends Paper {
     return this.isElementReady(endId);
   }
 
+  private bumpPendingEndpoint(endId: CellId | undefined, delta: 1 | -1): void {
+    if (!endId) return;
+    const count = (this.pendingEndpointIds.get(endId) ?? 0) + delta;
+    if (count <= 0) this.pendingEndpointIds.delete(endId);
+    else this.pendingEndpointIds.set(endId, count);
+  }
+
   /**
-   * Observe the portal nodes of every parked link's endpoints, so content
-   * mounted by a child-only React update still triggers a recheck.
+   * Observe one parked endpoint's portal node, so content mounted by a
+   * child-only React update still triggers a recheck. O(1) per call — a
+   * park observes its own two endpoints, an element mount observes itself.
    */
-  private observePendingLinkEndpoints(): void {
-    for (const linkId of this.pendingLinks) {
-      const link = this.getLinkView(linkId)?.model;
-      if (!link) continue;
-      for (const end of [link.source(), link.target()]) {
-        const endId = end.id;
-        if (!endId) continue;
-        const elementView = this.getElementView(endId);
-        if (!elementView?.el) continue;
-        const portalNode = this.getCellViewPortalNode(elementView);
-        if (!portalNode || this.observedPortalNodes.has(portalNode)) continue;
-        this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
-        this.portalObserver.observe(portalNode, { childList: true });
-        this.observedPortalNodes.add(portalNode);
-      }
-    }
+  private observeEndpoint(endId: CellId | undefined): void {
+    if (!endId) return;
+    const elementView = this.getElementView(endId);
+    if (!elementView?.el) return;
+    const portalNode = this.getCellViewPortalNode(elementView);
+    if (!portalNode || this.observedPortalNodes.has(portalNode)) return;
+    this.portalObserver ??= new MutationObserver(() => this.checkPendingLinks());
+    this.portalObserver.observe(portalNode, { childList: true });
+    this.observedPortalNodes.add(portalNode);
   }
 
   private disconnectPortalObserver(): void {
     this.portalObserver?.disconnect();
     this.observedPortalNodes.clear();
+    this.pendingEndpointIds.clear();
   }
 
   /**
@@ -201,6 +207,9 @@ export class PaperView extends Paper {
       if (linkView?.el) {
         linkView.el.style.visibility = '';
       }
+      const link = linkView?.model;
+      this.bumpPendingEndpoint(link?.source().id, -1);
+      this.bumpPendingEndpoint(link?.target().id, -1);
     }
 
     if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
@@ -230,8 +239,12 @@ export class PaperView extends Paper {
     }
 
     if (cell.isLink()) {
-      this.pendingLinks.delete(cellId);
-      if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
+      if (this.pendingLinks.delete(cellId)) {
+        const link = cell as dia.Link;
+        this.bumpPendingEndpoint(link.source().id, -1);
+        this.bumpPendingEndpoint(link.target().id, -1);
+        if (this.pendingLinks.size === 0) this.disconnectPortalObserver();
+      }
       this.viewChanges.set(cellId, { type: 'remove' });
       this.onViewMountChangeFlush();
     }
@@ -250,9 +263,12 @@ export class PaperView extends Paper {
     if (view.model.isElement()) {
       this.viewChanges.set(cellId, { type: 'add', data: view.model });
       this.onViewMountChangeFlush();
-      this.checkPendingLinks();
-      // Links can park before this endpoint's view existed — observe now.
-      this.observePendingLinkEndpoints();
+      // Only when parked links wait on THIS element (a link can park before
+      // its endpoint's view exists) — keeps unrelated element mounts O(1).
+      if (this.pendingEndpointIds.has(cellId)) {
+        this.checkPendingLinks();
+        if (this.pendingEndpointIds.has(cellId)) this.observeEndpoint(cellId);
+      }
       return;
     }
 
@@ -264,8 +280,15 @@ export class PaperView extends Paper {
 
       if (!isSourceReady || !isTargetReady) {
         view.el.style.visibility = 'hidden';
-        this.pendingLinks.add(cellId);
-        this.observePendingLinkEndpoints();
+        if (!this.pendingLinks.has(cellId)) {
+          this.pendingLinks.add(cellId);
+          const sourceId = link.source().id;
+          const targetId = link.target().id;
+          this.bumpPendingEndpoint(sourceId, 1);
+          this.bumpPendingEndpoint(targetId, 1);
+          this.observeEndpoint(sourceId);
+          this.observeEndpoint(targetId);
+        }
       }
 
       this.viewChanges.set(cellId, { type: 'add', data: view.model });

--- a/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
+++ b/packages/joint-react/src/store/__tests__/graph-projection-edge-cases.test.ts
@@ -87,13 +87,17 @@ describe('graphProjection — incremental remove of element with connected links
     ]);
     await flush();
 
-    // Build a synthetic change-set carrying just the element 'a' as a
-    // remove. Because the graph still owns the link 'l1' at the moment
-    // the LAYOUT_UPDATE_EVENT fires, the for-of over getConnectedLinks
-    // walks the link removal branch (lines 221-223).
-    const elementA = graph.getCell('a') as dia.Element;
-    const layoutChanges = new Map([['a', { type: 'remove' as const, data: elementA }]]);
-    graph.trigger('layout:update', { changes: layoutChanges });
+    // Lose the link's own remove event (flagged `isUpdateFromReact`, which
+    // graph-changes skips) so its record lingers in the container — the
+    // "missed link removal" the element-remove sweep exists for. Removing
+    // the element afterwards must prune the stranded link record even
+    // though `getConnectedLinks` can no longer name it (both cells are out
+    // of the graph by then).
+    graph.getCell('l1').remove({ isUpdateFromReact: true } as dia.Cell.DisconnectableOptions);
+    await flush();
+    expect(view.cells.has('l1')).toBe(true);
+
+    (graph.getCell('a') as dia.Element).remove();
     await flush();
 
     expect(view.cells.has('a')).toBe(false);

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -125,11 +125,32 @@ export function graphProjection<
     graph,
     onElementsSizeChange,
     onChanges: ({ changes, isInsideBatch, deferCommit, isReset }) => {
+      // Elements removed in this batch — swept ONCE after the loop for link
+      // records they may have stranded (see the sweep below).
+      let removedElementIds: Set<CellId> | undefined;
+
       for (const [id, change] of changes) {
         const { data, type } = change;
         switch (type) {
           case 'add':
           case 'change': {
+            // An entry can outlive its cell: `layout:update` batches (paper
+            // view-mount re-broadcasts, app layout pipelines applying async
+            // results) hold direct cell references, and a removal can land
+            // in between. Writing such an entry would RESURRECT the removed
+            // cell's record — the container would disagree with the graph
+            // forever, and a later re-add of the byte-identical cell
+            // (CommandManager undo) would merge into the stale record with
+            // no membership/version notification, leaving the cell
+            // unrendered. Gate on graph membership; repair the container
+            // when a stale record is present.
+            if (!graph.getCell(id)) {
+              if (currentRecord(id) !== undefined) {
+                stageRemove(id);
+                if (trackChanges) removed!.add(id);
+              }
+              continue;
+            }
             const isAdd = type === 'add';
             stageWrite(data, isAdd);
             if (trackChanges) {
@@ -155,18 +176,47 @@ export function graphProjection<
             break;
           }
           case 'remove': {
-            if (!data) continue;
+            // A `remove` entry is only a graph removal when the cell is
+            // actually gone — paper view-unmount notifications re-broadcast
+            // through `layout:update` (carrying no cell reference) can name
+            // a cell the paper merely unmounted, e.g. viewport culling.
+            if (graph.getCell(id)) continue;
             stageRemove(id);
             if (trackChanges) removed!.add(id);
-            if (data.isElement()) {
-              // Connected links are also removed by JointJS — mirror that.
-              for (const link of graph.getConnectedLinks(data)) {
-                stageRemove(link.id);
-                if (trackChanges) removed!.add(link.id);
-              }
+            if (data?.isElement()) {
+              removedElementIds ??= new Set();
+              removedElementIds.add(id);
             }
             break;
           }
+        }
+      }
+
+      // Connected links are removed by JointJS alongside their element and
+      // normally arrive as their own `remove` entries. The elements are
+      // already OUT of the graph by the time their entries process, so
+      // `graph.getConnectedLinks` can no longer name their links (it reads
+      // graph adjacency) — instead, sweep the container (committed snapshot
+      // + pending stages) once per batch for link records that reference a
+      // removed element and whose link the graph no longer holds, so a
+      // missed link removal can never strand a record. The graph check also
+      // protects links legitimately re-added within the same batch.
+      if (removedElementIds !== undefined) {
+        const elementIds = removedElementIds;
+        const referencesRemoved = (end: LinkJSONInit['source']): boolean =>
+          typeof end === 'object' && end?.id !== undefined && elementIds.has(end.id);
+        const staleLinkIds: CellId[] = [];
+        const collectStaleLink = (item: Element | Link): void => {
+          const { id: linkId, source, target } = item as LinkJSONInit;
+          if (linkId === undefined || graph.getCell(linkId)) return;
+          if (referencesRemoved(source) || referencesRemoved(target)) staleLinkIds.push(linkId);
+        };
+        for (const item of cells.getSnapshot()) collectStaleLink(item);
+        for (const item of pendingAdded.values()) collectStaleLink(item);
+        for (const item of pendingChanged.values()) collectStaleLink(item);
+        for (const linkId of staleLinkIds) {
+          stageRemove(linkId);
+          if (trackChanges) removed!.add(linkId);
         }
       }
 

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -125,8 +125,8 @@ export function graphProjection<
     graph,
     onElementsSizeChange,
     onChanges: ({ changes, isInsideBatch, deferCommit, isReset }) => {
-      // Elements removed in this batch — swept ONCE after the loop for link
-      // records they may have stranded (see the sweep below).
+      // Elements removed in this batch — swept once after the loop for link
+      // records they may have stranded.
       let removedElementIds: Set<CellId> | undefined;
 
       for (const [id, change] of changes) {
@@ -134,17 +134,14 @@ export function graphProjection<
         switch (type) {
           case 'add':
           case 'change': {
-            // An entry can outlive its cell: `layout:update` batches (paper
-            // view-mount re-broadcasts, app layout pipelines applying async
-            // results) hold direct cell references, and a removal can land
-            // in between. Writing such an entry would RESURRECT the removed
-            // cell's record — the container would disagree with the graph
-            // forever, and a later re-add of the byte-identical cell
-            // (CommandManager undo) would merge into the stale record with
-            // no membership/version notification, leaving the cell
-            // unrendered. Gate on graph membership; repair the container
-            // when a stale record is present.
-            if (!graph.getCell(id)) {
+            // An entry can outlive its cell: `layout:update` batches hold
+            // direct cell references, and a removal (or a remove + re-add of
+            // the same id) can land before the entry processes. Writing the
+            // entry's detached model would resurrect or overwrite the record
+            // with stale state, so always snapshot the graph's CURRENT model
+            // — and repair a lingering record when the cell is gone.
+            const cell = graph.getCell(id);
+            if (!cell) {
               if (currentRecord(id) !== undefined) {
                 stageRemove(id);
                 if (trackChanges) removed!.add(id);
@@ -152,7 +149,7 @@ export function graphProjection<
               continue;
             }
             const isAdd = type === 'add';
-            stageWrite(data, isAdd);
+            stageWrite(cell, isAdd);
             if (trackChanges) {
               // Report every primary add/change in the incremental delta using
               // the final staged record — NOT gated on whether this stageWrite
@@ -170,16 +167,15 @@ export function graphProjection<
             // or resized — its links' routes need re-snapshotting). Swept links
             // go to the container only, not the incremental callback — matching
             // the previous behaviour.
-            if (!isAdd && data.isElement()) {
-              for (const link of graph.getConnectedLinks(data)) stageWrite(link, false);
+            if (!isAdd && cell.isElement()) {
+              for (const link of graph.getConnectedLinks(cell)) stageWrite(link, false);
             }
             break;
           }
           case 'remove': {
-            // A `remove` entry is only a graph removal when the cell is
-            // actually gone — paper view-unmount notifications re-broadcast
-            // through `layout:update` (carrying no cell reference) can name
-            // a cell the paper merely unmounted, e.g. viewport culling.
+            // Only a graph removal when the cell is actually gone — a paper
+            // view-unmount notification (no cell reference) can name a cell
+            // the paper merely unmounted, e.g. viewport culling.
             if (graph.getCell(id)) continue;
             stageRemove(id);
             if (trackChanges) removed!.add(id);
@@ -192,15 +188,11 @@ export function graphProjection<
         }
       }
 
-      // Connected links are removed by JointJS alongside their element and
-      // normally arrive as their own `remove` entries. The elements are
-      // already OUT of the graph by the time their entries process, so
-      // `graph.getConnectedLinks` can no longer name their links (it reads
-      // graph adjacency) — instead, sweep the container (committed snapshot
-      // + pending stages) once per batch for link records that reference a
-      // removed element and whose link the graph no longer holds, so a
-      // missed link removal can never strand a record. The graph check also
-      // protects links legitimately re-added within the same batch.
+      // Connected links normally arrive as their own `remove` entries, but a
+      // missed one must not strand a record — the element is already out of
+      // the graph adjacency, so `getConnectedLinks` cannot name its links.
+      // One pass per removal batch over the committed snapshot + pending
+      // stages; links the graph still holds are kept.
       if (removedElementIds !== undefined) {
         const elementIds = removedElementIds;
         const referencesRemoved = (end: LinkJSONInit['source']): boolean =>

--- a/packages/joint-react/src/store/graph-projection.ts
+++ b/packages/joint-react/src/store/graph-projection.ts
@@ -175,8 +175,11 @@ export function graphProjection<
           case 'remove': {
             // Only a graph removal when the cell is actually gone — a paper
             // view-unmount notification (no cell reference) can name a cell
-            // the paper merely unmounted, e.g. viewport culling.
+            // the paper merely unmounted, e.g. viewport culling. A cell with
+            // no record left (already removed) reports nothing — re-reporting
+            // ids in later deltas would feed consumers stale removals.
             if (graph.getCell(id)) continue;
+            if (currentRecord(id) === undefined) continue;
             stageRemove(id);
             if (trackChanges) removed!.add(id);
             if (data?.isElement()) {
@@ -200,8 +203,11 @@ export function graphProjection<
         const staleLinkIds: CellId[] = [];
         const collectStaleLink = (item: Element | Link): void => {
           const { id: linkId, source, target } = item as LinkJSONInit;
-          if (linkId === undefined || graph.getCell(linkId)) return;
-          if (referencesRemoved(source) || referencesRemoved(target)) staleLinkIds.push(linkId);
+          if (linkId === undefined) return;
+          // Cheap Set checks first — `getCell` only runs for real candidates.
+          if (!referencesRemoved(source) && !referencesRemoved(target)) return;
+          if (graph.getCell(linkId)) return;
+          staleLinkIds.push(linkId);
         };
         for (const item of cells.getSnapshot()) collectStaleLink(item);
         for (const item of pendingAdded.values()) collectStaleLink(item);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `grunt test` locally
* [x] If applicable, there are new or updated unit tests validating the change
* [ ] If applicable, there are new or updated @types
* [ ] If applicable, documentation has been updated
-->

## Description

Dev-branch port of the externally-owned-graph undo fix (see the companion PR against
`master`: clientIO/joint#3494). The reworked projection on `dev` (immutable snapshot
container with `stageWrite`/`stageRemove` pending buckets) carries the identical defect —
verified by running the same failing test against `dev` before the fix.

Same three invariants, adapted to the staged container:

- `add`/`change` entries are gated on graph membership; a stale entry repairs a lingering
  record via `stageRemove` (only when `currentRecord(id)` exists, so the incremental delta
  is not polluted with removals of never-present ids).
- `remove` entries only apply when the cell has actually left the graph (paper view-unmount
  notifications can name still-mounted cells, e.g. viewport culling).
- The orphaned-link sweep runs once per batch over the committed snapshot plus both pending
  buckets, keyed on the batch's removed-element set, and skips links the graph still holds.

Plus the same `use-create-portal-paper.tsx` recheck of `pendingLinks` after element-portal
commits, and the same test files.

Note for the future `master` → `dev` sync: this PR pre-resolves the merge for
`graph-projection.ts` — on conflict, take the `dev` side (it already contains the fix, and
the shared `external-graph-undo.test.tsx` verifies the resolution). No changeset here on
purpose: the `master` PR carries the release entry, and a second one would duplicate the
changelog when `dev` merges down.

## Motivation and Context

Same customer report as the `master` PR: delete an element with a link, undo, and the
restored element renders empty with its link permanently hidden. `master` is the patch line
for the affected 4.3.5 release; this keeps `dev`'s state rework from shipping the same bug.

### Screenshots (if appropriate):